### PR TITLE
docs: specify delegated release service implementation

### DIFF
--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -58,6 +58,7 @@ The replacement implementation is complete through the publisher OAuth callback 
 - envelope encryption, publisher custody, generation-bound refresh operations, publisher application sessions, and identity/delegation callback routes pass real workerd tests; and
 - Cloudflare Access authenticates operators through role-specific audiences; a `ServiceControlDurableObject` owns service mode, publisher suspension, idempotency, audit, and epoch-bound publication permits; and
 - GitHub Actions OIDC verification normalizes repository, workflow, ref, environment, run, actor, and token identity without retaining the raw JWT; and
+- an isolated verifier Worker fetches through bounded DNS/private-range controls, validates artifact checksums and canonical bundles, and returns no file bytes; and
 - the Access/control top passes 139 release-service tests, and the workload/intent top passes 144; package typecheck, type-aware lint, and Worker builds pass on both.
 
 The public-client G0 lifecycle is complete on both providers: exact-scope authorization, forced refresh, and server revocation passed. npmX rejected its access token immediately after revocation. Cirrus retained the already-issued access token for its remaining lifetime while preventing future refresh. G0 still requires the deployed confidential-client run and client-key removal observation before either provider is advertised as supported by the hosted service.
@@ -761,6 +762,10 @@ PRs #2649 to #2651 form one merge unit in GitHub stack #2652. The first layer ve
 ### Active workload identity stack
 
 PRs #2653, #2654, #2656, #2657, and #2658 form GitHub stack #2655. They implement normalized GitHub workload identity, publisher-authorized workload policy with immutable repository IDs, package/version reservation, workload idempotency, the generation-guarded intent state machine, exact policy evaluation, admission digests, generation-bound publication capabilities, and alarm recovery to reconciliation. The next integration layer adds HTTP admission and Workflow start after the Access/control and workload stacks join.
+
+### Active verifier stack
+
+PR #2659 implements W6.1 and the artifact half of W6.2 on `feat/drs-release-verifier`, rooted on `main`. The verifier exposes one typed service-binding RPC method and has no OAuth, Access, Durable Object, service-control, or secret bindings. Provenance verification and the release-service binding are later layers of this independent stack.
 
 ### Planned GitHub stacks
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -241,7 +241,7 @@ Dependencies: G0 architecture and Access decisions.
 | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `W2.1` | Scaffold the Worker, static assets, test configuration, bindings, Wrangler Durable Object class migration, Workflow binding, verifier binding, and generated types |
 | `W2.2` | Add versioned JSON envelopes, request IDs, body limits, security headers, CORS policy, error handling, and route composition                         |
-| `W2.3` | Implement Access JWT verification, group-to-role mapping, CSRF, and operator mutation idempotency                                                    |
+| `W2.3` | Implement Access JWT verification, role-specific audience boundaries, CSRF, and operator mutation idempotency                                       |
 | `W2.4` | Implement `ServiceControlDurableObject`, service modes, publication permits, publisher controls, audit, and alarm-backed cleanup                     |
 | `W2.5` | Add health and readiness behavior that distinguishes configuration, binding, and dependency failure without exposing tenant state                    |
 | `W2.6` | Add CI lanes for Node tests, workerd tests, Worker build, binding generation, and packed-output checks                                               |
@@ -249,7 +249,7 @@ Dependencies: G0 architecture and Access decisions.
 ### Acceptance criteria
 
 - Production routes start only with complete required bindings and fail with public-safe configuration errors.
-- Access operator routes reject missing, wrong-audience, expired, malformed, and insufficient-group JWTs.
+- Access operator routes reject missing, wrong-audience, expired, malformed, non-human, and wrong-role JWTs.
 - Operator role boundaries prevent viewers and reviewers from executing admin-only actions.
 - CSRF and idempotency checks apply to every cookie-authenticated mutation.
 - Service mode transitions are atomic and append audit before returning success.

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -57,7 +57,8 @@ The replacement implementation is complete through the publisher OAuth callback 
 - the Worker serves confidential client metadata and overlapping JWKS, fails closed on invalid configuration, and keeps canonical publisher authority in SQLite-backed Durable Objects;
 - envelope encryption, publisher custody, generation-bound refresh operations, publisher application sessions, and identity/delegation callback routes pass real workerd tests; and
 - Cloudflare Access authenticates operators through role-specific audiences; a `ServiceControlDurableObject` owns service mode, publisher suspension, idempotency, audit, and epoch-bound publication permits; and
-- repository package typecheck, type-aware lint, 139 release-service tests, Worker build, and startup profiling pass on the top branch.
+- GitHub Actions OIDC verification normalizes repository, workflow, ref, environment, run, actor, and token identity without retaining the raw JWT; and
+- the Access/control top passes 139 release-service tests, and the workload-verifier branch passes 119; package typecheck, type-aware lint, and Worker builds pass on both.
 
 The public-client G0 lifecycle is complete on both providers: exact-scope authorization, forced refresh, and server revocation passed. npmX rejected its access token immediately after revocation. Cirrus retained the already-issued access token for its remaining lifetime while preventing future refresh. G0 still requires the deployed confidential-client run and client-key removal observation before either provider is advertised as supported by the hosted service.
 
@@ -756,6 +757,10 @@ feat/drs-confidential-oauth-callback
 ```
 
 PRs #2649 to #2651 form one merge unit in GitHub stack #2652. The first layer verifies Access role audiences and request protections. The second owns the complete initial control schema and state transitions. The third exposes the role-specific operator API.
+
+### Active workload identity stack
+
+PR #2653 implements W5.1 and W5.2 on `feat/drs-github-oidc-verifier`, based on the completed foundation stack. It freezes the normalized workload identity consumed by publisher policy and intent-admission work. Later branches in this merge unit add workload-policy storage and intent admission.
 
 ### Planned GitHub stacks
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -73,6 +73,9 @@ Closed PR #1908 remains donor history and is not a merge target. Its D1 custody 
 - Keep incomplete authority paths unreachable. A feature flag or undocumented route is not a sufficient boundary.
 - Put package and root-workspace changes in a designated integration worktree. Parallel worktrees do not all edit `pnpm-lock.yaml`, root `package.json`, CI, or generated binding types.
 - Represent every dependent PR lane as a GitHub stack managed with `gh-stack`. Independent workstreams use separate stacks rooted on `main`.
+- Treat each GitHub stack as one merge unit. Its branches are review boundaries, not deployable service versions. A partial stack merge requires an explicit integration gate that is independently usable.
+- Before the first service deployment, define the complete initial schema and persisted formats on their owning lowest branches. Do not add migrations or legacy readers solely for intermediate branches in an unmerged stack. After the first deployment, every persisted-state change uses a forward-only migration and preserves deployed data.
+- Merging an implementation stack does not authorize a deployment. The first hosted or self-hosted release waits for the complete service and its G7 production gate.
 - New public records and fields remain additive while experimental.
 - User-facing application strings use Lingui and RTL-safe layouts. The Access operator console follows the same UI quality rules even though its deployment audience is small.
 - Each published-package change includes a reviewed changeset.
@@ -137,7 +140,7 @@ W3 -> W8 -> W10 -> W12
 | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | **G0 Design**                   | RFC decisions reconciled; exact create-only scope proved on every claimed PDS; no broad fallback                                         | Authority-bearing implementation                   |
 | **G1 Contracts**                | Lexicons, direct-PDS reads, shared record/bundle/provenance reports, and fixtures pass in Node and workerd                               | Service Workflow and installer work                |
-| **G2 Durable state**            | Service shell, Access auth, control object, publisher object, migrations, state machine, idempotency, and alarms pass real workerd tests | OAuth, OIDC, Workflow integration                  |
+| **G2 Durable state**            | Service shell, Access auth, control object, publisher object, initial schema, state machine, idempotency, and alarms pass real workerd tests | OAuth, OIDC, Workflow integration                  |
 | **G3 Automatic vertical slice** | Controlled GitHub workflow publishes one valid non-escalating release and converges under retries                                        | Independent enforcement and private service trials |
 | **G4 Independent enforcement**  | A clean EmDash site accepts valid output and rejects every invalid service-output fixture                                                | Hosted limited beta                                |
 | **G5 Approval**                 | `always` and escalation releases require a valid current approver and passkey; every invalidation path re-approves                       | Broader publisher beta                             |
@@ -236,7 +239,7 @@ Dependencies: G0 architecture and Access decisions.
 
 | Task   | Work                                                                                                                                                 |
 | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `W2.1` | Scaffold the Worker, static assets, test configuration, bindings, Durable Object migrations, Workflow binding, verifier binding, and generated types |
+| `W2.1` | Scaffold the Worker, static assets, test configuration, bindings, Wrangler Durable Object class migration, Workflow binding, verifier binding, and generated types |
 | `W2.2` | Add versioned JSON envelopes, request IDs, body limits, security headers, CORS policy, error handling, and route composition                         |
 | `W2.3` | Implement Access JWT verification, group-to-role mapping, CSRF, and operator mutation idempotency                                                    |
 | `W2.4` | Implement `ServiceControlDurableObject`, service modes, publication permits, publisher controls, audit, and alarm-backed cleanup                     |
@@ -262,7 +265,7 @@ Dependencies: G0 architecture and Access decisions.
 Owner surface:
 
 - `apps/release-service/src/publisher-do/`
-- publisher-shard migrations and test fixtures
+- publisher-shard schema and test fixtures
 - publisher RPC types exported from one package-local entry point
 
 Dependencies: W2.1 and shared state/error contracts.
@@ -271,7 +274,7 @@ Dependencies: W2.1 and shared state/error contracts.
 
 | Task   | Work                                                                                                                                                                                     |
 | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `W3.1` | Implement forward-only object schema migration with `publisher`, `delegations`, `workload_policies`, `intents`, reservations, transitions, operations, audit, idempotency, and deadlines |
+| `W3.1` | Implement the complete initial object schema with `publisher`, `delegations`, `workload_policies`, `intents`, reservations, transitions, operations, audit, idempotency, and deadlines |
 | `W3.2` | Implement the complete intent state machine with expected-state and generation guards                                                                                                    |
 | `W3.3` | Implement package/version reservation and OIDC/request idempotency semantics                                                                                                             |
 | `W3.4` | Implement generation-bound refresh and publication operation tokens without external I/O inside transactions                                                                             |
@@ -282,7 +285,7 @@ Dependencies: W2.1 and shared state/error contracts.
 ### Acceptance criteria
 
 - `getByName(canonicalPublisherDid)` routes every package for one publisher to the same object.
-- Schema migration can restart after interruption and preserves existing rows.
+- Schema initialization is idempotent across object restarts.
 - Illegal state transitions and stale generations cannot change state.
 - Concurrent package/version reservations yield one owner and deterministic results for every loser.
 - Exact idempotent replay returns the stored intent; conflicting replay returns `IDEMPOTENCY_CONFLICT`.
@@ -453,7 +456,7 @@ Dependencies: W3 RPC conventions, W4 identity OAuth, W6 approval digest/event co
 | Task   | Work                                                                                                                              |
 | ------ | --------------------------------------------------------------------------------------------------------------------------------- |
 | `W8.1` | Port and review required-user-verification registration/authentication primitives in `@emdash-cms/auth`                           |
-| `W8.2` | Implement approver object schema, migrations, identity transactions, credentials, challenges, decisions, audit, and cleanup alarm |
+| `W8.2` | Implement the complete initial approver-object schema, identity transactions, credentials, challenges, decisions, audit, and cleanup alarm |
 | `W8.3` | Implement approver DID proof and short-lived approver sessions                                                                    |
 | `W8.4` | Implement multiple named passkeys, counter handling, revocation, and credential-safe serializers                                  |
 | `W8.5` | Define and compute the canonical approval digest and create single-use challenges                                                 |
@@ -602,7 +605,7 @@ Dependencies: begins at G1 and expands after every gate.
 | Task    | Work                                                                                                                                              |
 | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `W12.1` | Maintain one fixture corpus for records, bundles, provenance, workload claims, policy, approvals, and public/private errors                       |
-| `W12.2` | Build real workerd Durable Object and Workflow integration tests, including alarms, hibernation/restart, retries, and migrations                  |
+| `W12.2` | Build real workerd Durable Object and Workflow integration tests, including schema initialization, alarms, hibernation/restart, and retries       |
 | `W12.3` | Build browser OAuth, Access, WebAuthn, CSRF, isolation, localization, and RTL tests                                                               |
 | `W12.4` | Build controlled real-PDS and GitHub-OIDC end-to-end tests for hosted and self-host deployments                                                   |
 | `W12.5` | Add adversarial and fault-injection tests for replay, concurrency, substitution, SSRF, token leakage, ambiguous writes, pause races, and key loss |
@@ -613,7 +616,7 @@ Dependencies: begins at G1 and expands after every gate.
 
 - Every security invariant has at least one test that fails when its enforcement is removed.
 - Node and workerd share protocol fixtures but exercise their real runtime integrations.
-- Migration tests upgrade retained prior Durable Object schemas rather than asserting current SQL text.
+- After the first deployment, each Durable Object schema change adds an upgrade test from retained deployed state.
 - Fault injection at every external side-effect boundary converges to an allowed state.
 - Browser tests prove authentication-realm and publisher isolation, not only successful navigation.
 - Hosted and self-hosted end-to-end tests publish and independently install the same release.
@@ -622,6 +625,8 @@ Dependencies: begins at G1 and expands after every gate.
 ## Worktree and task strategy
 
 Use one worktree per PR-sized task. Independent lanes branch from current `main`; dependent lanes form short linear stacks. Do not put every workstream in one stack.
+
+Each linear stack merges as a unit. Splitting a change into dependent PRs improves review but does not create intermediate deployment support. Start another stack when the lower work has an independently usable integration gate; otherwise keep the dependency chain together.
 
 ### Worktree names and ownership
 
@@ -646,7 +651,7 @@ These names describe logical slots, not permission to keep all worktrees active.
 
 ### Dependency lanes
 
-Use separate `gh-stack` stacks for work that can merge independently:
+Use separate `gh-stack` stacks only for work that can merge independently:
 
 ```text
 Contract stack:
@@ -714,7 +719,7 @@ After every PR in a stack is ready and satisfies its gate, merge through `gh-sta
 gh stack merge <stack-number> --yes --squash
 ```
 
-Use the repository's selected merge method if it differs from squash. Stack merge is all-or-nothing unless the repository's merge queue processes the PRs separately. Scope a partial merge to a PR number only when the plan explicitly defines that PR as an integration gate.
+Use the repository's selected merge method if it differs from squash. Stack merge is all-or-nothing unless the repository's merge queue processes the PRs separately. Review completion, PR size, or an intermediate branch passing CI does not justify a partial merge. Scope a partial merge to a PR number only when the plan defines that PR as an independently usable integration gate.
 
 Do not add one branch to multiple stacks. When an independent stack needs a merged contract, rebase it onto updated `main`; do not share the contract branch between stacks.
 
@@ -735,6 +740,8 @@ main
 ```
 
 Each branch is one template-compliant draft PR. Create the PRs with their explicit parent bases before calling `gh stack link`; this prevents `gh-stack` from generating non-template PR bodies.
+
+The eight branches form one merge unit. The service has no supported intermediate deployment between them. The envelope-encryption branch defines the first persisted JOSE profile, and the publisher-object branch defines the complete initial schema used by every later branch. Do not add compatibility code for earlier branches in this stack.
 
 ### Planned GitHub stacks
 
@@ -860,7 +867,7 @@ The PR sequence is deliberately finer than the workstreams. Each PR leaves autho
 2. **Delegated release contracts** — profile/release types, exact scope, fixtures.
 3. **Shared record and provenance verification** — no service app behavior.
 4. **Release-service platform** — app, bindings, API foundation, Access auth, disabled control object.
-5. **Publisher object foundation** — schema, migration, state machine, audit, no OAuth or PDS calls.
+5. **Publisher object foundation** — complete initial schema, state machine, audit, no OAuth or PDS calls.
 6. **Publisher reservations and operations** — idempotency, deadlines, tokens, alarms.
 7. **Envelope encryption** — package-local crypto and fixtures.
 8. **Publisher OAuth identity and delegation** — authority stored but publication route absent.
@@ -880,7 +887,7 @@ The PR sequence is deliberately finer than the workstreams. Each PR leaves autho
 ## Definition of done for every implementation task
 
 - Behavior and failure behavior both have tests that would fail if enforcement were removed.
-- Durable Object storage changes use forward-only, restartable application schema migration.
+- After the first deployment, Durable Object storage changes use forward-only, restartable application schema migrations.
 - External effects have idempotency and reconciliation before connection to real authority.
 - Public errors use stable codes and contain no provider payload, secret, assertion, stack trace, or private evidence.
 - Authentication and authorization are tested independently.
@@ -903,7 +910,7 @@ The PR sequence is deliberately finer than the workstreams. Each PR leaves autho
 ### Durable state
 
 - [ ] Publisher and approver state route deterministically by canonical DID.
-- [ ] State-machine, reservation, idempotency, operation-token, alarm, migration, and audit tests pass in workerd.
+- [ ] State-machine, reservation, idempotency, operation-token, alarm, schema-initialization, and audit tests pass in workerd.
 - [ ] Workflows and optional D1 projections can be lost without losing canonical authorization or terminal release state.
 - [ ] No Durable Object critical section spans external I/O.
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -143,7 +143,7 @@ Dependencies: none.
 | --- | --- |
 | `W0.1` | Reconcile RFC #1870 with the Durable Object architecture, Access operator authentication, existing `emdash-plugin` command, and active experimental NSIDs |
 | `W0.2` | Freeze the first-release profile policy, provenance, workload policy, approval digest, intent state, and error contracts |
-| `W0.3` | Validate the exact create-only grant against the available Bluesky-hosted PDS and Cirrus test accounts |
+| `W0.3` | Validate the exact create-only grant against the available npmX-hosted Bluesky PDS and Cirrus test accounts |
 | `W0.4` | Validate confidential OAuth refresh, DPoP behavior, revocation, and client-key rotation with real authorization servers |
 | `W0.5` | Confirm current Workflow event, retention, retry, and test APIs support approval and recovery; record limits outside the protocol contract |
 | `W0.6` | Define hosted-service Access audience and group-to-role mapping and the self-host configuration contract |
@@ -151,7 +151,7 @@ Dependencies: none.
 ### Acceptance criteria
 
 - Every public contract has one normative shape and owner.
-- The exact scope creates a release and cannot update, delete, edit a profile, or write another collection on Bluesky-hosted PDS and Cirrus.
+- The exact scope creates a release and cannot update, delete, edit a profile, or write another collection on the Bluesky PDS implementation at npmX and on Cirrus.
 - Refresh and revocation observations are recorded with reproducible external steps.
 - An unsupported PDS is excluded from the support matrix instead of receiving a broader scope.
 - The Workflow design has a tested route for approval, rejection, cancellation, timeout, retry, and lost-instance recovery.
@@ -865,7 +865,7 @@ The PR sequence is deliberately finer than the workstreams. Each PR leaves autho
 ### Protocol and authority
 
 - [ ] RFC #1870 is accepted with the final actor, scope, policy, provenance, and approval contracts.
-- [ ] Bluesky-hosted PDS and Cirrus pass exact create-only, refresh, and revocation conformance.
+- [ ] The Bluesky PDS implementation at npmX and Cirrus pass exact create-only, refresh, and revocation conformance.
 - [ ] No broad scope, update, delete, or profile-write path exists in retained service code.
 - [ ] Shared verification is the only implementation used by service and installer.
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -760,7 +760,7 @@ PRs #2649 to #2651 form one merge unit in GitHub stack #2652. The first layer ve
 
 ### Active workload identity stack
 
-PRs #2653, #2654, and #2656 form GitHub stack #2655. They implement normalized GitHub workload identity, publisher-authorized workload policy with immutable repository IDs, package/version reservation, workload idempotency, and the generation-guarded intent state machine. The next layer adds HTTP admission and Workflow start.
+PRs #2653, #2654, #2656, and #2657 form GitHub stack #2655. They implement normalized GitHub workload identity, publisher-authorized workload policy with immutable repository IDs, package/version reservation, workload idempotency, the generation-guarded intent state machine, exact policy evaluation, and domain-separated admission digests. The next layer adds HTTP admission and Workflow start.
 
 ### Planned GitHub stacks
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -58,7 +58,7 @@ The replacement implementation is complete through the publisher OAuth callback 
 - envelope encryption, publisher custody, generation-bound refresh operations, publisher application sessions, and identity/delegation callback routes pass real workerd tests; and
 - Cloudflare Access authenticates operators through role-specific audiences; a `ServiceControlDurableObject` owns service mode, publisher suspension, idempotency, audit, and epoch-bound publication permits; and
 - GitHub Actions OIDC verification normalizes repository, workflow, ref, environment, run, actor, and token identity without retaining the raw JWT; and
-- the Access/control top passes 139 release-service tests, and the workload/intent top passes 131; package typecheck, type-aware lint, and Worker builds pass on both.
+- the Access/control top passes 139 release-service tests, and the workload/intent top passes 144; package typecheck, type-aware lint, and Worker builds pass on both.
 
 The public-client G0 lifecycle is complete on both providers: exact-scope authorization, forced refresh, and server revocation passed. npmX rejected its access token immediately after revocation. Cirrus retained the already-issued access token for its remaining lifetime while preventing future refresh. G0 still requires the deployed confidential-client run and client-key removal observation before either provider is advertised as supported by the hosted service.
 
@@ -760,7 +760,7 @@ PRs #2649 to #2651 form one merge unit in GitHub stack #2652. The first layer ve
 
 ### Active workload identity stack
 
-PRs #2653, #2654, #2656, and #2657 form GitHub stack #2655. They implement normalized GitHub workload identity, publisher-authorized workload policy with immutable repository IDs, package/version reservation, workload idempotency, the generation-guarded intent state machine, exact policy evaluation, and domain-separated admission digests. The next layer adds HTTP admission and Workflow start.
+PRs #2653, #2654, #2656, #2657, and #2658 form GitHub stack #2655. They implement normalized GitHub workload identity, publisher-authorized workload policy with immutable repository IDs, package/version reservation, workload idempotency, the generation-guarded intent state machine, exact policy evaluation, admission digests, generation-bound publication capabilities, and alarm recovery to reconciliation. The next integration layer adds HTTP admission and Workflow start after the Access/control and workload stacks join.
 
 ### Planned GitHub stacks
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -1,0 +1,911 @@
+# Delegated release service implementation plan
+
+Status: Proposed
+
+Companion specification: [Delegated release service](./delegated-release-service.md)
+
+Related design: [RFC PR #1870](https://github.com/emdash-cms/emdash/pull/1870)
+
+## Outcome
+
+This plan delivers a hosted and self-hostable delegated release service in reviewable increments. A GitHub Actions workflow can publish an attested sandboxed-plugin release through a publisher's exact create-only AT Protocol delegation. Invalid output remains un-installable because EmDash independently repeats verification. Releases that expand declared access or use `confirmation: always` require a profile-authorized, user-verified passkey decision.
+
+Canonical service state is sharded by publisher or approver DID in SQLite-backed Durable Objects. Workflows coordinate long-running work. D1, when introduced, is a rebuildable cross-publisher operator projection and never participates in authorization.
+
+## Existing implementation baseline
+
+The implementation starts from current `main`, not from the #1908 integration branch.
+
+### Available on `main`
+
+- `@emdash-cms/registry-lexicons` exports the active package/profile records and `getDelegatedReleasePermission()`.
+- `@emdash-cms/plugin-types` provides manifest validation, declared-access canonicalization, comparison, and escalation detection.
+- `@emdash-cms/registry-verification` provides guarded resource fetching, multihash verification, canonical bundle validation, record/policy verification, and GitHub Sigstore/SLSA verification in Node and workerd.
+- The registry client and plugin CLI already have AT Protocol publishing and credential foundations.
+
+### Donor material on #1908
+
+The old branch contains reviewed or tested implementations for:
+
+- required-user-verification WebAuthn primitives;
+- confidential OAuth metadata and storage experiments;
+- versioned envelope encryption;
+- GitHub Actions OIDC verification;
+- service API response and request-security foundations;
+- an isolated verifier Worker; and
+- create-only publishing and installer-verification prototypes.
+
+Each donor unit must be compared with current `main`, the accepted specification, and current platform APIs. Port bounded commits or code paths with provenance. Do not merge, rebase, or cherry-pick the whole integration branch.
+
+### Superseded assumptions
+
+The new implementation does not retain:
+
+- D1 as canonical service state;
+- D1 coordination leases;
+- a D1 transactional outbox as the release lifecycle;
+- AT Protocol login for service operators;
+- one large publisher/operator console;
+- Queue-plus-cron orchestration for release intents; or
+- aggregator historical-policy enforcement as a prerequisite for the first service release.
+
+## Execution rules
+
+- The companion specification is the source of truth. A workstream may refine an implementation detail but cannot weaken a security invariant.
+- Complete failing behavior tests with each implementation. Security and failure tests are not deferred to the conformance workstream.
+- Keep publisher, approver, operator, and CI authentication realms separate in types, middleware, cookies, and routes.
+- Keep canonical authorization state in Durable Objects. A projection or Workflow result cannot authorize a transition.
+- Use Durable Object RPC for typed state operations. Do not hold `blockConcurrencyWhile()` across external I/O.
+- Every external side effect has a generation-bound operation token, idempotency identity, or deterministic reconciliation path before it is enabled.
+- Keep incomplete authority paths unreachable. A feature flag or undocumented route is not a sufficient boundary.
+- Put package and root-workspace changes in a designated integration worktree. Parallel worktrees do not all edit `pnpm-lock.yaml`, root `package.json`, CI, or generated binding types.
+- Represent every dependent PR lane as a GitHub stack managed with `gh-stack`. Independent workstreams use separate stacks rooted on `main`.
+- New public records and fields remain additive while experimental.
+- User-facing application strings use Lingui and RTL-safe layouts. The Access operator console follows the same UI quality rules even though its deployment audience is small.
+- Each published-package change includes a reviewed changeset.
+
+## Workstream dependency graph
+
+```mermaid
+flowchart TD
+    W0[W0 Design and feasibility]
+    W1[W1 Protocol and shared verification]
+    W2[W2 Service shell and control plane]
+    W3[W3 Publisher Durable Object]
+    W4[W4 Publisher OAuth delegation]
+    W5[W5 Workload identity and intent admission]
+    W6[W6 Verification Workflow]
+    W7[W7 Publication and reconciliation]
+    W8[W8 Approver Durable Object and passkeys]
+    W9[W9 Independent installer enforcement]
+    W10[W10 Clients and web surfaces]
+    W11[W11 Operations and self-hosting]
+    W12[W12 Conformance and security]
+
+    W0 --> W1
+    W0 --> W2
+    W1 --> W4
+    W1 --> W6
+    W1 --> W9
+    W2 --> W3
+    W2 --> W11
+    W3 --> W4
+    W3 --> W5
+    W3 --> W6
+    W3 --> W8
+    W4 --> W7
+    W5 --> W6
+    W6 --> W7
+    W6 --> W8
+    W7 --> W10
+    W8 --> W10
+    W9 --> W12
+    W10 --> W12
+    W11 --> W12
+    W7 --> W12
+    W8 --> W12
+```
+
+The service critical path is:
+
+```text
+W0 -> W1 -> W2 -> W3 -> W4/W5 -> W6 -> W7 -> W9/W12
+```
+
+Approval and product surfaces follow a parallel path after the publisher object contract stabilizes:
+
+```text
+W3 -> W8 -> W10 -> W12
+```
+
+## Integration gates
+
+| Gate | Required evidence | Unblocks |
+| --- | --- | --- |
+| **G0 Design** | RFC decisions reconciled; exact create-only scope proved on every claimed PDS; no broad fallback | Authority-bearing implementation |
+| **G1 Contracts** | Lexicons, direct-PDS reads, shared record/bundle/provenance reports, and fixtures pass in Node and workerd | Service Workflow and installer work |
+| **G2 Durable state** | Service shell, Access auth, control object, publisher object, migrations, state machine, idempotency, and alarms pass real workerd tests | OAuth, OIDC, Workflow integration |
+| **G3 Automatic vertical slice** | Controlled GitHub workflow publishes one valid non-escalating release and converges under retries | Independent enforcement and private service trials |
+| **G4 Independent enforcement** | A clean EmDash site accepts valid output and rejects every invalid service-output fixture | Hosted limited beta |
+| **G5 Approval** | `always` and escalation releases require a valid current approver and passkey; every invalidation path re-approves | Broader publisher beta |
+| **G6 Operational beta** | Pause, suspension, revocation, reconciliation, key rotation, backup/export, alerts, and self-host path work without database edits | Public beta |
+| **G7 Production** | End-to-end conformance, recovery drills, and external security review have no unresolved critical/high findings | Production launch |
+
+## W0 Design and feasibility
+
+Owner surface: RFC, external validation, retained conformance fixtures.
+
+Dependencies: none.
+
+### Tasks
+
+| Task | Work |
+| --- | --- |
+| `W0.1` | Reconcile RFC #1870 with the Durable Object architecture, Access operator authentication, existing `emdash-plugin` command, and active experimental NSIDs |
+| `W0.2` | Freeze the first-release profile policy, provenance, workload policy, approval digest, intent state, and error contracts |
+| `W0.3` | Validate the exact create-only grant against the available Bluesky-hosted PDS and Cirrus test accounts |
+| `W0.4` | Validate confidential OAuth refresh, DPoP behavior, revocation, and client-key rotation with real authorization servers |
+| `W0.5` | Confirm current Workflow event, retention, retry, and test APIs support approval and recovery; record limits outside the protocol contract |
+| `W0.6` | Define hosted-service Access audience and group-to-role mapping and the self-host configuration contract |
+
+### Acceptance criteria
+
+- Every public contract has one normative shape and owner.
+- The exact scope creates a release and cannot update, delete, edit a profile, or write another collection on Bluesky-hosted PDS and Cirrus.
+- Refresh and revocation observations are recorded with reproducible external steps.
+- An unsupported PDS is excluded from the support matrix instead of receiving a broader scope.
+- The Workflow design has a tested route for approval, rejection, cancellation, timeout, retry, and lost-instance recovery.
+- The RFC and technical specification contain no contradictory actor names, CLI commands, or trust claims.
+
+### Parallelism
+
+`W0.3`, `W0.4`, `W0.5`, and `W0.6` can run in separate research tasks. Only `W0.1` edits the RFC. Research tasks return concise evidence to the coordinator rather than landing prototype applications or unrelated dependencies.
+
+## W1 Protocol and shared verification
+
+Owner surface:
+
+- `packages/registry-lexicons/`
+- `packages/registry-verification/`
+- `packages/registry-client/src/direct-pds/`
+- `packages/plugin-types/` only for shared declared-access behavior
+- protocol fixtures under the owning packages
+
+Dependencies: G0 contract decisions.
+
+### Tasks
+
+| Task | Work |
+| --- | --- |
+| `W1.1` | Audit profile/release lexicons and generated types against the accepted RFC; keep additions optional |
+| `W1.2` | Finalize the exact permission helper and create-only publishing client without update/delete escape hatches |
+| `W1.3` | Complete authoritative direct-PDS profile, release, list, and deterministic-key reads |
+| `W1.4` | Produce one structured record/policy report covering normalized policy, profile CID, release CID, provenance status, and stable error codes |
+| `W1.5` | Confirm canonical bundle/manifest and declared-access reports share one implementation across service and installer |
+| `W1.6` | Expand real provenance fixtures for valid, missing, corrupt, substituted, foreign-source, wrong-builder, and unsupported predicates |
+| `W1.7` | Verify packed published output in Node and workerd and retain interop fixtures outside planning documents |
+
+### Acceptance criteria
+
+- Existing publishing flows preserve unknown and known extensions.
+- The create-only helper has no callable update or delete operation and rejects a mismatched collection.
+- Direct-PDS reads fail with stable codes for DID, PDS, record, CID, lexicon, identity, and policy failures.
+- The same fixtures produce equivalent reports in Node and workerd.
+- Manifest access comparison detects every broadened category, operation, and recognized constraint.
+- Unsupported supplied provenance fails as unverifiable rather than being treated as absent or valid.
+- Installer and service can consume the same public report types without importing application code.
+
+### Parallelism
+
+Split into at most two worktrees after `W1.1` freezes types:
+
+- direct-PDS and record-policy verification (`W1.2` to `W1.4`);
+- provenance and packed-output fixtures (`W1.5` to `W1.7`).
+
+Both worktrees must avoid editing the same barrel files. The contracts worktree owns final exports and generated lexicons.
+
+## W2 Service shell and control plane
+
+Owner surface:
+
+- `apps/release-service/package.json`
+- `apps/release-service/wrangler.jsonc`
+- `apps/release-service/src/index.ts`
+- `apps/release-service/src/env.ts`
+- `apps/release-service/src/api/`
+- `apps/release-service/src/access/`
+- `apps/release-service/src/control-do/`
+- root workspace and CI integration for the application
+
+Dependencies: G0 architecture and Access decisions.
+
+### Tasks
+
+| Task | Work |
+| --- | --- |
+| `W2.1` | Scaffold the Worker, static assets, test configuration, bindings, Durable Object migrations, Workflow binding, verifier binding, and generated types |
+| `W2.2` | Add versioned JSON envelopes, request IDs, body limits, security headers, CORS policy, error handling, and route composition |
+| `W2.3` | Implement Access JWT verification, group-to-role mapping, CSRF, and operator mutation idempotency |
+| `W2.4` | Implement `ServiceControlDurableObject`, service modes, publication permits, publisher controls, audit, and alarm-backed cleanup |
+| `W2.5` | Add health and readiness behavior that distinguishes configuration, binding, and dependency failure without exposing tenant state |
+| `W2.6` | Add CI lanes for Node tests, workerd tests, Worker build, binding generation, and packed-output checks |
+
+### Acceptance criteria
+
+- Production routes start only with complete required bindings and fail with public-safe configuration errors.
+- Access operator routes reject missing, wrong-audience, expired, malformed, and insufficient-group JWTs.
+- Operator role boundaries prevent viewers and reviewers from executing admin-only actions.
+- CSRF and idempotency checks apply to every cookie-authenticated mutation.
+- Service mode transitions are atomic and append audit before returning success.
+- A fresh publication permit reflects the latest service mode and cannot be reused after the mode epoch changes.
+- Worker and Durable Object tests run against the real workerd runtime.
+
+### Parallelism
+
+`W2.2` API foundations and `W2.3` Access authentication may run in parallel after `W2.1` lands. `W2.4` owns the control-object schema and must not share its directory with either task. One integration owner updates root workspace files, CI, `wrangler.jsonc`, and generated binding types.
+
+## W3 Publisher Durable Object
+
+Owner surface:
+
+- `apps/release-service/src/publisher-do/`
+- publisher-shard migrations and test fixtures
+- publisher RPC types exported from one package-local entry point
+
+Dependencies: W2.1 and shared state/error contracts.
+
+### Tasks
+
+| Task | Work |
+| --- | --- |
+| `W3.1` | Implement forward-only object schema migration with `publisher`, `delegations`, `workload_policies`, `intents`, reservations, transitions, operations, audit, idempotency, and deadlines |
+| `W3.2` | Implement the complete intent state machine with expected-state and generation guards |
+| `W3.3` | Implement package/version reservation and OIDC/request idempotency semantics |
+| `W3.4` | Implement generation-bound refresh and publication operation tokens without external I/O inside transactions |
+| `W3.5` | Implement append-only audit and public/private serializers |
+| `W3.6` | Implement one-alarm deadline queue for operation recovery, intent expiry, session cleanup, and audit/snapshot scheduling |
+| `W3.7` | Implement publisher session epoch and publisher/service suspension checks |
+
+### Acceptance criteria
+
+- `getByName(canonicalPublisherDid)` routes every package for one publisher to the same object.
+- Schema migration can restart after interruption and preserves existing rows.
+- Illegal state transitions and stale generations cannot change state.
+- Concurrent package/version reservations yield one owner and deterministic results for every loser.
+- Exact idempotent replay returns the stored intent; conflicting replay returns `IDEMPOTENCY_CONFLICT`.
+- Only the current operation token can complete refresh or publication.
+- Alarm recovery marks abandoned operations for reconciliation without losing the next scheduled deadline.
+- No RPC holds `blockConcurrencyWhile()` while calling another service or the network.
+
+### Parallelism
+
+The schema/state-machine task (`W3.1` and `W3.2`) lands first. Reservations/idempotency (`W3.3`), operations (`W3.4`), and serializers/audit (`W3.5`) can then run as stacked child branches with non-overlapping modules. Alarm and suspension integration (`W3.6` and `W3.7`) follows those contracts.
+
+## W4 Publisher OAuth delegation
+
+Owner surface:
+
+- `apps/release-service/src/oauth/`
+- `apps/release-service/src/crypto/`
+- publisher identity/session routes
+- publisher delegation RPC adapter
+
+Dependencies: W1 exact permission, W2 API, W3 delegation and operation RPCs.
+
+### Tasks
+
+| Task | Work |
+| --- | --- |
+| `W4.1` | Implement confidential-client metadata, versioned JWKS, PKCE/state/nonce transactions, and callback validation |
+| `W4.2` | Implement identity-only publisher login and short-lived publisher application sessions |
+| `W4.3` | Implement exact-scope delegation authorization and returned-grant validation |
+| `W4.4` | Port and review versioned envelope encryption with publisher/field-associated data |
+| `W4.5` | Persist encrypted sessions in the publisher object and implement serialized refresh using operation tokens |
+| `W4.6` | Implement publisher and operator revocation, client-key rotation, reauthorization, and failure classification |
+
+### Acceptance criteria
+
+- OAuth state, PKCE, nonce, redirect URI, issuer, subject, and scope mismatches fail closed.
+- Identity login does not leave a durable PDS write session.
+- Delegation accepts only the exact active collection/create scope.
+- Ciphertext copied to another publisher, table, row, or field cannot decrypt.
+- Concurrent refresh attempts produce one accepted session generation and discard stale results.
+- Revoked or unrefreshable authority blocks new publication and requests publisher reauthorization.
+- Logs, errors, audit, fixtures, and snapshots contain no plaintext token or DPoP key.
+
+### Parallelism
+
+OAuth protocol (`W4.1` to `W4.3`) and encryption (`W4.4`) can run in parallel. Integration with publisher storage (`W4.5`) starts after both land. Revocation/rotation (`W4.6`) follows the integrated path.
+
+## W5 Workload identity and intent admission
+
+Owner surface:
+
+- `apps/release-service/src/workload/`
+- `apps/release-service/src/intents/admission/`
+- GitHub OIDC fixtures
+- workload-policy publisher routes
+
+Dependencies: W2 API, W3 workload/idempotency RPCs, frozen W1 repository canonicalization.
+
+### Tasks
+
+| Task | Work |
+| --- | --- |
+| `W5.1` | Define issuer-neutral verified-workload types and error codes |
+| `W5.2` | Implement GitHub issuer/JWKS verification and audience, expiry, repository, workflow, ref, environment, run ID, and run-attempt normalization |
+| `W5.3` | Implement publisher-authorized workload-policy create, replace, disable, and audit operations |
+| `W5.4` | Implement intent request schema, token disposal, request digest, service/publisher admission, reservation, and Workflow start |
+| `W5.5` | Implement OIDC-authenticated intent status and cancellation using fresh matching workload identity |
+| `W5.6` | Add dry-run admission that validates OIDC and policy without reserving or publishing a version |
+
+### Acceptance criteria
+
+- A valid configured GitHub workflow creates one intent and Workflow instance.
+- Wrong issuer, signature, audience, expiry, repository, workflow, ref, environment, run identity, or inactive policy fails with a stable code.
+- The raw OIDC token is absent from storage, logs, audit, Workflow parameters, and errors.
+- Repeated identical submission returns the original intent; changed payload under the same identity fails.
+- A paused or suspended publisher cannot create an intent.
+- Cancellation is valid only before publication and requires matching workload identity or publisher ownership.
+- Dry-run cannot reserve a version or create a publication operation.
+
+### Parallelism
+
+OIDC verification (`W5.1` and `W5.2`) and workload-policy CRUD (`W5.3`) can run in parallel after their interfaces freeze. Admission (`W5.4`) combines them. Status/cancel and dry-run can run as separate child tasks afterward.
+
+## W6 Verification Workflow and isolated verifier
+
+Owner surface:
+
+- `apps/release-service/src/workflows/`
+- `apps/release-service/src/verification/`
+- `apps/release-verifier/`
+- Workflow fixtures and introspection tests
+
+Dependencies: G1, W3 intent RPCs, W5 admitted intents.
+
+### Tasks
+
+| Task | Work |
+| --- | --- |
+| `W6.1` | Scaffold the verifier Worker with only the required egress/config bindings and shared-verification dependencies |
+| `W6.2` | Implement bounded artifact and provenance verification reports over the service binding |
+| `W6.3` | Implement Workflow steps for authoritative profile, release-key absence, access baseline, artifact, provenance, workload binding, and policy decision |
+| `W6.4` | Persist every step result through the publisher object and make static step names replay-safe |
+| `W6.5` | Implement `awaiting_approval`, decision event, cancellation event, timeout, and expiry behavior |
+| `W6.6` | Implement lost/expired Workflow recovery from authoritative intent and audit state |
+
+### Acceptance criteria
+
+- The verifier has no publisher OAuth, Access, Durable Object, or service-control authority.
+- SSRF, redirect, DNS rebinding, unsupported protocol, oversized, slow, and malformed-resource cases fail with bounded public-safe reports.
+- Every verification input is tied to recorded profile CID, baseline CID, artifact checksum, provenance checksum, and workload claims.
+- Workflow replay skips completed semantic work or receives the same idempotent result.
+- A Workflow crash after any step resumes without duplicating an intent transition or external side effect.
+- Approval timeout produces `expired`; rejection and cancellation cannot fall through to publication.
+- Authoritative state is sufficient to restart recovery when Workflow instance data is unavailable.
+
+### Parallelism
+
+Verifier Worker (`W6.1` and `W6.2`) and Workflow state orchestration (`W6.3` skeleton and `W6.4`) can run in separate worktrees against agreed report/RPC interfaces. Approval waiting and recovery begin after the main Workflow path integrates.
+
+## W7 Publication and reconciliation
+
+Owner surface:
+
+- `apps/release-service/src/publishing/`
+- publication steps in the release Workflow
+- create/reconcile PDS fixtures
+
+Dependencies: W4 delegation, W6 verified intents, W2 service permits.
+
+### Tasks
+
+| Task | Work |
+| --- | --- |
+| `W7.1` | Implement final re-fetch/reverification and invalidation of changed profile, baseline, artifact, provenance, workload, or policy |
+| `W7.2` | Implement fresh service permit, publisher revocation check, publication operation token, and serialized session refresh |
+| `W7.3` | Implement deterministic create-only release publication |
+| `W7.4` | Implement exact-match, absence, conflict, and transient ambiguous-write reconciliation |
+| `W7.5` | Implement alarm/operator recovery and bounded retry policy |
+| `W7.6` | Emit terminal audit and optional projection events only after authoritative completion |
+
+### Acceptance criteria
+
+- No release is written from stale verification or approval inputs.
+- Pause, suspension, or delegation revocation immediately before the write blocks publication.
+- Concurrent publication within one publisher produces one active operation token.
+- A timeout before, during, or after `createRecord` converges without creating a second semantic release.
+- Exact existing record is successful replay; different existing record is terminal conflict.
+- Operator reconciliation cannot mark an absent or conflicting record as published.
+- Published state records the authoritative AT URI and CID and is immutable.
+
+### Parallelism
+
+Final invalidation (`W7.1`) and PDS client/reconciliation fixtures (`W7.3` and `W7.4`) can run in parallel. Coordination (`W7.2`) and recovery (`W7.5`) must be reviewed together because they define the external-side-effect boundary.
+
+## W8 Approver Durable Object and passkeys
+
+Owner surface:
+
+- `apps/release-service/src/approver-do/`
+- `apps/release-service/src/approvals/`
+- required-UV additions in `packages/auth/`
+- approver OAuth and WebAuthn fixtures
+
+Dependencies: W3 RPC conventions, W4 identity OAuth, W6 approval digest/event contract.
+
+### Tasks
+
+| Task | Work |
+| --- | --- |
+| `W8.1` | Port and review required-user-verification registration/authentication primitives in `@emdash-cms/auth` |
+| `W8.2` | Implement approver object schema, migrations, identity transactions, credentials, challenges, decisions, audit, and cleanup alarm |
+| `W8.3` | Implement approver DID proof and short-lived approver sessions |
+| `W8.4` | Implement multiple named passkeys, counter handling, revocation, and credential-safe serializers |
+| `W8.5` | Define and compute the canonical approval digest and create single-use challenges |
+| `W8.6` | Verify approve/reject assertions, return idempotent receipts, validate current profile membership, and deliver the Workflow event |
+| `W8.7` | Invalidate outstanding challenges on rejection, cancellation, expiry, digest change, or credential revocation |
+
+### Acceptance criteria
+
+- One approver DID routes to one object and can own multiple independently revocable credentials.
+- Registration and authentication require user verification.
+- OAuth identity must equal the DID named by the approver session and current profile.
+- Challenges are random, digest-bound, single-use, origin/RP-bound, and expire.
+- Cloned/counter-regressed, revoked, unknown, non-UV, wrong-origin, wrong-digest, replayed, and expired assertions fail closed.
+- The same valid decision replay returns the same receipt; a conflicting decision under the same key fails.
+- A stale approval receipt cannot authorize publication after any digest input changes.
+
+### Parallelism
+
+Shared auth primitives (`W8.1`) and object schema (`W8.2`) can run in parallel. DID/session integration (`W8.3`) and credential management (`W8.4`) follow the schema. Digest/decision integration (`W8.5` to `W8.7`) forms one stacked sequence.
+
+## W9 Independent installer enforcement
+
+Owner surface:
+
+- `packages/core/src/api/handlers/registry.ts`
+- registry install/update tests
+- minimal admin provenance presentation only when required for consent
+- query-count snapshots if behavior legitimately changes them
+
+Dependencies: G1 shared verification. It can proceed independently of W2 to W8.
+
+### Tasks
+
+| Task | Work |
+| --- | --- |
+| `W9.1` | Replace duplicate install verification with shared record, bundle, manifest, and provenance reports |
+| `W9.2` | Fetch authoritative profile/release records directly and evaluate current signed profile policy |
+| `W9.3` | Enforce required provenance and fail supplied invalid/unverifiable provenance regardless of policy default |
+| `W9.4` | Present provenance and policy status in install/update consent without trusting service or aggregator verdicts |
+| `W9.5` | Add install/update conformance fixtures shared with service output |
+
+### Acceptance criteria
+
+- The installer accepts a valid delegated release without contacting the release service.
+- It rejects missing required provenance and every invalid/unverifiable supplied provenance case.
+- It detects artifact, manifest, declared-access, package, version, source, builder, and record substitution.
+- Aggregator envelope status and release-service state cannot change the verification result.
+- Update performs the same checks and requires renewed capability consent when access broadens.
+- No query is added to the logged-out public-render hot path.
+
+### Parallelism
+
+This is an independent stack after G1. Keep it separate from the service stack until shared report types stabilize, then rebase onto the merged contract PRs.
+
+## W10 Clients and web surfaces
+
+Owner surface:
+
+- `packages/registry-client/src/release-service/`
+- `packages/plugin-cli/`
+- a new official GitHub Action package or action directory
+- `apps/release-service/src/publisher-ui/`
+- `apps/release-service/src/approver-ui/`
+- `apps/release-service/src/admin-ui/`
+
+Dependencies: stable APIs from W4 to W8 and W2 Access roles.
+
+### Tasks
+
+| Task | Work |
+| --- | --- |
+| `W10.1` | Add typed API client, polling, stable error mapping, and idempotency helpers |
+| `W10.2` | Build the official GitHub Action for OIDC, submission, status, approval URL, and terminal output |
+| `W10.3` | Add CLI commands for delegate, revoke, workload policy, dry run, submit/status/cancel, enrol, and approve/reject |
+| `W10.4` | Build publisher delegation, workload, intent, approver-status, and audit views |
+| `W10.5` | Build approval detail, declared-access diff, provenance/workload evidence, and passkey decision views |
+| `W10.6` | Build Access operator status, pause, publisher lookup, suspension, revocation, reconciliation, and audit views |
+| `W10.7` | Complete Lingui, accessibility, keyboard, responsive, and Arabic RTL coverage |
+
+### Acceptance criteria
+
+- CI needs no static secret and prints stable intent/published outputs.
+- CLI and web clients show the same state and error semantics.
+- Publisher UI cannot access another publisher shard.
+- Approval UI exposes enough immutable evidence to identify package, version, source, workflow, commit, artifact, provenance, policy, and access diff before passkey use.
+- Operator UI cannot call publisher or approver mutation routes.
+- All strings are localized and all layouts use logical direction-safe styling.
+- Browser tests cover publisher OAuth, Access roles, passkey enrolment/approval, cancellation, pause, and reconciliation.
+
+### Parallelism
+
+After the API client lands, Action/CLI (`W10.2` and `W10.3`), publisher UI (`W10.4`), approver UI (`W10.5`), and operator UI (`W10.6`) can run in four independent worktrees because they own separate directories. Localization/accessibility completion follows each UI increment rather than waiting for `W10.7` as a cleanup PR.
+
+## W11 Operations and self-hosting
+
+Owner surface:
+
+- `apps/release-service/src/projection/`
+- `apps/release-service/src/backup/`
+- operational metrics/logging modules
+- deployment configuration and runbooks
+- optional D1 projection migrations
+
+Dependencies: W2 control plane and W3 publisher audit contract. Work can begin before publication is complete.
+
+### Tasks
+
+| Task | Work |
+| --- | --- |
+| `W11.1` | Decide whether direct DID lookup is sufficient for beta; if not, build Queue-to-D1 sanitized operator projection and rebuild tooling |
+| `W11.2` | Implement encrypted publisher snapshots and append-only audit exports to R2 with bounded resumable scheduling |
+| `W11.3` | Implement encryption-key activation, background re-encryption, verification, retirement, and emergency rotation |
+| `W11.4` | Add structured logs, metrics, alerts, health checks, correlation IDs, and privacy redaction |
+| `W11.5` | Add per-publisher, per-repository, and per-workload abuse/rate controls without a global request bottleneck |
+| `W11.6` | Document and test Access, Durable Object, Workflow, verifier, Secrets Store, R2, optional D1, and custom-domain self-host deployment |
+| `W11.7` | Write incident, revocation, PDS outage, ambiguous write, key compromise, shard restore, Workflow loss, and rollback runbooks |
+
+### Acceptance criteria
+
+- Deleting the optional D1 projection does not change authorization or release state, and a rebuild restores operator search.
+- Snapshot/export contains no plaintext secret and restore never revives revoked or expired authority automatically.
+- Key rotation can stop, resume, and prove every retained ciphertext readable before retirement.
+- Alerts cover publication pause, refresh failure, reconciliation backlog, shard migration failure, verifier failure, Access denial spikes, and audit/export gaps.
+- Abuse controls cannot let one publisher exhaust or block another publisher shard.
+- A fresh self-host deployment passes the same service conformance suite as the hosted service.
+- Operators can execute every runbook without direct Durable Object SQLite edits.
+
+### Parallelism
+
+Projection (`W11.1`), backup/key management (`W11.2` and `W11.3`), and observability/self-hosting (`W11.4` to `W11.7`) can run as separate stacks after the authoritative audit/event contract freezes. The projection remains optional and must not block the critical path.
+
+## W12 Conformance and security
+
+Owner surface:
+
+- cross-package conformance fixtures
+- workerd integration tests
+- browser tests
+- external test-PDS harness documentation
+- security review closure
+
+Dependencies: begins at G1 and expands after every gate.
+
+### Tasks
+
+| Task | Work |
+| --- | --- |
+| `W12.1` | Maintain one fixture corpus for records, bundles, provenance, workload claims, policy, approvals, and public/private errors |
+| `W12.2` | Build real workerd Durable Object and Workflow integration tests, including alarms, hibernation/restart, retries, and migrations |
+| `W12.3` | Build browser OAuth, Access, WebAuthn, CSRF, isolation, localization, and RTL tests |
+| `W12.4` | Build controlled real-PDS and GitHub-OIDC end-to-end tests for hosted and self-host deployments |
+| `W12.5` | Add adversarial and fault-injection tests for replay, concurrency, substitution, SSRF, token leakage, ambiguous writes, pause races, and key loss |
+| `W12.6` | Run backup/restore, encryption rotation, Access compromise, delegation revocation, Workflow loss, PDS outage, and rollback drills |
+| `W12.7` | Complete external security review and track closure by severity |
+
+### Acceptance criteria
+
+- Every security invariant has at least one test that fails when its enforcement is removed.
+- Node and workerd share protocol fixtures but exercise their real runtime integrations.
+- Migration tests upgrade retained prior Durable Object schemas rather than asserting current SQL text.
+- Fault injection at every external side-effect boundary converges to an allowed state.
+- Browser tests prove authentication-realm and publisher isolation, not only successful navigation.
+- Hosted and self-hosted end-to-end tests publish and independently install the same release.
+- No unresolved critical/high external-review finding remains at production launch.
+
+## Worktree and task strategy
+
+Use one worktree per PR-sized task. Independent lanes branch from current `main`; dependent lanes form short linear stacks. Do not put every workstream in one stack.
+
+### Worktree names and ownership
+
+| Lane | Suggested worktree | Suggested branch | Initial scope |
+| --- | --- | --- | --- |
+| Coordinator | `emdash-drs-integration` | `feat/drs-integration` | Spec, dependency coordination, root workspace/CI, final gates |
+| Feasibility | `emdash-drs-w0` | `docs/drs-feasibility` | W0 evidence and RFC updates |
+| Contracts | `emdash-drs-w1` | `feat/drs-contracts` | W1 packages and fixtures |
+| Platform | `emdash-drs-w2` | `feat/drs-platform` | W2 app scaffold, bindings, Access, control object |
+| Publisher state | `emdash-drs-w3` | `feat/drs-publisher-do` | W3 publisher object only |
+| OAuth | `emdash-drs-w4` | `feat/drs-oauth` | W4 OAuth and encryption only |
+| Workload | `emdash-drs-w5` | `feat/drs-github-oidc` | W5 OIDC, workload policy, admission |
+| Verification | `emdash-drs-w6` | `feat/drs-verification-workflow` | W6 Workflow and verifier |
+| Publication | `emdash-drs-w7` | `feat/drs-publication` | W7 PDS write/reconciliation |
+| Approval | `emdash-drs-w8` | `feat/drs-approval` | W8 approver object/passkeys |
+| Installer | `emdash-drs-w9` | `feat/drs-installer-policy` | W9 core install/update enforcement |
+| Clients | `emdash-drs-w10` | `feat/drs-clients` | W10 API client, Action, CLI, UIs split further as needed |
+| Operations | `emdash-drs-w11` | `feat/drs-operations` | W11 projection, backup, observability, self-hosting |
+| Conformance | `emdash-drs-w12` | `test/drs-conformance` | W12 shared cross-component tests |
+
+These names describe logical slots, not permission to keep all worktrees active. Limit active implementation worktrees to the current execution wave.
+
+### Dependency lanes
+
+Use separate `gh-stack` stacks for work that can merge independently:
+
+```text
+Contract stack:
+  main -> drs-contracts -> drs-record-verification
+
+Service stack:
+  main -> drs-platform -> drs-publisher-do -> drs-oauth
+       -> drs-intent-workflow -> drs-publication
+
+Approval stack:
+  merged drs-publisher-do -> drs-approver-do -> drs-approval-integration
+
+Consumer stack:
+  merged drs-contracts -> drs-installer-policy
+
+Operations stack:
+  merged drs-platform/publisher audit contract -> drs-operations
+```
+
+When a parent PR merges, sync or rebase the remaining child stack. Do not branch unrelated work from a large integration branch.
+
+### `gh-stack` PR workflow
+
+Git worktrees own implementation branches. `gh-stack` owns the corresponding PR dependency graph and merge operation once branches reach the PR stage.
+
+Before creating stacks, configure the repository for non-interactive operation:
+
+```sh
+git config rerere.enabled true
+git config remote.pushDefault origin
+```
+
+The repository has multiple remotes, so every `gh stack` command that accepts a remote must pass `--remote origin` unless `remote.pushDefault` has already been verified.
+
+Because branches are developed in separate git worktrees, use the remote-only linking workflow rather than trying to check every branch out in one local `gh-stack` workspace:
+
+1. Push each worktree branch explicitly.
+2. Create its draft PR with the correct parent branch and a fully completed `.github/PULL_REQUEST_TEMPLATE.md` body.
+3. Link the existing branch PRs into a stack from bottom to top.
+
+For example, the platform stack is linked after its draft PRs exist:
+
+```sh
+gh stack link --base main --remote origin \
+	feat/drs-platform \
+	feat/drs-publisher-do \
+	feat/drs-oauth
+```
+
+`gh stack link` finds the existing PRs, corrects their base branches, and creates or updates the GitHub stack without adding local stack state. Do not let it create a PR with an auto-generated body; every EmDash PR must use the repository template.
+
+Use the non-interactive view command for status and automation:
+
+```sh
+gh stack view --json
+```
+
+Never run `gh stack view` without `--json`. Never run `gh stack checkout`, `gh stack init`, or `gh stack add` without an explicit target branch or PR. If a stack is checked out into a dedicated integration worktree, use `gh stack sync --remote origin` for routine parent rebases and `gh stack rebase --continue` or `--abort` for conflict recovery.
+
+When review finds a lower-layer issue, fix it on the lower branch, then cascade the change upward. Do not place a protocol, schema, or API fix in a dependent UI or integration PR merely to avoid rebasing.
+
+After every PR in a stack is ready and satisfies its gate, merge through `gh-stack`, not `gh pr merge`:
+
+```sh
+gh stack merge <stack-number> --yes --squash
+```
+
+Use the repository's selected merge method if it differs from squash. Stack merge is all-or-nothing unless the repository's merge queue processes the PRs separately. Scope a partial merge to a PR number only when the plan explicitly defines that PR as an integration gate.
+
+Do not add one branch to multiple stacks. When an independent stack needs a merged contract, rebase it onto updated `main`; do not share the contract branch between stacks.
+
+### Planned GitHub stacks
+
+| Stack | Bottom-to-top branches | Merge gate |
+| --- | --- | --- |
+| **Contracts** | `feat/drs-contracts` -> `feat/drs-record-verification` | G1 |
+| **Platform state** | `feat/drs-platform` -> `feat/drs-publisher-do` -> `feat/drs-publisher-operations` | G2 |
+| **Publisher authority** | `feat/drs-encryption` -> `feat/drs-oauth` -> `feat/drs-github-oidc` -> `feat/drs-intent-admission` | G2/G3 prerequisites |
+| **Automatic publication** | `feat/drs-verifier` -> `feat/drs-verification-workflow` -> `feat/drs-publication` | G3 |
+| **Independent consumer** | `feat/drs-installer-policy` | G4; independent stack rooted on merged contracts |
+| **Approval** | `feat/drs-required-uv` -> `feat/drs-approver-do` -> `feat/drs-approval-integration` | G5 |
+| **Clients** | `feat/drs-api-client` -> `feat/drs-github-action` -> `feat/drs-cli` | G5/G6 |
+| **Publisher UI** | `feat/drs-publisher-ui` -> `feat/drs-approver-ui` | G5/G6 |
+| **Operator UI** | `feat/drs-operator-ui` | G6; independent after Access APIs merge |
+| **Operations** | `feat/drs-backup` -> `feat/drs-observability` -> `feat/drs-self-hosting` | G6 |
+| **Conformance** | `test/drs-conformance` -> `test/drs-recovery-drills` | G7 |
+
+If a listed stack grows beyond a coherent review story, finish and merge the completed lower stack at its gate, then start a new stack from updated `main`. Do not keep a months-long stack open merely to preserve the table above.
+
+### Worktree task brief
+
+Every delegated task receives:
+
+1. Objective and non-goals.
+2. Exact base branch or parent PR.
+3. Allowed file/directory ownership.
+4. Interfaces it may consume and interfaces it may change.
+5. Numbered acceptance criteria from this plan.
+6. Required tests and commands.
+7. Donor commits or files that may be consulted.
+8. Explicit handoff artifacts: commits, test output, remaining risks, and migration notes.
+
+If the task discovers a required change outside its file ownership, it reports the dependency to the coordinator or lower stack owner. It does not edit another active worktree's surface.
+
+### Shared-file coordination
+
+These files are serialized through the coordinator or named owner:
+
+| Hotspot | Owner |
+| --- | --- |
+| Root `package.json`, `pnpm-workspace.yaml`, and `pnpm-lock.yaml` | Coordinator |
+| `.github/workflows/ci.yml` | Coordinator after workstream test commands are known |
+| `apps/release-service/wrangler.jsonc` and generated Worker types | W2 platform owner |
+| `apps/release-service/src/env.ts` | W2 platform owner; bindings are proposed through interface changes |
+| Registry lexicons and generated types | W1 contract owner |
+| Package barrel exports | Owning package's lowest stack branch |
+| Companion specification and this plan | Coordinator |
+| Changeset consolidation | Coordinator before final PR submission |
+
+The platform scaffold should declare the planned Durable Object, Workflow, verifier, R2, Secrets Store, Queue, and optional D1 interfaces early. Downstream worktrees implement behind those interfaces instead of repeatedly modifying environment types and configuration.
+
+### Parallel execution waves
+
+#### Wave 0: decisions
+
+Run in parallel:
+
+- W0 exact-scope/PDS validation;
+- W0 Workflow and Access validation;
+- W1 audit of already-merged shared verification.
+
+Merge condition: G0.
+
+#### Wave 1: foundations
+
+Run in parallel:
+
+- W1 contract and verification stack;
+- W2 platform/API/Access/control stack;
+- W12 fixture corpus skeleton.
+
+Merge condition: G1 and W2.1.
+
+#### Wave 2: durable ownership
+
+Run with at most three implementation worktrees:
+
+- W3 publisher object state machine;
+- W4 encryption and OAuth protocol, initially against an in-memory interface fixture;
+- W5 GitHub OIDC verifier and normalized workload types;
+- W9 installer enforcement may run separately after G1 if capacity permits.
+
+Integration order: W3, then W4/W5 adapters. Merge condition: G2.
+
+#### Wave 3: automatic release
+
+Run in parallel:
+
+- W6 isolated verifier;
+- W6 Workflow orchestration;
+- W9 installer enforcement;
+- W11 observability and backup design against frozen audit events.
+
+Then integrate W7 publication and reconciliation. Merge condition: G3, followed by G4.
+
+#### Wave 4: approval and clients
+
+Run in parallel:
+
+- W8 shared required-UV auth and approver object;
+- W10 typed client and GitHub Action;
+- W10 publisher UI;
+- W10 Access operator UI.
+
+Approval integration and approver UI follow the W8 digest/receipt contract. Merge condition: G5.
+
+#### Wave 5: operations and launch
+
+Run in parallel:
+
+- W11 optional projection and rebuild;
+- W11 backup/key rotation;
+- W11 self-hosting/runbooks;
+- W12 browser, real-PDS, fault-injection, and recovery suites.
+
+Merge condition: G6 and then G7.
+
+## Recommended PR sequence
+
+The PR sequence is deliberately finer than the workstreams. Each PR leaves authority unreachable or safe by default.
+
+1. **RFC and feasibility evidence** — decisions and supported-PDS matrix only.
+2. **Delegated release contracts** — profile/release types, exact scope, fixtures.
+3. **Shared record and provenance verification** — no service app behavior.
+4. **Release-service platform** — app, bindings, API foundation, Access auth, disabled control object.
+5. **Publisher object foundation** — schema, migration, state machine, audit, no OAuth or PDS calls.
+6. **Publisher reservations and operations** — idempotency, deadlines, tokens, alarms.
+7. **Envelope encryption** — package-local crypto and fixtures.
+8. **Publisher OAuth identity and delegation** — authority stored but publication route absent.
+9. **GitHub workload verification and policy** — admission verification, no PDS write.
+10. **Release-intent admission and Workflow shell** — intents verify but cannot publish.
+11. **Isolated verifier and complete verification stages** — terminal verified/invalid outcomes.
+12. **Create-only publication and reconciliation** — private controlled vertical slice.
+13. **Independent installer enforcement** — required before hosted beta.
+14. **Approver object and required-UV credentials** — enrolment only.
+15. **Digest-bound approval integration** — `always` and escalation lifecycle.
+16. **Typed client, GitHub Action, and CLI** — supported automation surface.
+17. **Publisher and approver web surfaces** — full self-service path.
+18. **Access operator console** — operational UI over already-enforced APIs.
+19. **Projection, backup, key rotation, alerts, and self-hosting** — G6 closure.
+20. **Conformance, drills, and security-review closure** — G7.
+
+## Definition of done for every implementation task
+
+- Behavior and failure behavior both have tests that would fail if enforcement were removed.
+- Durable Object storage changes use forward-only, restartable application schema migration.
+- External effects have idempotency and reconciliation before connection to real authority.
+- Public errors use stable codes and contain no provider payload, secret, assertion, stack trace, or private evidence.
+- Authentication and authorization are tested independently.
+- New API lists use cursor pagination and bounded limits.
+- New user-facing strings use Lingui and layouts pass RTL review.
+- Published-package changes include a proportional changeset.
+- The affected package/app builds and typechecks.
+- `pnpm lint:quick`, targeted Node/workerd/browser tests, formatting, and `git diff --check` pass.
+- The task handoff records exact verification, unrun checks, migration effects, and remaining risk.
+
+## Final acceptance checklist
+
+### Protocol and authority
+
+- [ ] RFC #1870 is accepted with the final actor, scope, policy, provenance, and approval contracts.
+- [ ] Bluesky-hosted PDS and Cirrus pass exact create-only, refresh, and revocation conformance.
+- [ ] No broad scope, update, delete, or profile-write path exists in retained service code.
+- [ ] Shared verification is the only implementation used by service and installer.
+
+### Durable state
+
+- [ ] Publisher and approver state route deterministically by canonical DID.
+- [ ] State-machine, reservation, idempotency, operation-token, alarm, migration, and audit tests pass in workerd.
+- [ ] Workflows and optional D1 projections can be lost without losing canonical authorization or terminal release state.
+- [ ] No Durable Object critical section spans external I/O.
+
+### Authentication
+
+- [ ] CI, publisher, approver, and Access operator authentication realms are isolated.
+- [ ] OAuth delegation is encrypted, refresh-safe, revocable, and exact-scope.
+- [ ] GitHub OIDC policy rejects every mismatched claim dimension.
+- [ ] Access roles cannot publish, approve, or create publisher authority.
+
+### Verification and publication
+
+- [ ] Valid non-escalating release publishes automatically.
+- [ ] Invalid record, bundle, manifest, access, artifact, provenance, source, builder, workload, or policy input never reaches publication.
+- [ ] Ambiguous writes converge through deterministic reconciliation.
+- [ ] Pause, suspension, revocation, profile change, baseline change, and approval invalidation close every pre-write race.
+
+### Approval
+
+- [ ] `confirmation: always` and access escalation require an eligible approver.
+- [ ] Passkey registration and decisions require user verification.
+- [ ] Challenge, digest, credential, identity, replay, expiry, revocation, and counter attacks fail closed.
+- [ ] Human approval cannot override failed verification.
+
+### Independent consumption and moderation
+
+- [ ] A clean installer independently accepts valid output and rejects invalid service output.
+- [ ] Installer behavior does not depend on release-service or aggregator verdicts.
+- [ ] Successfully published releases still follow independent metadata-labeller visibility policy.
+
+### Operations
+
+- [ ] Pause, publisher suspension, delegation revocation, reconciliation, key rotation, backup/export, restore, and rollback work through supported tools.
+- [ ] Optional D1 projection is rebuildable and non-authoritative.
+- [ ] Hosted and self-hosted deployments pass the same conformance suite.
+- [ ] External security review has no unresolved critical/high findings.

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -29,7 +29,7 @@ The old branch contains reviewed or tested implementations for:
 
 - required-user-verification WebAuthn primitives;
 - confidential OAuth metadata and storage experiments;
-- versioned envelope encryption;
+- compact JOSE envelope encryption;
 - GitHub Actions OIDC verification;
 - service API response and request-security foundations;
 - an isolated verifier Worker; and
@@ -315,7 +315,7 @@ Dependencies: W1 exact permission, W2 API, W3 delegation and operation RPCs.
 | `W4.1` | Implement confidential-client metadata, versioned JWKS, PKCE/state/nonce transactions, and callback validation |
 | `W4.2` | Implement identity-only publisher login and short-lived publisher application sessions                         |
 | `W4.3` | Implement exact-scope delegation authorization and returned-grant validation                                   |
-| `W4.4` | Port and review versioned envelope encryption with publisher/field-associated data                             |
+| `W4.4` | Implement and review compact JWE with `jose`, wrapped per-value content keys, and publisher/field context binding |
 | `W4.5` | Persist encrypted sessions in the publisher object and implement serialized refresh using operation tokens     |
 | `W4.6` | Implement publisher and operator revocation, client-key rotation, reauthorization, and failure classification  |
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -58,7 +58,7 @@ The replacement implementation is complete through the publisher OAuth callback 
 - envelope encryption, publisher custody, generation-bound refresh operations, publisher application sessions, and identity/delegation callback routes pass real workerd tests; and
 - Cloudflare Access authenticates operators through role-specific audiences; a `ServiceControlDurableObject` owns service mode, publisher suspension, idempotency, audit, and epoch-bound publication permits; and
 - GitHub Actions OIDC verification normalizes repository, workflow, ref, environment, run, actor, and token identity without retaining the raw JWT; and
-- the Access/control top passes 139 release-service tests, and the workload-verifier branch passes 119; package typecheck, type-aware lint, and Worker builds pass on both.
+- the Access/control top passes 139 release-service tests, and the workload/intent top passes 131; package typecheck, type-aware lint, and Worker builds pass on both.
 
 The public-client G0 lifecycle is complete on both providers: exact-scope authorization, forced refresh, and server revocation passed. npmX rejected its access token immediately after revocation. Cirrus retained the already-issued access token for its remaining lifetime while preventing future refresh. G0 still requires the deployed confidential-client run and client-key removal observation before either provider is advertised as supported by the hosted service.
 
@@ -760,7 +760,7 @@ PRs #2649 to #2651 form one merge unit in GitHub stack #2652. The first layer ve
 
 ### Active workload identity stack
 
-PR #2653 implements W5.1 and W5.2 on `feat/drs-github-oidc-verifier`, based on the completed foundation stack. It freezes the normalized workload identity consumed by publisher policy and intent-admission work. Later branches in this merge unit add workload-policy storage and intent admission.
+PRs #2653, #2654, and #2656 form GitHub stack #2655. They implement normalized GitHub workload identity, publisher-authorized workload policy with immutable repository IDs, package/version reservation, workload idempotency, and the generation-guarded intent state machine. The next layer adds HTTP admission and Workflow start.
 
 ### Planned GitHub stacks
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -51,12 +51,13 @@ The new implementation does not retain:
 
 ### Current execution state
 
-The replacement implementation is rebased on current `main` and complete through the publisher OAuth callback vertical slice:
+The replacement implementation is complete through the publisher OAuth callback and service-control vertical slices:
 
 - the G0 harness requests only the active create-only release scope and has successful authorization/prohibition evidence for the Bluesky PDS implementation hosted by npmX and for Cirrus;
 - the Worker serves confidential client metadata and overlapping JWKS, fails closed on invalid configuration, and keeps canonical publisher authority in SQLite-backed Durable Objects;
 - envelope encryption, publisher custody, generation-bound refresh operations, publisher application sessions, and identity/delegation callback routes pass real workerd tests; and
-- repository package typecheck, type-aware lint, and package tests pass on the top branch. One transient fixed-port collision in the sandbox-workerd suite passed on immediate isolated rerun.
+- Cloudflare Access authenticates operators through role-specific audiences; a `ServiceControlDurableObject` owns service mode, publisher suspension, idempotency, audit, and epoch-bound publication permits; and
+- repository package typecheck, type-aware lint, 137 release-service tests, Worker build, and startup profiling pass on the top branch.
 
 The public-client G0 lifecycle is complete on both providers: exact-scope authorization, forced refresh, and server revocation passed. npmX rejected its access token immediately after revocation. Cirrus retained the already-issued access token for its remaining lifetime while preventing future refresh. G0 still requires the deployed confidential-client run and client-key removal observation before either provider is advertised as supported by the hosted service.
 
@@ -742,6 +743,19 @@ main
 Each branch is one template-compliant draft PR. Create the PRs with their explicit parent bases before calling `gh stack link`; this prevents `gh-stack` from generating non-template PR bodies.
 
 The eight branches form one merge unit. The service has no supported intermediate deployment between them. The envelope-encryption branch defines the first persisted JOSE profile, and the publisher-object branch defines the complete initial schema used by every later branch. Do not add compatibility code for earlier branches in this stack.
+
+### Active Access and control stack
+
+The next three-PR stack is based on the completed foundation stack:
+
+```text
+feat/drs-confidential-oauth-callback
+└── feat/drs-access-auth
+    └── feat/drs-service-control-do
+        └── feat/drs-service-control-api
+```
+
+PRs #2649 to #2651 form one merge unit in GitHub stack #2652. The first layer verifies Access role audiences and request protections. The second owns the complete initial control schema and state transitions. The third exposes the role-specific operator API.
 
 ### Planned GitHub stacks
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -765,7 +765,7 @@ PRs #2653, #2654, #2656, #2657, and #2658 form GitHub stack #2655. They implemen
 
 ### Active verifier stack
 
-PR #2659 implements W6.1 and the artifact half of W6.2 on `feat/drs-release-verifier`, rooted on `main`. The verifier exposes one typed service-binding RPC method and has no OAuth, Access, Durable Object, service-control, or secret bindings. Provenance verification and the release-service binding are later layers of this independent stack.
+PRs #2659 and #2660 form GitHub stack #2661, rooted on `main`. They implement W6.1 and W6.2: a typed service-binding RPC Worker with no OAuth, Access, Durable Object, service-control, or secret bindings; bounded DNS and artifact fetching; checksum and canonical bundle verification; SHA-256/384/512 artifact digest candidates; and signed Sigstore/SLSA provenance verification in the same isolated invocation. The release-service binding and Workflow orchestration are later integration layers.
 
 ### Planned GitHub stacks
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -133,16 +133,16 @@ W3 -> W8 -> W10 -> W12
 
 ## Integration gates
 
-| Gate | Required evidence | Unblocks |
-| --- | --- | --- |
-| **G0 Design** | RFC decisions reconciled; exact create-only scope proved on every claimed PDS; no broad fallback | Authority-bearing implementation |
-| **G1 Contracts** | Lexicons, direct-PDS reads, shared record/bundle/provenance reports, and fixtures pass in Node and workerd | Service Workflow and installer work |
-| **G2 Durable state** | Service shell, Access auth, control object, publisher object, migrations, state machine, idempotency, and alarms pass real workerd tests | OAuth, OIDC, Workflow integration |
-| **G3 Automatic vertical slice** | Controlled GitHub workflow publishes one valid non-escalating release and converges under retries | Independent enforcement and private service trials |
-| **G4 Independent enforcement** | A clean EmDash site accepts valid output and rejects every invalid service-output fixture | Hosted limited beta |
-| **G5 Approval** | `always` and escalation releases require a valid current approver and passkey; every invalidation path re-approves | Broader publisher beta |
-| **G6 Operational beta** | Pause, suspension, revocation, reconciliation, key rotation, backup/export, alerts, and self-host path work without database edits | Public beta |
-| **G7 Production** | End-to-end conformance, recovery drills, and external security review have no unresolved critical/high findings | Production launch |
+| Gate                            | Required evidence                                                                                                                        | Unblocks                                           |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| **G0 Design**                   | RFC decisions reconciled; exact create-only scope proved on every claimed PDS; no broad fallback                                         | Authority-bearing implementation                   |
+| **G1 Contracts**                | Lexicons, direct-PDS reads, shared record/bundle/provenance reports, and fixtures pass in Node and workerd                               | Service Workflow and installer work                |
+| **G2 Durable state**            | Service shell, Access auth, control object, publisher object, migrations, state machine, idempotency, and alarms pass real workerd tests | OAuth, OIDC, Workflow integration                  |
+| **G3 Automatic vertical slice** | Controlled GitHub workflow publishes one valid non-escalating release and converges under retries                                        | Independent enforcement and private service trials |
+| **G4 Independent enforcement**  | A clean EmDash site accepts valid output and rejects every invalid service-output fixture                                                | Hosted limited beta                                |
+| **G5 Approval**                 | `always` and escalation releases require a valid current approver and passkey; every invalidation path re-approves                       | Broader publisher beta                             |
+| **G6 Operational beta**         | Pause, suspension, revocation, reconciliation, key rotation, backup/export, alerts, and self-host path work without database edits       | Public beta                                        |
+| **G7 Production**               | End-to-end conformance, recovery drills, and external security review have no unresolved critical/high findings                          | Production launch                                  |
 
 ## W0 Design and feasibility
 
@@ -152,14 +152,14 @@ Dependencies: none.
 
 ### Tasks
 
-| Task | Work |
-| --- | --- |
+| Task   | Work                                                                                                                                                      |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `W0.1` | Reconcile RFC #1870 with the Durable Object architecture, Access operator authentication, existing `emdash-plugin` command, and active experimental NSIDs |
-| `W0.2` | Freeze the first-release profile policy, provenance, workload policy, approval digest, intent state, and error contracts |
-| `W0.3` | Validate the exact create-only grant against the available npmX-hosted Bluesky PDS and Cirrus test accounts |
-| `W0.4` | Validate confidential OAuth refresh, DPoP behavior, revocation, and client-key rotation with real authorization servers |
-| `W0.5` | Confirm current Workflow event, retention, retry, and test APIs support approval and recovery; record limits outside the protocol contract |
-| `W0.6` | Define hosted-service Access audience and group-to-role mapping and the self-host configuration contract |
+| `W0.2` | Freeze the first-release profile policy, provenance, workload policy, approval digest, intent state, and error contracts                                  |
+| `W0.3` | Validate the exact create-only grant against the available npmX-hosted Bluesky PDS and Cirrus test accounts                                               |
+| `W0.4` | Validate confidential OAuth refresh, DPoP behavior, revocation, and client-key rotation with real authorization servers                                   |
+| `W0.5` | Confirm current Workflow event, retention, retry, and test APIs support approval and recovery; record limits outside the protocol contract                |
+| `W0.6` | Define hosted-service Access audience and group-to-role mapping and the self-host configuration contract                                                  |
 
 ### Acceptance criteria
 
@@ -188,15 +188,15 @@ Dependencies: G0 contract decisions.
 
 ### Tasks
 
-| Task | Work |
-| --- | --- |
-| `W1.1` | Audit profile/release lexicons and generated types against the accepted RFC; keep additions optional |
-| `W1.2` | Finalize the exact permission helper and create-only publishing client without update/delete escape hatches |
-| `W1.3` | Complete authoritative direct-PDS profile, release, list, and deterministic-key reads |
+| Task   | Work                                                                                                                                        |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `W1.1` | Audit profile/release lexicons and generated types against the accepted RFC; keep additions optional                                        |
+| `W1.2` | Finalize the exact permission helper and create-only publishing client without update/delete escape hatches                                 |
+| `W1.3` | Complete authoritative direct-PDS profile, release, list, and deterministic-key reads                                                       |
 | `W1.4` | Produce one structured record/policy report covering normalized policy, profile CID, release CID, provenance status, and stable error codes |
-| `W1.5` | Confirm canonical bundle/manifest and declared-access reports share one implementation across service and installer |
-| `W1.6` | Expand real provenance fixtures for valid, missing, corrupt, substituted, foreign-source, wrong-builder, and unsupported predicates |
-| `W1.7` | Verify packed published output in Node and workerd and retain interop fixtures outside planning documents |
+| `W1.5` | Confirm canonical bundle/manifest and declared-access reports share one implementation across service and installer                         |
+| `W1.6` | Expand real provenance fixtures for valid, missing, corrupt, substituted, foreign-source, wrong-builder, and unsupported predicates         |
+| `W1.7` | Verify packed published output in Node and workerd and retain interop fixtures outside planning documents                                   |
 
 ### Acceptance criteria
 
@@ -234,14 +234,14 @@ Dependencies: G0 architecture and Access decisions.
 
 ### Tasks
 
-| Task | Work |
-| --- | --- |
+| Task   | Work                                                                                                                                                 |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `W2.1` | Scaffold the Worker, static assets, test configuration, bindings, Durable Object migrations, Workflow binding, verifier binding, and generated types |
-| `W2.2` | Add versioned JSON envelopes, request IDs, body limits, security headers, CORS policy, error handling, and route composition |
-| `W2.3` | Implement Access JWT verification, group-to-role mapping, CSRF, and operator mutation idempotency |
-| `W2.4` | Implement `ServiceControlDurableObject`, service modes, publication permits, publisher controls, audit, and alarm-backed cleanup |
-| `W2.5` | Add health and readiness behavior that distinguishes configuration, binding, and dependency failure without exposing tenant state |
-| `W2.6` | Add CI lanes for Node tests, workerd tests, Worker build, binding generation, and packed-output checks |
+| `W2.2` | Add versioned JSON envelopes, request IDs, body limits, security headers, CORS policy, error handling, and route composition                         |
+| `W2.3` | Implement Access JWT verification, group-to-role mapping, CSRF, and operator mutation idempotency                                                    |
+| `W2.4` | Implement `ServiceControlDurableObject`, service modes, publication permits, publisher controls, audit, and alarm-backed cleanup                     |
+| `W2.5` | Add health and readiness behavior that distinguishes configuration, binding, and dependency failure without exposing tenant state                    |
+| `W2.6` | Add CI lanes for Node tests, workerd tests, Worker build, binding generation, and packed-output checks                                               |
 
 ### Acceptance criteria
 
@@ -269,15 +269,15 @@ Dependencies: W2.1 and shared state/error contracts.
 
 ### Tasks
 
-| Task | Work |
-| --- | --- |
+| Task   | Work                                                                                                                                                                                     |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `W3.1` | Implement forward-only object schema migration with `publisher`, `delegations`, `workload_policies`, `intents`, reservations, transitions, operations, audit, idempotency, and deadlines |
-| `W3.2` | Implement the complete intent state machine with expected-state and generation guards |
-| `W3.3` | Implement package/version reservation and OIDC/request idempotency semantics |
-| `W3.4` | Implement generation-bound refresh and publication operation tokens without external I/O inside transactions |
-| `W3.5` | Implement append-only audit and public/private serializers |
-| `W3.6` | Implement one-alarm deadline queue for operation recovery, intent expiry, session cleanup, and audit/snapshot scheduling |
-| `W3.7` | Implement publisher session epoch and publisher/service suspension checks |
+| `W3.2` | Implement the complete intent state machine with expected-state and generation guards                                                                                                    |
+| `W3.3` | Implement package/version reservation and OIDC/request idempotency semantics                                                                                                             |
+| `W3.4` | Implement generation-bound refresh and publication operation tokens without external I/O inside transactions                                                                             |
+| `W3.5` | Implement append-only audit and public/private serializers                                                                                                                               |
+| `W3.6` | Implement one-alarm deadline queue for operation recovery, intent expiry, session cleanup, and audit/snapshot scheduling                                                                 |
+| `W3.7` | Implement publisher session epoch and publisher/service suspension checks                                                                                                                |
 
 ### Acceptance criteria
 
@@ -307,14 +307,14 @@ Dependencies: W1 exact permission, W2 API, W3 delegation and operation RPCs.
 
 ### Tasks
 
-| Task | Work |
-| --- | --- |
+| Task   | Work                                                                                                           |
+| ------ | -------------------------------------------------------------------------------------------------------------- |
 | `W4.1` | Implement confidential-client metadata, versioned JWKS, PKCE/state/nonce transactions, and callback validation |
-| `W4.2` | Implement identity-only publisher login and short-lived publisher application sessions |
-| `W4.3` | Implement exact-scope delegation authorization and returned-grant validation |
-| `W4.4` | Port and review versioned envelope encryption with publisher/field-associated data |
-| `W4.5` | Persist encrypted sessions in the publisher object and implement serialized refresh using operation tokens |
-| `W4.6` | Implement publisher and operator revocation, client-key rotation, reauthorization, and failure classification |
+| `W4.2` | Implement identity-only publisher login and short-lived publisher application sessions                         |
+| `W4.3` | Implement exact-scope delegation authorization and returned-grant validation                                   |
+| `W4.4` | Port and review versioned envelope encryption with publisher/field-associated data                             |
+| `W4.5` | Persist encrypted sessions in the publisher object and implement serialized refresh using operation tokens     |
+| `W4.6` | Implement publisher and operator revocation, client-key rotation, reauthorization, and failure classification  |
 
 ### Acceptance criteria
 
@@ -343,14 +343,14 @@ Dependencies: W2 API, W3 workload/idempotency RPCs, frozen W1 repository canonic
 
 ### Tasks
 
-| Task | Work |
-| --- | --- |
-| `W5.1` | Define issuer-neutral verified-workload types and error codes |
+| Task   | Work                                                                                                                                          |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `W5.1` | Define issuer-neutral verified-workload types and error codes                                                                                 |
 | `W5.2` | Implement GitHub issuer/JWKS verification and audience, expiry, repository, workflow, ref, environment, run ID, and run-attempt normalization |
-| `W5.3` | Implement publisher-authorized workload-policy create, replace, disable, and audit operations |
-| `W5.4` | Implement intent request schema, token disposal, request digest, service/publisher admission, reservation, and Workflow start |
-| `W5.5` | Implement OIDC-authenticated intent status and cancellation using fresh matching workload identity |
-| `W5.6` | Add dry-run admission that validates OIDC and policy without reserving or publishing a version |
+| `W5.3` | Implement publisher-authorized workload-policy create, replace, disable, and audit operations                                                 |
+| `W5.4` | Implement intent request schema, token disposal, request digest, service/publisher admission, reservation, and Workflow start                 |
+| `W5.5` | Implement OIDC-authenticated intent status and cancellation using fresh matching workload identity                                            |
+| `W5.6` | Add dry-run admission that validates OIDC and policy without reserving or publishing a version                                                |
 
 ### Acceptance criteria
 
@@ -379,14 +379,14 @@ Dependencies: G1, W3 intent RPCs, W5 admitted intents.
 
 ### Tasks
 
-| Task | Work |
-| --- | --- |
-| `W6.1` | Scaffold the verifier Worker with only the required egress/config bindings and shared-verification dependencies |
-| `W6.2` | Implement bounded artifact and provenance verification reports over the service binding |
+| Task   | Work                                                                                                                                                  |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `W6.1` | Scaffold the verifier Worker with only the required egress/config bindings and shared-verification dependencies                                       |
+| `W6.2` | Implement bounded artifact and provenance verification reports over the service binding                                                               |
 | `W6.3` | Implement Workflow steps for authoritative profile, release-key absence, access baseline, artifact, provenance, workload binding, and policy decision |
-| `W6.4` | Persist every step result through the publisher object and make static step names replay-safe |
-| `W6.5` | Implement `awaiting_approval`, decision event, cancellation event, timeout, and expiry behavior |
-| `W6.6` | Implement lost/expired Workflow recovery from authoritative intent and audit state |
+| `W6.4` | Persist every step result through the publisher object and make static step names replay-safe                                                         |
+| `W6.5` | Implement `awaiting_approval`, decision event, cancellation event, timeout, and expiry behavior                                                       |
+| `W6.6` | Implement lost/expired Workflow recovery from authoritative intent and audit state                                                                    |
 
 ### Acceptance criteria
 
@@ -414,14 +414,14 @@ Dependencies: W4 delegation, W6 verified intents, W2 service permits.
 
 ### Tasks
 
-| Task | Work |
-| --- | --- |
+| Task   | Work                                                                                                                             |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------- |
 | `W7.1` | Implement final re-fetch/reverification and invalidation of changed profile, baseline, artifact, provenance, workload, or policy |
-| `W7.2` | Implement fresh service permit, publisher revocation check, publication operation token, and serialized session refresh |
-| `W7.3` | Implement deterministic create-only release publication |
-| `W7.4` | Implement exact-match, absence, conflict, and transient ambiguous-write reconciliation |
-| `W7.5` | Implement alarm/operator recovery and bounded retry policy |
-| `W7.6` | Emit terminal audit and optional projection events only after authoritative completion |
+| `W7.2` | Implement fresh service permit, publisher revocation check, publication operation token, and serialized session refresh          |
+| `W7.3` | Implement deterministic create-only release publication                                                                          |
+| `W7.4` | Implement exact-match, absence, conflict, and transient ambiguous-write reconciliation                                           |
+| `W7.5` | Implement alarm/operator recovery and bounded retry policy                                                                       |
+| `W7.6` | Emit terminal audit and optional projection events only after authoritative completion                                           |
 
 ### Acceptance criteria
 
@@ -450,15 +450,15 @@ Dependencies: W3 RPC conventions, W4 identity OAuth, W6 approval digest/event co
 
 ### Tasks
 
-| Task | Work |
-| --- | --- |
-| `W8.1` | Port and review required-user-verification registration/authentication primitives in `@emdash-cms/auth` |
+| Task   | Work                                                                                                                              |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `W8.1` | Port and review required-user-verification registration/authentication primitives in `@emdash-cms/auth`                           |
 | `W8.2` | Implement approver object schema, migrations, identity transactions, credentials, challenges, decisions, audit, and cleanup alarm |
-| `W8.3` | Implement approver DID proof and short-lived approver sessions |
-| `W8.4` | Implement multiple named passkeys, counter handling, revocation, and credential-safe serializers |
-| `W8.5` | Define and compute the canonical approval digest and create single-use challenges |
+| `W8.3` | Implement approver DID proof and short-lived approver sessions                                                                    |
+| `W8.4` | Implement multiple named passkeys, counter handling, revocation, and credential-safe serializers                                  |
+| `W8.5` | Define and compute the canonical approval digest and create single-use challenges                                                 |
 | `W8.6` | Verify approve/reject assertions, return idempotent receipts, validate current profile membership, and deliver the Workflow event |
-| `W8.7` | Invalidate outstanding challenges on rejection, cancellation, expiry, digest change, or credential revocation |
+| `W8.7` | Invalidate outstanding challenges on rejection, cancellation, expiry, digest change, or credential revocation                     |
 
 ### Acceptance criteria
 
@@ -487,13 +487,13 @@ Dependencies: G1 shared verification. It can proceed independently of W2 to W8.
 
 ### Tasks
 
-| Task | Work |
-| --- | --- |
-| `W9.1` | Replace duplicate install verification with shared record, bundle, manifest, and provenance reports |
-| `W9.2` | Fetch authoritative profile/release records directly and evaluate current signed profile policy |
-| `W9.3` | Enforce required provenance and fail supplied invalid/unverifiable provenance regardless of policy default |
+| Task   | Work                                                                                                           |
+| ------ | -------------------------------------------------------------------------------------------------------------- |
+| `W9.1` | Replace duplicate install verification with shared record, bundle, manifest, and provenance reports            |
+| `W9.2` | Fetch authoritative profile/release records directly and evaluate current signed profile policy                |
+| `W9.3` | Enforce required provenance and fail supplied invalid/unverifiable provenance regardless of policy default     |
 | `W9.4` | Present provenance and policy status in install/update consent without trusting service or aggregator verdicts |
-| `W9.5` | Add install/update conformance fixtures shared with service output |
+| `W9.5` | Add install/update conformance fixtures shared with service output                                             |
 
 ### Acceptance criteria
 
@@ -523,15 +523,15 @@ Dependencies: stable APIs from W4 to W8 and W2 Access roles.
 
 ### Tasks
 
-| Task | Work |
-| --- | --- |
-| `W10.1` | Add typed API client, polling, stable error mapping, and idempotency helpers |
-| `W10.2` | Build the official GitHub Action for OIDC, submission, status, approval URL, and terminal output |
+| Task    | Work                                                                                                             |
+| ------- | ---------------------------------------------------------------------------------------------------------------- |
+| `W10.1` | Add typed API client, polling, stable error mapping, and idempotency helpers                                     |
+| `W10.2` | Build the official GitHub Action for OIDC, submission, status, approval URL, and terminal output                 |
 | `W10.3` | Add CLI commands for delegate, revoke, workload policy, dry run, submit/status/cancel, enrol, and approve/reject |
-| `W10.4` | Build publisher delegation, workload, intent, approver-status, and audit views |
-| `W10.5` | Build approval detail, declared-access diff, provenance/workload evidence, and passkey decision views |
-| `W10.6` | Build Access operator status, pause, publisher lookup, suspension, revocation, reconciliation, and audit views |
-| `W10.7` | Complete Lingui, accessibility, keyboard, responsive, and Arabic RTL coverage |
+| `W10.4` | Build publisher delegation, workload, intent, approver-status, and audit views                                   |
+| `W10.5` | Build approval detail, declared-access diff, provenance/workload evidence, and passkey decision views            |
+| `W10.6` | Build Access operator status, pause, publisher lookup, suspension, revocation, reconciliation, and audit views   |
+| `W10.7` | Complete Lingui, accessibility, keyboard, responsive, and Arabic RTL coverage                                    |
 
 ### Acceptance criteria
 
@@ -561,15 +561,15 @@ Dependencies: W2 control plane and W3 publisher audit contract. Work can begin b
 
 ### Tasks
 
-| Task | Work |
-| --- | --- |
+| Task    | Work                                                                                                                                 |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `W11.1` | Decide whether direct DID lookup is sufficient for beta; if not, build Queue-to-D1 sanitized operator projection and rebuild tooling |
-| `W11.2` | Implement encrypted publisher snapshots and append-only audit exports to R2 with bounded resumable scheduling |
-| `W11.3` | Implement encryption-key activation, background re-encryption, verification, retirement, and emergency rotation |
-| `W11.4` | Add structured logs, metrics, alerts, health checks, correlation IDs, and privacy redaction |
-| `W11.5` | Add per-publisher, per-repository, and per-workload abuse/rate controls without a global request bottleneck |
+| `W11.2` | Implement encrypted publisher snapshots and append-only audit exports to R2 with bounded resumable scheduling                        |
+| `W11.3` | Implement encryption-key activation, background re-encryption, verification, retirement, and emergency rotation                      |
+| `W11.4` | Add structured logs, metrics, alerts, health checks, correlation IDs, and privacy redaction                                          |
+| `W11.5` | Add per-publisher, per-repository, and per-workload abuse/rate controls without a global request bottleneck                          |
 | `W11.6` | Document and test Access, Durable Object, Workflow, verifier, Secrets Store, R2, optional D1, and custom-domain self-host deployment |
-| `W11.7` | Write incident, revocation, PDS outage, ambiguous write, key compromise, shard restore, Workflow loss, and rollback runbooks |
+| `W11.7` | Write incident, revocation, PDS outage, ambiguous write, key compromise, shard restore, Workflow loss, and rollback runbooks         |
 
 ### Acceptance criteria
 
@@ -599,15 +599,15 @@ Dependencies: begins at G1 and expands after every gate.
 
 ### Tasks
 
-| Task | Work |
-| --- | --- |
-| `W12.1` | Maintain one fixture corpus for records, bundles, provenance, workload claims, policy, approvals, and public/private errors |
-| `W12.2` | Build real workerd Durable Object and Workflow integration tests, including alarms, hibernation/restart, retries, and migrations |
-| `W12.3` | Build browser OAuth, Access, WebAuthn, CSRF, isolation, localization, and RTL tests |
-| `W12.4` | Build controlled real-PDS and GitHub-OIDC end-to-end tests for hosted and self-host deployments |
+| Task    | Work                                                                                                                                              |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `W12.1` | Maintain one fixture corpus for records, bundles, provenance, workload claims, policy, approvals, and public/private errors                       |
+| `W12.2` | Build real workerd Durable Object and Workflow integration tests, including alarms, hibernation/restart, retries, and migrations                  |
+| `W12.3` | Build browser OAuth, Access, WebAuthn, CSRF, isolation, localization, and RTL tests                                                               |
+| `W12.4` | Build controlled real-PDS and GitHub-OIDC end-to-end tests for hosted and self-host deployments                                                   |
 | `W12.5` | Add adversarial and fault-injection tests for replay, concurrency, substitution, SSRF, token leakage, ambiguous writes, pause races, and key loss |
-| `W12.6` | Run backup/restore, encryption rotation, Access compromise, delegation revocation, Workflow loss, PDS outage, and rollback drills |
-| `W12.7` | Complete external security review and track closure by severity |
+| `W12.6` | Run backup/restore, encryption rotation, Access compromise, delegation revocation, Workflow loss, PDS outage, and rollback drills                 |
+| `W12.7` | Complete external security review and track closure by severity                                                                                   |
 
 ### Acceptance criteria
 
@@ -625,22 +625,22 @@ Use one worktree per PR-sized task. Independent lanes branch from current `main`
 
 ### Worktree names and ownership
 
-| Lane | Suggested worktree | Suggested branch | Initial scope |
-| --- | --- | --- | --- |
-| Coordinator | `emdash-drs-integration` | `feat/drs-integration` | Spec, dependency coordination, root workspace/CI, final gates |
-| Feasibility | `emdash-drs-w0` | `docs/drs-feasibility` | W0 evidence and RFC updates |
-| Contracts | `emdash-drs-w1` | `feat/drs-contracts` | W1 packages and fixtures |
-| Platform | `emdash-drs-w2` | `feat/drs-platform` | W2 app scaffold, bindings, Access, control object |
-| Publisher state | `emdash-drs-w3` | `feat/drs-publisher-do` | W3 publisher object only |
-| OAuth | `emdash-drs-w4` | `feat/drs-oauth` | W4 OAuth and encryption only |
-| Workload | `emdash-drs-w5` | `feat/drs-github-oidc` | W5 OIDC, workload policy, admission |
-| Verification | `emdash-drs-w6` | `feat/drs-verification-workflow` | W6 Workflow and verifier |
-| Publication | `emdash-drs-w7` | `feat/drs-publication` | W7 PDS write/reconciliation |
-| Approval | `emdash-drs-w8` | `feat/drs-approval` | W8 approver object/passkeys |
-| Installer | `emdash-drs-w9` | `feat/drs-installer-policy` | W9 core install/update enforcement |
-| Clients | `emdash-drs-w10` | `feat/drs-clients` | W10 API client, Action, CLI, UIs split further as needed |
-| Operations | `emdash-drs-w11` | `feat/drs-operations` | W11 projection, backup, observability, self-hosting |
-| Conformance | `emdash-drs-w12` | `test/drs-conformance` | W12 shared cross-component tests |
+| Lane            | Suggested worktree       | Suggested branch                 | Initial scope                                                 |
+| --------------- | ------------------------ | -------------------------------- | ------------------------------------------------------------- |
+| Coordinator     | `emdash-drs-integration` | `feat/drs-integration`           | Spec, dependency coordination, root workspace/CI, final gates |
+| Feasibility     | `emdash-drs-w0`          | `docs/drs-feasibility`           | W0 evidence and RFC updates                                   |
+| Contracts       | `emdash-drs-w1`          | `feat/drs-contracts`             | W1 packages and fixtures                                      |
+| Platform        | `emdash-drs-w2`          | `feat/drs-platform`              | W2 app scaffold, bindings, Access, control object             |
+| Publisher state | `emdash-drs-w3`          | `feat/drs-publisher-do`          | W3 publisher object only                                      |
+| OAuth           | `emdash-drs-w4`          | `feat/drs-oauth`                 | W4 OAuth and encryption only                                  |
+| Workload        | `emdash-drs-w5`          | `feat/drs-github-oidc`           | W5 OIDC, workload policy, admission                           |
+| Verification    | `emdash-drs-w6`          | `feat/drs-verification-workflow` | W6 Workflow and verifier                                      |
+| Publication     | `emdash-drs-w7`          | `feat/drs-publication`           | W7 PDS write/reconciliation                                   |
+| Approval        | `emdash-drs-w8`          | `feat/drs-approval`              | W8 approver object/passkeys                                   |
+| Installer       | `emdash-drs-w9`          | `feat/drs-installer-policy`      | W9 core install/update enforcement                            |
+| Clients         | `emdash-drs-w10`         | `feat/drs-clients`               | W10 API client, Action, CLI, UIs split further as needed      |
+| Operations      | `emdash-drs-w11`         | `feat/drs-operations`            | W11 projection, backup, observability, self-hosting           |
+| Conformance     | `emdash-drs-w12`         | `test/drs-conformance`           | W12 shared cross-component tests                              |
 
 These names describe logical slots, not permission to keep all worktrees active. Limit active implementation worktrees to the current execution wave.
 
@@ -738,19 +738,19 @@ Each branch is one template-compliant draft PR. Create the PRs with their explic
 
 ### Planned GitHub stacks
 
-| Stack | Bottom-to-top branches | Merge gate |
-| --- | --- | --- |
-| **Contracts** | `feat/drs-contracts` -> `feat/drs-record-verification` | G1 |
-| **Platform state** | `feat/drs-platform` -> `feat/drs-publisher-do` -> `feat/drs-publisher-operations` | G2 |
-| **Publisher authority** | `feat/drs-encryption` -> `feat/drs-oauth` -> `feat/drs-github-oidc` -> `feat/drs-intent-admission` | G2/G3 prerequisites |
-| **Automatic publication** | `feat/drs-verifier` -> `feat/drs-verification-workflow` -> `feat/drs-publication` | G3 |
-| **Independent consumer** | `feat/drs-installer-policy` | G4; independent stack rooted on merged contracts |
-| **Approval** | `feat/drs-required-uv` -> `feat/drs-approver-do` -> `feat/drs-approval-integration` | G5 |
-| **Clients** | `feat/drs-api-client` -> `feat/drs-github-action` -> `feat/drs-cli` | G5/G6 |
-| **Publisher UI** | `feat/drs-publisher-ui` -> `feat/drs-approver-ui` | G5/G6 |
-| **Operator UI** | `feat/drs-operator-ui` | G6; independent after Access APIs merge |
-| **Operations** | `feat/drs-backup` -> `feat/drs-observability` -> `feat/drs-self-hosting` | G6 |
-| **Conformance** | `test/drs-conformance` -> `test/drs-recovery-drills` | G7 |
+| Stack                     | Bottom-to-top branches                                                                             | Merge gate                                       |
+| ------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **Contracts**             | `feat/drs-contracts` -> `feat/drs-record-verification`                                             | G1                                               |
+| **Platform state**        | `feat/drs-platform` -> `feat/drs-publisher-do` -> `feat/drs-publisher-operations`                  | G2                                               |
+| **Publisher authority**   | `feat/drs-encryption` -> `feat/drs-oauth` -> `feat/drs-github-oidc` -> `feat/drs-intent-admission` | G2/G3 prerequisites                              |
+| **Automatic publication** | `feat/drs-verifier` -> `feat/drs-verification-workflow` -> `feat/drs-publication`                  | G3                                               |
+| **Independent consumer**  | `feat/drs-installer-policy`                                                                        | G4; independent stack rooted on merged contracts |
+| **Approval**              | `feat/drs-required-uv` -> `feat/drs-approver-do` -> `feat/drs-approval-integration`                | G5                                               |
+| **Clients**               | `feat/drs-api-client` -> `feat/drs-github-action` -> `feat/drs-cli`                                | G5/G6                                            |
+| **Publisher UI**          | `feat/drs-publisher-ui` -> `feat/drs-approver-ui`                                                  | G5/G6                                            |
+| **Operator UI**           | `feat/drs-operator-ui`                                                                             | G6; independent after Access APIs merge          |
+| **Operations**            | `feat/drs-backup` -> `feat/drs-observability` -> `feat/drs-self-hosting`                           | G6                                               |
+| **Conformance**           | `test/drs-conformance` -> `test/drs-recovery-drills`                                               | G7                                               |
 
 If a listed stack grows beyond a coherent review story, finish and merge the completed lower stack at its gate, then start a new stack from updated `main`. Do not keep a months-long stack open merely to preserve the table above.
 
@@ -773,16 +773,16 @@ If the task discovers a required change outside its file ownership, it reports t
 
 These files are serialized through the coordinator or named owner:
 
-| Hotspot | Owner |
-| --- | --- |
-| Root `package.json`, `pnpm-workspace.yaml`, and `pnpm-lock.yaml` | Coordinator |
-| `.github/workflows/ci.yml` | Coordinator after workstream test commands are known |
-| `apps/release-service/wrangler.jsonc` and generated Worker types | W2 platform owner |
-| `apps/release-service/src/env.ts` | W2 platform owner; bindings are proposed through interface changes |
-| Registry lexicons and generated types | W1 contract owner |
-| Package barrel exports | Owning package's lowest stack branch |
-| Companion specification and this plan | Coordinator |
-| Changeset consolidation | Coordinator before final PR submission |
+| Hotspot                                                          | Owner                                                              |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Root `package.json`, `pnpm-workspace.yaml`, and `pnpm-lock.yaml` | Coordinator                                                        |
+| `.github/workflows/ci.yml`                                       | Coordinator after workstream test commands are known               |
+| `apps/release-service/wrangler.jsonc` and generated Worker types | W2 platform owner                                                  |
+| `apps/release-service/src/env.ts`                                | W2 platform owner; bindings are proposed through interface changes |
+| Registry lexicons and generated types                            | W1 contract owner                                                  |
+| Package barrel exports                                           | Owning package's lowest stack branch                               |
+| Companion specification and this plan                            | Coordinator                                                        |
+| Changeset consolidation                                          | Coordinator before final PR submission                             |
 
 The platform scaffold should declare the planned Durable Object, Workflow, verifier, R2, Secrets Store, Queue, and optional D1 interfaces early. Downstream worktrees implement behind those interfaces instead of repeatedly modifying environment types and configuration.
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -57,7 +57,7 @@ The replacement implementation is complete through the publisher OAuth callback 
 - the Worker serves confidential client metadata and overlapping JWKS, fails closed on invalid configuration, and keeps canonical publisher authority in SQLite-backed Durable Objects;
 - envelope encryption, publisher custody, generation-bound refresh operations, publisher application sessions, and identity/delegation callback routes pass real workerd tests; and
 - Cloudflare Access authenticates operators through role-specific audiences; a `ServiceControlDurableObject` owns service mode, publisher suspension, idempotency, audit, and epoch-bound publication permits; and
-- repository package typecheck, type-aware lint, 137 release-service tests, Worker build, and startup profiling pass on the top branch.
+- repository package typecheck, type-aware lint, 139 release-service tests, Worker build, and startup profiling pass on the top branch.
 
 The public-client G0 lifecycle is complete on both providers: exact-scope authorization, forced refresh, and server revocation passed. npmX rejected its access token immediately after revocation. Cirrus retained the already-issued access token for its remaining lifetime while preventing future refresh. G0 still requires the deployed confidential-client run and client-key removal observation before either provider is advertised as supported by the hosted service.
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -139,16 +139,16 @@ W3 -> W8 -> W10 -> W12
 
 ## Integration gates
 
-| Gate                            | Required evidence                                                                                                                        | Unblocks                                           |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| **G0 Design**                   | RFC decisions reconciled; exact create-only scope proved on every claimed PDS; no broad fallback                                         | Authority-bearing implementation                   |
-| **G1 Contracts**                | Lexicons, direct-PDS reads, shared record/bundle/provenance reports, and fixtures pass in Node and workerd                               | Service Workflow and installer work                |
+| Gate                            | Required evidence                                                                                                                            | Unblocks                                           |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| **G0 Design**                   | RFC decisions reconciled; exact create-only scope proved on every claimed PDS; no broad fallback                                             | Authority-bearing implementation                   |
+| **G1 Contracts**                | Lexicons, direct-PDS reads, shared record/bundle/provenance reports, and fixtures pass in Node and workerd                                   | Service Workflow and installer work                |
 | **G2 Durable state**            | Service shell, Access auth, control object, publisher object, initial schema, state machine, idempotency, and alarms pass real workerd tests | OAuth, OIDC, Workflow integration                  |
-| **G3 Automatic vertical slice** | Controlled GitHub workflow publishes one valid non-escalating release and converges under retries                                        | Independent enforcement and private service trials |
-| **G4 Independent enforcement**  | A clean EmDash site accepts valid output and rejects every invalid service-output fixture                                                | Hosted limited beta                                |
-| **G5 Approval**                 | `always` and escalation releases require a valid current approver and passkey; every invalidation path re-approves                       | Broader publisher beta                             |
-| **G6 Operational beta**         | Pause, suspension, revocation, reconciliation, key rotation, backup/export, alerts, and self-host path work without database edits       | Public beta                                        |
-| **G7 Production**               | End-to-end conformance, recovery drills, and external security review have no unresolved critical/high findings                          | Production launch                                  |
+| **G3 Automatic vertical slice** | Controlled GitHub workflow publishes one valid non-escalating release and converges under retries                                            | Independent enforcement and private service trials |
+| **G4 Independent enforcement**  | A clean EmDash site accepts valid output and rejects every invalid service-output fixture                                                    | Hosted limited beta                                |
+| **G5 Approval**                 | `always` and escalation releases require a valid current approver and passkey; every invalidation path re-approves                           | Broader publisher beta                             |
+| **G6 Operational beta**         | Pause, suspension, revocation, reconciliation, key rotation, backup/export, alerts, and self-host path work without database edits           | Public beta                                        |
+| **G7 Production**               | End-to-end conformance, recovery drills, and external security review have no unresolved critical/high findings                              | Production launch                                  |
 
 ## W0 Design and feasibility
 
@@ -240,14 +240,14 @@ Dependencies: G0 architecture and Access decisions.
 
 ### Tasks
 
-| Task   | Work                                                                                                                                                 |
-| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task   | Work                                                                                                                                                               |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `W2.1` | Scaffold the Worker, static assets, test configuration, bindings, Wrangler Durable Object class migration, Workflow binding, verifier binding, and generated types |
-| `W2.2` | Add versioned JSON envelopes, request IDs, body limits, security headers, CORS policy, error handling, and route composition                         |
-| `W2.3` | Implement Access JWT verification, role-specific audience boundaries, CSRF, and operator mutation idempotency                                       |
-| `W2.4` | Implement `ServiceControlDurableObject`, service modes, publication permits, publisher controls, audit, and alarm-backed cleanup                     |
-| `W2.5` | Add health and readiness behavior that distinguishes configuration, binding, and dependency failure without exposing tenant state                    |
-| `W2.6` | Add CI lanes for Node tests, workerd tests, Worker build, binding generation, and packed-output checks                                               |
+| `W2.2` | Add versioned JSON envelopes, request IDs, body limits, security headers, CORS policy, error handling, and route composition                                       |
+| `W2.3` | Implement Access JWT verification, role-specific audience boundaries, CSRF, and operator mutation idempotency                                                      |
+| `W2.4` | Implement `ServiceControlDurableObject`, service modes, publication permits, publisher controls, audit, and alarm-backed cleanup                                   |
+| `W2.5` | Add health and readiness behavior that distinguishes configuration, binding, and dependency failure without exposing tenant state                                  |
+| `W2.6` | Add CI lanes for Node tests, workerd tests, Worker build, binding generation, and packed-output checks                                                             |
 
 ### Acceptance criteria
 
@@ -275,15 +275,15 @@ Dependencies: W2.1 and shared state/error contracts.
 
 ### Tasks
 
-| Task   | Work                                                                                                                                                                                     |
-| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task   | Work                                                                                                                                                                                   |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `W3.1` | Implement the complete initial object schema with `publisher`, `delegations`, `workload_policies`, `intents`, reservations, transitions, operations, audit, idempotency, and deadlines |
-| `W3.2` | Implement the complete intent state machine with expected-state and generation guards                                                                                                    |
-| `W3.3` | Implement package/version reservation and OIDC/request idempotency semantics                                                                                                             |
-| `W3.4` | Implement generation-bound refresh and publication operation tokens without external I/O inside transactions                                                                             |
-| `W3.5` | Implement append-only audit and public/private serializers                                                                                                                               |
-| `W3.6` | Implement one-alarm deadline queue for operation recovery, intent expiry, session cleanup, and audit/snapshot scheduling                                                                 |
-| `W3.7` | Implement publisher session epoch and publisher/service suspension checks                                                                                                                |
+| `W3.2` | Implement the complete intent state machine with expected-state and generation guards                                                                                                  |
+| `W3.3` | Implement package/version reservation and OIDC/request idempotency semantics                                                                                                           |
+| `W3.4` | Implement generation-bound refresh and publication operation tokens without external I/O inside transactions                                                                           |
+| `W3.5` | Implement append-only audit and public/private serializers                                                                                                                             |
+| `W3.6` | Implement one-alarm deadline queue for operation recovery, intent expiry, session cleanup, and audit/snapshot scheduling                                                               |
+| `W3.7` | Implement publisher session epoch and publisher/service suspension checks                                                                                                              |
 
 ### Acceptance criteria
 
@@ -313,14 +313,14 @@ Dependencies: W1 exact permission, W2 API, W3 delegation and operation RPCs.
 
 ### Tasks
 
-| Task   | Work                                                                                                           |
-| ------ | -------------------------------------------------------------------------------------------------------------- |
-| `W4.1` | Implement confidential-client metadata, versioned JWKS, PKCE/state/nonce transactions, and callback validation |
-| `W4.2` | Implement identity-only publisher login and short-lived publisher application sessions                         |
-| `W4.3` | Implement exact-scope delegation authorization and returned-grant validation                                   |
+| Task   | Work                                                                                                              |
+| ------ | ----------------------------------------------------------------------------------------------------------------- |
+| `W4.1` | Implement confidential-client metadata, versioned JWKS, PKCE/state/nonce transactions, and callback validation    |
+| `W4.2` | Implement identity-only publisher login and short-lived publisher application sessions                            |
+| `W4.3` | Implement exact-scope delegation authorization and returned-grant validation                                      |
 | `W4.4` | Implement and review compact JWE with `jose`, wrapped per-value content keys, and publisher/field context binding |
-| `W4.5` | Persist encrypted sessions in the publisher object and implement serialized refresh using operation tokens     |
-| `W4.6` | Implement publisher and operator revocation, client-key rotation, reauthorization, and failure classification  |
+| `W4.5` | Persist encrypted sessions in the publisher object and implement serialized refresh using operation tokens        |
+| `W4.6` | Implement publisher and operator revocation, client-key rotation, reauthorization, and failure classification     |
 
 ### Acceptance criteria
 
@@ -456,15 +456,15 @@ Dependencies: W3 RPC conventions, W4 identity OAuth, W6 approval digest/event co
 
 ### Tasks
 
-| Task   | Work                                                                                                                              |
-| ------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| `W8.1` | Port and review required-user-verification registration/authentication primitives in `@emdash-cms/auth`                           |
+| Task   | Work                                                                                                                                       |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `W8.1` | Port and review required-user-verification registration/authentication primitives in `@emdash-cms/auth`                                    |
 | `W8.2` | Implement the complete initial approver-object schema, identity transactions, credentials, challenges, decisions, audit, and cleanup alarm |
-| `W8.3` | Implement approver DID proof and short-lived approver sessions                                                                    |
-| `W8.4` | Implement multiple named passkeys, counter handling, revocation, and credential-safe serializers                                  |
-| `W8.5` | Define and compute the canonical approval digest and create single-use challenges                                                 |
-| `W8.6` | Verify approve/reject assertions, return idempotent receipts, validate current profile membership, and deliver the Workflow event |
-| `W8.7` | Invalidate outstanding challenges on rejection, cancellation, expiry, digest change, or credential revocation                     |
+| `W8.3` | Implement approver DID proof and short-lived approver sessions                                                                             |
+| `W8.4` | Implement multiple named passkeys, counter handling, revocation, and credential-safe serializers                                           |
+| `W8.5` | Define and compute the canonical approval digest and create single-use challenges                                                          |
+| `W8.6` | Verify approve/reject assertions, return idempotent receipts, validate current profile membership, and deliver the Workflow event          |
+| `W8.7` | Invalidate outstanding challenges on rejection, cancellation, expiry, digest change, or credential revocation                              |
 
 ### Acceptance criteria
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -58,9 +58,9 @@ The replacement implementation is rebased on current `main` and complete through
 - envelope encryption, publisher custody, generation-bound refresh operations, publisher application sessions, and identity/delegation callback routes pass real workerd tests; and
 - repository package typecheck, type-aware lint, and package tests pass on the top branch. One transient fixed-port collision in the sandbox-workerd suite passed on immediate isolated rerun.
 
-G0 remains open for external refresh and revocation proof. The first test authorizations predated persistence of the loopback client's redirect URI and scope. npmX rejected refresh under a reconstructed client ID; the corrected harness now refuses that unsafe reconstruction before network access. Both providers require one browser reauthorization before noninteractive refresh and revocation can be repeated.
+The public-client G0 lifecycle is complete on both providers: exact-scope authorization, forced refresh, and server revocation passed. npmX rejected its access token immediately after revocation. Cirrus retained the already-issued access token for its remaining lifetime while preventing future refresh. G0 still requires the deployed confidential-client run and client-key removal observation before either provider is advertised as supported by the hosted service.
 
-Draft PR #1908 remains donor history and is not a merge target. Its D1 custody and coordination model does not satisfy this plan. Draft PR #1909 is the independent metadata-labeling service and does not join the delegated-release service stack.
+Closed PR #1908 remains donor history and is not a merge target. Its D1 custody and coordination model does not satisfy this plan. Draft PR #1909 is the independent metadata-labeling service and does not join the delegated-release service stack.
 
 ## Execution rules
 

--- a/docs/technical-specs/delegated-release-service-implementation-plan.md
+++ b/docs/technical-specs/delegated-release-service-implementation-plan.md
@@ -1,6 +1,6 @@
 # Delegated release service implementation plan
 
-Status: Proposed
+Status: In progress
 
 Companion specification: [Delegated release service](./delegated-release-service.md)
 
@@ -48,6 +48,19 @@ The new implementation does not retain:
 - one large publisher/operator console;
 - Queue-plus-cron orchestration for release intents; or
 - aggregator historical-policy enforcement as a prerequisite for the first service release.
+
+### Current execution state
+
+The replacement implementation is rebased on current `main` and complete through the publisher OAuth callback vertical slice:
+
+- the G0 harness requests only the active create-only release scope and has successful authorization/prohibition evidence for the Bluesky PDS implementation hosted by npmX and for Cirrus;
+- the Worker serves confidential client metadata and overlapping JWKS, fails closed on invalid configuration, and keeps canonical publisher authority in SQLite-backed Durable Objects;
+- envelope encryption, publisher custody, generation-bound refresh operations, publisher application sessions, and identity/delegation callback routes pass real workerd tests; and
+- repository package typecheck, type-aware lint, and package tests pass on the top branch. One transient fixed-port collision in the sandbox-workerd suite passed on immediate isolated rerun.
+
+G0 remains open for external refresh and revocation proof. The first test authorizations predated persistence of the loopback client's redirect URI and scope. npmX rejected refresh under a reconstructed client ID; the corrected harness now refuses that unsafe reconstruction before network access. Both providers require one browser reauthorization before noninteractive refresh and revocation can be repeated.
+
+Draft PR #1908 remains donor history and is not a merge target. Its D1 custody and coordination model does not satisfy this plan. Draft PR #1909 is the independent metadata-labeling service and does not join the delegated-release service stack.
 
 ## Execution rules
 
@@ -704,6 +717,24 @@ gh stack merge <stack-number> --yes --squash
 Use the repository's selected merge method if it differs from squash. Stack merge is all-or-nothing unless the repository's merge queue processes the PRs separately. Scope a partial merge to a PR number only when the plan explicitly defines that PR as an integration gate.
 
 Do not add one branch to multiple stacks. When an independent stack needs a merged contract, rebase it onto updated `main`; do not share the contract branch between stacks.
+
+### Active foundation stack
+
+The current bottom-to-top branch chain is:
+
+```text
+main
+└── feat/drs-g0-conformance
+    └── feat/drs-platform-oauth-metadata
+        └── feat/drs-envelope-encryption
+            └── feat/drs-publisher-do-oauth-custody
+                └── feat/drs-publisher-refresh-operations
+                    └── feat/drs-oauth-custody-adapter
+                        └── feat/drs-publisher-application-sessions
+                            └── feat/drs-confidential-oauth-callback
+```
+
+Each branch is one template-compliant draft PR. Create the PRs with their explicit parent bases before calling `gh stack link`; this prevents `gh-stack` from generating non-template PR bodies.
 
 ### Planned GitHub stacks
 

--- a/docs/technical-specs/delegated-release-service.md
+++ b/docs/technical-specs/delegated-release-service.md
@@ -96,6 +96,8 @@ const permission = getDelegatedReleasePermission();
 
 The service does not hard-code the experimental or future stable NSID. A namespace migration requires a new publisher grant because AT Protocol repository scope is collection-specific.
 
+The first release requests this granular permission directly rather than wrapping it in an AT Protocol permission set. Permission sets are useful when an application needs many permissions under one Lexicon namespace; this service needs one create-only repository permission. Direct scope keeps the effective authority visible in client metadata, stored delegation state, audit output, and conformance evidence. A future permission-set alias is acceptable only if every supported PDS resolves it to the identical collection and `create` action and the full authorization, refresh, and revocation matrix is repeated.
+
 The initial support matrix contains:
 
 - Bluesky PDS software hosted by npmX (`npmx.social`); and

--- a/docs/technical-specs/delegated-release-service.md
+++ b/docs/technical-specs/delegated-release-service.md
@@ -47,15 +47,15 @@ The service has four independent authentication realms. Credentials and sessions
 | Approver         | AT Protocol OAuth plus an enrolled passkey | Approve or reject one exact release intent                                 |
 | Service operator | Cloudflare Access                          | Observe, pause, suspend, revoke, retry, and recover the service            |
 
-Cloudflare Access protects `/admin/*` and the operator API. The Worker verifies the Access JWT's issuer, audience, expiry, and group claims. Access-injected identity headers are not sufficient by themselves. Operator mutations retain CSRF and idempotency protection.
+Cloudflare Access protects `/admin/*` and the operator API. The Worker verifies the `Cf-Access-Jwt-Assertion` signature, team issuer, role-specific audience, time claims, token type, and human identity. Access-injected identity headers and the browser cookie are not sufficient by themselves. Operator mutations retain CSRF and idempotency protection.
 
-Deployments map Access groups to three service roles:
+Deployments use separate Access policy and audience boundaries for three service roles:
 
 - `viewer` reads health, publisher state, intent state, and sanitized audit data;
 - `reviewer` cancels unpublished intents and triggers bounded reconciliation; and
 - `admin` changes service mode, suspends publishers, revokes retained authority, and operates key or recovery controls.
 
-Role names are stable application contracts. Each deployment configures the Access group identifiers that grant them. No Access role can establish publisher delegation, authorize workload policy, enrol an approver, approve an intent, or publish a release.
+Role names and audience bindings are stable application contracts. Each deployment assigns its operator groups to the appropriate Access policies; Access evaluates membership before forwarding the request. The Worker does not authorize from optional group claims because Access may trim custom claims to fit its cookie limit. No Access role can establish publisher delegation, authorize workload policy, enrol an approver, approve an intent, or publish a release.
 
 Publisher and approver OAuth proves control of a DID. After a successful identity-only OAuth flow, the service may issue a short-lived application session. That session cannot write to the PDS. The separately authorized release delegation is encrypted and stored in the publisher's Durable Object.
 

--- a/docs/technical-specs/delegated-release-service.md
+++ b/docs/technical-specs/delegated-release-service.md
@@ -465,6 +465,8 @@ Revocation does not remove an already published record. Record removal or yankin
 
 The public service API is versioned under `/v1`.
 
+Health endpoints are outside the versioned API. `GET /health` is configuration-independent process liveness. `GET /ready` loads required configuration and checks the service-control shard, but returns no tenant or operational state.
+
 ### CI API
 
 | Method and path                        | Purpose                                                           |

--- a/docs/technical-specs/delegated-release-service.md
+++ b/docs/technical-specs/delegated-release-service.md
@@ -501,14 +501,14 @@ The public service API is versioned under `/v1`.
 
 | Method and path                            | Purpose                                          |
 | ------------------------------------------ | ------------------------------------------------ |
-| `GET /admin/api/status`                    | Read service mode and component health           |
-| `POST /admin/api/pause`                    | Change admission or publication mode             |
-| `GET /admin/api/publishers/{did}`          | Read authoritative sanitized publisher state     |
-| `POST /admin/api/publishers/{did}/suspend` | Suspend or restore publisher admission           |
-| `POST /admin/api/publishers/{did}/revoke`  | Revoke retained service authority                |
-| `POST /admin/api/intents/{id}/cancel`      | Stop an unpublished intent                       |
-| `POST /admin/api/intents/{id}/reconcile`   | Trigger bounded reconciliation                   |
-| `GET /admin/api/audit`                     | Query global or projected operational audit data |
+| `GET /admin/api/viewer/status`                             | Read service mode and component health           |
+| `GET /admin/api/viewer/publisher-control?did={did}`         | Read authoritative publisher control state       |
+| `GET /admin/api/viewer/audit`                              | Query global or projected operational audit data |
+| `POST /admin/api/reviewer/intents/{id}/cancel`             | Stop an unpublished intent                       |
+| `POST /admin/api/reviewer/intents/{id}/reconcile`          | Trigger bounded reconciliation                   |
+| `POST /admin/api/admin/service-mode`                       | Change admission or publication mode             |
+| `POST /admin/api/admin/publisher-control`                  | Suspend or restore publisher admission           |
+| `POST /admin/api/admin/publishers/{did}/revoke-authority`  | Revoke retained service authority                |
 
 State-changing requests require content-type validation, CSRF where cookies are used, and idempotency keys. API errors expose stable codes and public-safe messages.
 

--- a/docs/technical-specs/delegated-release-service.md
+++ b/docs/technical-specs/delegated-release-service.md
@@ -543,15 +543,18 @@ Provider payloads, tokens, secrets, raw assertions, private evidence, and stack 
 
 ## Encryption and key management
 
-Envelope encryption uses a versioned master key from Secrets Store or an equivalent Worker secret binding. The key is read inside request or RPC scope and is never logged or persisted. Each encrypted value includes:
+Envelope encryption uses compact JSON Web Encryption (JWE) through `jose`. A versioned 256-bit master key from Secrets Store or an equivalent Worker secret binding acts as an `A256GCMKW` key-encryption key. Each value receives a fresh content-encryption key, and `A256GCM` encrypts the payload. Master keys are read inside request or RPC scope and are never logged or persisted.
 
-- algorithm and envelope version;
-- master-key version;
-- nonce;
-- ciphertext and authentication tag; and
-- associated-data version.
+Each compact JWE includes:
 
-Associated data binds the deployment, publisher DID, object class, table, row identity, and field purpose. Swapping ciphertext between publishers or fields fails authentication.
+- the key-management and content-encryption algorithms;
+- the master-key version and initial profile version;
+- a wrapped content-encryption key;
+- key-wrap and content-encryption nonces and authentication tags;
+- ciphertext; and
+- a critical SHA-256 context digest.
+
+The protected header is authenticated as JWE associated data. Its context digest binds the deployment, publisher DID, object class, table, row identity, field purpose, and master-key version. Swapping ciphertext between publishers or fields fails authentication.
 
 Routine rotation introduces a new active version, retains old versions for decryption, re-encrypts in bounded publisher-shard batches, verifies completion through audit/export data, and only then retires the old version. Emergency rotation pauses publication first. Missing key material fails closed and requires operator recovery; it never silently discards or recreates delegation.
 

--- a/docs/technical-specs/delegated-release-service.md
+++ b/docs/technical-specs/delegated-release-service.md
@@ -596,13 +596,14 @@ Recovery prefers removal of authority. If encrypted session state cannot be prov
 
 ## Compatibility and rollout
 
+- The first deployment uses one complete initial Durable Object schema and one initial encryption profile. Implementation PR boundaries do not create schema versions or legacy ciphertext formats.
 - Protocol additions remain optional while the registry is experimental.
 - Interactive publisher-owned CLI publication continues to work.
 - Existing releases without provenance remain installable unless signed package policy requires provenance.
 - The delegated service itself always requires provenance for its releases.
 - A stable release-collection namespace requires a fresh delegation grant.
 - Old application versions tolerate the optional profile and release extension fields.
-- A rolling service deployment must tolerate shards at the previous application schema version until their forward migration completes.
+- After the first deployment, a rolling service update must tolerate shards at the previous application schema version until their forward migration completes.
 
 ## System acceptance criteria
 
@@ -647,7 +648,7 @@ The service is complete only when all of the following hold:
 
 ### Platform and operations
 
-- Durable Object migrations preserve existing delegation, intent, credential, and audit data.
+- After the first deployment, Durable Object migrations preserve existing delegation, intent, credential, and audit data.
 - Encryption-key rotation completes without losing authority or leaving values unreadable.
 - Encrypted snapshots and audit exports restore into a fresh deployment without automatically reviving expired or revoked authority.
 - Hosted and self-hosted deployments pass the same protocol and service conformance suite.

--- a/docs/technical-specs/delegated-release-service.md
+++ b/docs/technical-specs/delegated-release-service.md
@@ -160,14 +160,17 @@ interface GitHubWorkloadPolicy {
 	publisherDid: string;
 	packageSlug: string;
 	repository: string;
+	repositoryId: string;
+	repositoryOwnerId: string;
 	workflowRef: string;
 	allowedRefs?: string[];
 	allowedEnvironments?: string[];
 	active: boolean;
+	stateVersion: number;
 }
 ```
 
-This policy narrows who may submit an intent. It cannot weaken the signed package policy or change publisher records.
+Repository and owner IDs preserve the authorization boundary across GitHub renames or name reuse. This policy narrows who may submit an intent. It cannot weaken the signed package policy or change publisher records.
 
 ## Architecture
 

--- a/docs/technical-specs/delegated-release-service.md
+++ b/docs/technical-specs/delegated-release-service.md
@@ -504,16 +504,16 @@ Health endpoints are outside the versioned API. `GET /health` is configuration-i
 
 ### Access operator API
 
-| Method and path                            | Purpose                                          |
-| ------------------------------------------ | ------------------------------------------------ |
-| `GET /admin/api/viewer/status`                             | Read service mode and component health           |
-| `GET /admin/api/viewer/publisher-control?did={did}`         | Read authoritative publisher control state       |
-| `GET /admin/api/viewer/audit`                              | Query global or projected operational audit data |
-| `POST /admin/api/reviewer/intents/{id}/cancel`             | Stop an unpublished intent                       |
-| `POST /admin/api/reviewer/intents/{id}/reconcile`          | Trigger bounded reconciliation                   |
-| `POST /admin/api/admin/service-mode`                       | Change admission or publication mode             |
-| `POST /admin/api/admin/publisher-control`                  | Suspend or restore publisher admission           |
-| `POST /admin/api/admin/publishers/{did}/revoke-authority`  | Revoke retained service authority                |
+| Method and path                                           | Purpose                                          |
+| --------------------------------------------------------- | ------------------------------------------------ |
+| `GET /admin/api/viewer/status`                            | Read service mode and component health           |
+| `GET /admin/api/viewer/publisher-control?did={did}`       | Read authoritative publisher control state       |
+| `GET /admin/api/viewer/audit`                             | Query global or projected operational audit data |
+| `POST /admin/api/reviewer/intents/{id}/cancel`            | Stop an unpublished intent                       |
+| `POST /admin/api/reviewer/intents/{id}/reconcile`         | Trigger bounded reconciliation                   |
+| `POST /admin/api/admin/service-mode`                      | Change admission or publication mode             |
+| `POST /admin/api/admin/publisher-control`                 | Suspend or restore publisher admission           |
+| `POST /admin/api/admin/publishers/{did}/revoke-authority` | Revoke retained service authority                |
 
 State-changing requests require content-type validation, CSRF where cookies are used, and idempotency keys. API errors expose stable codes and public-safe messages.
 

--- a/docs/technical-specs/delegated-release-service.md
+++ b/docs/technical-specs/delegated-release-service.md
@@ -98,7 +98,7 @@ The service does not hard-code the experimental or future stable NSID. A namespa
 
 The initial support matrix contains:
 
-- Bluesky-hosted PDS; and
+- Bluesky PDS software hosted by npmX (`npmx.social`); and
 - Cirrus.
 
 Disposable accounts are available for both implementations. Credentials and recovery material remain outside the repository. Neither implementation is advertised as supported until its conformance run passes.
@@ -608,7 +608,7 @@ The service is complete only when all of the following hold:
 
 ### Delegation and identity
 
-- A publisher authorizes the exact create-only release grant on Bluesky-hosted PDS and Cirrus.
+- A publisher authorizes the exact create-only release grant on the Bluesky PDS implementation at npmX and on Cirrus.
 - The retained session creates a new release and cannot update it, delete it, edit a profile, or write another collection.
 - Revocation prevents new publication and eventual refresh; emergency service revocation removes retained authority.
 - Cloudflare Access operators cannot reach publisher, approver, or CI-authorized actions.

--- a/docs/technical-specs/delegated-release-service.md
+++ b/docs/technical-specs/delegated-release-service.md
@@ -1,0 +1,652 @@
+# Delegated release service
+
+Status: Proposed
+
+Related design: [RFC PR #1870](https://github.com/emdash-cms/emdash/pull/1870)
+
+## Summary
+
+The delegated release service lets a plugin publisher authorize automated releases without placing an AT Protocol account credential in continuous integration. The publisher grants the service create-only access to the package-release collection. A GitHub Actions workflow authenticates to the service with OpenID Connect (OIDC), submits an artifact and provenance document, and receives either a published release or an intent waiting for passkey approval.
+
+The service is a delegated writer, not a registry or trust authority. It cannot edit package profiles, overwrite releases, host artifacts, moderate listings, or make an invalid release installable. EmDash installers independently verify the publisher's records, artifact, manifest, provenance, and signed package policy.
+
+Canonical service state is sharded across SQLite-backed Durable Objects. A `PublisherDurableObject` owns each publisher's delegations, workload policies, release intents, reservations, and audit history. An `ApproverDurableObject` owns each approver's passkeys and challenges. A small `ServiceControlDurableObject` owns global pause and key-version state. Cloudflare Workflows orchestrate long-running verification and approval waits but do not replace the Durable Objects as the source of truth.
+
+## Goals
+
+- Publish an immutable sandboxed-plugin release from GitHub Actions without a stored AT Protocol credential in the runner.
+- Restrict the service's durable AT Protocol grant to creating records in the active release collection.
+- Bind every automated release to its source repository, workflow, commit, artifact, and provenance.
+- Require a user-verified passkey decision when signed package policy requires confirmation or declared access expands.
+- Preserve publisher ownership of package policy and approver membership in the publisher's PDS.
+- Let an EmDash installer reject invalid service output without consulting or trusting the service.
+- Provide a hosted service and the same Workers-based application for self-hosting.
+- Support operator incident response through a Cloudflare Access-protected admin surface without giving operators publisher authority.
+
+## Non-goals
+
+- Native-plugin distribution.
+- Artifact or provenance hosting.
+- Plugin-listing or metadata moderation.
+- Code-quality or malware assessment beyond canonical bundle, manifest, and provenance verification.
+- Editing package profiles from the release service.
+- Non-GitHub workload issuers in the first release.
+- Quorum approval or signed approval receipts verifiable by installers.
+- Generic user-defined OIDC claim expressions.
+- Billing, organization management, or a general-purpose CI platform.
+- Making the aggregator authoritative for publisher records, policy, or provenance.
+
+## Actors and authentication
+
+The service has four independent authentication realms. Credentials and sessions from one realm never authorize another.
+
+| Actor | Authentication | Authority |
+| --- | --- | --- |
+| CI workflow | GitHub Actions OIDC | Submit an intent for a configured repository and workflow |
+| Publisher | AT Protocol OAuth | Establish or revoke delegation and configure service-local workload policy |
+| Approver | AT Protocol OAuth plus an enrolled passkey | Approve or reject one exact release intent |
+| Service operator | Cloudflare Access | Observe, pause, suspend, revoke, retry, and recover the service |
+
+Cloudflare Access protects `/admin/*` and the operator API. The Worker verifies the Access JWT's issuer, audience, expiry, and group claims. Access-injected identity headers are not sufficient by themselves. Operator mutations retain CSRF and idempotency protection.
+
+Deployments map Access groups to three service roles:
+
+- `viewer` reads health, publisher state, intent state, and sanitized audit data;
+- `reviewer` cancels unpublished intents and triggers bounded reconciliation; and
+- `admin` changes service mode, suspends publishers, revokes retained authority, and operates key or recovery controls.
+
+Role names are stable application contracts. Each deployment configures the Access group identifiers that grant them. No Access role can establish publisher delegation, authorize workload policy, enrol an approver, approve an intent, or publish a release.
+
+Publisher and approver OAuth proves control of a DID. After a successful identity-only OAuth flow, the service may issue a short-lived application session. That session cannot write to the PDS. The separately authorized release delegation is encrypted and stored in the publisher's Durable Object.
+
+GitHub Actions OIDC tokens are audience-bound to the service. The service persists normalized claims and token identifiers, not the raw token.
+
+## Security invariants
+
+The implementation must preserve these invariants:
+
+1. CI never receives or stores an AT Protocol refresh token, DPoP key, app password, or delegated release session.
+2. The delegated grant is the exact create-only scope returned by `getDelegatedReleasePermission()` from `@emdash-cms/registry-lexicons`.
+3. The service never requests or stores package-profile write scope.
+4. The delegated path exposes no update or delete operation for a release record.
+5. A package version maps to one deterministic record key and one reservation in the publisher shard.
+6. Publisher records are read directly from the DID-resolved PDS. Aggregator output is never an authority input.
+7. Supplied artifact and provenance bytes pass the shared SSRF-safe fetcher and their signed checksums.
+8. Record, bundle, manifest, provenance, workload, policy, and access checks run after submission and again immediately before publication.
+9. Human approval cannot override failed verification. It authorizes only a valid release that policy requires a human to confirm.
+10. Approval is bound to the intent, workload claims, profile CID, baseline release CID, artifact and provenance checksums, declared-access diff, approver DID, and decision.
+11. Passkey approval requires WebAuthn user verification, not only user presence.
+12. A listed but unenrolled DID cannot approve. Enrolment and approval are separate ceremonies.
+13. An Access operator can remove or suspend authority but cannot create publisher authority, edit signed policy, enrol an approver, or approve a release.
+14. Durable Object state and a PDS write are never treated as one transaction. Ambiguous writes are reconciled by reading the deterministic key.
+15. OAuth sessions, DPoP keys, emails, and future webhook secrets are application-encrypted before persistence.
+16. Workflows, projections, and notification queues are recoverable coordination or read models, not canonical authorization state.
+
+## Protocol contracts
+
+### Delegated permission
+
+The active release collection and OAuth scope come from `@emdash-cms/registry-lexicons`:
+
+```ts
+const permission = getDelegatedReleasePermission();
+// permission.collection identifies the release NSID.
+// permission.scope grants only create access to that collection.
+```
+
+The service does not hard-code the experimental or future stable NSID. A namespace migration requires a new publisher grant because AT Protocol repository scope is collection-specific.
+
+The initial support matrix contains:
+
+- Bluesky-hosted PDS; and
+- Cirrus.
+
+Disposable accounts are available for both implementations. Credentials and recovery material remain outside the repository. Neither implementation is advertised as supported until its conformance run passes.
+
+The supported-PDS matrix must prove that each claimed implementation:
+
+- accepts a create in the release collection;
+- rejects an update to the created release;
+- rejects deletion through the delegated path;
+- rejects profile writes and writes to unrelated collections;
+- supports refresh and explicit revocation as claimed by the service; and
+- stops accepting refreshed authority after revocation and client-key removal according to the authorization server's documented behavior.
+
+There is no broad-scope fallback.
+
+### Signed package profile policy
+
+The package profile extension supplies the publisher-controlled policy:
+
+```ts
+interface PackageProfileExtension {
+	repository: string;
+	releasePolicy?: {
+		requireProvenance?: boolean;
+		confirmation?: "escalation-only" | "always";
+		approvers?: string[];
+	};
+}
+```
+
+The service normalizes omitted values to the protocol defaults. It validates the repository as a canonical HTTPS source URL and every approver as a DID. The release service can display this policy but cannot change it.
+
+The delegated path always requires supported provenance, even when `requireProvenance` is absent. The profile field communicates the publisher's requirement to every installer and non-delegated publisher. A supplied unsupported predicate is present-but-unverifiable and fails delegated publication.
+
+### Signed release provenance
+
+The release extension identifies the provenance document and the source it must describe:
+
+```ts
+interface ReleaseProvenance {
+	predicateType: string;
+	url: string;
+	checksum: string;
+	sourceRepository: string;
+	builderId: string;
+}
+```
+
+The first release understands SLSA provenance v1 in a Sigstore bundle. The provenance checksum covers the fetched provenance document. Its subject digest covers the package artifact. The source repository and builder identity must agree with the signed package profile, registered workload policy, GitHub OIDC claims, and provenance statement.
+
+### Service-local workload policy
+
+The publisher authorizes a service-local workload policy after proving the publisher DID:
+
+```ts
+interface GitHubWorkloadPolicy {
+	publisherDid: string;
+	packageSlug: string;
+	repository: string;
+	workflowRef: string;
+	allowedRefs?: string[];
+	allowedEnvironments?: string[];
+	active: boolean;
+}
+```
+
+This policy narrows who may submit an intent. It cannot weaken the signed package policy or change publisher records.
+
+## Architecture
+
+```text
+GitHub Actions                         Publisher or approver browser
+      | OIDC                                      | AT Protocol OAuth
+      |                                           | WebAuthn when approving
+      v                                           v
++---------------------------------------------------------------------+
+| Release-service Worker                                             |
+| Public API, publisher UI, approver UI, Access-protected admin      |
++--------------+--------------------+--------------------+-------------+
+               |                    |                    |
+               v                    v                    v
+       PublisherDurableObject  ApproverDurableObject  ServiceControlDO
+          publisher DID shard    approver DID shard      service shard
+               |
+               | intent ID
+               v
+       ReleaseIntentWorkflow -------> isolated verifier Worker
+               |                              |
+               |                              v
+               |                     artifact/provenance hosts
+               v
+         publisher PDS
+
+Optional read models:
+  DO events -> Queue -> D1 operator projection
+  DO snapshots and audit exports -> R2
+```
+
+### Release-service Worker
+
+The stateless Worker owns HTTP concerns:
+
+- route and method dispatch;
+- request parsing and size limits;
+- authentication-realm selection;
+- Access JWT, application session, CSRF, OIDC, and idempotency checks;
+- deterministic routing to Durable Objects;
+- static publisher, approver, and operator assets;
+- public health responses that expose no tenant data; and
+- stable API error envelopes and request IDs.
+
+Business state transitions live in Durable Object RPC methods, not route handlers.
+
+### `PublisherDurableObject`
+
+The Worker routes with `getByName(canonicalPublisherDid)`. The DID is the coordination atom because one AT Protocol session and PDS serialize authority for all packages owned by that publisher.
+
+The object owns:
+
+- publisher status and tenancy;
+- encrypted delegated OAuth session and key version;
+- workload policies;
+- release intents and immutable transition history;
+- package/version reservations;
+- OIDC and request idempotency;
+- refresh and publication operation tokens;
+- publisher-scoped audit events; and
+- publisher-session revocation epochs.
+
+SQLite constraints enforce uniqueness for package/version reservations, workload-policy identity, intent idempotency, and transition sequence numbers. RPC methods perform synchronous SQLite transactions for related state changes. The object never holds `blockConcurrencyWhile()` across an external request.
+
+Slow external work uses a persistent operation-token protocol:
+
+```text
+Workflow -> beginPublication(intentId)
+PublisherDO -> transition to publishing; return generation-bound token
+Workflow -> refresh session and call the PDS
+Workflow -> completePublication(token, result)
+```
+
+Only the current token can complete the operation. The object schedules its one alarm for the earliest refresh, publication, expiry, or cleanup deadline. The alarm marks abandoned operations for reconciliation and schedules the next pending deadline.
+
+### `ApproverDurableObject`
+
+The Worker routes with `getByName(canonicalApproverDid)`. The object owns:
+
+- identity-proof transactions;
+- enrolled WebAuthn credentials;
+- credential names, counters, transports, creation, last use, and revocation;
+- approval challenges bound to an approval digest;
+- challenge expiry and single-use state; and
+- approver-scoped audit events.
+
+The object verifies a passkey decision and returns a receipt containing the approver DID, intent ID, digest, decision, credential ID, and verification time. The publisher object stores the receipt against the intent. Cross-object calls are replay-safe but are not treated as one transaction. Final verification checks that the approver DID is still authorized by the current profile.
+
+### `ServiceControlDurableObject`
+
+One low-traffic object owns:
+
+- service mode: `active`, `admission-paused`, or `publication-paused`;
+- active and readable encryption-key versions;
+- hosted-service publisher allowlist or suspension defaults;
+- operator mutation idempotency; and
+- global operational audit events.
+
+Intent admission checks the service mode. Every publication obtains a fresh publication permit immediately before the PDS write. A cached permit cannot authorize publication.
+
+### Release Workflow
+
+One Workflow instance orchestrates one intent. The instance ID is derived from the immutable intent ID. Step names are deterministic. Each step either reads or commits its result through the publisher object before proceeding.
+
+The Workflow owns:
+
+- durable retry timing;
+- isolated verification steps;
+- waiting for approval, rejection, cancellation, or expiry;
+- publication and ambiguous-write reconciliation; and
+- non-critical completion fan-out.
+
+The Workflow does not own the authoritative intent state. If Workflow state is lost after its retention period, the publisher object and audit history remain sufficient to determine the release state and start recovery.
+
+### Verifier Worker
+
+The verifier is a separate Worker reached through a service binding. It has no publisher OAuth binding, operator authentication secret, or Durable Object namespace. It:
+
+- fetches artifacts and provenance through the shared guarded fetcher;
+- enforces redirect, DNS, protocol, time, and size policy;
+- validates checksums and canonical bundle structure;
+- reconciles the bundled manifest with the proposed record;
+- verifies supported Sigstore/SLSA provenance; and
+- returns a bounded, serializable report without artifact bytes or secrets.
+
+Artifact and provenance hosting remain the publisher's responsibility.
+
+### Optional D1 operator projection
+
+Cross-publisher operator search is not naturally shard-local. If direct publisher-DID lookup becomes insufficient, Durable Objects emit projection events through a Queue. A consumer writes a sanitized read model to D1.
+
+The projection may include publisher DID, package, intent state, timestamps, public error code, and suspension status. It excludes OAuth material, private approval details, raw OIDC claims, emails, and WebAuthn credential data.
+
+All operator mutations route to the authoritative Durable Object and return its result. The D1 projection can be deleted and rebuilt without changing authorization or release outcomes.
+
+### R2 backup and audit export
+
+Encrypted publisher snapshots and append-only audit exports may be written to R2. Snapshot production must be bounded and resumable. A restore never revives expired or revoked authority automatically. If an OAuth session cannot be restored safely, the publisher reauthorizes delegation.
+
+## Durable Object schemas
+
+The following schemas describe required data and constraints. Exact SQL belongs with the implementation.
+
+### Publisher shard
+
+| Table | Required properties |
+| --- | --- |
+| `publisher` | One row; DID, status, creation time, suspension reason code, session epoch |
+| `delegations` | Encrypted session envelope, exact scope, PDS, client key ID, expiry, refresh metadata, encryption-key version, revocation state |
+| `workload_policies` | Package slug, repository, workflow reference, ref/environment restrictions, active state, authorizing publisher identity |
+| `intents` | ULID, package/version, state, Workflow ID, normalized OIDC claims, record inputs, verification summaries, approval digest, result URI/CID, error code |
+| `intent_transitions` | Intent ID, monotonic sequence, from/to state, actor realm and identity, reason code, timestamp |
+| `release_reservations` | Unique package/version, intent ID, reservation state |
+| `idempotency_keys` | Realm, key, request digest, intent/result reference, expiry |
+| `operations` | Kind, generation, token hash, intent ID, start/deadline, completion state |
+| `audit_events` | Monotonic sequence, event type, actor realm, actor identity, subject, public-safe payload, timestamp |
+| `deadlines` | Kind, subject ID, scheduled time, generation |
+
+Sensitive values are encrypted individually with associated data binding the publisher DID, table, row identity, and key version. The database never stores an encryption master key.
+
+### Approver shard
+
+| Table | Required properties |
+| --- | --- |
+| `approver` | One row; DID, status, session epoch |
+| `credentials` | Credential ID, public key, counter, transports, name, creation, last use, revocation |
+| `identity_transactions` | OAuth state hash, PKCE state, expiry, completion |
+| `approval_challenges` | Challenge hash, intent ID, publisher DID, approval digest, expiry, consumed time |
+| `decisions` | Idempotency key, intent ID, digest, decision, credential ID, verification time |
+| `audit_events` | Monotonic sequence, event type, subject, public-safe payload, timestamp |
+| `deadlines` | Challenge or session cleanup deadline and generation |
+
+### Service-control shard
+
+| Table | Required properties |
+| --- | --- |
+| `service_state` | Current mode, epoch, reason code, Access operator identity, changed time |
+| `encryption_keys` | Key version, status, activation and retirement metadata; never key material |
+| `publisher_controls` | Publisher DID, allow/suspend state, reason code, operator identity, timestamp |
+| `operator_idempotency` | Mutation key, request digest, result, expiry |
+| `audit_events` | Monotonic sequence, operator identity, action, subject, public-safe payload, timestamp |
+
+## Release intent state machine
+
+The canonical state machine is:
+
+```text
+received -> verifying -> verified
+                         |       |
+                         |       +-> ready -> publishing -> reconciling -> published
+                         |
+                         +-> awaiting_approval -> ready
+
+Non-success terminals:
+  invalid, rejected, cancelled, expired, failed, conflict
+```
+
+Allowed transitions are explicit. Compare-and-set transition methods take the expected state and generation. Unknown or repeated transitions return the stored result when idempotent and reject when the requested payload conflicts.
+
+`failed` represents an exhausted service or dependency failure after valid input. `invalid` represents a permanent input, identity, policy, bundle, or provenance failure. Neither is manually approvable. `conflict` means the deterministic release key contains a different record.
+
+## Publisher onboarding
+
+1. The publisher starts an identity-only AT Protocol OAuth flow.
+2. The service resolves and verifies the publisher DID and PDS.
+3. Hosted-service admission policy permits or rejects the publisher.
+4. The publisher authorizes the exact create-only release scope.
+5. The service verifies the returned grant and stores the encrypted session in the publisher object.
+6. The publisher registers a package-to-GitHub-workload policy.
+7. The service fetches and validates the signed package profile.
+8. Profile-listed approvers separately prove their DIDs and enrol passkeys.
+9. A dry-run submission verifies OIDC and provenance configuration without reserving or publishing a version.
+
+The publisher can revoke the delegation from the service or directly through the authorization server. The service treats refresh failure after revocation as terminal authority loss, not as a retry loop.
+
+## Release submission
+
+1. GitHub Actions builds and bundles the plugin.
+2. CI emits SLSA provenance and uploads artifact and provenance bytes to stable HTTPS URLs.
+3. CI requests an OIDC token whose audience is the release service.
+4. The Action submits the token, package/version, URLs, checksums, release record, and idempotency key.
+5. The Worker verifies request shape, OIDC signature and claims, and routes to the publisher object.
+6. The publisher object verifies workload-policy admission, reserves package/version, creates the intent, and records normalized claims.
+7. The object creates the Workflow instance using the intent ID.
+8. The API returns the intent resource. Publication is always asynchronous even when it completes quickly.
+
+The idempotency identity includes publisher DID, package, version, GitHub repository, workflow, run ID, and run attempt. Repeating the same request returns the existing intent. Reusing the identity with a different request digest returns `IDEMPOTENCY_CONFLICT`.
+
+## Verification
+
+The Workflow performs these checks in order:
+
+1. Resolve the publisher DID and authoritative PDS.
+2. Fetch the current package profile and record its CID.
+3. Validate package identity, profile extension, canonical repository, policy, and approver DIDs.
+4. Confirm the proposed release key is absent.
+5. Select the highest-semver existing release as the access baseline, excluding the proposed key. Record its CID, or the empty baseline for the first release.
+6. Ask the verifier Worker to fetch and validate the artifact.
+7. Confirm bundle package, version, manifest, and declared access match the proposed release.
+8. Ask the verifier to fetch and validate provenance.
+9. Match the artifact digest, source repository, builder, workflow, commit, and relevant GitHub claims.
+10. Compute the canonical declared-access diff against the baseline.
+11. Resolve `confirmation: always` or escalation-only policy.
+12. Persist a bounded verification report and its input CIDs/checksums.
+
+A missing or invalid supported provenance document is `invalid`. Approval cannot change that result.
+
+## Approval
+
+If approval is required, the publisher object stores an approval digest and transitions to `awaiting_approval`. The Workflow waits for a decision event with a bounded expiry.
+
+An approver:
+
+1. establishes a publisher-independent application session after AT Protocol OAuth;
+2. opens the intent and reviews its source, workload, artifact, provenance, profile policy, baseline, and access diff;
+3. requests a challenge from the approver object;
+4. signs the approval digest using an active, user-verified credential; and
+5. submits `approve` or `reject` with an idempotency key.
+
+The service accepts the receipt only if the current profile still lists the approver DID. A rejection is terminal. A cancellation or expiry invalidates outstanding challenges. A new profile CID, access baseline, artifact checksum, provenance checksum, or workload claim set creates a new digest and requires a new approval.
+
+## Publication and reconciliation
+
+Before publication, the Workflow repeats every authoritative read and verification step. It then:
+
+1. obtains a fresh publication permit from the service-control object;
+2. obtains a generation-bound publication operation token from the publisher object;
+3. refreshes the encrypted AT Protocol session if required under a separate generation-bound refresh operation;
+4. creates the deterministic release record without an update path;
+5. completes the operation with the confirmed URI and CID; or
+6. enters reconciliation when the external result is ambiguous.
+
+Reconciliation reads the deterministic release key directly from the PDS:
+
+- an exact semantic and CID match completes publication;
+- confirmed absence permits an idempotent create retry;
+- a different record at the key transitions to `conflict`; and
+- a transient inability to establish presence or absence remains `reconciling` with bounded retries and operator visibility.
+
+The service never reports `published` from an HTTP status alone when the response may be ambiguous.
+
+## Cancellation, revocation, and suspension
+
+- CI may cancel its own intent before `publishing` using a fresh matching OIDC identity.
+- The publisher may cancel an intent before `publishing` through its application session.
+- An approver may reject but cannot cancel on behalf of the publisher.
+- An Access operator may cancel or quarantine an intent for incident response but cannot transition it to `ready` or `published`.
+- Publisher revocation blocks new intents and refresh, and publication checks revocation immediately before the write.
+- Service pause is checked at admission and again before the write.
+- A publisher suspension blocks all publisher shards without deleting audit or encrypted state.
+
+Revocation does not remove an already published record. Record removal or yanking follows the registry protocol and publisher authority model outside this service.
+
+## HTTP API
+
+The public service API is versioned under `/v1`.
+
+### CI API
+
+| Method and path | Purpose |
+| --- | --- |
+| `POST /v1/release-intents` | Submit or replay an OIDC-authenticated intent |
+| `GET /v1/release-intents/{id}` | Read status using matching workload identity or publisher session |
+| `POST /v1/release-intents/{id}/cancel` | Cancel before publication |
+
+### Publisher API
+
+| Method and path | Purpose |
+| --- | --- |
+| `GET /v1/publisher` | Read publisher and delegation state |
+| `POST /v1/publisher/delegation` | Start or complete exact-scope delegation |
+| `DELETE /v1/publisher/delegation` | Revoke retained authority |
+| `GET /v1/publisher/workloads` | List package workload policies |
+| `POST /v1/publisher/workloads` | Create or replace an authorized policy |
+| `DELETE /v1/publisher/workloads/{id}` | Disable a policy |
+| `GET /v1/publisher/intents` | List publisher intents with cursor pagination |
+
+### Approver API
+
+| Method and path | Purpose |
+| --- | --- |
+| `GET /v1/approver/credentials` | List active and revoked passkeys |
+| `POST /v1/approver/credentials/options` | Begin enrolment |
+| `POST /v1/approver/credentials` | Finish enrolment |
+| `DELETE /v1/approver/credentials/{id}` | Revoke one credential |
+| `GET /v1/approvals/{intentId}` | Read approval-safe intent details |
+| `POST /v1/approvals/{intentId}/options` | Create a digest-bound challenge |
+| `POST /v1/approvals/{intentId}` | Approve or reject |
+
+### Access operator API
+
+| Method and path | Purpose |
+| --- | --- |
+| `GET /admin/api/status` | Read service mode and component health |
+| `POST /admin/api/pause` | Change admission or publication mode |
+| `GET /admin/api/publishers/{did}` | Read authoritative sanitized publisher state |
+| `POST /admin/api/publishers/{did}/suspend` | Suspend or restore publisher admission |
+| `POST /admin/api/publishers/{did}/revoke` | Revoke retained service authority |
+| `POST /admin/api/intents/{id}/cancel` | Stop an unpublished intent |
+| `POST /admin/api/intents/{id}/reconcile` | Trigger bounded reconciliation |
+| `GET /admin/api/audit` | Query global or projected operational audit data |
+
+State-changing requests require content-type validation, CSRF where cookies are used, and idempotency keys. API errors expose stable codes and public-safe messages.
+
+## Error model
+
+At minimum, the API and Workflow use these error classes:
+
+| Code | Meaning | Retry behavior |
+| --- | --- | --- |
+| `AUTH_INVALID` | Authentication or session proof failed | Permanent for request |
+| `ACCESS_DENIED` | Verified actor lacks required role or ownership | Permanent |
+| `PUBLISHER_SUSPENDED` | Hosted service or operator blocked the publisher | Retry after state change |
+| `SERVICE_PAUSED` | Admission or publication is paused | Retry after state change |
+| `DELEGATION_REQUIRED` | No usable exact-scope session exists | Publisher must reauthorize |
+| `WORKLOAD_NOT_ALLOWED` | OIDC claims do not match active policy | Permanent until policy changes |
+| `IDEMPOTENCY_CONFLICT` | Same key was used with a different request | Permanent |
+| `VERSION_RESERVED` | Package/version belongs to another intent | Permanent or return owner intent |
+| `RELEASE_EXISTS` | Proposed deterministic key already exists | Permanent unless exact replay |
+| `PROFILE_CHANGED` | Authoritative policy changed after verification or approval | Reverify and possibly reapprove |
+| `BASELINE_CHANGED` | Access baseline changed | Reverify and possibly reapprove |
+| `ARTIFACT_INVALID` | Fetch, checksum, bundle, or manifest failed | Permanent for supplied input |
+| `PROVENANCE_INVALID` | Provenance or workload binding failed | Permanent for supplied input |
+| `APPROVAL_REQUIRED` | Valid release awaits human decision | Not an error state |
+| `APPROVAL_INVALID` | DID, credential, challenge, digest, or UV failed | Permanent for attempt |
+| `DELEGATION_REVOKED` | Session was revoked or cannot refresh | Publisher must reauthorize |
+| `PDS_TRANSIENT` | PDS result is retryable | Workflow retry |
+| `PDS_AMBIGUOUS` | Create outcome is unknown | Reconciliation |
+| `RELEASE_CONFLICT` | Deterministic key contains different data | Terminal conflict |
+| `INTERNAL_ERROR` | Public-safe catch-all | Operator-visible correlation ID |
+
+Provider payloads, tokens, secrets, raw assertions, private evidence, and stack traces never enter public errors or persistent generic error strings.
+
+## Encryption and key management
+
+Envelope encryption uses a versioned master key from Secrets Store or an equivalent Worker secret binding. The key is read inside request or RPC scope and is never logged or persisted. Each encrypted value includes:
+
+- algorithm and envelope version;
+- master-key version;
+- nonce;
+- ciphertext and authentication tag; and
+- associated-data version.
+
+Associated data binds the deployment, publisher DID, object class, table, row identity, and field purpose. Swapping ciphertext between publishers or fields fails authentication.
+
+Routine rotation introduces a new active version, retains old versions for decryption, re-encrypts in bounded publisher-shard batches, verifies completion through audit/export data, and only then retires the old version. Emergency rotation pauses publication first. Missing key material fails closed and requires operator recovery; it never silently discards or recreates delegation.
+
+## Audit and privacy
+
+Every security-relevant state change appends an immutable audit event in the authoritative shard before returning success. Events name the actor realm (`oidc`, `publisher`, `approver`, `access`, or `system`), stable actor identity, action, subject, reason code, and timestamp.
+
+Audit payloads may include normalized repository, workflow, package, version, public record identifiers, and digest prefixes. They exclude raw tokens, assertions, OAuth sessions, DPoP keys, email bodies, WebAuthn public-key material, and artifact contents.
+
+Access operator views use the least detailed representation required for operations. Publisher and approver views cannot read another publisher's private intents or credentials.
+
+## Listing moderation integration
+
+Publishing and listing moderation remain independent:
+
+1. The delegated service creates a valid release record.
+2. The aggregator observes the record.
+3. Metadata labellers assess the exact visible profile and release CIDs.
+4. Default admin discovery requires the configured positive moderation labels.
+
+The delegated service neither issues moderation labels nor bypasses the aggregator's visibility policy. A successfully published release may remain absent from default discovery while moderation is pending.
+
+## Operations and recovery
+
+The Access admin exposes service mode, publisher lookup, stuck operations, reconciliation, authority revocation, suspension, encryption-key status, Workflow status, and sanitized audit events.
+
+Required runbooks cover:
+
+- compromised service encryption key;
+- compromised Access operator identity;
+- publisher-requested revocation;
+- authorization-server outage;
+- PDS write ambiguity;
+- Workflow loss or prolonged retry;
+- verifier egress failure;
+- Durable Object schema migration failure;
+- lost or corrupt publisher shard;
+- passkey compromise or counter anomaly; and
+- hosted-service rollback.
+
+Recovery prefers removal of authority. If encrypted session state cannot be proved correct, revoke or disable it and require publisher reauthorization.
+
+## Compatibility and rollout
+
+- Protocol additions remain optional while the registry is experimental.
+- Interactive publisher-owned CLI publication continues to work.
+- Existing releases without provenance remain installable unless signed package policy requires provenance.
+- The delegated service itself always requires provenance for its releases.
+- A stable release-collection namespace requires a fresh delegation grant.
+- Old application versions tolerate the optional profile and release extension fields.
+- A rolling service deployment must tolerate shards at the previous application schema version until their forward migration completes.
+
+## System acceptance criteria
+
+The service is complete only when all of the following hold:
+
+### Delegation and identity
+
+- A publisher authorizes the exact create-only release grant on Bluesky-hosted PDS and Cirrus.
+- The retained session creates a new release and cannot update it, delete it, edit a profile, or write another collection.
+- Revocation prevents new publication and eventual refresh; emergency service revocation removes retained authority.
+- Cloudflare Access operators cannot reach publisher, approver, or CI-authorized actions.
+
+### Workload and verification
+
+- A configured GitHub workflow can submit an intent; a wrong repository, workflow, audience, ref, environment, run identity, or expired token cannot.
+- Replaying the same request returns the same intent; changing the payload under the same idempotency identity fails.
+- Artifact, bundle, manifest, declared access, provenance, source, builder, and commit substitution tests fail closed.
+- The service reads authoritative profile and release records directly from the publisher PDS.
+
+### Approval
+
+- An ordinary non-escalating release publishes automatically under `escalation-only`.
+- `confirmation: always` and declared-access expansion wait for approval.
+- An unlisted, unenrolled, revoked, cloned, non-user-verified, or digest-mismatched credential cannot approve.
+- Profile, baseline, artifact, provenance, or workload changes invalidate prior approval.
+- Approval never converts invalid verification into a publishable release.
+
+### Publication and recovery
+
+- Concurrent submissions cannot claim the same publisher/package/version.
+- OAuth refresh and PDS publication serialize within a publisher shard without holding a Durable Object-wide external-I/O lock.
+- Duplicate Workflow execution cannot create a second semantic release or duplicate a terminal transition.
+- A timeout before, during, or after the PDS write converges to published, retryable absence, or conflict through reconciliation.
+- Service pause and publisher suspension are enforced immediately before the write.
+
+### Independent consumption
+
+- A clean EmDash site independently accepts a valid delegated release.
+- It rejects absent, malformed, mismatched, unsupported, or invalid required provenance even if the service marked the intent published.
+- It rejects a bundle whose manifest differs from the signed release's declared access.
+- Listing moderation remains required independently for default admin discovery.
+
+### Platform and operations
+
+- Durable Object migrations preserve existing delegation, intent, credential, and audit data.
+- Encryption-key rotation completes without losing authority or leaving values unreadable.
+- Encrypted snapshots and audit exports restore into a fresh deployment without automatically reviving expired or revoked authority.
+- Hosted and self-hosted deployments pass the same protocol and service conformance suite.
+- External security review has no unresolved critical or high findings before production launch.

--- a/docs/technical-specs/delegated-release-service.md
+++ b/docs/technical-specs/delegated-release-service.md
@@ -40,12 +40,12 @@ Canonical service state is sharded across SQLite-backed Durable Objects. A `Publ
 
 The service has four independent authentication realms. Credentials and sessions from one realm never authorize another.
 
-| Actor | Authentication | Authority |
-| --- | --- | --- |
-| CI workflow | GitHub Actions OIDC | Submit an intent for a configured repository and workflow |
-| Publisher | AT Protocol OAuth | Establish or revoke delegation and configure service-local workload policy |
-| Approver | AT Protocol OAuth plus an enrolled passkey | Approve or reject one exact release intent |
-| Service operator | Cloudflare Access | Observe, pause, suspend, revoke, retry, and recover the service |
+| Actor            | Authentication                             | Authority                                                                  |
+| ---------------- | ------------------------------------------ | -------------------------------------------------------------------------- |
+| CI workflow      | GitHub Actions OIDC                        | Submit an intent for a configured repository and workflow                  |
+| Publisher        | AT Protocol OAuth                          | Establish or revoke delegation and configure service-local workload policy |
+| Approver         | AT Protocol OAuth plus an enrolled passkey | Approve or reject one exact release intent                                 |
+| Service operator | Cloudflare Access                          | Observe, pause, suspend, revoke, retry, and recover the service            |
 
 Cloudflare Access protects `/admin/*` and the operator API. The Worker verifies the Access JWT's issuer, audience, expiry, and group claims. Access-injected identity headers are not sufficient by themselves. Operator mutations retain CSRF and idempotency protection.
 
@@ -311,42 +311,42 @@ The following schemas describe required data and constraints. Exact SQL belongs 
 
 ### Publisher shard
 
-| Table | Required properties |
-| --- | --- |
-| `publisher` | One row; DID, status, creation time, suspension reason code, session epoch |
-| `delegations` | Encrypted session envelope, exact scope, PDS, client key ID, expiry, refresh metadata, encryption-key version, revocation state |
-| `workload_policies` | Package slug, repository, workflow reference, ref/environment restrictions, active state, authorizing publisher identity |
-| `intents` | ULID, package/version, state, Workflow ID, normalized OIDC claims, record inputs, verification summaries, approval digest, result URI/CID, error code |
-| `intent_transitions` | Intent ID, monotonic sequence, from/to state, actor realm and identity, reason code, timestamp |
-| `release_reservations` | Unique package/version, intent ID, reservation state |
-| `idempotency_keys` | Realm, key, request digest, intent/result reference, expiry |
-| `operations` | Kind, generation, token hash, intent ID, start/deadline, completion state |
-| `audit_events` | Monotonic sequence, event type, actor realm, actor identity, subject, public-safe payload, timestamp |
-| `deadlines` | Kind, subject ID, scheduled time, generation |
+| Table                  | Required properties                                                                                                                                   |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `publisher`            | One row; DID, status, creation time, suspension reason code, session epoch                                                                            |
+| `delegations`          | Encrypted session envelope, exact scope, PDS, client key ID, expiry, refresh metadata, encryption-key version, revocation state                       |
+| `workload_policies`    | Package slug, repository, workflow reference, ref/environment restrictions, active state, authorizing publisher identity                              |
+| `intents`              | ULID, package/version, state, Workflow ID, normalized OIDC claims, record inputs, verification summaries, approval digest, result URI/CID, error code |
+| `intent_transitions`   | Intent ID, monotonic sequence, from/to state, actor realm and identity, reason code, timestamp                                                        |
+| `release_reservations` | Unique package/version, intent ID, reservation state                                                                                                  |
+| `idempotency_keys`     | Realm, key, request digest, intent/result reference, expiry                                                                                           |
+| `operations`           | Kind, generation, token hash, intent ID, start/deadline, completion state                                                                             |
+| `audit_events`         | Monotonic sequence, event type, actor realm, actor identity, subject, public-safe payload, timestamp                                                  |
+| `deadlines`            | Kind, subject ID, scheduled time, generation                                                                                                          |
 
 Sensitive values are encrypted individually with associated data binding the publisher DID, table, row identity, and key version. The database never stores an encryption master key.
 
 ### Approver shard
 
-| Table | Required properties |
-| --- | --- |
-| `approver` | One row; DID, status, session epoch |
-| `credentials` | Credential ID, public key, counter, transports, name, creation, last use, revocation |
-| `identity_transactions` | OAuth state hash, PKCE state, expiry, completion |
-| `approval_challenges` | Challenge hash, intent ID, publisher DID, approval digest, expiry, consumed time |
-| `decisions` | Idempotency key, intent ID, digest, decision, credential ID, verification time |
-| `audit_events` | Monotonic sequence, event type, subject, public-safe payload, timestamp |
-| `deadlines` | Challenge or session cleanup deadline and generation |
+| Table                   | Required properties                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------ |
+| `approver`              | One row; DID, status, session epoch                                                  |
+| `credentials`           | Credential ID, public key, counter, transports, name, creation, last use, revocation |
+| `identity_transactions` | OAuth state hash, PKCE state, expiry, completion                                     |
+| `approval_challenges`   | Challenge hash, intent ID, publisher DID, approval digest, expiry, consumed time     |
+| `decisions`             | Idempotency key, intent ID, digest, decision, credential ID, verification time       |
+| `audit_events`          | Monotonic sequence, event type, subject, public-safe payload, timestamp              |
+| `deadlines`             | Challenge or session cleanup deadline and generation                                 |
 
 ### Service-control shard
 
-| Table | Required properties |
-| --- | --- |
-| `service_state` | Current mode, epoch, reason code, Access operator identity, changed time |
-| `encryption_keys` | Key version, status, activation and retirement metadata; never key material |
-| `publisher_controls` | Publisher DID, allow/suspend state, reason code, operator identity, timestamp |
-| `operator_idempotency` | Mutation key, request digest, result, expiry |
-| `audit_events` | Monotonic sequence, operator identity, action, subject, public-safe payload, timestamp |
+| Table                  | Required properties                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------- |
+| `service_state`        | Current mode, epoch, reason code, Access operator identity, changed time               |
+| `encryption_keys`      | Key version, status, activation and retirement metadata; never key material            |
+| `publisher_controls`   | Publisher DID, allow/suspend state, reason code, operator identity, timestamp          |
+| `operator_idempotency` | Mutation key, request digest, result, expiry                                           |
+| `audit_events`         | Monotonic sequence, operator identity, action, subject, public-safe payload, timestamp |
 
 ## Release intent state machine
 
@@ -465,48 +465,48 @@ The public service API is versioned under `/v1`.
 
 ### CI API
 
-| Method and path | Purpose |
-| --- | --- |
-| `POST /v1/release-intents` | Submit or replay an OIDC-authenticated intent |
-| `GET /v1/release-intents/{id}` | Read status using matching workload identity or publisher session |
-| `POST /v1/release-intents/{id}/cancel` | Cancel before publication |
+| Method and path                        | Purpose                                                           |
+| -------------------------------------- | ----------------------------------------------------------------- |
+| `POST /v1/release-intents`             | Submit or replay an OIDC-authenticated intent                     |
+| `GET /v1/release-intents/{id}`         | Read status using matching workload identity or publisher session |
+| `POST /v1/release-intents/{id}/cancel` | Cancel before publication                                         |
 
 ### Publisher API
 
-| Method and path | Purpose |
-| --- | --- |
-| `GET /v1/publisher` | Read publisher and delegation state |
-| `POST /v1/publisher/delegation` | Start or complete exact-scope delegation |
-| `DELETE /v1/publisher/delegation` | Revoke retained authority |
-| `GET /v1/publisher/workloads` | List package workload policies |
-| `POST /v1/publisher/workloads` | Create or replace an authorized policy |
-| `DELETE /v1/publisher/workloads/{id}` | Disable a policy |
-| `GET /v1/publisher/intents` | List publisher intents with cursor pagination |
+| Method and path                       | Purpose                                       |
+| ------------------------------------- | --------------------------------------------- |
+| `GET /v1/publisher`                   | Read publisher and delegation state           |
+| `POST /v1/publisher/delegation`       | Start or complete exact-scope delegation      |
+| `DELETE /v1/publisher/delegation`     | Revoke retained authority                     |
+| `GET /v1/publisher/workloads`         | List package workload policies                |
+| `POST /v1/publisher/workloads`        | Create or replace an authorized policy        |
+| `DELETE /v1/publisher/workloads/{id}` | Disable a policy                              |
+| `GET /v1/publisher/intents`           | List publisher intents with cursor pagination |
 
 ### Approver API
 
-| Method and path | Purpose |
-| --- | --- |
-| `GET /v1/approver/credentials` | List active and revoked passkeys |
-| `POST /v1/approver/credentials/options` | Begin enrolment |
-| `POST /v1/approver/credentials` | Finish enrolment |
-| `DELETE /v1/approver/credentials/{id}` | Revoke one credential |
-| `GET /v1/approvals/{intentId}` | Read approval-safe intent details |
-| `POST /v1/approvals/{intentId}/options` | Create a digest-bound challenge |
-| `POST /v1/approvals/{intentId}` | Approve or reject |
+| Method and path                         | Purpose                           |
+| --------------------------------------- | --------------------------------- |
+| `GET /v1/approver/credentials`          | List active and revoked passkeys  |
+| `POST /v1/approver/credentials/options` | Begin enrolment                   |
+| `POST /v1/approver/credentials`         | Finish enrolment                  |
+| `DELETE /v1/approver/credentials/{id}`  | Revoke one credential             |
+| `GET /v1/approvals/{intentId}`          | Read approval-safe intent details |
+| `POST /v1/approvals/{intentId}/options` | Create a digest-bound challenge   |
+| `POST /v1/approvals/{intentId}`         | Approve or reject                 |
 
 ### Access operator API
 
-| Method and path | Purpose |
-| --- | --- |
-| `GET /admin/api/status` | Read service mode and component health |
-| `POST /admin/api/pause` | Change admission or publication mode |
-| `GET /admin/api/publishers/{did}` | Read authoritative sanitized publisher state |
-| `POST /admin/api/publishers/{did}/suspend` | Suspend or restore publisher admission |
-| `POST /admin/api/publishers/{did}/revoke` | Revoke retained service authority |
-| `POST /admin/api/intents/{id}/cancel` | Stop an unpublished intent |
-| `POST /admin/api/intents/{id}/reconcile` | Trigger bounded reconciliation |
-| `GET /admin/api/audit` | Query global or projected operational audit data |
+| Method and path                            | Purpose                                          |
+| ------------------------------------------ | ------------------------------------------------ |
+| `GET /admin/api/status`                    | Read service mode and component health           |
+| `POST /admin/api/pause`                    | Change admission or publication mode             |
+| `GET /admin/api/publishers/{did}`          | Read authoritative sanitized publisher state     |
+| `POST /admin/api/publishers/{did}/suspend` | Suspend or restore publisher admission           |
+| `POST /admin/api/publishers/{did}/revoke`  | Revoke retained service authority                |
+| `POST /admin/api/intents/{id}/cancel`      | Stop an unpublished intent                       |
+| `POST /admin/api/intents/{id}/reconcile`   | Trigger bounded reconciliation                   |
+| `GET /admin/api/audit`                     | Query global or projected operational audit data |
 
 State-changing requests require content-type validation, CSRF where cookies are used, and idempotency keys. API errors expose stable codes and public-safe messages.
 
@@ -514,28 +514,28 @@ State-changing requests require content-type validation, CSRF where cookies are 
 
 At minimum, the API and Workflow use these error classes:
 
-| Code | Meaning | Retry behavior |
-| --- | --- | --- |
-| `AUTH_INVALID` | Authentication or session proof failed | Permanent for request |
-| `ACCESS_DENIED` | Verified actor lacks required role or ownership | Permanent |
-| `PUBLISHER_SUSPENDED` | Hosted service or operator blocked the publisher | Retry after state change |
-| `SERVICE_PAUSED` | Admission or publication is paused | Retry after state change |
-| `DELEGATION_REQUIRED` | No usable exact-scope session exists | Publisher must reauthorize |
-| `WORKLOAD_NOT_ALLOWED` | OIDC claims do not match active policy | Permanent until policy changes |
-| `IDEMPOTENCY_CONFLICT` | Same key was used with a different request | Permanent |
-| `VERSION_RESERVED` | Package/version belongs to another intent | Permanent or return owner intent |
-| `RELEASE_EXISTS` | Proposed deterministic key already exists | Permanent unless exact replay |
-| `PROFILE_CHANGED` | Authoritative policy changed after verification or approval | Reverify and possibly reapprove |
-| `BASELINE_CHANGED` | Access baseline changed | Reverify and possibly reapprove |
-| `ARTIFACT_INVALID` | Fetch, checksum, bundle, or manifest failed | Permanent for supplied input |
-| `PROVENANCE_INVALID` | Provenance or workload binding failed | Permanent for supplied input |
-| `APPROVAL_REQUIRED` | Valid release awaits human decision | Not an error state |
-| `APPROVAL_INVALID` | DID, credential, challenge, digest, or UV failed | Permanent for attempt |
-| `DELEGATION_REVOKED` | Session was revoked or cannot refresh | Publisher must reauthorize |
-| `PDS_TRANSIENT` | PDS result is retryable | Workflow retry |
-| `PDS_AMBIGUOUS` | Create outcome is unknown | Reconciliation |
-| `RELEASE_CONFLICT` | Deterministic key contains different data | Terminal conflict |
-| `INTERNAL_ERROR` | Public-safe catch-all | Operator-visible correlation ID |
+| Code                   | Meaning                                                     | Retry behavior                   |
+| ---------------------- | ----------------------------------------------------------- | -------------------------------- |
+| `AUTH_INVALID`         | Authentication or session proof failed                      | Permanent for request            |
+| `ACCESS_DENIED`        | Verified actor lacks required role or ownership             | Permanent                        |
+| `PUBLISHER_SUSPENDED`  | Hosted service or operator blocked the publisher            | Retry after state change         |
+| `SERVICE_PAUSED`       | Admission or publication is paused                          | Retry after state change         |
+| `DELEGATION_REQUIRED`  | No usable exact-scope session exists                        | Publisher must reauthorize       |
+| `WORKLOAD_NOT_ALLOWED` | OIDC claims do not match active policy                      | Permanent until policy changes   |
+| `IDEMPOTENCY_CONFLICT` | Same key was used with a different request                  | Permanent                        |
+| `VERSION_RESERVED`     | Package/version belongs to another intent                   | Permanent or return owner intent |
+| `RELEASE_EXISTS`       | Proposed deterministic key already exists                   | Permanent unless exact replay    |
+| `PROFILE_CHANGED`      | Authoritative policy changed after verification or approval | Reverify and possibly reapprove  |
+| `BASELINE_CHANGED`     | Access baseline changed                                     | Reverify and possibly reapprove  |
+| `ARTIFACT_INVALID`     | Fetch, checksum, bundle, or manifest failed                 | Permanent for supplied input     |
+| `PROVENANCE_INVALID`   | Provenance or workload binding failed                       | Permanent for supplied input     |
+| `APPROVAL_REQUIRED`    | Valid release awaits human decision                         | Not an error state               |
+| `APPROVAL_INVALID`     | DID, credential, challenge, digest, or UV failed            | Permanent for attempt            |
+| `DELEGATION_REVOKED`   | Session was revoked or cannot refresh                       | Publisher must reauthorize       |
+| `PDS_TRANSIENT`        | PDS result is retryable                                     | Workflow retry                   |
+| `PDS_AMBIGUOUS`        | Create outcome is unknown                                   | Reconciliation                   |
+| `RELEASE_CONFLICT`     | Deterministic key contains different data                   | Terminal conflict                |
+| `INTERNAL_ERROR`       | Public-safe catch-all                                       | Operator-visible correlation ID  |
 
 Provider payloads, tokens, secrets, raw assertions, private evidence, and stack traces never enter public errors or persistent generic error strings.
 


### PR DESCRIPTION
## What does this PR do?

Adds the current delegated release service specification and implementation plan. The documents define Durable Object ownership, Cloudflare Access operator authentication, exact create-only AT Protocol authority, verification and approval invariants, failure recovery, acceptance gates, parallel workstreams, worktree ownership, and stacked-PR sequencing.

Related to RFC #1870 and Discussion #1590.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1590

Typecheck, lint, tests, admin i18n, and changesets are not applicable to these internal technical specifications.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 (Codex)

## Screenshots / test output

Not applicable; the specification and plan were reviewed against the current implementation, package contracts, Cloudflare platform guidance, and the real npmX/Cirrus conformance evidence.

