### PR TITLE
feat(registry): add listing moderation contracts

### DIFF
--- a/.changeset/quiet-listings-pass.md
+++ b/.changeset/quiet-listings-pass.md
@@ -1,0 +1,8 @@
+---
+"@emdash-cms/registry-moderation": minor
+"@emdash-cms/registry-lexicons": minor
+---
+
+Adds shared, CID-bound plugin-listing moderation contracts for reducing signed AT Protocol labels and deciding which package-profile and release revisions are eligible for display.
+
+The registry Lexicons add experimental public assessment and policy queries. The contracts cover publisher-controlled listing metadata and displayed media; they do not assess plugin code.

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/getLatestRelease.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/getLatestRelease.json
@@ -34,6 +34,10 @@
 				{
 					"name": "NotFound",
 					"description": "No eligible release for the given (did, package)."
+				},
+				{
+					"name": "ListingUnavailable",
+					"description": "The package is indexed but has no release revision available under the aggregator's listing policy. No publisher-controlled content is returned."
 				}
 			]
 		}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/getPackage.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/getPackage.json
@@ -34,6 +34,10 @@
 				{
 					"name": "NotFound",
 					"description": "No package indexed under the given (did, slug). Aggregators that hard-delete on publisher deletion (rather than soft-deleting) return NotFound for both the never-indexed and the deleted cases — clients should treat them equivalently."
+				},
+				{
+					"name": "ListingUnavailable",
+					"description": "The package is indexed but has no profile revision available under the aggregator's listing policy. No publisher-controlled content is returned."
 				}
 			]
 		}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/listReleases.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/listReleases.json
@@ -61,6 +61,10 @@
 				{
 					"name": "NotFound",
 					"description": "No package indexed under the given (did, package)."
+				},
+				{
+					"name": "ListingUnavailable",
+					"description": "The package is indexed but no release revision is available under the aggregator's listing policy. No publisher-controlled content is returned."
 				}
 			]
 		}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/resolvePackage.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/resolvePackage.json
@@ -38,6 +38,10 @@
 				{
 					"name": "NotFound",
 					"description": "No package indexed under the resolved (did, slug)."
+				},
+				{
+					"name": "ListingUnavailable",
+					"description": "The resolved package is indexed but has no profile revision available under the aggregator's listing policy. No publisher-controlled content is returned."
 				}
 			]
 		}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/defs.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/defs.json
@@ -103,14 +103,13 @@
 					"type": "string",
 					"knownValues": [
 						"explicit-sexual-content",
-						"hateful-content",
+						"hateful-or-dehumanizing-content",
 						"graphic-violence",
-						"phishing",
-						"impersonation",
+						"phishing-or-credential-solicitation",
+						"material-impersonation",
 						"scam-or-spam",
-						"malicious-link",
-						"misleading-content",
-						"uncertain"
+						"malicious-or-deceptive-link",
+						"misleading-media-or-claims"
 					]
 				},
 				"reasonCode": {

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/defs.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/defs.json
@@ -1,0 +1,464 @@
+{
+	"lexicon": 1,
+	"id": "com.emdashcms.experimental.labeler.defs",
+	"description": "Public assessment and policy views for the experimental EmDash plugin-listing labeler. Signed moderation decisions use com.atproto.label definitions. EXPERIMENTAL.",
+	"defs": {
+		"assessmentSubject": {
+			"type": "object",
+			"description": "An exact publisher record revision assessed for display in a plugin listing.",
+			"required": ["kind", "uri", "cid"],
+			"properties": {
+				"kind": {
+					"type": "string",
+					"knownValues": ["profile", "release"],
+					"description": "Whether the record supplies package-profile metadata or release metadata and media."
+				},
+				"uri": {
+					"type": "string",
+					"format": "at-uri",
+					"description": "AT URI of the assessed record."
+				},
+				"cid": {
+					"type": "string",
+					"format": "cid",
+					"description": "CID of the exact assessed record revision."
+				}
+			}
+		},
+		"coverage": {
+			"type": "object",
+			"description": "Completion state for every class of publisher-controlled content the admin may display or link.",
+			"required": ["text", "links", "media"],
+			"properties": {
+				"text": {
+					"type": "string",
+					"knownValues": ["complete", "not-present", "unavailable"]
+				},
+				"links": {
+					"type": "string",
+					"knownValues": ["complete", "not-present", "unavailable"]
+				},
+				"media": {
+					"type": "string",
+					"knownValues": ["complete", "not-present", "partial", "unavailable"]
+				}
+			}
+		},
+		"publicFinding": {
+			"type": "object",
+			"description": "A bounded, public-safe policy finding. It contains no publisher content or private evidence.",
+			"required": ["category", "reasonCode", "summary"],
+			"properties": {
+				"category": {
+					"type": "string",
+					"knownValues": [
+						"explicit-sexual-content",
+						"hateful-content",
+						"graphic-violence",
+						"phishing",
+						"impersonation",
+						"scam-or-spam",
+						"malicious-link",
+						"misleading-content",
+						"uncertain"
+					]
+				},
+				"reasonCode": {
+					"type": "string",
+					"description": "Stable code defined by the assessment's policy version.",
+					"minLength": 1,
+					"maxLength": 64
+				},
+				"summary": {
+					"type": "string",
+					"description": "Labeler-authored public explanation without raw assessed content.",
+					"minLength": 1,
+					"maxLength": 512
+				}
+			}
+		},
+		"modelDescriptor": {
+			"type": "object",
+			"description": "Versioned inference configuration used for one assessment purpose.",
+			"required": ["purpose", "provider", "modelId", "modelVersion", "promptHash"],
+			"properties": {
+				"purpose": {
+					"type": "string",
+					"knownValues": ["text", "image"]
+				},
+				"provider": {
+					"type": "string",
+					"knownValues": ["workers-ai"],
+					"maxLength": 64
+				},
+				"modelId": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 256
+				},
+				"modelVersion": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 128
+				},
+				"promptHash": {
+					"type": "string",
+					"description": "Stable digest of the prompt and strict output contract.",
+					"minLength": 1,
+					"maxLength": 128
+				}
+			}
+		},
+		"manualDecision": {
+			"type": "object",
+			"description": "Public portion of an exact-revision operator decision.",
+			"required": ["outcome", "reasonCode", "decidedAt"],
+			"properties": {
+				"outcome": {
+					"type": "string",
+					"knownValues": ["approved", "blocked"]
+				},
+				"reasonCode": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 64
+				},
+				"decidedAt": {
+					"type": "string",
+					"format": "datetime"
+				}
+			}
+		},
+		"publicAssessment": {
+			"type": "object",
+			"description": "Public-safe explanation of one immutable metadata-only assessment run. The labels field contains standard signed ATProto labels and is the moderation authority.",
+			"required": [
+				"id",
+				"src",
+				"subject",
+				"state",
+				"coverage",
+				"reasonCodes",
+				"findings",
+				"assessmentSchemaVersion",
+				"policyVersion",
+				"parserVersion",
+				"models",
+				"labels",
+				"createdAt"
+			],
+			"properties": {
+				"id": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 100
+				},
+				"src": {
+					"type": "string",
+					"format": "did",
+					"description": "DID that issues this assessment's signed labels."
+				},
+				"subject": {
+					"type": "ref",
+					"ref": "#assessmentSubject"
+				},
+				"state": {
+					"type": "string",
+					"knownValues": ["pending", "passed", "review", "blocked", "error", "superseded"]
+				},
+				"coverage": {
+					"type": "ref",
+					"ref": "#coverage"
+				},
+				"reasonCodes": {
+					"type": "array",
+					"description": "Stable public reason codes defined by policyVersion.",
+					"maxLength": 32,
+					"items": {
+						"type": "string",
+						"minLength": 1,
+						"maxLength": 64
+					}
+				},
+				"findings": {
+					"type": "array",
+					"maxLength": 32,
+					"items": {
+						"type": "ref",
+						"ref": "#publicFinding"
+					}
+				},
+				"summary": {
+					"type": "string",
+					"description": "Optional labeler-authored public summary without raw assessed content.",
+					"maxLength": 1024
+				},
+				"assessmentSchemaVersion": {
+					"type": "integer",
+					"minimum": 1
+				},
+				"policyVersion": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 128
+				},
+				"parserVersion": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 128
+				},
+				"models": {
+					"type": "array",
+					"maxLength": 4,
+					"items": {
+						"type": "ref",
+						"ref": "#modelDescriptor"
+					}
+				},
+				"labels": {
+					"type": "array",
+					"description": "Standard signed ATProto labels issued by this assessment run.",
+					"maxLength": 16,
+					"items": {
+						"type": "ref",
+						"ref": "com.atproto.label.defs#label"
+					}
+				},
+				"manualDecision": {
+					"type": "ref",
+					"ref": "#manualDecision"
+				},
+				"createdAt": {
+					"type": "string",
+					"format": "datetime"
+				},
+				"completedAt": {
+					"type": "string",
+					"format": "datetime"
+				},
+				"supersededByAssessmentId": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 100
+				}
+			}
+		},
+		"currentAssessmentView": {
+			"type": "object",
+			"description": "Current assessment and effective standard labels for one exact record revision.",
+			"required": ["src", "subject", "assessment", "activeLabels"],
+			"properties": {
+				"src": {
+					"type": "string",
+					"format": "did"
+				},
+				"subject": {
+					"type": "ref",
+					"ref": "#assessmentSubject"
+				},
+				"assessment": {
+					"type": "ref",
+					"ref": "#publicAssessment"
+				},
+				"activeLabels": {
+					"type": "array",
+					"maxLength": 16,
+					"items": {
+						"type": "ref",
+						"ref": "com.atproto.label.defs#label"
+					}
+				}
+			}
+		},
+		"subjectPolicy": {
+			"type": "object",
+			"required": ["kind", "collection"],
+			"properties": {
+				"kind": {
+					"type": "string",
+					"knownValues": ["profile", "release"]
+				},
+				"collection": {
+					"type": "string",
+					"format": "nsid"
+				}
+			}
+		},
+		"reasonCodeDefinition": {
+			"type": "object",
+			"required": ["code", "description"],
+			"properties": {
+				"code": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 64
+				},
+				"description": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 512
+				}
+			}
+		},
+		"labelDefinition": {
+			"type": "object",
+			"description": "Public policy meaning for a standard ATProto label value; this is not a second label format.",
+			"required": ["value", "officialEffect", "subjectKinds", "issuanceModes"],
+			"properties": {
+				"value": {
+					"type": "string",
+					"knownValues": [
+						"listing-passed",
+						"listing-pending",
+						"listing-review",
+						"listing-error",
+						"listing-blocked",
+						"listing-overridden",
+						"!takedown"
+					],
+					"minLength": 1,
+					"maxLength": 128
+				},
+				"officialEffect": {
+					"type": "string",
+					"knownValues": ["eligible", "ineligible", "informational", "redact"]
+				},
+				"subjectKinds": {
+					"type": "array",
+					"minLength": 1,
+					"maxLength": 2,
+					"items": {
+						"type": "string",
+						"knownValues": ["profile", "release"]
+					}
+				},
+				"issuanceModes": {
+					"type": "array",
+					"minLength": 1,
+					"maxLength": 3,
+					"items": {
+						"type": "string",
+						"knownValues": ["automated", "reviewer", "admin"]
+					}
+				}
+			}
+		},
+		"publicApi": {
+			"type": "object",
+			"required": [
+				"baseUrl",
+				"getAssessmentNsid",
+				"getCurrentAssessmentNsid",
+				"listAssessmentsNsid",
+				"getPolicyNsid"
+			],
+			"properties": {
+				"baseUrl": {
+					"type": "string",
+					"format": "uri",
+					"maxLength": 2048
+				},
+				"getAssessmentNsid": {
+					"type": "string",
+					"format": "nsid"
+				},
+				"getCurrentAssessmentNsid": {
+					"type": "string",
+					"format": "nsid"
+				},
+				"listAssessmentsNsid": {
+					"type": "string",
+					"format": "nsid"
+				},
+				"getPolicyNsid": {
+					"type": "string",
+					"format": "nsid"
+				}
+			}
+		},
+		"labelerPolicy": {
+			"type": "object",
+			"description": "Versioned public description of this labeler's metadata-only assessment and standard-label policy.",
+			"required": [
+				"schemaVersion",
+				"policyVersion",
+				"effectiveAt",
+				"labelerDid",
+				"assessmentSchemaVersion",
+				"parserVersion",
+				"supportedSubjects",
+				"reasonCodes",
+				"labels",
+				"models",
+				"publicApi"
+			],
+			"properties": {
+				"schemaVersion": {
+					"type": "integer",
+					"minimum": 1,
+					"maximum": 1
+				},
+				"policyVersion": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 128
+				},
+				"effectiveAt": {
+					"type": "string",
+					"format": "datetime"
+				},
+				"labelerDid": {
+					"type": "string",
+					"format": "did"
+				},
+				"assessmentSchemaVersion": {
+					"type": "integer",
+					"minimum": 1
+				},
+				"parserVersion": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 128
+				},
+				"supportedSubjects": {
+					"type": "array",
+					"minLength": 1,
+					"maxLength": 2,
+					"items": {
+						"type": "ref",
+						"ref": "#subjectPolicy"
+					}
+				},
+				"reasonCodes": {
+					"type": "array",
+					"maxLength": 64,
+					"items": {
+						"type": "ref",
+						"ref": "#reasonCodeDefinition"
+					}
+				},
+				"labels": {
+					"type": "array",
+					"minLength": 1,
+					"maxLength": 16,
+					"items": {
+						"type": "ref",
+						"ref": "#labelDefinition"
+					}
+				},
+				"models": {
+					"type": "array",
+					"maxLength": 4,
+					"items": {
+						"type": "ref",
+						"ref": "#modelDescriptor"
+					}
+				},
+				"publicApi": {
+					"type": "ref",
+					"ref": "#publicApi"
+				}
+			}
+		}
+	}
+}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/defs.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/defs.json
@@ -1,7 +1,7 @@
 {
 	"lexicon": 1,
 	"id": "com.emdashcms.experimental.labeler.defs",
-	"description": "Public assessment and policy views for the experimental EmDash plugin-listing labeler. Signed moderation decisions use com.atproto.label definitions. EXPERIMENTAL.",
+	"description": "Public assessment and policy views for the experimental EmDash plugin-listing labeler. Effective moderation decisions are standard signed labels served through com.atproto.label queries and subscriptions. EXPERIMENTAL.",
 	"defs": {
 		"assessmentSubject": {
 			"type": "object",
@@ -22,6 +22,56 @@
 					"type": "string",
 					"format": "cid",
 					"description": "CID of the exact assessed record revision."
+				}
+			}
+		},
+		"signedLabel": {
+			"type": "object",
+			"description": "A standard AT Protocol label with a required signature. Its payload and stored history are immutable; query and subscription delivery may replace sig with a signature from the current key during key rotation.",
+			"required": ["ver", "src", "uri", "val", "cts", "sig"],
+			"properties": {
+				"ver": {
+					"type": "integer",
+					"description": "AT Protocol label version."
+				},
+				"src": {
+					"type": "string",
+					"format": "did",
+					"description": "DID of the label issuer."
+				},
+				"uri": {
+					"type": "string",
+					"format": "uri",
+					"description": "Resource to which the label applies."
+				},
+				"cid": {
+					"type": "string",
+					"format": "cid",
+					"description": "Optional CID of the exact resource revision to which the label applies."
+				},
+				"val": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 128,
+					"description": "Label value."
+				},
+				"neg": {
+					"type": "boolean",
+					"description": "Whether this event negates prior label state."
+				},
+				"cts": {
+					"type": "string",
+					"format": "datetime",
+					"description": "Time at which the label was created."
+				},
+				"exp": {
+					"type": "string",
+					"format": "datetime",
+					"description": "Optional time after which the label no longer applies."
+				},
+				"sig": {
+					"type": "bytes",
+					"description": "Signature over the canonical DAG-CBOR label payload."
 				}
 			}
 		},
@@ -131,7 +181,7 @@
 		},
 		"publicAssessment": {
 			"type": "object",
-			"description": "Public-safe explanation of one immutable metadata-only assessment run. The labels field contains standard signed ATProto labels and is the moderation authority.",
+			"description": "Public-safe explanation of one immutable metadata-only assessment run. Its labels field contains signed outcome labels emitted by that run, not a second source of effective moderation state.",
 			"required": [
 				"id",
 				"src",
@@ -217,11 +267,11 @@
 				},
 				"labels": {
 					"type": "array",
-					"description": "Standard signed ATProto labels issued by this assessment run.",
+					"description": "Signed outcome labels emitted by this assessment run. Effective moderation state comes from com.atproto.label queries and subscriptions.",
 					"maxLength": 16,
 					"items": {
 						"type": "ref",
-						"ref": "com.atproto.label.defs#label"
+						"ref": "#signedLabel"
 					}
 				},
 				"manualDecision": {
@@ -245,7 +295,7 @@
 		},
 		"currentAssessmentView": {
 			"type": "object",
-			"description": "Current assessment and effective standard labels for one exact record revision.",
+			"description": "Current assessment and effective standard signed labels for one exact record revision. activeLabels is the moderation authority for this view.",
 			"required": ["src", "subject", "assessment", "activeLabels"],
 			"properties": {
 				"src": {
@@ -262,10 +312,11 @@
 				},
 				"activeLabels": {
 					"type": "array",
+					"description": "Effective signed label state for this exact record revision.",
 					"maxLength": 16,
 					"items": {
 						"type": "ref",
-						"ref": "com.atproto.label.defs#label"
+						"ref": "#signedLabel"
 					}
 				}
 			}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/getAssessment.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/getAssessment.json
@@ -1,0 +1,38 @@
+{
+	"lexicon": 1,
+	"id": "com.emdashcms.experimental.labeler.getAssessment",
+	"description": "Fetch one immutable public metadata assessment by ID. EXPERIMENTAL.",
+	"defs": {
+		"main": {
+			"type": "query",
+			"parameters": {
+				"type": "params",
+				"required": ["id"],
+				"properties": {
+					"id": {
+						"type": "string",
+						"minLength": 1,
+						"maxLength": 100
+					}
+				}
+			},
+			"output": {
+				"encoding": "application/json",
+				"schema": {
+					"type": "ref",
+					"ref": "com.emdashcms.experimental.labeler.defs#publicAssessment"
+				}
+			},
+			"errors": [
+				{
+					"name": "InvalidRequest",
+					"description": "The assessment ID is invalid."
+				},
+				{
+					"name": "NotFound",
+					"description": "No public assessment exists with this ID."
+				}
+			]
+		}
+	}
+}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/getCurrentAssessment.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/getCurrentAssessment.json
@@ -1,0 +1,49 @@
+{
+	"lexicon": 1,
+	"id": "com.emdashcms.experimental.labeler.getCurrentAssessment",
+	"description": "Fetch the effective assessment and signed label state for an exact package-profile or release revision. EXPERIMENTAL.",
+	"defs": {
+		"main": {
+			"type": "query",
+			"parameters": {
+				"type": "params",
+				"required": ["kind", "uri", "cid"],
+				"properties": {
+					"kind": {
+						"type": "string",
+						"knownValues": ["profile", "release"]
+					},
+					"uri": {
+						"type": "string",
+						"format": "at-uri"
+					},
+					"cid": {
+						"type": "string",
+						"format": "cid"
+					}
+				}
+			},
+			"output": {
+				"encoding": "application/json",
+				"schema": {
+					"type": "ref",
+					"ref": "com.emdashcms.experimental.labeler.defs#currentAssessmentView"
+				}
+			},
+			"errors": [
+				{
+					"name": "InvalidRequest",
+					"description": "The subject kind, URI, or CID is invalid or inconsistent."
+				},
+				{
+					"name": "NotFound",
+					"description": "No public assessment exists for this exact record revision."
+				},
+				{
+					"name": "ConflictingLabels",
+					"description": "The winning signed label state contains conflicting events and is withheld."
+				}
+			]
+		}
+	}
+}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/getPolicy.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/getPolicy.json
@@ -1,0 +1,17 @@
+{
+	"lexicon": 1,
+	"id": "com.emdashcms.experimental.labeler.getPolicy",
+	"description": "Fetch the current public metadata-assessment and standard-label policy. EXPERIMENTAL.",
+	"defs": {
+		"main": {
+			"type": "query",
+			"output": {
+				"encoding": "application/json",
+				"schema": {
+					"type": "ref",
+					"ref": "com.emdashcms.experimental.labeler.defs#labelerPolicy"
+				}
+			}
+		}
+	}
+}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/listAssessments.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/labeler/listAssessments.json
@@ -1,0 +1,72 @@
+{
+	"lexicon": 1,
+	"id": "com.emdashcms.experimental.labeler.listAssessments",
+	"description": "Page through public metadata assessments using bounded subject and state filters. EXPERIMENTAL.",
+	"defs": {
+		"main": {
+			"type": "query",
+			"parameters": {
+				"type": "params",
+				"properties": {
+					"kind": {
+						"type": "string",
+						"knownValues": ["profile", "release"]
+					},
+					"uri": {
+						"type": "string",
+						"format": "at-uri"
+					},
+					"cid": {
+						"type": "string",
+						"format": "cid"
+					},
+					"state": {
+						"type": "string",
+						"knownValues": ["pending", "passed", "review", "blocked", "error", "superseded"]
+					},
+					"limit": {
+						"type": "integer",
+						"minimum": 1,
+						"maximum": 100,
+						"default": 50
+					},
+					"cursor": {
+						"type": "string",
+						"maxLength": 1024
+					}
+				}
+			},
+			"output": {
+				"encoding": "application/json",
+				"schema": {
+					"type": "object",
+					"required": ["assessments"],
+					"properties": {
+						"assessments": {
+							"type": "array",
+							"maxLength": 100,
+							"items": {
+								"type": "ref",
+								"ref": "com.emdashcms.experimental.labeler.defs#publicAssessment"
+							}
+						},
+						"cursor": {
+							"type": "string",
+							"maxLength": 1024
+						}
+					}
+				}
+			},
+			"errors": [
+				{
+					"name": "InvalidRequest",
+					"description": "The supplied filters are invalid or inconsistent."
+				},
+				{
+					"name": "InvalidCursor",
+					"description": "The pagination cursor is invalid or expired."
+				}
+			]
+		}
+	}
+}

--- a/packages/registry-lexicons/package.json
+++ b/packages/registry-lexicons/package.json
@@ -45,6 +45,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "catalog:",
 		"@atcute/lex-cli": "catalog:",
+		"@emdash-cms/registry-moderation": "workspace:*",
 		"publint": "catalog:",
 		"tsdown": "catalog:",
 		"typescript": "catalog:",

--- a/packages/registry-lexicons/src/generated/index.ts
+++ b/packages/registry-lexicons/src/generated/index.ts
@@ -4,6 +4,11 @@ export * as ComEmdashcmsExperimentalAggregatorGetPackage from "./types/com/emdas
 export * as ComEmdashcmsExperimentalAggregatorListReleases from "./types/com/emdashcms/experimental/aggregator/listReleases.js";
 export * as ComEmdashcmsExperimentalAggregatorResolvePackage from "./types/com/emdashcms/experimental/aggregator/resolvePackage.js";
 export * as ComEmdashcmsExperimentalAggregatorSearchPackages from "./types/com/emdashcms/experimental/aggregator/searchPackages.js";
+export * as ComEmdashcmsExperimentalLabelerDefs from "./types/com/emdashcms/experimental/labeler/defs.js";
+export * as ComEmdashcmsExperimentalLabelerGetAssessment from "./types/com/emdashcms/experimental/labeler/getAssessment.js";
+export * as ComEmdashcmsExperimentalLabelerGetCurrentAssessment from "./types/com/emdashcms/experimental/labeler/getCurrentAssessment.js";
+export * as ComEmdashcmsExperimentalLabelerGetPolicy from "./types/com/emdashcms/experimental/labeler/getPolicy.js";
+export * as ComEmdashcmsExperimentalLabelerListAssessments from "./types/com/emdashcms/experimental/labeler/listAssessments.js";
 export * as ComEmdashcmsExperimentalPackageProfile from "./types/com/emdashcms/experimental/package/profile.js";
 export * as ComEmdashcmsExperimentalPackageProfileExtension from "./types/com/emdashcms/experimental/package/profileExtension.js";
 export * as ComEmdashcmsExperimentalPackageRelease from "./types/com/emdashcms/experimental/package/release.js";

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/defs.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/defs.ts
@@ -379,13 +379,12 @@ const _publicFindingSchema = /*#__PURE__*/ v.object({
 	category: /*#__PURE__*/ v.string<
 		| "explicit-sexual-content"
 		| "graphic-violence"
-		| "hateful-content"
-		| "impersonation"
-		| "malicious-link"
-		| "misleading-content"
-		| "phishing"
+		| "hateful-or-dehumanizing-content"
+		| "malicious-or-deceptive-link"
+		| "material-impersonation"
+		| "misleading-media-or-claims"
+		| "phishing-or-credential-solicitation"
 		| "scam-or-spam"
-		| "uncertain"
 		| (string & {})
 	>(),
 	/**

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/defs.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/defs.ts
@@ -1,6 +1,5 @@
 import type {} from "@atcute/lexicons";
 import * as v from "@atcute/lexicons/validations";
-import * as ComAtprotoLabelDefs from "@atcute/atproto/types/label/defs";
 
 const _assessmentSubjectSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
@@ -42,13 +41,13 @@ const _currentAssessmentViewSchema = /*#__PURE__*/ v.object({
 		),
 	),
 	/**
+	 * Effective signed label state for this exact record revision.
 	 * @maxLength 16
 	 */
 	get activeLabels() {
-		return /*#__PURE__*/ v.constrain(
-			/*#__PURE__*/ v.array(ComAtprotoLabelDefs.labelSchema),
-			[/*#__PURE__*/ v.arrayLength(0, 16)],
-		);
+		return /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.array(signedLabelSchema), [
+			/*#__PURE__*/ v.arrayLength(0, 16),
+		]);
 	},
 	get assessment() {
 		return publicAssessmentSchema;
@@ -290,14 +289,13 @@ const _publicAssessmentSchema = /*#__PURE__*/ v.object({
 		/*#__PURE__*/ v.stringLength(1, 100),
 	]),
 	/**
-	 * Standard signed ATProto labels issued by this assessment run.
+	 * Signed outcome labels emitted by this assessment run. Effective moderation state comes from com.atproto.label queries and subscriptions.
 	 * @maxLength 16
 	 */
 	get labels() {
-		return /*#__PURE__*/ v.constrain(
-			/*#__PURE__*/ v.array(ComAtprotoLabelDefs.labelSchema),
-			[/*#__PURE__*/ v.arrayLength(0, 16)],
-		);
+		return /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.array(signedLabelSchema), [
+			/*#__PURE__*/ v.arrayLength(0, 16),
+		]);
 	},
 	get manualDecision() {
 		return /*#__PURE__*/ v.optional(manualDecisionSchema);
@@ -428,6 +426,53 @@ const _reasonCodeDefinitionSchema = /*#__PURE__*/ v.object({
 		/*#__PURE__*/ v.stringLength(1, 512),
 	]),
 });
+const _signedLabelSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeler.defs#signedLabel",
+		),
+	),
+	/**
+	 * Optional CID of the exact resource revision to which the label applies.
+	 */
+	cid: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.cidString()),
+	/**
+	 * Time at which the label was created.
+	 */
+	cts: /*#__PURE__*/ v.datetimeString(),
+	/**
+	 * Optional time after which the label no longer applies.
+	 */
+	exp: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.datetimeString()),
+	/**
+	 * Whether this event negates prior label state.
+	 */
+	neg: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.boolean()),
+	/**
+	 * Signature over the canonical DAG-CBOR label payload.
+	 */
+	sig: /*#__PURE__*/ v.bytes(),
+	/**
+	 * DID of the label issuer.
+	 */
+	src: /*#__PURE__*/ v.didString(),
+	/**
+	 * Resource to which the label applies.
+	 */
+	uri: /*#__PURE__*/ v.genericUriString(),
+	/**
+	 * Label value.
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	val: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+	/**
+	 * AT Protocol label version.
+	 */
+	ver: /*#__PURE__*/ v.integer(),
+});
 const _subjectPolicySchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
 		/*#__PURE__*/ v.literal(
@@ -449,6 +494,7 @@ type publicApi$schematype = typeof _publicApiSchema;
 type publicAssessment$schematype = typeof _publicAssessmentSchema;
 type publicFinding$schematype = typeof _publicFindingSchema;
 type reasonCodeDefinition$schematype = typeof _reasonCodeDefinitionSchema;
+type signedLabel$schematype = typeof _signedLabelSchema;
 type subjectPolicy$schematype = typeof _subjectPolicySchema;
 
 export interface assessmentSubjectSchema extends assessmentSubject$schematype {}
@@ -462,6 +508,7 @@ export interface publicApiSchema extends publicApi$schematype {}
 export interface publicAssessmentSchema extends publicAssessment$schematype {}
 export interface publicFindingSchema extends publicFinding$schematype {}
 export interface reasonCodeDefinitionSchema extends reasonCodeDefinition$schematype {}
+export interface signedLabelSchema extends signedLabel$schematype {}
 export interface subjectPolicySchema extends subjectPolicy$schematype {}
 
 export const assessmentSubjectSchema =
@@ -482,6 +529,7 @@ export const publicAssessmentSchema =
 export const publicFindingSchema = _publicFindingSchema as publicFindingSchema;
 export const reasonCodeDefinitionSchema =
 	_reasonCodeDefinitionSchema as reasonCodeDefinitionSchema;
+export const signedLabelSchema = _signedLabelSchema as signedLabelSchema;
 export const subjectPolicySchema = _subjectPolicySchema as subjectPolicySchema;
 
 export interface AssessmentSubject extends v.InferInput<
@@ -513,6 +561,7 @@ export interface PublicFinding extends v.InferInput<
 export interface ReasonCodeDefinition extends v.InferInput<
 	typeof reasonCodeDefinitionSchema
 > {}
+export interface SignedLabel extends v.InferInput<typeof signedLabelSchema> {}
 export interface SubjectPolicy extends v.InferInput<
 	typeof subjectPolicySchema
 > {}

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/defs.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/defs.ts
@@ -1,0 +1,518 @@
+import type {} from "@atcute/lexicons";
+import * as v from "@atcute/lexicons/validations";
+import * as ComAtprotoLabelDefs from "@atcute/atproto/types/label/defs";
+
+const _assessmentSubjectSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeler.defs#assessmentSubject",
+		),
+	),
+	/**
+	 * CID of the exact assessed record revision.
+	 */
+	cid: /*#__PURE__*/ v.cidString(),
+	/**
+	 * Whether the record supplies package-profile metadata or release metadata and media.
+	 */
+	kind: /*#__PURE__*/ v.string<"profile" | "release" | (string & {})>(),
+	/**
+	 * AT URI of the assessed record.
+	 */
+	uri: /*#__PURE__*/ v.resourceUriString(),
+});
+const _coverageSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal("com.emdashcms.experimental.labeler.defs#coverage"),
+	),
+	links: /*#__PURE__*/ v.string<
+		"complete" | "not-present" | "unavailable" | (string & {})
+	>(),
+	media: /*#__PURE__*/ v.string<
+		"complete" | "not-present" | "partial" | "unavailable" | (string & {})
+	>(),
+	text: /*#__PURE__*/ v.string<
+		"complete" | "not-present" | "unavailable" | (string & {})
+	>(),
+});
+const _currentAssessmentViewSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeler.defs#currentAssessmentView",
+		),
+	),
+	/**
+	 * @maxLength 16
+	 */
+	get activeLabels() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(ComAtprotoLabelDefs.labelSchema),
+			[/*#__PURE__*/ v.arrayLength(0, 16)],
+		);
+	},
+	get assessment() {
+		return publicAssessmentSchema;
+	},
+	src: /*#__PURE__*/ v.didString(),
+	get subject() {
+		return assessmentSubjectSchema;
+	},
+});
+const _labelDefinitionSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeler.defs#labelDefinition",
+		),
+	),
+	/**
+	 * @minLength 1
+	 * @maxLength 3
+	 */
+	issuanceModes: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.array(
+			/*#__PURE__*/ v.string<
+				"admin" | "automated" | "reviewer" | (string & {})
+			>(),
+		),
+		[/*#__PURE__*/ v.arrayLength(1, 3)],
+	),
+	officialEffect: /*#__PURE__*/ v.string<
+		"eligible" | "ineligible" | "informational" | "redact" | (string & {})
+	>(),
+	/**
+	 * @minLength 1
+	 * @maxLength 2
+	 */
+	subjectKinds: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.array(
+			/*#__PURE__*/ v.string<"profile" | "release" | (string & {})>(),
+		),
+		[/*#__PURE__*/ v.arrayLength(1, 2)],
+	),
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	value: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.string<
+			| "!takedown"
+			| "listing-blocked"
+			| "listing-error"
+			| "listing-overridden"
+			| "listing-passed"
+			| "listing-pending"
+			| "listing-review"
+			| (string & {})
+		>(),
+		[/*#__PURE__*/ v.stringLength(1, 128)],
+	),
+});
+const _labelerPolicySchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeler.defs#labelerPolicy",
+		),
+	),
+	/**
+	 * @minimum 1
+	 */
+	assessmentSchemaVersion: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.integer(),
+		[/*#__PURE__*/ v.integerRange(1)],
+	),
+	effectiveAt: /*#__PURE__*/ v.datetimeString(),
+	labelerDid: /*#__PURE__*/ v.didString(),
+	/**
+	 * @minLength 1
+	 * @maxLength 16
+	 */
+	get labels() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(labelDefinitionSchema),
+			[/*#__PURE__*/ v.arrayLength(1, 16)],
+		);
+	},
+	/**
+	 * @maxLength 4
+	 */
+	get models() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(modelDescriptorSchema),
+			[/*#__PURE__*/ v.arrayLength(0, 4)],
+		);
+	},
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	parserVersion: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	policyVersion: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+	get publicApi() {
+		return publicApiSchema;
+	},
+	/**
+	 * @maxLength 64
+	 */
+	get reasonCodes() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(reasonCodeDefinitionSchema),
+			[/*#__PURE__*/ v.arrayLength(0, 64)],
+		);
+	},
+	/**
+	 * @minimum 1
+	 * @maximum 1
+	 */
+	schemaVersion: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [
+		/*#__PURE__*/ v.integerRange(1, 1),
+	]),
+	/**
+	 * @minLength 1
+	 * @maxLength 2
+	 */
+	get supportedSubjects() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(subjectPolicySchema),
+			[/*#__PURE__*/ v.arrayLength(1, 2)],
+		);
+	},
+});
+const _manualDecisionSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeler.defs#manualDecision",
+		),
+	),
+	decidedAt: /*#__PURE__*/ v.datetimeString(),
+	outcome: /*#__PURE__*/ v.string<"approved" | "blocked" | (string & {})>(),
+	/**
+	 * @minLength 1
+	 * @maxLength 64
+	 */
+	reasonCode: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 64),
+	]),
+});
+const _modelDescriptorSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeler.defs#modelDescriptor",
+		),
+	),
+	/**
+	 * @minLength 1
+	 * @maxLength 256
+	 */
+	modelId: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 256),
+	]),
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	modelVersion: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+	/**
+	 * Stable digest of the prompt and strict output contract.
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	promptHash: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+	/**
+	 * @maxLength 64
+	 */
+	provider: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.string<"workers-ai" | (string & {})>(),
+		[/*#__PURE__*/ v.stringLength(0, 64)],
+	),
+	purpose: /*#__PURE__*/ v.string<"image" | "text" | (string & {})>(),
+});
+const _publicApiSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeler.defs#publicApi",
+		),
+	),
+	/**
+	 * @maxLength 2048
+	 */
+	baseUrl: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.genericUriString(), [
+		/*#__PURE__*/ v.stringLength(0, 2048),
+	]),
+	getAssessmentNsid: /*#__PURE__*/ v.nsidString(),
+	getCurrentAssessmentNsid: /*#__PURE__*/ v.nsidString(),
+	getPolicyNsid: /*#__PURE__*/ v.nsidString(),
+	listAssessmentsNsid: /*#__PURE__*/ v.nsidString(),
+});
+const _publicAssessmentSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeler.defs#publicAssessment",
+		),
+	),
+	/**
+	 * @minimum 1
+	 */
+	assessmentSchemaVersion: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.integer(),
+		[/*#__PURE__*/ v.integerRange(1)],
+	),
+	completedAt: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.datetimeString()),
+	get coverage() {
+		return coverageSchema;
+	},
+	createdAt: /*#__PURE__*/ v.datetimeString(),
+	/**
+	 * @maxLength 32
+	 */
+	get findings() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(publicFindingSchema),
+			[/*#__PURE__*/ v.arrayLength(0, 32)],
+		);
+	},
+	/**
+	 * @minLength 1
+	 * @maxLength 100
+	 */
+	id: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 100),
+	]),
+	/**
+	 * Standard signed ATProto labels issued by this assessment run.
+	 * @maxLength 16
+	 */
+	get labels() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(ComAtprotoLabelDefs.labelSchema),
+			[/*#__PURE__*/ v.arrayLength(0, 16)],
+		);
+	},
+	get manualDecision() {
+		return /*#__PURE__*/ v.optional(manualDecisionSchema);
+	},
+	/**
+	 * @maxLength 4
+	 */
+	get models() {
+		return /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.array(modelDescriptorSchema),
+			[/*#__PURE__*/ v.arrayLength(0, 4)],
+		);
+	},
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	parserVersion: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+	/**
+	 * @minLength 1
+	 * @maxLength 128
+	 */
+	policyVersion: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 128),
+	]),
+	/**
+	 * Stable public reason codes defined by policyVersion.
+	 * @maxLength 32
+	 */
+	reasonCodes: /*#__PURE__*/ v.constrain(
+		/*#__PURE__*/ v.array(
+			/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+				/*#__PURE__*/ v.stringLength(1, 64),
+			]),
+		),
+		[/*#__PURE__*/ v.arrayLength(0, 32)],
+	),
+	/**
+	 * DID that issues this assessment's signed labels.
+	 */
+	src: /*#__PURE__*/ v.didString(),
+	state: /*#__PURE__*/ v.string<
+		| "blocked"
+		| "error"
+		| "passed"
+		| "pending"
+		| "review"
+		| "superseded"
+		| (string & {})
+	>(),
+	get subject() {
+		return assessmentSubjectSchema;
+	},
+	/**
+	 * Optional labeler-authored public summary without raw assessed content.
+	 * @maxLength 1024
+	 */
+	summary: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+			/*#__PURE__*/ v.stringLength(0, 1024),
+		]),
+	),
+	/**
+	 * @minLength 1
+	 * @maxLength 100
+	 */
+	supersededByAssessmentId: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+			/*#__PURE__*/ v.stringLength(1, 100),
+		]),
+	),
+});
+const _publicFindingSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeler.defs#publicFinding",
+		),
+	),
+	category: /*#__PURE__*/ v.string<
+		| "explicit-sexual-content"
+		| "graphic-violence"
+		| "hateful-content"
+		| "impersonation"
+		| "malicious-link"
+		| "misleading-content"
+		| "phishing"
+		| "scam-or-spam"
+		| "uncertain"
+		| (string & {})
+	>(),
+	/**
+	 * Stable code defined by the assessment's policy version.
+	 * @minLength 1
+	 * @maxLength 64
+	 */
+	reasonCode: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 64),
+	]),
+	/**
+	 * Labeler-authored public explanation without raw assessed content.
+	 * @minLength 1
+	 * @maxLength 512
+	 */
+	summary: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 512),
+	]),
+});
+const _reasonCodeDefinitionSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeler.defs#reasonCodeDefinition",
+		),
+	),
+	/**
+	 * @minLength 1
+	 * @maxLength 64
+	 */
+	code: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 64),
+	]),
+	/**
+	 * @minLength 1
+	 * @maxLength 512
+	 */
+	description: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 512),
+	]),
+});
+const _subjectPolicySchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.labeler.defs#subjectPolicy",
+		),
+	),
+	collection: /*#__PURE__*/ v.nsidString(),
+	kind: /*#__PURE__*/ v.string<"profile" | "release" | (string & {})>(),
+});
+
+type assessmentSubject$schematype = typeof _assessmentSubjectSchema;
+type coverage$schematype = typeof _coverageSchema;
+type currentAssessmentView$schematype = typeof _currentAssessmentViewSchema;
+type labelDefinition$schematype = typeof _labelDefinitionSchema;
+type labelerPolicy$schematype = typeof _labelerPolicySchema;
+type manualDecision$schematype = typeof _manualDecisionSchema;
+type modelDescriptor$schematype = typeof _modelDescriptorSchema;
+type publicApi$schematype = typeof _publicApiSchema;
+type publicAssessment$schematype = typeof _publicAssessmentSchema;
+type publicFinding$schematype = typeof _publicFindingSchema;
+type reasonCodeDefinition$schematype = typeof _reasonCodeDefinitionSchema;
+type subjectPolicy$schematype = typeof _subjectPolicySchema;
+
+export interface assessmentSubjectSchema extends assessmentSubject$schematype {}
+export interface coverageSchema extends coverage$schematype {}
+export interface currentAssessmentViewSchema extends currentAssessmentView$schematype {}
+export interface labelDefinitionSchema extends labelDefinition$schematype {}
+export interface labelerPolicySchema extends labelerPolicy$schematype {}
+export interface manualDecisionSchema extends manualDecision$schematype {}
+export interface modelDescriptorSchema extends modelDescriptor$schematype {}
+export interface publicApiSchema extends publicApi$schematype {}
+export interface publicAssessmentSchema extends publicAssessment$schematype {}
+export interface publicFindingSchema extends publicFinding$schematype {}
+export interface reasonCodeDefinitionSchema extends reasonCodeDefinition$schematype {}
+export interface subjectPolicySchema extends subjectPolicy$schematype {}
+
+export const assessmentSubjectSchema =
+	_assessmentSubjectSchema as assessmentSubjectSchema;
+export const coverageSchema = _coverageSchema as coverageSchema;
+export const currentAssessmentViewSchema =
+	_currentAssessmentViewSchema as currentAssessmentViewSchema;
+export const labelDefinitionSchema =
+	_labelDefinitionSchema as labelDefinitionSchema;
+export const labelerPolicySchema = _labelerPolicySchema as labelerPolicySchema;
+export const manualDecisionSchema =
+	_manualDecisionSchema as manualDecisionSchema;
+export const modelDescriptorSchema =
+	_modelDescriptorSchema as modelDescriptorSchema;
+export const publicApiSchema = _publicApiSchema as publicApiSchema;
+export const publicAssessmentSchema =
+	_publicAssessmentSchema as publicAssessmentSchema;
+export const publicFindingSchema = _publicFindingSchema as publicFindingSchema;
+export const reasonCodeDefinitionSchema =
+	_reasonCodeDefinitionSchema as reasonCodeDefinitionSchema;
+export const subjectPolicySchema = _subjectPolicySchema as subjectPolicySchema;
+
+export interface AssessmentSubject extends v.InferInput<
+	typeof assessmentSubjectSchema
+> {}
+export interface Coverage extends v.InferInput<typeof coverageSchema> {}
+export interface CurrentAssessmentView extends v.InferInput<
+	typeof currentAssessmentViewSchema
+> {}
+export interface LabelDefinition extends v.InferInput<
+	typeof labelDefinitionSchema
+> {}
+export interface LabelerPolicy extends v.InferInput<
+	typeof labelerPolicySchema
+> {}
+export interface ManualDecision extends v.InferInput<
+	typeof manualDecisionSchema
+> {}
+export interface ModelDescriptor extends v.InferInput<
+	typeof modelDescriptorSchema
+> {}
+export interface PublicApi extends v.InferInput<typeof publicApiSchema> {}
+export interface PublicAssessment extends v.InferInput<
+	typeof publicAssessmentSchema
+> {}
+export interface PublicFinding extends v.InferInput<
+	typeof publicFindingSchema
+> {}
+export interface ReasonCodeDefinition extends v.InferInput<
+	typeof reasonCodeDefinitionSchema
+> {}
+export interface SubjectPolicy extends v.InferInput<
+	typeof subjectPolicySchema
+> {}

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/getAssessment.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/getAssessment.ts
@@ -1,0 +1,40 @@
+import type {} from "@atcute/lexicons";
+import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
+import * as ComEmdashcmsExperimentalLabelerDefs from "./defs.js";
+
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.labeler.getAssessment",
+	{
+		params: /*#__PURE__*/ v.object({
+			/**
+			 * @minLength 1
+			 * @maxLength 100
+			 */
+			id: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+				/*#__PURE__*/ v.stringLength(1, 100),
+			]),
+		}),
+		output: {
+			type: "lex",
+			get schema() {
+				return ComEmdashcmsExperimentalLabelerDefs.publicAssessmentSchema;
+			},
+		},
+	},
+);
+
+type main$schematype = typeof _mainSchema;
+
+export interface mainSchema extends main$schematype {}
+
+export const mainSchema = _mainSchema as mainSchema;
+
+export interface $params extends v.InferInput<mainSchema["params"]> {}
+export type $output = v.InferXRPCBodyInput<mainSchema["output"]>;
+
+declare module "@atcute/lexicons/ambient" {
+	interface XRPCQueries {
+		"com.emdashcms.experimental.labeler.getAssessment": mainSchema;
+	}
+}

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/getCurrentAssessment.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/getCurrentAssessment.ts
@@ -1,0 +1,36 @@
+import type {} from "@atcute/lexicons";
+import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
+import * as ComEmdashcmsExperimentalLabelerDefs from "./defs.js";
+
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.labeler.getCurrentAssessment",
+	{
+		params: /*#__PURE__*/ v.object({
+			cid: /*#__PURE__*/ v.cidString(),
+			kind: /*#__PURE__*/ v.string<"profile" | "release" | (string & {})>(),
+			uri: /*#__PURE__*/ v.resourceUriString(),
+		}),
+		output: {
+			type: "lex",
+			get schema() {
+				return ComEmdashcmsExperimentalLabelerDefs.currentAssessmentViewSchema;
+			},
+		},
+	},
+);
+
+type main$schematype = typeof _mainSchema;
+
+export interface mainSchema extends main$schematype {}
+
+export const mainSchema = _mainSchema as mainSchema;
+
+export interface $params extends v.InferInput<mainSchema["params"]> {}
+export type $output = v.InferXRPCBodyInput<mainSchema["output"]>;
+
+declare module "@atcute/lexicons/ambient" {
+	interface XRPCQueries {
+		"com.emdashcms.experimental.labeler.getCurrentAssessment": mainSchema;
+	}
+}

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/getPolicy.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/getPolicy.ts
@@ -1,0 +1,32 @@
+import type {} from "@atcute/lexicons";
+import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
+import * as ComEmdashcmsExperimentalLabelerDefs from "./defs.js";
+
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.labeler.getPolicy",
+	{
+		params: null,
+		output: {
+			type: "lex",
+			get schema() {
+				return ComEmdashcmsExperimentalLabelerDefs.labelerPolicySchema;
+			},
+		},
+	},
+);
+
+type main$schematype = typeof _mainSchema;
+
+export interface mainSchema extends main$schematype {}
+
+export const mainSchema = _mainSchema as mainSchema;
+
+export interface $params {}
+export type $output = v.InferXRPCBodyInput<mainSchema["output"]>;
+
+declare module "@atcute/lexicons/ambient" {
+	interface XRPCQueries {
+		"com.emdashcms.experimental.labeler.getPolicy": mainSchema;
+	}
+}

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/listAssessments.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/labeler/listAssessments.ts
@@ -1,0 +1,86 @@
+import type {} from "@atcute/lexicons";
+import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
+import * as ComEmdashcmsExperimentalLabelerDefs from "./defs.js";
+
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.labeler.listAssessments",
+	{
+		params: /*#__PURE__*/ v.object({
+			cid: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.cidString()),
+			/**
+			 * @maxLength 1024
+			 */
+			cursor: /*#__PURE__*/ v.optional(
+				/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+					/*#__PURE__*/ v.stringLength(0, 1024),
+				]),
+			),
+			kind: /*#__PURE__*/ v.optional(
+				/*#__PURE__*/ v.string<"profile" | "release" | (string & {})>(),
+			),
+			/**
+			 * @minimum 1
+			 * @maximum 100
+			 * @default 50
+			 */
+			limit: /*#__PURE__*/ v.optional(
+				/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [
+					/*#__PURE__*/ v.integerRange(1, 100),
+				]),
+				50,
+			),
+			state: /*#__PURE__*/ v.optional(
+				/*#__PURE__*/ v.string<
+					| "blocked"
+					| "error"
+					| "passed"
+					| "pending"
+					| "review"
+					| "superseded"
+					| (string & {})
+				>(),
+			),
+			uri: /*#__PURE__*/ v.optional(/*#__PURE__*/ v.resourceUriString()),
+		}),
+		output: {
+			type: "lex",
+			schema: /*#__PURE__*/ v.object({
+				/**
+				 * @maxLength 100
+				 */
+				get assessments() {
+					return /*#__PURE__*/ v.constrain(
+						/*#__PURE__*/ v.array(
+							ComEmdashcmsExperimentalLabelerDefs.publicAssessmentSchema,
+						),
+						[/*#__PURE__*/ v.arrayLength(0, 100)],
+					);
+				},
+				/**
+				 * @maxLength 1024
+				 */
+				cursor: /*#__PURE__*/ v.optional(
+					/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+						/*#__PURE__*/ v.stringLength(0, 1024),
+					]),
+				),
+			}),
+		},
+	},
+);
+
+type main$schematype = typeof _mainSchema;
+
+export interface mainSchema extends main$schematype {}
+
+export const mainSchema = _mainSchema as mainSchema;
+
+export interface $params extends v.InferInput<mainSchema["params"]> {}
+export interface $output extends v.InferXRPCBodyInput<mainSchema["output"]> {}
+
+declare module "@atcute/lexicons/ambient" {
+	interface XRPCQueries {
+		"com.emdashcms.experimental.labeler.listAssessments": mainSchema;
+	}
+}

--- a/packages/registry-lexicons/src/index.ts
+++ b/packages/registry-lexicons/src/index.ts
@@ -28,6 +28,12 @@ export * as AggregatorListReleases from "./generated/types/com/emdashcms/experim
 export * as AggregatorResolvePackage from "./generated/types/com/emdashcms/experimental/aggregator/resolvePackage.js";
 export * as AggregatorSearchPackages from "./generated/types/com/emdashcms/experimental/aggregator/searchPackages.js";
 
+export * as LabelerDefs from "./generated/types/com/emdashcms/experimental/labeler/defs.js";
+export * as LabelerGetAssessment from "./generated/types/com/emdashcms/experimental/labeler/getAssessment.js";
+export * as LabelerGetCurrentAssessment from "./generated/types/com/emdashcms/experimental/labeler/getCurrentAssessment.js";
+export * as LabelerGetPolicy from "./generated/types/com/emdashcms/experimental/labeler/getPolicy.js";
+export * as LabelerListAssessments from "./generated/types/com/emdashcms/experimental/labeler/listAssessments.js";
+
 export * as PackageProfile from "./generated/types/com/emdashcms/experimental/package/profile.js";
 export * as PackageProfileExtension from "./generated/types/com/emdashcms/experimental/package/profileExtension.js";
 export * as PackageRelease from "./generated/types/com/emdashcms/experimental/package/release.js";
@@ -54,6 +60,11 @@ export const NSID = {
 	aggregatorListReleases: "com.emdashcms.experimental.aggregator.listReleases",
 	aggregatorResolvePackage: "com.emdashcms.experimental.aggregator.resolvePackage",
 	aggregatorSearchPackages: "com.emdashcms.experimental.aggregator.searchPackages",
+	labelerDefs: "com.emdashcms.experimental.labeler.defs",
+	labelerGetAssessment: "com.emdashcms.experimental.labeler.getAssessment",
+	labelerGetCurrentAssessment: "com.emdashcms.experimental.labeler.getCurrentAssessment",
+	labelerGetPolicy: "com.emdashcms.experimental.labeler.getPolicy",
+	labelerListAssessments: "com.emdashcms.experimental.labeler.listAssessments",
 } as const;
 
 export type NSIDValue = (typeof NSID)[keyof typeof NSID];
@@ -99,6 +110,10 @@ export const QUERY_NSIDS = [
 	NSID.aggregatorListReleases,
 	NSID.aggregatorResolvePackage,
 	NSID.aggregatorSearchPackages,
+	NSID.labelerGetAssessment,
+	NSID.labelerGetCurrentAssessment,
+	NSID.labelerGetPolicy,
+	NSID.labelerListAssessments,
 ] as const;
 
 import type * as PackageProfileNs from "./generated/types/com/emdashcms/experimental/package/profile.js";

--- a/packages/registry-lexicons/tests/labeler.test.ts
+++ b/packages/registry-lexicons/tests/labeler.test.ts
@@ -1,6 +1,8 @@
 import { is } from "@atcute/lexicons/validations";
+import { MODERATION_FINDING_CATEGORIES } from "@emdash-cms/registry-moderation";
 import { describe, expect, it } from "vitest";
 
+import labelerDefsLexicon from "../lexicons/com/emdashcms/experimental/labeler/defs.json" with { type: "json" };
 import {
 	LabelerDefs,
 	LabelerGetAssessment,
@@ -117,7 +119,7 @@ describe("labeler assessment lexicons", () => {
 
 	it("bounds public reason codes and findings", () => {
 		const finding: LabelerDefs.PublicFinding = {
-			category: "phishing",
+			category: "phishing-or-credential-solicitation",
 			reasonCode: "phishing-review",
 			summary: "Link behavior requires operator review.",
 		};
@@ -135,6 +137,12 @@ describe("labeler assessment lexicons", () => {
 				summary: "x".repeat(513),
 			}),
 		).toBe(false);
+	});
+
+	it("publishes the moderation package's finding categories", () => {
+		expect(labelerDefsLexicon.defs.publicFinding.properties.category.knownValues).toEqual(
+			MODERATION_FINDING_CATEGORIES,
+		);
 	});
 
 	it("validates a public manual decision without operator-private fields", () => {

--- a/packages/registry-lexicons/tests/labeler.test.ts
+++ b/packages/registry-lexicons/tests/labeler.test.ts
@@ -31,6 +31,7 @@ const label = {
 	cid: subject.cid,
 	val: "listing-passed",
 	cts: "2026-08-20T12:01:00Z",
+	sig: { $bytes: "AA==" },
 } as const;
 
 const assessment: LabelerDefs.PublicAssessment = {
@@ -66,6 +67,25 @@ describe("labeler assessment lexicons", () => {
 
 		expect(is(LabelerDefs.publicAssessmentSchema, assessment)).toBe(true);
 		expect(is(LabelerDefs.currentAssessmentViewSchema, current)).toBe(true);
+	});
+
+	it("requires signatures on public assessment and current labels", () => {
+		const { sig: _signature, ...unsigned } = label;
+
+		expect(
+			is(LabelerDefs.publicAssessmentSchema, {
+				...assessment,
+				labels: [unsigned],
+			}),
+		).toBe(false);
+		expect(
+			is(LabelerDefs.currentAssessmentViewSchema, {
+				src: assessment.src,
+				subject,
+				assessment,
+				activeLabels: [unsigned],
+			}),
+		).toBe(false);
 	});
 
 	it("represents every public assessment state", () => {

--- a/packages/registry-lexicons/tests/labeler.test.ts
+++ b/packages/registry-lexicons/tests/labeler.test.ts
@@ -1,0 +1,199 @@
+import { is } from "@atcute/lexicons/validations";
+import { describe, expect, it } from "vitest";
+
+import {
+	LabelerDefs,
+	LabelerGetAssessment,
+	LabelerGetCurrentAssessment,
+	LabelerGetPolicy,
+	LabelerListAssessments,
+	NSID,
+} from "../src/index.js";
+
+const subject: LabelerDefs.AssessmentSubject = {
+	kind: "profile",
+	uri: "at://did:plc:publisher/com.emdashcms.experimental.package.profile/gallery",
+	cid: "bafyreiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+};
+
+const model: LabelerDefs.ModelDescriptor = {
+	purpose: "text",
+	provider: "workers-ai",
+	modelId: "@cf/meta/llama-3.1-8b-instruct",
+	modelVersion: "2026-08-01",
+	promptHash: "sha256:4e07408562bedb8b60ce05c1decfe3ad16b722309c8e",
+};
+
+const label = {
+	ver: 1,
+	src: "did:web:labels.emdashcms.com",
+	uri: subject.uri,
+	cid: subject.cid,
+	val: "listing-passed",
+	cts: "2026-08-20T12:01:00Z",
+} as const;
+
+const assessment: LabelerDefs.PublicAssessment = {
+	id: "asmt_01K33QGCAGQ4GEXGAAZ7PEQRQ8",
+	src: label.src,
+	subject,
+	state: "passed",
+	coverage: {
+		text: "complete",
+		links: "complete",
+		media: "not-present",
+	},
+	reasonCodes: [],
+	findings: [],
+	summary: "Required listing checks completed.",
+	assessmentSchemaVersion: 1,
+	policyVersion: "listing-policy-2026-08-20",
+	parserVersion: "metadata-parser-1",
+	models: [model],
+	labels: [label],
+	createdAt: "2026-08-20T12:00:00Z",
+	completedAt: "2026-08-20T12:01:00Z",
+};
+
+describe("labeler assessment lexicons", () => {
+	it("validates an exact-CID metadata assessment using standard ATProto labels", () => {
+		const current: LabelerGetCurrentAssessment.$output = {
+			src: assessment.src,
+			subject,
+			assessment,
+			activeLabels: [label],
+		};
+
+		expect(is(LabelerDefs.publicAssessmentSchema, assessment)).toBe(true);
+		expect(is(LabelerDefs.currentAssessmentViewSchema, current)).toBe(true);
+	});
+
+	it("represents every public assessment state", () => {
+		const states = ["pending", "passed", "review", "blocked", "error", "superseded"];
+
+		for (const state of states) {
+			expect(is(LabelerDefs.publicAssessmentSchema, { ...assessment, state })).toBe(true);
+		}
+	});
+
+	it("requires an exact subject kind, URI, and CID", () => {
+		expect(is(LabelerDefs.assessmentSubjectSchema, subject)).toBe(true);
+		expect(is(LabelerDefs.assessmentSubjectSchema, { uri: subject.uri, cid: subject.cid })).toBe(
+			false,
+		);
+		expect(
+			is(LabelerDefs.assessmentSubjectSchema, {
+				...subject,
+				uri: "https://example.com/plugin",
+			}),
+		).toBe(false);
+		expect(
+			is(LabelerDefs.assessmentSubjectSchema, {
+				...subject,
+				cid: "not-a-cid",
+			}),
+		).toBe(false);
+	});
+
+	it("bounds public reason codes and findings", () => {
+		const finding: LabelerDefs.PublicFinding = {
+			category: "phishing",
+			reasonCode: "phishing-review",
+			summary: "Link behavior requires operator review.",
+		};
+
+		expect(is(LabelerDefs.publicFindingSchema, finding)).toBe(true);
+		expect(
+			is(LabelerDefs.publicAssessmentSchema, {
+				...assessment,
+				reasonCodes: Array.from({ length: 33 }).fill("review-required"),
+			}),
+		).toBe(false);
+		expect(
+			is(LabelerDefs.publicFindingSchema, {
+				...finding,
+				summary: "x".repeat(513),
+			}),
+		).toBe(false);
+	});
+
+	it("validates a public manual decision without operator-private fields", () => {
+		const blocked: LabelerDefs.PublicAssessment = {
+			...assessment,
+			state: "blocked",
+			reasonCodes: ["operator-blocked"],
+			labels: [{ ...label, val: "listing-blocked" }],
+			manualDecision: {
+				outcome: "blocked",
+				reasonCode: "operator-blocked",
+				decidedAt: "2026-08-20T13:00:00Z",
+			},
+		};
+
+		expect(is(LabelerDefs.publicAssessmentSchema, blocked)).toBe(true);
+	});
+
+	it("validates public query parameters and pagination bounds", () => {
+		const current: LabelerGetCurrentAssessment.$params = subject;
+		const list: LabelerListAssessments.$params = {
+			kind: "profile",
+			uri: subject.uri,
+			cid: subject.cid,
+			state: "review",
+			limit: 50,
+		};
+
+		expect(is(LabelerGetAssessment.mainSchema.params, { id: assessment.id })).toBe(true);
+		expect(is(LabelerGetCurrentAssessment.mainSchema.params, current)).toBe(true);
+		expect(is(LabelerListAssessments.mainSchema.params, list)).toBe(true);
+		expect(is(LabelerGetAssessment.mainSchema.params, { id: "" })).toBe(false);
+		expect(is(LabelerListAssessments.mainSchema.params, { limit: 101 })).toBe(false);
+		expect(is(LabelerListAssessments.mainSchema.params, { cursor: "x".repeat(1025) })).toBe(false);
+	});
+});
+
+describe("labeler policy lexicon", () => {
+	it("describes metadata-only subjects, model versions, and standard label effects", () => {
+		const policy: LabelerGetPolicy.$output = {
+			schemaVersion: 1,
+			policyVersion: assessment.policyVersion,
+			effectiveAt: "2026-08-20T00:00:00Z",
+			labelerDid: assessment.src,
+			assessmentSchemaVersion: 1,
+			parserVersion: assessment.parserVersion,
+			supportedSubjects: [
+				{ kind: "profile", collection: NSID.packageProfile },
+				{ kind: "release", collection: NSID.packageRelease },
+			],
+			reasonCodes: [
+				{
+					code: "incomplete-coverage",
+					description: "A required metadata coverage stage did not complete.",
+				},
+			],
+			labels: [
+				{
+					value: "listing-passed",
+					officialEffect: "eligible",
+					subjectKinds: ["profile", "release"],
+					issuanceModes: ["automated", "reviewer"],
+				},
+			],
+			models: [model],
+			publicApi: {
+				baseUrl: "https://labels.emdashcms.com/xrpc/",
+				getAssessmentNsid: NSID.labelerGetAssessment,
+				getCurrentAssessmentNsid: NSID.labelerGetCurrentAssessment,
+				listAssessmentsNsid: NSID.labelerListAssessments,
+				getPolicyNsid: NSID.labelerGetPolicy,
+			},
+		};
+		const listed: LabelerListAssessments.$output = { assessments: [assessment] };
+
+		expect(is(LabelerGetPolicy.mainSchema.output.schema, policy)).toBe(true);
+		expect(is(LabelerListAssessments.mainSchema.output.schema, listed)).toBe(true);
+		expect(is(LabelerGetPolicy.mainSchema.output.schema, { ...policy, schemaVersion: 2 })).toBe(
+			false,
+		);
+	});
+});

--- a/packages/registry-lexicons/tests/types.test.ts
+++ b/packages/registry-lexicons/tests/types.test.ts
@@ -324,6 +324,11 @@ describe("NSID map", () => {
 			"com.emdashcms.experimental.aggregator.listReleases",
 			"com.emdashcms.experimental.aggregator.resolvePackage",
 			"com.emdashcms.experimental.aggregator.searchPackages",
+			"com.emdashcms.experimental.labeler.defs",
+			"com.emdashcms.experimental.labeler.getAssessment",
+			"com.emdashcms.experimental.labeler.getCurrentAssessment",
+			"com.emdashcms.experimental.labeler.getPolicy",
+			"com.emdashcms.experimental.labeler.listAssessments",
 		].toSorted();
 
 		const actual = Object.values(NSID).toSorted();

--- a/packages/registry-moderation/package.json
+++ b/packages/registry-moderation/package.json
@@ -1,0 +1,55 @@
+{
+	"name": "@emdash-cms/registry-moderation",
+	"version": "0.0.0",
+	"description": "Shared listing-label reduction, visibility policy, and metadata moderation contracts for the EmDash plugin registry.",
+	"type": "module",
+	"main": "dist/index.js",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		},
+		"./fixtures": {
+			"types": "./dist/fixtures/index.d.ts",
+			"default": "./dist/fixtures/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsdown",
+		"dev": "tsdown --watch",
+		"prepublishOnly": "node --run build",
+		"typecheck": "tsgo --noEmit",
+		"test": "vitest run",
+		"check": "publint && attw --pack --ignore-rules=cjs-resolves-to-esm --ignore-rules=no-resolution"
+	},
+	"devDependencies": {
+		"@arethetypeswrong/cli": "catalog:",
+		"publint": "catalog:",
+		"tsdown": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"dependencies": {
+		"@atcute/cbor": "catalog:",
+		"@atcute/cid": "catalog:",
+		"@atcute/crypto": "catalog:",
+		"@atcute/multibase": "catalog:"
+	},
+	"keywords": [
+		"emdash",
+		"plugin-registry",
+		"atproto",
+		"moderation"
+	],
+	"author": "Matt Kane",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/emdash-cms/emdash.git",
+		"directory": "packages/registry-moderation"
+	},
+	"homepage": "https://github.com/emdash-cms/emdash"
+}

--- a/packages/registry-moderation/src/evaluate.ts
+++ b/packages/registry-moderation/src/evaluate.ts
@@ -1,0 +1,299 @@
+import {
+	isVerifiedListingLabel,
+	parseListingLabel,
+	type VerifiedListingLabel,
+} from "./label-crypto.js";
+import {
+	LISTING_LABELS,
+	isListingLabelActive,
+	reduceListingLabels,
+	type ListingLabelEvent,
+	type ListingSubjectKind,
+} from "./labels.js";
+import { PROFILE_COLLECTION, RELEASE_COLLECTION } from "./labels.js";
+import {
+	assertListingModerationPolicy,
+	stateSources,
+	type ListingModerationPolicy,
+} from "./policy.js";
+import { assertCanonicalCid, assertDid, parseAtUri } from "./validation.js";
+
+export type ListingVisibilityState =
+	| "deleted"
+	| "tombstoned"
+	| "takedown"
+	| "blocked"
+	| "conflict"
+	| "passed"
+	| "unavailable";
+
+export interface ListingSubjectRevision {
+	uri: string;
+	cid: string;
+	kind: ListingSubjectKind;
+	publisherDid: string;
+	profileUri?: string;
+	deleted?: boolean;
+	tombstoned?: boolean;
+}
+
+export interface EvaluateListingVisibilityInput {
+	subject: ListingSubjectRevision;
+	policy: ListingModerationPolicy;
+	labels: readonly VerifiedListingLabel[];
+	evaluatedAt: Date | string;
+}
+
+export interface EvaluateHydratedListingVisibilityInput extends Omit<
+	EvaluateListingVisibilityInput,
+	"labels"
+> {
+	labels: readonly ListingLabelEvent[];
+}
+
+export interface ListingVisibility {
+	visible: boolean;
+	state: ListingVisibilityState;
+	reasonCodes: readonly string[];
+	positiveSources: readonly string[];
+	missingPositiveSources: readonly string[];
+	applicableLabels: readonly ListingLabelEvent[];
+}
+
+const TERMINAL_VALUES = new Set<string>([
+	LISTING_LABELS.passed,
+	LISTING_LABELS.pending,
+	LISTING_LABELS.review,
+	LISTING_LABELS.error,
+]);
+
+function validateSubject(subject: ListingSubjectRevision): void {
+	assertDid(subject.publisherDid, "subject.publisherDid");
+	assertCanonicalCid(subject.cid, "subject.cid");
+	const parsed = parseAtUri(subject.uri, "subject.uri");
+	if (parsed.authority !== subject.publisherDid) {
+		throw new TypeError("subject.uri authority must match subject.publisherDid");
+	}
+	const expectedCollection = subject.kind === "profile" ? PROFILE_COLLECTION : RELEASE_COLLECTION;
+	if (parsed.collection !== expectedCollection) {
+		throw new TypeError("subject.uri collection must match subject.kind");
+	}
+	if (subject.profileUri !== undefined) {
+		const profile = parseAtUri(subject.profileUri, "subject.profileUri");
+		if (profile.authority !== subject.publisherDid || profile.collection !== PROFILE_COLLECTION) {
+			throw new TypeError("subject.profileUri must identify the publisher's profile record");
+		}
+	}
+}
+
+function appliesToRevision(label: ListingLabelEvent, subject: ListingSubjectRevision): boolean {
+	return label.uri === subject.uri && label.cid === subject.cid;
+}
+
+function result(
+	state: ListingVisibilityState,
+	reasonCodes: readonly string[],
+	positiveSources: readonly string[],
+	missingPositiveSources: readonly string[],
+	applicableLabels: readonly ListingLabelEvent[],
+): ListingVisibility {
+	return {
+		visible: state === "passed",
+		state,
+		reasonCodes,
+		positiveSources,
+		missingPositiveSources,
+		applicableLabels,
+	};
+}
+
+function evaluateListingVisibilityCore(
+	input: EvaluateHydratedListingVisibilityInput,
+): ListingVisibility {
+	assertListingModerationPolicy(input.policy);
+	validateSubject(input.subject);
+	if (input.subject.deleted) {
+		return result("deleted", ["publisher-deleted"], [], input.policy.requiredPositiveSources, []);
+	}
+	if (input.subject.tombstoned) {
+		return result(
+			"tombstoned",
+			["publisher-tombstoned"],
+			[],
+			input.policy.requiredPositiveSources,
+			[],
+		);
+	}
+
+	const reduction = reduceListingLabels(input.labels, input.evaluatedAt);
+	const acceptedStates = stateSources(input.policy);
+	const active = reduction.states.filter((state) => state.active).map((state) => state.winner);
+	const collisionCandidates = reduction.states
+		.flatMap((state) => state.collision)
+		.filter((label) => isListingLabelActive(label, input.evaluatedAt));
+	const enforcementCandidates = [...active, ...collisionCandidates];
+	const redactionUris = new Set(
+		[input.subject.uri, input.subject.profileUri, input.subject.publisherDid].filter(
+			(value): value is string => value !== undefined,
+		),
+	);
+	const takedowns = enforcementCandidates.filter(
+		(label) =>
+			label.val === LISTING_LABELS.takedown &&
+			input.policy.redactionSources.includes(label.src) &&
+			redactionUris.has(label.uri) &&
+			(label.cid === undefined ||
+				(label.uri === input.subject.uri && label.cid === input.subject.cid)),
+	);
+	if (takedowns.length > 0) {
+		return result(
+			"takedown",
+			["active-takedown"],
+			[],
+			input.policy.requiredPositiveSources,
+			takedowns,
+		);
+	}
+
+	const applicable = active.filter(
+		(label) => acceptedStates.has(label.src) && appliesToRevision(label, input.subject),
+	);
+	const collisionApplicable = collisionCandidates.filter(
+		(label) => acceptedStates.has(label.src) && appliesToRevision(label, input.subject),
+	);
+	const blocks = [...applicable, ...collisionApplicable].filter(
+		(label) => label.val === LISTING_LABELS.blocked,
+	);
+	if (blocks.length > 0) {
+		return result("blocked", ["exact-cid-block"], [], input.policy.requiredPositiveSources, [
+			...applicable,
+			...collisionApplicable,
+		]);
+	}
+
+	const collisions = reduction.states.filter(
+		(state) =>
+			state.collision.length > 0 &&
+			state.collision.some(
+				(label) =>
+					isListingLabelActive(label, input.evaluatedAt) &&
+					acceptedStates.has(label.src) &&
+					appliesToRevision(label, input.subject),
+			),
+	);
+	const terminalValues = new Set(
+		applicable.filter((label) => TERMINAL_VALUES.has(label.val)).map((label) => label.val),
+	);
+	if (collisions.length > 0 || terminalValues.size > 1) {
+		return result(
+			"conflict",
+			["conflicting-terminal-state"],
+			[],
+			input.policy.requiredPositiveSources,
+			applicable,
+		);
+	}
+
+	const positiveSources = input.policy.requiredPositiveSources.filter((source) =>
+		applicable.some((label) => label.src === source && label.val === LISTING_LABELS.passed),
+	);
+	const missingPositiveSources = input.policy.requiredPositiveSources.filter(
+		(source) => !positiveSources.includes(source),
+	);
+	if (missingPositiveSources.length === 0) {
+		return result("passed", ["required-positive-labels"], positiveSources, [], applicable);
+	}
+
+	const reasonCodes = ["missing-required-positive-label"];
+	if (applicable.some((label) => label.val === LISTING_LABELS.pending)) {
+		reasonCodes.push("listing-pending");
+	}
+	if (applicable.some((label) => label.val === LISTING_LABELS.review)) {
+		reasonCodes.push("listing-review");
+	}
+	if (applicable.some((label) => label.val === LISTING_LABELS.error)) {
+		reasonCodes.push("listing-error");
+	}
+	if (applicable.some((label) => label.val === LISTING_LABELS.overridden)) {
+		reasonCodes.push("override-without-pass");
+	}
+	return result("unavailable", reasonCodes, positiveSources, missingPositiveSources, applicable);
+}
+
+export function evaluateListingVisibility(
+	input: EvaluateListingVisibilityInput,
+): ListingVisibility {
+	for (const label of input.labels) {
+		if (!isVerifiedListingLabel(label)) {
+			throw new TypeError(
+				"labels must be verified by verifyListingLabel before visibility evaluation",
+			);
+		}
+	}
+	return evaluateListingVisibilityCore(input);
+}
+
+/**
+ * Evaluates structurally validated labels loaded from an already authenticated store.
+ * This function does not verify signatures and must never receive network or client input.
+ */
+export function evaluateHydratedListingVisibility(
+	input: EvaluateHydratedListingVisibilityInput,
+): ListingVisibility {
+	return evaluateListingVisibilityCore({
+		...input,
+		labels: input.labels.map((label) => parseListingLabel(label)),
+	});
+}
+
+export interface SelectApprovedRevisionInput {
+	revisions: readonly (ListingSubjectRevision & { observedAt: string })[];
+	policy: ListingModerationPolicy;
+	labels: readonly VerifiedListingLabel[];
+	evaluatedAt: Date | string;
+	currentDeleted?: boolean;
+}
+
+export interface SelectHydratedApprovedRevisionInput extends Omit<
+	SelectApprovedRevisionInput,
+	"labels"
+> {
+	labels: readonly ListingLabelEvent[];
+}
+
+export function selectLatestApprovedRevision(
+	input: SelectApprovedRevisionInput,
+): ListingSubjectRevision | null {
+	if (input.currentDeleted) return null;
+	const candidates = input.revisions
+		.filter(
+			(revision) =>
+				evaluateListingVisibility({
+					subject: revision,
+					policy: input.policy,
+					labels: input.labels,
+					evaluatedAt: input.evaluatedAt,
+				}).visible,
+		)
+		.toSorted((left, right) => right.observedAt.localeCompare(left.observedAt));
+	return candidates[0] ?? null;
+}
+
+/** Selects from labels whose signatures were verified before persistence. */
+export function selectLatestHydratedApprovedRevision(
+	input: SelectHydratedApprovedRevisionInput,
+): ListingSubjectRevision | null {
+	if (input.currentDeleted) return null;
+	const candidates = input.revisions
+		.filter(
+			(revision) =>
+				evaluateHydratedListingVisibility({
+					subject: revision,
+					policy: input.policy,
+					labels: input.labels,
+					evaluatedAt: input.evaluatedAt,
+				}).visible,
+		)
+		.toSorted((left, right) => right.observedAt.localeCompare(left.observedAt));
+	return candidates[0] ?? null;
+}

--- a/packages/registry-moderation/src/findings.ts
+++ b/packages/registry-moderation/src/findings.ts
@@ -1,0 +1,50 @@
+import { isModerationFindingCategory, type ModerationFindingCategory } from "./policy.js";
+import { record, runtimeSchema, stringArray, stringValue } from "./schema.js";
+
+export interface NormalizedModerationFinding {
+	category: ModerationFindingCategory;
+	recommendation: "none" | "review";
+	confidence: number;
+	summary: string;
+	evidenceRefs: string[];
+}
+
+export interface ModerationCoverage {
+	text: "complete" | "not-present" | "unavailable";
+	links: "complete" | "not-present" | "unavailable";
+	media: "complete" | "not-present" | "partial" | "unavailable";
+}
+
+function parseFinding(value: unknown): NormalizedModerationFinding {
+	const finding = record(value, "finding", [
+		"category",
+		"recommendation",
+		"confidence",
+		"summary",
+		"evidenceRefs",
+	]);
+	const category = finding["category"];
+	if (!isModerationFindingCategory(category)) {
+		throw new TypeError("finding.category is not recognized");
+	}
+	if (finding["recommendation"] !== "none" && finding["recommendation"] !== "review") {
+		throw new TypeError("finding.recommendation must be none or review");
+	}
+	if (
+		typeof finding["confidence"] !== "number" ||
+		!Number.isFinite(finding["confidence"]) ||
+		finding["confidence"] < 0 ||
+		finding["confidence"] > 1
+	) {
+		throw new TypeError("finding.confidence must be between zero and one");
+	}
+	return {
+		category,
+		recommendation: finding["recommendation"],
+		confidence: finding["confidence"],
+		summary: stringValue(finding["summary"], "finding.summary", 500),
+		evidenceRefs: stringArray(finding["evidenceRefs"], "finding.evidenceRefs", 32),
+	};
+}
+
+export const NormalizedModerationFindingSchema = runtimeSchema(parseFinding);

--- a/packages/registry-moderation/src/fixtures/index.ts
+++ b/packages/registry-moderation/src/fixtures/index.ts
@@ -1,0 +1,4 @@
+export * from "./inputs.js";
+export * from "./policy.js";
+export * from "./prohibited-inputs.js";
+export * from "./transitions.js";

--- a/packages/registry-moderation/src/fixtures/inputs.ts
+++ b/packages/registry-moderation/src/fixtures/inputs.ts
@@ -1,0 +1,115 @@
+import type {
+	CanonicalProfileModerationInput,
+	CanonicalReleaseModerationInput,
+} from "../inputs.js";
+
+export const FIXTURE_PUBLISHER_DID = "did:plc:listingfixture000000000000";
+export const FIXTURE_PROFILE_URI = `at://${FIXTURE_PUBLISHER_DID}/com.emdashcms.experimental.package.profile/gallery`;
+export const FIXTURE_RELEASE_URI = `at://${FIXTURE_PUBLISHER_DID}/com.emdashcms.experimental.package.release/gallery:1.2.3`;
+export const FIXTURE_PROFILE_CID = "bafyreiabaeaqcaibaeaqcaibaeaqcaibaeaqcaibaeaqcaibaeaqcaibae";
+export const FIXTURE_RELEASE_CID = "bafyreiacaibaeaqcaibaeaqcaibaeaqcaibaeaqcaibaeaqcaibaeaqcai";
+
+export const PROFILE_MODERATION_INPUT_FIXTURE = {
+	schemaVersion: 1,
+	subject: { uri: FIXTURE_PROFILE_URI, cid: FIXTURE_PROFILE_CID, kind: "profile" },
+	publisherDid: FIXTURE_PUBLISHER_DID,
+	slug: "gallery",
+	name: "Gallery",
+	description: "A media gallery for EmDash.",
+	keywords: ["gallery", "media"],
+	license: "MIT",
+	sections: {
+		description: "## Gallery\n\nBuild galleries.",
+		installation: "Install from the plugin registry.",
+		faq: "Frequently asked questions.",
+		changelog: "Version history.",
+		security: "Report security issues privately.",
+	},
+	authors: [
+		{
+			name: "Example Publisher",
+			url: "https://publisher.example/about",
+			email: "plugins@publisher.example",
+		},
+	],
+	security: [
+		{
+			url: "https://publisher.example/security",
+			email: "security@publisher.example",
+		},
+	],
+	lastUpdated: "2026-08-24T00:00:00.000Z",
+} as const satisfies CanonicalProfileModerationInput;
+
+export const RELEASE_MODERATION_INPUT_FIXTURE = {
+	schemaVersion: 1,
+	subject: { uri: FIXTURE_RELEASE_URI, cid: FIXTURE_RELEASE_CID, kind: "release" },
+	publisherDid: FIXTURE_PUBLISHER_DID,
+	packageSlug: "gallery",
+	version: "1.2.3",
+	repositoryUrl: "https://code.example/publisher/gallery",
+	requires: { "env:emdash": ">=0.9.0", "env:astro": ">=6.0.0" },
+	sbom: { format: "cyclonedx", url: "https://downloads.example/gallery/sbom.json" },
+	media: [
+		{
+			kind: "icon",
+			index: 0,
+			id: "icon",
+			url: "https://media.example/gallery/icon.png",
+			checksum: "bafkiconchecksum",
+			contentType: "image/png",
+			width: 512,
+			height: 512,
+			language: "en",
+			verified: {
+				sha256: "11".repeat(32),
+				mimeType: "image/png",
+				byteLength: 1024,
+				width: 512,
+				height: 512,
+				contentRef: "quarantine://media/icon",
+			},
+		},
+		{
+			kind: "banner",
+			index: 0,
+			url: "https://media.example/gallery/banner.webp",
+			checksum: "bafkbannerchecksum",
+		},
+		{
+			kind: "screenshot",
+			index: 0,
+			url: "https://media.example/gallery/screenshot-1.webp",
+			checksum: "bafkscreenshotchecksum",
+		},
+	],
+} as const satisfies CanonicalReleaseModerationInput;
+
+export const MODERATION_INPUT_FIELDS_FIXTURE = {
+	profile: [
+		"slug",
+		"name",
+		"description",
+		"keywords",
+		"license",
+		"sections",
+		"authors.name",
+		"authors.url",
+		"authors.email",
+		"security.url",
+		"security.email",
+		"lastUpdated",
+	],
+	release: [
+		"packageSlug",
+		"version",
+		"repositoryUrl",
+		"requires.keys",
+		"requires.constraints",
+		"sbom.format",
+		"sbom.url",
+		"media.icon",
+		"media.banner",
+		"media.screenshot",
+	],
+} as const;

--- a/packages/registry-moderation/src/fixtures/policy.ts
+++ b/packages/registry-moderation/src/fixtures/policy.ts
@@ -1,0 +1,16 @@
+import { MODERATION_FINDING_CATEGORIES, type ListingModerationPolicy } from "../policy.js";
+
+export const FIXTURE_LABELER_DID = "did:web:listing-labeler.emdashcms.test";
+export const FIXTURE_STATE_DID = "did:web:state-labeler.emdashcms.test";
+export const FIXTURE_REDACTION_DID = "did:web:redaction-labeler.emdashcms.test";
+
+export const INITIAL_LISTING_POLICY_FIXTURE = {
+	schemaVersion: 1,
+	policyVersion: "listing-metadata-v1",
+	effectiveAt: "2026-08-24T00:00:00.000Z",
+	requiredPositiveSources: [FIXTURE_LABELER_DID],
+	acceptedStateSources: [FIXTURE_STATE_DID],
+	redactionSources: [FIXTURE_REDACTION_DID],
+	autoPass: "disabled",
+	prohibitedCategories: MODERATION_FINDING_CATEGORIES,
+} as const satisfies ListingModerationPolicy;

--- a/packages/registry-moderation/src/fixtures/prohibited-inputs.ts
+++ b/packages/registry-moderation/src/fixtures/prohibited-inputs.ts
@@ -1,0 +1,33 @@
+export const PROHIBITED_ASSESSMENT_INPUTS_FIXTURE = {
+	neverFetch: [
+		"profile.authors[].url",
+		"profile.security[].url",
+		"release.repo",
+		"release.artifacts.package.url",
+		"release.sbom.url",
+		"release.provenance.url",
+		"release.sourceArchive.url",
+		"markdown.links[]",
+	],
+	neverModel: [
+		"release.artifacts.package",
+		"release.manifest",
+		"release.declaredAccess",
+		"release.sbom.checksum",
+		"release.sbom.document",
+		"release.provenance",
+		"release.sourceArchive",
+		"release.sourceRepository.content",
+		"release.provides",
+		"release.suggests",
+		"release.auth",
+		"release.extensions",
+	],
+	descriptorOnly: [
+		"profile.authors[].url",
+		"profile.security[].url",
+		"release.repo",
+		"release.sbom.format",
+		"release.sbom.url",
+	],
+} as const;

--- a/packages/registry-moderation/src/fixtures/transitions.ts
+++ b/packages/registry-moderation/src/fixtures/transitions.ts
@@ -1,0 +1,250 @@
+import type { ListingSubjectRevision, ListingVisibilityState } from "../evaluate.js";
+import { LISTING_LABELS, type ListingLabelEvent } from "../labels.js";
+import { FIXTURE_PROFILE_CID, FIXTURE_PROFILE_URI, FIXTURE_PUBLISHER_DID } from "./inputs.js";
+import { FIXTURE_LABELER_DID, FIXTURE_REDACTION_DID, FIXTURE_STATE_DID } from "./policy.js";
+
+export const FIXTURE_NEW_PROFILE_CID =
+	"bafyreiadambqgaydambqgaydambqgaydambqgaydambqgaydambqgaydam";
+
+const OLD_PROFILE: ListingSubjectRevision = {
+	uri: FIXTURE_PROFILE_URI,
+	cid: FIXTURE_PROFILE_CID,
+	kind: "profile",
+	publisherDid: FIXTURE_PUBLISHER_DID,
+};
+
+const NEW_PROFILE: ListingSubjectRevision = { ...OLD_PROFILE, cid: FIXTURE_NEW_PROFILE_CID };
+
+function label(
+	val: ListingLabelEvent["val"],
+	cts: string,
+	options: Partial<ListingLabelEvent> = {},
+): ListingLabelEvent {
+	return {
+		ver: 1,
+		src: FIXTURE_LABELER_DID,
+		uri: FIXTURE_PROFILE_URI,
+		cid: FIXTURE_PROFILE_CID,
+		val,
+		cts,
+		...options,
+	};
+}
+
+const OLD_PASS = label(LISTING_LABELS.passed, "2026-08-24T00:00:01.000Z");
+const NEW_PENDING = label(LISTING_LABELS.pending, "2026-08-24T00:00:02.000Z", {
+	cid: FIXTURE_NEW_PROFILE_CID,
+});
+const NEW_REVIEW = label(LISTING_LABELS.review, "2026-08-24T00:00:03.000Z", {
+	cid: FIXTURE_NEW_PROFILE_CID,
+});
+const NEW_ERROR = label(LISTING_LABELS.error, "2026-08-24T00:00:03.000Z", {
+	cid: FIXTURE_NEW_PROFILE_CID,
+});
+const NEW_BLOCK = label(LISTING_LABELS.blocked, "2026-08-24T00:00:04.000Z", {
+	cid: FIXTURE_NEW_PROFILE_CID,
+});
+const NEW_PASS = label(LISTING_LABELS.passed, "2026-08-24T00:00:05.000Z", {
+	cid: FIXTURE_NEW_PROFILE_CID,
+});
+const NEGATE_NEW_PASS = label(LISTING_LABELS.passed, "2026-08-24T00:00:06.000Z", {
+	cid: FIXTURE_NEW_PROFILE_CID,
+	neg: true,
+});
+
+export interface ListingTransitionFixture {
+	id: string;
+	subject: ListingSubjectRevision;
+	labels: readonly ListingLabelEvent[];
+	expectedState: ListingVisibilityState;
+}
+
+export const LISTING_TRANSITION_FIXTURES: readonly ListingTransitionFixture[] = [
+	{ id: "unlabelled", subject: OLD_PROFILE, labels: [], expectedState: "unavailable" },
+	{
+		id: "override-alone",
+		subject: OLD_PROFILE,
+		labels: [label(LISTING_LABELS.overridden, "2026-08-24T00:00:01.000Z")],
+		expectedState: "unavailable",
+	},
+	{ id: "old-pass", subject: OLD_PROFILE, labels: [OLD_PASS], expectedState: "passed" },
+	{
+		id: "old-pass-new-pending-old-view",
+		subject: OLD_PROFILE,
+		labels: [OLD_PASS, NEW_PENDING],
+		expectedState: "passed",
+	},
+	{
+		id: "old-pass-new-pending-new-view",
+		subject: NEW_PROFILE,
+		labels: [OLD_PASS, NEW_PENDING],
+		expectedState: "unavailable",
+	},
+	{
+		id: "old-pass-new-review-old-view",
+		subject: OLD_PROFILE,
+		labels: [OLD_PASS, NEW_REVIEW],
+		expectedState: "passed",
+	},
+	{
+		id: "old-pass-new-error-old-view",
+		subject: OLD_PROFILE,
+		labels: [OLD_PASS, NEW_ERROR],
+		expectedState: "passed",
+	},
+	{
+		id: "new-review-unavailable",
+		subject: NEW_PROFILE,
+		labels: [OLD_PASS, NEW_REVIEW],
+		expectedState: "unavailable",
+	},
+	{
+		id: "new-error-unavailable",
+		subject: NEW_PROFILE,
+		labels: [OLD_PASS, NEW_ERROR],
+		expectedState: "unavailable",
+	},
+	{
+		id: "old-pass-new-block-old-view",
+		subject: OLD_PROFILE,
+		labels: [OLD_PASS, NEW_BLOCK],
+		expectedState: "passed",
+	},
+	{
+		id: "new-pass-supersedes-old",
+		subject: OLD_PROFILE,
+		labels: [OLD_PASS, NEW_PASS],
+		expectedState: "unavailable",
+	},
+	{
+		id: "new-pass-visible",
+		subject: NEW_PROFILE,
+		labels: [OLD_PASS, NEW_PASS],
+		expectedState: "passed",
+	},
+	{
+		id: "manual-approval-pass-and-override",
+		subject: NEW_PROFILE,
+		labels: [
+			OLD_PASS,
+			NEW_PASS,
+			label(LISTING_LABELS.overridden, "2026-08-24T00:00:05.000Z", {
+				cid: FIXTURE_NEW_PROFILE_CID,
+			}),
+		],
+		expectedState: "passed",
+	},
+	{
+		id: "blocking-new-pass-does-not-revive-old",
+		subject: OLD_PROFILE,
+		labels: [OLD_PASS, NEW_PASS, NEGATE_NEW_PASS, NEW_BLOCK],
+		expectedState: "unavailable",
+	},
+	{
+		id: "exact-cid-block",
+		subject: NEW_PROFILE,
+		labels: [OLD_PASS, NEW_PASS, NEW_BLOCK],
+		expectedState: "blocked",
+	},
+	{
+		id: "conflicting-terminal-state",
+		subject: OLD_PROFILE,
+		labels: [
+			OLD_PASS,
+			label(LISTING_LABELS.review, "2026-08-24T00:00:02.000Z", {
+				src: FIXTURE_STATE_DID,
+			}),
+		],
+		expectedState: "conflict",
+	},
+	{
+		id: "publisher-takedown",
+		subject: OLD_PROFILE,
+		labels: [
+			OLD_PASS,
+			label(LISTING_LABELS.takedown, "2026-08-24T00:00:02.000Z", {
+				src: FIXTURE_REDACTION_DID,
+				uri: FIXTURE_PUBLISHER_DID,
+				cid: undefined,
+			}),
+		],
+		expectedState: "takedown",
+	},
+	{
+		id: "deleted",
+		subject: { ...OLD_PROFILE, deleted: true },
+		labels: [OLD_PASS],
+		expectedState: "deleted",
+	},
+	{
+		id: "tombstoned",
+		subject: { ...OLD_PROFILE, tombstoned: true },
+		labels: [OLD_PASS],
+		expectedState: "tombstoned",
+	},
+] as const;
+
+export const LABEL_TRANSITION_RULES_FIXTURE = [
+	{
+		actor: "automation",
+		action: "start",
+		issues: [LISTING_LABELS.pending],
+		negatesForExactCid: [],
+		preserves: [
+			LISTING_LABELS.passed,
+			LISTING_LABELS.blocked,
+			LISTING_LABELS.overridden,
+			LISTING_LABELS.takedown,
+		],
+	},
+	{
+		actor: "automation",
+		action: "complete-pass",
+		issues: [LISTING_LABELS.passed],
+		negatesForExactCid: [LISTING_LABELS.pending, LISTING_LABELS.review, LISTING_LABELS.error],
+		preserves: [LISTING_LABELS.blocked, LISTING_LABELS.overridden, LISTING_LABELS.takedown],
+	},
+	{
+		actor: "automation",
+		action: "complete-review",
+		issues: [LISTING_LABELS.review],
+		negatesForExactCid: [LISTING_LABELS.pending, LISTING_LABELS.passed, LISTING_LABELS.error],
+		preserves: [LISTING_LABELS.blocked, LISTING_LABELS.overridden, LISTING_LABELS.takedown],
+	},
+	{
+		actor: "automation",
+		action: "complete-error",
+		issues: [LISTING_LABELS.error],
+		negatesForExactCid: [LISTING_LABELS.pending, LISTING_LABELS.passed, LISTING_LABELS.review],
+		preserves: [LISTING_LABELS.blocked, LISTING_LABELS.overridden, LISTING_LABELS.takedown],
+	},
+	{
+		actor: "reviewer",
+		action: "approve",
+		issues: [LISTING_LABELS.passed, LISTING_LABELS.overridden],
+		negatesForExactCid: [LISTING_LABELS.review, LISTING_LABELS.error, LISTING_LABELS.blocked],
+		preserves: [LISTING_LABELS.takedown],
+	},
+	{
+		actor: "reviewer",
+		action: "block",
+		issues: [LISTING_LABELS.blocked],
+		negatesForExactCid: [LISTING_LABELS.passed, LISTING_LABELS.overridden],
+		preserves: [LISTING_LABELS.takedown],
+	},
+	{
+		actor: "admin",
+		action: "takedown",
+		issues: [LISTING_LABELS.takedown],
+		negatesForExactCid: [],
+		preserves: [],
+	},
+	{
+		actor: "admin",
+		action: "retract-takedown",
+		issues: [],
+		negatesForExactCid: [],
+		negatesForSubject: [LISTING_LABELS.takedown],
+		preserves: [],
+	},
+] as const;

--- a/packages/registry-moderation/src/index.ts
+++ b/packages/registry-moderation/src/index.ts
@@ -1,0 +1,8 @@
+export * from "./evaluate.js";
+export * from "./findings.js";
+export * from "./inputs.js";
+export * from "./label-crypto.js";
+export * from "./labels.js";
+export * from "./policy.js";
+export * from "./withdrawal.js";
+export type { RuntimeSchema } from "./schema.js";

--- a/packages/registry-moderation/src/inputs.ts
+++ b/packages/registry-moderation/src/inputs.ts
@@ -1,0 +1,343 @@
+import { PROFILE_COLLECTION, RELEASE_COLLECTION, type ListingSubjectKind } from "./labels.js";
+import {
+	dictionary,
+	integerValue,
+	optionalBoolean,
+	optionalInteger,
+	optionalString,
+	record,
+	runtimeSchema,
+	stringArray,
+	stringValue,
+} from "./schema.js";
+import { assertCanonicalCid, assertDid, parseAtUri } from "./validation.js";
+
+export interface ModerationSubject {
+	uri: string;
+	cid: string;
+	kind: ListingSubjectKind;
+}
+
+export interface CanonicalAuthorInput {
+	name: string;
+	url?: string;
+	email?: string;
+}
+
+export interface CanonicalContactInput {
+	url?: string;
+	email?: string;
+}
+
+export interface CanonicalProfileModerationInput {
+	schemaVersion: 1;
+	subject: ModerationSubject & { kind: "profile" };
+	publisherDid: string;
+	slug: string;
+	name?: string;
+	description?: string;
+	keywords: readonly string[];
+	license: string;
+	sections: Readonly<Record<string, string>>;
+	authors: readonly CanonicalAuthorInput[];
+	security: readonly CanonicalContactInput[];
+	lastUpdated?: string;
+}
+
+export type DisplayMediaKind = "icon" | "banner" | "screenshot";
+export const RENDERED_PROFILE_SECTION_KEYS = [
+	"description",
+	"installation",
+	"faq",
+	"changelog",
+	"security",
+] as const;
+
+export interface CanonicalMediaDescriptor {
+	kind: DisplayMediaKind;
+	index: number;
+	id?: string;
+	url: string;
+	checksum: string;
+	contentType?: string;
+	requiresAuth?: boolean;
+	releaseAsset?: boolean;
+	width?: number;
+	height?: number;
+	language?: string;
+	verified?: {
+		sha256: string;
+		mimeType: string;
+		byteLength: number;
+		width: number;
+		height: number;
+		contentRef: string;
+	};
+}
+
+export interface CanonicalReleaseModerationInput {
+	schemaVersion: 1;
+	subject: ModerationSubject & { kind: "release" };
+	publisherDid: string;
+	packageSlug: string;
+	version: string;
+	repositoryUrl?: string;
+	requires: Readonly<Record<string, string>>;
+	sbom?: { format?: string; url?: string };
+	media: readonly CanonicalMediaDescriptor[];
+}
+
+function parseSubject(
+	value: unknown,
+	kind: "profile",
+	publisherDid: string,
+): ModerationSubject & { kind: "profile" };
+function parseSubject(
+	value: unknown,
+	kind: "release",
+	publisherDid: string,
+): ModerationSubject & { kind: "release" };
+function parseSubject(
+	value: unknown,
+	kind: ListingSubjectKind,
+	publisherDid: string,
+): ModerationSubject {
+	const subject = record(value, "subject", ["uri", "cid", "kind"]);
+	const uri = stringValue(subject["uri"], "subject.uri", 2048);
+	const cid = stringValue(subject["cid"], "subject.cid", 256);
+	if (subject["kind"] !== kind) throw new TypeError(`subject.kind must be ${kind}`);
+	const expectedCollection = kind === "profile" ? PROFILE_COLLECTION : RELEASE_COLLECTION;
+	const parsed = parseAtUri(uri, "subject.uri");
+	if (parsed.authority !== publisherDid) {
+		throw new TypeError("subject.uri authority must match publisherDid");
+	}
+	if (parsed.collection !== expectedCollection) {
+		throw new TypeError(`subject.uri must target ${expectedCollection}`);
+	}
+	assertCanonicalCid(cid, "subject.cid");
+	return { uri, cid, kind };
+}
+
+function parsePublisherDid(value: unknown): string {
+	const publisherDid = stringValue(value, "publisherDid", 256);
+	assertDid(publisherDid, "publisherDid");
+	return publisherDid;
+}
+
+function parseAuthors(value: unknown): CanonicalAuthorInput[] {
+	if (!Array.isArray(value) || value.length === 0 || value.length > 32) {
+		throw new TypeError("authors must contain between 1 and 32 entries");
+	}
+	return value.map((entry, index) => {
+		const author = record(entry, `authors[${index}]`, ["name", "url", "email"]);
+		return {
+			name: stringValue(author["name"], `authors[${index}].name`, 256),
+			url: optionalString(author["url"], `authors[${index}].url`, 1024),
+			email: optionalString(author["email"], `authors[${index}].email`, 256),
+		};
+	});
+}
+
+function parseContacts(value: unknown): CanonicalContactInput[] {
+	if (!Array.isArray(value) || value.length === 0 || value.length > 8) {
+		throw new TypeError("security must contain between 1 and 8 entries");
+	}
+	return value.map((entry, index) => {
+		const contact = record(entry, `security[${index}]`, ["url", "email"]);
+		const parsed = {
+			url: optionalString(contact["url"], `security[${index}].url`, 1024),
+			email: optionalString(contact["email"], `security[${index}].email`, 256),
+		};
+		if (!parsed.url && !parsed.email) {
+			throw new TypeError(`security[${index}] must contain url or email`);
+		}
+		return parsed;
+	});
+}
+
+function parseStringRecord(
+	value: unknown,
+	field: string,
+	maxItems: number,
+	allowedKeys?: readonly string[],
+): Record<string, string> {
+	const source = dictionary(value, field);
+	const entries = Object.entries(source);
+	if (entries.length > maxItems) throw new TypeError(`${field} has too many entries`);
+	if (allowedKeys && entries.some(([key]) => !allowedKeys.includes(key))) {
+		throw new TypeError(`${field} contains a field that official clients do not render`);
+	}
+	return Object.fromEntries(
+		entries.map(([key, item]) => [
+			stringValue(key, `${field} key`, 128),
+			stringValue(item, `${field}.${key}`),
+		]),
+	);
+}
+
+function parseProfile(value: unknown): CanonicalProfileModerationInput {
+	const profile = record(value, "profile input", [
+		"schemaVersion",
+		"subject",
+		"publisherDid",
+		"slug",
+		"name",
+		"description",
+		"keywords",
+		"license",
+		"sections",
+		"authors",
+		"security",
+		"lastUpdated",
+	]);
+	if (profile["schemaVersion"] !== 1) throw new TypeError("schemaVersion must be 1");
+	const publisherDid = parsePublisherDid(profile["publisherDid"]);
+	const subject = parseSubject(profile["subject"], "profile", publisherDid);
+	const slug = stringValue(profile["slug"], "slug", 64);
+	if (parseAtUri(subject.uri, "subject.uri").rkey !== slug) {
+		throw new TypeError("slug must match the profile record key");
+	}
+	return {
+		schemaVersion: 1,
+		subject,
+		publisherDid,
+		slug,
+		name: optionalString(profile["name"], "name", 1024),
+		description: optionalString(profile["description"], "description", 1024),
+		keywords: stringArray(profile["keywords"], "keywords", 5),
+		license: stringValue(profile["license"], "license", 256),
+		sections: parseStringRecord(
+			profile["sections"],
+			"sections",
+			RENDERED_PROFILE_SECTION_KEYS.length,
+			RENDERED_PROFILE_SECTION_KEYS,
+		),
+		authors: parseAuthors(profile["authors"]),
+		security: parseContacts(profile["security"]),
+		lastUpdated: optionalString(profile["lastUpdated"], "lastUpdated", 64),
+	};
+}
+
+function parseVerifiedMedia(value: unknown, field: string): CanonicalMediaDescriptor["verified"] {
+	if (value === undefined) return undefined;
+	const verified = record(value, field, [
+		"sha256",
+		"mimeType",
+		"byteLength",
+		"width",
+		"height",
+		"contentRef",
+	]);
+	return {
+		sha256: stringValue(verified["sha256"], `${field}.sha256`, 128),
+		mimeType: stringValue(verified["mimeType"], `${field}.mimeType`, 256),
+		byteLength: integerValue(verified["byteLength"], `${field}.byteLength`),
+		width: integerValue(verified["width"], `${field}.width`),
+		height: integerValue(verified["height"], `${field}.height`),
+		contentRef: stringValue(verified["contentRef"], `${field}.contentRef`, 512),
+	};
+}
+
+function parseMedia(value: unknown): CanonicalMediaDescriptor[] {
+	if (!Array.isArray(value) || value.length > 10) {
+		throw new TypeError("media must be an array of at most 10 entries");
+	}
+	const parsed = value.map((entry, index) => {
+		const field = `media[${index}]`;
+		const media = record(entry, field, [
+			"kind",
+			"index",
+			"id",
+			"url",
+			"checksum",
+			"contentType",
+			"requiresAuth",
+			"releaseAsset",
+			"width",
+			"height",
+			"language",
+			"verified",
+		]);
+		const kind = media["kind"];
+		if (!isDisplayMediaKind(kind)) {
+			throw new TypeError(`${field}.kind is not display media`);
+		}
+		return {
+			kind,
+			index: integerValue(media["index"], `${field}.index`),
+			id: optionalString(media["id"], `${field}.id`, 128),
+			url: stringValue(media["url"], `${field}.url`, 2048),
+			checksum: stringValue(media["checksum"], `${field}.checksum`, 256),
+			contentType: optionalString(media["contentType"], `${field}.contentType`, 256),
+			requiresAuth: optionalBoolean(media["requiresAuth"], `${field}.requiresAuth`),
+			releaseAsset: optionalBoolean(media["releaseAsset"], `${field}.releaseAsset`),
+			width: optionalInteger(media["width"], `${field}.width`),
+			height: optionalInteger(media["height"], `${field}.height`),
+			language: optionalString(media["language"], `${field}.language`, 64),
+			verified: parseVerifiedMedia(media["verified"], `${field}.verified`),
+		};
+	});
+	const keys = parsed.map((media) => `${media.kind}:${media.index}`);
+	if (new Set(keys).size !== keys.length) throw new TypeError("media entries must be unique");
+	if (parsed.filter((media) => media.kind === "icon").length > 1) {
+		throw new TypeError("media may contain at most one icon");
+	}
+	if (parsed.filter((media) => media.kind === "banner").length > 1) {
+		throw new TypeError("media may contain at most one banner");
+	}
+	if (parsed.filter((media) => media.kind === "screenshot").length > 8) {
+		throw new TypeError("media may contain at most eight screenshots");
+	}
+	if (parsed.some((media) => media.kind !== "screenshot" && media.index !== 0)) {
+		throw new TypeError("icon and banner media indices must be zero");
+	}
+	return parsed;
+}
+
+function parseRelease(value: unknown): CanonicalReleaseModerationInput {
+	const release = record(value, "release input", [
+		"schemaVersion",
+		"subject",
+		"publisherDid",
+		"packageSlug",
+		"version",
+		"repositoryUrl",
+		"requires",
+		"sbom",
+		"media",
+	]);
+	if (release["schemaVersion"] !== 1) throw new TypeError("schemaVersion must be 1");
+	const publisherDid = parsePublisherDid(release["publisherDid"]);
+	const subject = parseSubject(release["subject"], "release", publisherDid);
+	const packageSlug = stringValue(release["packageSlug"], "packageSlug", 64);
+	const version = stringValue(release["version"], "version", 64);
+	if (parseAtUri(subject.uri, "subject.uri").rkey !== `${packageSlug}:${version}`) {
+		throw new TypeError("packageSlug and version must match the release record key");
+	}
+	let sbom: CanonicalReleaseModerationInput["sbom"];
+	if (release["sbom"] !== undefined) {
+		const source = record(release["sbom"], "sbom", ["format", "url"]);
+		sbom = {
+			format: optionalString(source["format"], "sbom.format", 32),
+			url: optionalString(source["url"], "sbom.url", 2048),
+		};
+	}
+	return {
+		schemaVersion: 1,
+		subject,
+		publisherDid,
+		packageSlug,
+		version,
+		repositoryUrl: optionalString(release["repositoryUrl"], "repositoryUrl", 1024),
+		requires: parseStringRecord(release["requires"], "requires", 64),
+		sbom,
+		media: parseMedia(release["media"]),
+	};
+}
+
+export const CanonicalProfileModerationInputSchema = runtimeSchema(parseProfile);
+export const CanonicalReleaseModerationInputSchema = runtimeSchema(parseRelease);
+
+function isDisplayMediaKind(value: unknown): value is DisplayMediaKind {
+	return value === "icon" || value === "banner" || value === "screenshot";
+}

--- a/packages/registry-moderation/src/label-crypto.ts
+++ b/packages/registry-moderation/src/label-crypto.ts
@@ -1,0 +1,311 @@
+import { encode, toBytes } from "@atcute/cbor";
+import { P256PrivateKey, P256PublicKey, parsePublicMultikey } from "@atcute/crypto";
+import { fromBase64Url, toBase64Url } from "@atcute/multibase";
+
+import { PROFILE_COLLECTION, RELEASE_COLLECTION, type ListingLabelEvent } from "./labels.js";
+import { assertCanonicalCid, assertDid, isDid, parseAtUri, parseInstant } from "./validation.js";
+
+export interface SignedListingLabel extends ListingLabelEvent {
+	sig: Uint8Array;
+}
+
+const verifiedListingLabel = Symbol("verifiedListingLabel");
+const verifiedListingLabels = new WeakSet<object>();
+
+export type VerifiedListingLabel = Readonly<ListingLabelEvent> & {
+	readonly [verifiedListingLabel]: true;
+};
+
+export interface DidVerificationMethod {
+	id: string;
+	type: string;
+	controller: string;
+	publicKeyMultibase: string;
+}
+
+export interface LabelDidDocument {
+	id: string;
+	verificationMethod?: readonly DidVerificationMethod[];
+}
+
+export type LabelDidResolver = (did: string) => Promise<LabelDidDocument>;
+
+export interface CreateListingLabelSignerInput {
+	issuerDid: string;
+	privateKey: string;
+	resolveDid: LabelDidResolver;
+}
+
+export interface ListingLabelSigner {
+	readonly issuerDid: string;
+	sign(label: Omit<ListingLabelEvent, "src">): Promise<SignedListingLabel>;
+}
+
+export interface ListingLabelVerificationInput {
+	label: SignedListingLabel;
+	resolveDid: LabelDidResolver;
+}
+
+export class InvalidListingLabelSignatureError extends TypeError {
+	constructor(message: string) {
+		super(message);
+		this.name = "InvalidListingLabelSignatureError";
+	}
+}
+
+const P256_ORDER = BigInt("0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551");
+const LABEL_FIELDS = new Set(["ver", "src", "uri", "cid", "val", "neg", "cts", "exp"]);
+const SIGNED_LABEL_FIELDS = new Set([...LABEL_FIELDS, "sig"]);
+const PRINTABLE_LABEL_VALUE = /^[^\p{Cc}]{1,128}$/u;
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+
+function scalarToBigInt(bytes: Uint8Array): bigint {
+	let value = 0n;
+	for (const byte of bytes) value = (value << 8n) | BigInt(byte);
+	return value;
+}
+
+function utf8Length(value: string): number {
+	let length = 0;
+	for (let index = 0; index < value.length; index++) {
+		const codeUnit = value.charCodeAt(index);
+		if (codeUnit <= 0x7f) length++;
+		else if (codeUnit <= 0x7ff) length += 2;
+		else if (
+			codeUnit >= 0xd800 &&
+			codeUnit <= 0xdbff &&
+			value.charCodeAt(index + 1) >= 0xdc00 &&
+			value.charCodeAt(index + 1) <= 0xdfff
+		) {
+			length += 4;
+			index++;
+		} else length += 3;
+	}
+	return length;
+}
+
+function validateLabelValue(value: unknown): asserts value is string {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		!PRINTABLE_LABEL_VALUE.test(value) ||
+		utf8Length(value) > 128
+	) {
+		throw new TypeError(
+			"label.val must be a non-empty printable string of at most 128 UTF-8 bytes",
+		);
+	}
+}
+
+function validateLabelUri(value: unknown): asserts value is string {
+	if (isDid(value)) return;
+	const subject = parseAtUri(value, "label.uri");
+	if (subject.collection !== PROFILE_COLLECTION && subject.collection !== RELEASE_COLLECTION) {
+		throw new TypeError("label.uri must identify a plugin profile or release record");
+	}
+}
+
+function getField(value: object, field: string): unknown {
+	return Object.getOwnPropertyDescriptor(value, field)?.value;
+}
+
+function validateLabelObject(value: unknown, signed: true): SignedListingLabel;
+function validateLabelObject(value: unknown, signed: false): ListingLabelEvent;
+function validateLabelObject(
+	value: unknown,
+	signed: boolean,
+): SignedListingLabel | ListingLabelEvent {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new TypeError("label must be an object");
+	}
+	const fields = signed ? SIGNED_LABEL_FIELDS : LABEL_FIELDS;
+	for (const field of Object.keys(value)) {
+		if (!fields.has(field)) throw new TypeError(`label contains unsupported field: ${field}`);
+	}
+	if (getField(value, "ver") !== 1) throw new TypeError("label.ver must be 1");
+	const src = getField(value, "src");
+	const uri = getField(value, "uri");
+	const cid = getField(value, "cid");
+	const val = getField(value, "val");
+	const neg = getField(value, "neg");
+	const cts = getField(value, "cts");
+	const exp = getField(value, "exp");
+	assertDid(src, "label.src");
+	validateLabelUri(uri);
+	validateLabelValue(val);
+	if (typeof cts !== "string") throw new TypeError("label.cts must be a valid RFC 3339 timestamp");
+	parseInstant(cts, "label.cts");
+	if (cid !== undefined) assertCanonicalCid(cid, "label.cid");
+	if (isDid(uri) && cid !== undefined) throw new TypeError("DID-scoped labels must not have a CID");
+	if (neg !== undefined && typeof neg !== "boolean") {
+		throw new TypeError("label.neg must be a boolean");
+	}
+	if (exp !== undefined) {
+		if (typeof exp !== "string") {
+			throw new TypeError("label.exp must be a valid RFC 3339 timestamp");
+		}
+		parseInstant(exp, "label.exp");
+	}
+	const canonical = {
+		ver: 1 as const,
+		src,
+		uri,
+		...(cid === undefined ? {} : { cid }),
+		val,
+		...(neg === true ? { neg: true } : {}),
+		cts,
+		...(exp === undefined ? {} : { exp }),
+	};
+	if (!signed) return canonical;
+	const sig = getField(value, "sig");
+	if (!(sig instanceof Uint8Array) || sig.length !== 64) {
+		throw new TypeError("label.sig must be a 64-byte compact P-256 signature");
+	}
+	return { ...canonical, sig: Uint8Array.from(sig) };
+}
+
+function canonicalLabelBytes(label: ListingLabelEvent): Uint8Array {
+	return encode(validateLabelObject(label, false));
+}
+
+export function parseListingLabel(value: unknown): ListingLabelEvent {
+	return validateLabelObject(value, false);
+}
+
+export function parseSignedListingLabel(value: unknown): SignedListingLabel {
+	return validateLabelObject(value, true);
+}
+
+export function encodeSignedListingLabel(label: SignedListingLabel): Uint8Array {
+	const { sig, ...unsigned } = parseSignedListingLabel(label);
+	return encode({ ...unsigned, sig: toBytes(sig) });
+}
+
+function importPrivateScalar(value: string): Promise<P256PrivateKey> {
+	if (!BASE64URL.test(value)) {
+		throw new TypeError("privateKey must be canonical unpadded base64url");
+	}
+	let bytes: Uint8Array;
+	try {
+		bytes = fromBase64Url(value);
+	} catch {
+		throw new TypeError("privateKey must be canonical unpadded base64url");
+	}
+	if (bytes.length !== 32 || toBase64Url(bytes) !== value) {
+		throw new TypeError("privateKey must be canonical unpadded base64url for exactly 32 bytes");
+	}
+	const scalar = scalarToBigInt(bytes);
+	if (scalar === 0n || scalar >= P256_ORDER) {
+		throw new TypeError("privateKey must be in the P-256 scalar range");
+	}
+	return P256PrivateKey.importRaw(bytes);
+}
+
+function normalizedMethodId(documentId: string, methodId: string): string {
+	return methodId.startsWith("#") ? `${documentId}${methodId}` : methodId;
+}
+
+async function resolveLabelPublicKey(
+	did: string,
+	resolveDid: LabelDidResolver,
+): Promise<P256PublicKey> {
+	const document = await resolveDid(did);
+	assertDid(document.id, "DID document id");
+	if (document.id !== did) throw new TypeError("DID document id does not match label source");
+	const ids = new Set<string>();
+	let signingMethod: DidVerificationMethod | undefined;
+	for (const method of document.verificationMethod ?? []) {
+		const id = normalizedMethodId(document.id, method.id);
+		if (ids.has(id)) throw new TypeError("DID document has duplicate verification method ids");
+		ids.add(id);
+		if (id === `${did}#atproto_label`) signingMethod = { ...method, id };
+	}
+	if (!signingMethod) throw new TypeError("DID document has no #atproto_label verification method");
+	if (signingMethod.type !== "Multikey" || signingMethod.controller !== did) {
+		throw new TypeError("#atproto_label verification method must be a controller-owned Multikey");
+	}
+	let parsed: ReturnType<typeof parsePublicMultikey>;
+	try {
+		parsed = parsePublicMultikey(signingMethod.publicKeyMultibase);
+	} catch {
+		throw new TypeError("#atproto_label verification method has an invalid Multikey");
+	}
+	if (
+		parsed.type !== "p256" ||
+		parsed.publicKeyBytes.length !== 33 ||
+		![2, 3].includes(parsed.publicKeyBytes[0]!)
+	) {
+		throw new TypeError("#atproto_label verification method must contain a compressed P-256 key");
+	}
+	const key = await P256PublicKey.importRaw(parsed.publicKeyBytes);
+	if ((await key.exportPublicKey("multikey")) !== signingMethod.publicKeyMultibase) {
+		throw new TypeError("#atproto_label verification method uses a non-canonical P-256 Multikey");
+	}
+	return key;
+}
+
+export async function createListingLabelSigner(
+	input: CreateListingLabelSignerInput,
+): Promise<ListingLabelSigner> {
+	assertDid(input.issuerDid, "issuerDid");
+	const key = await importPrivateScalar(input.privateKey);
+	const resolved = await resolveLabelPublicKey(input.issuerDid, input.resolveDid);
+	if ((await key.exportPublicKey("multikey")) !== (await resolved.exportPublicKey("multikey"))) {
+		throw new TypeError(
+			"privateKey does not match the issuer DID #atproto_label verification method",
+		);
+	}
+	return {
+		issuerDid: input.issuerDid,
+		async sign(label) {
+			const unsigned = validateLabelObject({ ...label, src: input.issuerDid }, false);
+			return { ...unsigned, sig: await key.sign(canonicalLabelBytes(unsigned)) };
+		},
+	};
+}
+
+function brandVerifiedListingLabel(label: ListingLabelEvent): VerifiedListingLabel {
+	const verified: VerifiedListingLabel = { ...label, [verifiedListingLabel]: true };
+	Object.defineProperty(verified, verifiedListingLabel, { value: true, enumerable: false });
+	Object.freeze(verified);
+	verifiedListingLabels.add(verified);
+	return verified;
+}
+
+export function isVerifiedListingLabel(value: unknown): value is VerifiedListingLabel {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		verifiedListingLabels.has(value) &&
+		Object.getOwnPropertyDescriptor(value, verifiedListingLabel)?.value === true
+	);
+}
+
+export async function verifyListingLabelWithPublicKey(input: {
+	label: SignedListingLabel;
+	expectedSource: string;
+	publicKey: P256PublicKey;
+}): Promise<VerifiedListingLabel> {
+	assertDid(input.expectedSource, "expectedSource");
+	const label = parseSignedListingLabel(input.label);
+	if (label.src !== input.expectedSource) {
+		throw new TypeError("label.src does not match expectedSource");
+	}
+	const { sig, ...unsigned } = label;
+	if (!(await input.publicKey.verify(sig, canonicalLabelBytes(unsigned)))) {
+		throw new InvalidListingLabelSignatureError("label signature is invalid");
+	}
+	return brandVerifiedListingLabel(unsigned);
+}
+
+export async function verifyListingLabel(
+	input: ListingLabelVerificationInput,
+): Promise<VerifiedListingLabel> {
+	const label = parseSignedListingLabel(input.label);
+	const publicKey = await resolveLabelPublicKey(label.src, input.resolveDid);
+	return verifyListingLabelWithPublicKey({
+		label,
+		expectedSource: label.src,
+		publicKey,
+	});
+}

--- a/packages/registry-moderation/src/labels.ts
+++ b/packages/registry-moderation/src/labels.ts
@@ -1,0 +1,118 @@
+import { compareInstants, parseAtUri, parseInstant, type ParsedInstant } from "./validation.js";
+
+export const PROFILE_COLLECTION = "com.emdashcms.experimental.package.profile";
+export const RELEASE_COLLECTION = "com.emdashcms.experimental.package.release";
+
+export const LISTING_LABELS = {
+	passed: "listing-passed",
+	pending: "listing-pending",
+	review: "listing-review",
+	error: "listing-error",
+	blocked: "listing-blocked",
+	overridden: "listing-overridden",
+	takedown: "!takedown",
+} as const;
+
+export type ListingLabelValue = (typeof LISTING_LABELS)[keyof typeof LISTING_LABELS];
+export type ListingSubjectKind = "profile" | "release";
+
+export interface ListingLabelEvent {
+	ver: 1;
+	src: string;
+	uri: string;
+	val: ListingLabelValue | (string & {});
+	cts: string;
+	cid?: string;
+	neg?: boolean;
+	exp?: string;
+}
+
+export interface ReducedListingLabel {
+	key: string;
+	winner: ListingLabelEvent;
+	active: boolean;
+	collision: readonly ListingLabelEvent[];
+}
+
+export interface ListingLabelReduction {
+	states: readonly ReducedListingLabel[];
+	byKey: ReadonlyMap<string, ReducedListingLabel>;
+}
+
+export function listingLabelKey(label: Pick<ListingLabelEvent, "src" | "uri" | "val">): string {
+	return `${label.src}\u0000${label.uri}\u0000${label.val}`;
+}
+
+function sameEvent(left: ListingLabelEvent, right: ListingLabelEvent): boolean {
+	return (
+		left.ver === right.ver &&
+		left.src === right.src &&
+		left.uri === right.uri &&
+		left.cid === right.cid &&
+		left.val === right.val &&
+		(left.neg === true) === (right.neg === true) &&
+		left.cts === right.cts &&
+		left.exp === right.exp
+	);
+}
+
+function isActiveAt(label: ListingLabelEvent, now: ParsedInstant): boolean {
+	return (
+		label.neg !== true &&
+		(label.exp === undefined || compareInstants(parseInstant(label.exp, "label.exp"), now) > 0)
+	);
+}
+
+export function isListingLabelActive(
+	label: ListingLabelEvent,
+	evaluatedAt: Date | string,
+): boolean {
+	return isActiveAt(label, parseInstant(evaluatedAt, "evaluatedAt"));
+}
+
+export function reduceListingLabels(
+	labels: readonly ListingLabelEvent[],
+	evaluatedAt: Date | string,
+): ListingLabelReduction {
+	const now = parseInstant(evaluatedAt, "evaluatedAt");
+	const streams = new Map<string, { label: ListingLabelEvent; cts: ParsedInstant }[]>();
+	for (const label of labels) {
+		const key = listingLabelKey(label);
+		const entry = { label, cts: parseInstant(label.cts, "label.cts") };
+		const stream = streams.get(key);
+		if (stream) stream.push(entry);
+		else streams.set(key, [entry]);
+	}
+
+	const states: ReducedListingLabel[] = [];
+	for (const [key, stream] of streams) {
+		const winners = stream.filter((candidate) =>
+			stream.every((other) => compareInstants(candidate.cts, other.cts) >= 0),
+		);
+		const winner = winners[0];
+		if (!winner) continue;
+		const collision = winners.some((candidate) => !sameEvent(candidate.label, winner.label))
+			? winners.map((candidate) => candidate.label)
+			: [];
+		states.push({
+			key,
+			winner: winner.label,
+			active: collision.length === 0 && isActiveAt(winner.label, now),
+			collision,
+		});
+	}
+	states.sort((left, right) => left.key.localeCompare(right.key));
+	return { states, byKey: new Map(states.map((state) => [state.key, state])) };
+}
+
+export function subjectKindFromUri(uri: string): ListingSubjectKind | null {
+	let collection: string;
+	try {
+		collection = parseAtUri(uri, "subject.uri").collection;
+	} catch {
+		return null;
+	}
+	if (collection === PROFILE_COLLECTION) return "profile";
+	if (collection === RELEASE_COLLECTION) return "release";
+	return null;
+}

--- a/packages/registry-moderation/src/policy.ts
+++ b/packages/registry-moderation/src/policy.ts
@@ -1,0 +1,126 @@
+import { LISTING_LABELS, type ListingLabelValue } from "./labels.js";
+import { record, runtimeSchema, stringArray, stringValue } from "./schema.js";
+import { assertDid, parseInstant } from "./validation.js";
+
+export interface ListingModerationPolicy {
+	schemaVersion: 1;
+	policyVersion: string;
+	effectiveAt: string;
+	requiredPositiveSources: readonly string[];
+	acceptedStateSources: readonly string[];
+	redactionSources: readonly string[];
+	autoPass: "disabled" | "assisted";
+	prohibitedCategories: readonly ModerationFindingCategory[];
+}
+
+export const MODERATION_FINDING_CATEGORIES = [
+	"explicit-sexual-content",
+	"hateful-or-dehumanizing-content",
+	"graphic-violence",
+	"phishing-or-credential-solicitation",
+	"material-impersonation",
+	"scam-or-spam",
+	"malicious-or-deceptive-link",
+	"misleading-media-or-claims",
+] as const;
+
+export type ModerationFindingCategory = (typeof MODERATION_FINDING_CATEGORIES)[number];
+
+export function isModerationFindingCategory(value: unknown): value is ModerationFindingCategory {
+	return MODERATION_FINDING_CATEGORIES.some((category) => category === value);
+}
+
+export const STATE_LABEL_VALUES: readonly ListingLabelValue[] = [
+	LISTING_LABELS.passed,
+	LISTING_LABELS.pending,
+	LISTING_LABELS.review,
+	LISTING_LABELS.error,
+	LISTING_LABELS.blocked,
+	LISTING_LABELS.overridden,
+];
+
+export function stateSources(policy: ListingModerationPolicy): ReadonlySet<string> {
+	return new Set([...policy.requiredPositiveSources, ...policy.acceptedStateSources]);
+}
+
+export function assertListingModerationPolicy(value: ListingModerationPolicy): void {
+	if (value.schemaVersion !== 1) throw new TypeError("policy.schemaVersion must be 1");
+	if (!value.policyVersion) throw new TypeError("policy.policyVersion must not be empty");
+	parseInstant(value.effectiveAt, "policy.effectiveAt");
+	for (const [field, sources] of [
+		["requiredPositiveSources", value.requiredPositiveSources],
+		["acceptedStateSources", value.acceptedStateSources],
+		["redactionSources", value.redactionSources],
+	] as const) {
+		if (new Set(sources).size !== sources.length) {
+			throw new TypeError(`policy.${field} must not contain duplicate sources`);
+		}
+		for (const source of sources) assertDid(source, `policy.${field}`);
+	}
+	if (value.requiredPositiveSources.length === 0) {
+		throw new TypeError("policy.requiredPositiveSources must not be empty");
+	}
+	if (value.autoPass !== "disabled" && value.autoPass !== "assisted") {
+		throw new TypeError("policy.autoPass must be disabled or assisted");
+	}
+	if (new Set(value.prohibitedCategories).size !== value.prohibitedCategories.length) {
+		throw new TypeError("policy.prohibitedCategories must not contain duplicates");
+	}
+	for (const category of value.prohibitedCategories) {
+		if (!(MODERATION_FINDING_CATEGORIES as readonly string[]).includes(category)) {
+			throw new TypeError(`policy contains unknown category: ${category}`);
+		}
+	}
+}
+
+function parsePolicy(value: unknown): ListingModerationPolicy {
+	const policy = record(value, "policy", [
+		"schemaVersion",
+		"policyVersion",
+		"effectiveAt",
+		"requiredPositiveSources",
+		"acceptedStateSources",
+		"redactionSources",
+		"autoPass",
+		"prohibitedCategories",
+	]);
+	const autoPass = policy["autoPass"];
+	if (autoPass !== "disabled" && autoPass !== "assisted") {
+		throw new TypeError("policy.autoPass must be disabled or assisted");
+	}
+	if (policy["schemaVersion"] !== 1) throw new TypeError("policy.schemaVersion must be 1");
+	const prohibitedValues = stringArray(
+		policy["prohibitedCategories"],
+		"policy.prohibitedCategories",
+		MODERATION_FINDING_CATEGORIES.length,
+	);
+	const prohibitedCategories: ModerationFindingCategory[] = [];
+	for (const category of prohibitedValues) {
+		if (!isModerationFindingCategory(category)) {
+			throw new TypeError(`policy contains unknown category: ${category}`);
+		}
+		prohibitedCategories.push(category);
+	}
+	const parsed: ListingModerationPolicy = {
+		schemaVersion: 1,
+		policyVersion: stringValue(policy["policyVersion"], "policy.policyVersion", 128),
+		effectiveAt: stringValue(policy["effectiveAt"], "policy.effectiveAt", 64),
+		requiredPositiveSources: stringArray(
+			policy["requiredPositiveSources"],
+			"policy.requiredPositiveSources",
+			16,
+		),
+		acceptedStateSources: stringArray(
+			policy["acceptedStateSources"],
+			"policy.acceptedStateSources",
+			16,
+		),
+		redactionSources: stringArray(policy["redactionSources"], "policy.redactionSources", 16),
+		autoPass,
+		prohibitedCategories,
+	};
+	assertListingModerationPolicy(parsed);
+	return parsed;
+}
+
+export const ListingModerationPolicySchema = runtimeSchema(parsePolicy);

--- a/packages/registry-moderation/src/schema.ts
+++ b/packages/registry-moderation/src/schema.ts
@@ -1,0 +1,100 @@
+export interface ParseSuccess<T> {
+	success: true;
+	data: T;
+}
+
+export interface ParseFailure {
+	success: false;
+	error: TypeError;
+}
+
+export interface RuntimeSchema<T> {
+	parse(value: unknown): T;
+	safeParse(value: unknown): ParseSuccess<T> | ParseFailure;
+}
+
+export function runtimeSchema<T>(parser: (value: unknown) => T): RuntimeSchema<T> {
+	return {
+		parse: parser,
+		safeParse(value) {
+			try {
+				return { success: true, data: parser(value) };
+			} catch (error) {
+				return {
+					success: false,
+					error:
+						error instanceof TypeError ? error : new TypeError("Invalid value", { cause: error }),
+				};
+			}
+		},
+	};
+}
+
+export function record(
+	value: unknown,
+	field: string,
+	allowed: readonly string[],
+): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new TypeError(`${field} must be an object`);
+	}
+	const output: Record<string, unknown> = {};
+	for (const key of Object.keys(value)) {
+		if (!allowed.includes(key)) throw new TypeError(`${field} contains unsupported field: ${key}`);
+		output[key] = Object.getOwnPropertyDescriptor(value, key)?.value;
+	}
+	return output;
+}
+
+export function dictionary(value: unknown, field: string): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new TypeError(`${field} must be an object`);
+	}
+	const output: Record<string, unknown> = {};
+	for (const key of Object.keys(value)) {
+		output[key] = Object.getOwnPropertyDescriptor(value, key)?.value;
+	}
+	return output;
+}
+
+export function stringValue(value: unknown, field: string, maxLength = 20_000): string {
+	if (typeof value !== "string" || value.length === 0 || value.length > maxLength) {
+		throw new TypeError(`${field} must be a non-empty string of at most ${maxLength} characters`);
+	}
+	return value;
+}
+
+export function optionalString(
+	value: unknown,
+	field: string,
+	maxLength?: number,
+): string | undefined {
+	return value === undefined ? undefined : stringValue(value, field, maxLength);
+}
+
+export function stringArray(value: unknown, field: string, maxItems: number): string[] {
+	if (!Array.isArray(value) || value.length > maxItems) {
+		throw new TypeError(`${field} must be an array of at most ${maxItems} strings`);
+	}
+	return value.map((item, index) => stringValue(item, `${field}[${index}]`));
+}
+
+export function optionalInteger(value: unknown, field: string): number | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+		throw new TypeError(`${field} must be a non-negative integer`);
+	}
+	return value;
+}
+
+export function integerValue(value: unknown, field: string): number {
+	const parsed = optionalInteger(value, field);
+	if (parsed === undefined) throw new TypeError(`${field} is required`);
+	return parsed;
+}
+
+export function optionalBoolean(value: unknown, field: string): boolean | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== "boolean") throw new TypeError(`${field} must be boolean`);
+	return value;
+}

--- a/packages/registry-moderation/src/validation.ts
+++ b/packages/registry-moderation/src/validation.ts
@@ -1,0 +1,135 @@
+import { fromString as cidFromString, toString as cidToString } from "@atcute/cid";
+
+const DID_METHOD = "[a-z0-9]+";
+const DID_ID_SEGMENT = "(?:[A-Za-z0-9._-]|%[0-9A-Fa-f]{2})+";
+const DID = new RegExp(`^did:${DID_METHOD}:${DID_ID_SEGMENT}(?::${DID_ID_SEGMENT})*$`);
+const RECORD_KEY = /^[A-Za-z0-9._~:-]{1,512}$/;
+const RFC3339 = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/;
+
+export interface ParsedAtUri {
+	authority: string;
+	collection: string;
+	rkey: string;
+}
+
+export interface ParsedInstant {
+	seconds: bigint;
+	fraction: string;
+}
+
+export function isDid(value: unknown): value is string {
+	return typeof value === "string" && DID.test(value);
+}
+
+export function assertDid(value: unknown, field: string): asserts value is string {
+	if (!isDid(value)) throw new TypeError(`${field} must be a valid DID`);
+}
+
+export function assertCanonicalCid(value: unknown, field: string): asserts value is string {
+	if (typeof value !== "string") throw new TypeError(`${field} must be a canonical CID`);
+	try {
+		const cid = cidFromString(value);
+		if (cidToString(cid) !== value) throw new TypeError();
+	} catch {
+		throw new TypeError(`${field} must be a canonical CID`);
+	}
+}
+
+export function parseAtUri(value: unknown, field: string): ParsedAtUri {
+	if (typeof value !== "string" || !value.startsWith("at://")) {
+		throw new TypeError(`${field} must be an at:// record URI`);
+	}
+	const path = value.slice(5);
+	const firstSlash = path.indexOf("/");
+	const secondSlash = path.indexOf("/", firstSlash + 1);
+	if (
+		firstSlash <= 0 ||
+		secondSlash <= firstSlash + 1 ||
+		path.slice(secondSlash + 1).includes("/")
+	) {
+		throw new TypeError(`${field} must include one collection and record key`);
+	}
+	const authority = path.slice(0, firstSlash);
+	const collection = path.slice(firstSlash + 1, secondSlash);
+	const rkey = path.slice(secondSlash + 1);
+	assertDid(authority, `${field} authority`);
+	if (!RECORD_KEY.test(rkey) || rkey === "." || rkey === "..") {
+		throw new TypeError(`${field} must have a valid record key`);
+	}
+	return { authority, collection, rkey };
+}
+
+function daysFromCivil(year: bigint, month: bigint, day: bigint): bigint {
+	const adjustedYear = year - (month <= 2n ? 1n : 0n);
+	const era = (adjustedYear >= 0n ? adjustedYear : adjustedYear - 399n) / 400n;
+	const yearOfEra = adjustedYear - era * 400n;
+	const shiftedMonth = month + (month > 2n ? -3n : 9n);
+	const dayOfYear = (153n * shiftedMonth + 2n) / 5n + day - 1n;
+	const dayOfEra = yearOfEra * 365n + yearOfEra / 4n - yearOfEra / 100n + dayOfYear;
+	return era * 146_097n + dayOfEra - 719_468n;
+}
+
+function isLeapYear(year: number): boolean {
+	return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+export function parseInstant(value: Date | string, field: string): ParsedInstant {
+	if (value instanceof Date) {
+		if (Number.isNaN(value.getTime())) throw new TypeError(`${field} must be a valid timestamp`);
+		return {
+			seconds: BigInt(Math.floor(value.getTime() / 1000)),
+			fraction: `${value.getMilliseconds()}`.padStart(3, "0"),
+		};
+	}
+	const match = RFC3339.exec(value);
+	if (!match) throw new TypeError(`${field} must be a valid RFC 3339 timestamp`);
+	const [, yearText, monthText, dayText, hourText, minuteText, secondText, fraction = "", zone] =
+		match;
+	const year = Number(yearText);
+	const month = Number(monthText);
+	const day = Number(dayText);
+	const hour = Number(hourText);
+	const minute = Number(minuteText);
+	const second = Number(secondText);
+	const monthLengths = [31, isLeapYear(year) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+	if (
+		year === 0 ||
+		month < 1 ||
+		month > 12 ||
+		day < 1 ||
+		day > monthLengths[month - 1]! ||
+		hour > 23 ||
+		minute > 59 ||
+		second > 59
+	) {
+		throw new TypeError(`${field} must be a valid RFC 3339 timestamp`);
+	}
+	let offset = 0n;
+	if (zone !== "Z") {
+		const zoneText = zone!;
+		const offsetHours = Number(zoneText.slice(1, 3));
+		const offsetMinutes = Number(zoneText.slice(4, 6));
+		if (offsetHours > 23 || offsetMinutes > 59 || zoneText === "-00:00") {
+			throw new TypeError(`${field} must be a valid RFC 3339 timestamp`);
+		}
+		offset = BigInt(offsetHours * 3600 + offsetMinutes * 60) * (zoneText[0] === "+" ? 1n : -1n);
+	}
+	return {
+		seconds:
+			daysFromCivil(BigInt(year), BigInt(month), BigInt(day)) * 86_400n +
+			BigInt(hour * 3600 + minute * 60 + second) -
+			offset,
+		fraction,
+	};
+}
+
+export function compareInstants(left: ParsedInstant, right: ParsedInstant): number {
+	if (left.seconds !== right.seconds) return left.seconds < right.seconds ? -1 : 1;
+	const length = Math.max(left.fraction.length, right.fraction.length);
+	for (let index = 0; index < length; index++) {
+		const leftDigit = left.fraction[index] ?? "0";
+		const rightDigit = right.fraction[index] ?? "0";
+		if (leftDigit !== rightDigit) return leftDigit < rightDigit ? -1 : 1;
+	}
+	return 0;
+}

--- a/packages/registry-moderation/src/withdrawal.ts
+++ b/packages/registry-moderation/src/withdrawal.ts
@@ -1,0 +1,69 @@
+import {
+	isVerifiedListingLabel,
+	parseListingLabel,
+	type VerifiedListingLabel,
+} from "./label-crypto.js";
+import { isListingLabelActive, reduceListingLabels, type ListingLabelEvent } from "./labels.js";
+
+export const LEGACY_RELEASE_WITHDRAWAL_LABEL = "security:yanked";
+export const RELEASE_WITHDRAWAL_LABEL = "security-yanked";
+
+const RELEASE_WITHDRAWAL_VALUES = new Set<string>([
+	LEGACY_RELEASE_WITHDRAWAL_LABEL,
+	RELEASE_WITHDRAWAL_LABEL,
+]);
+
+export interface ReleaseWithdrawalInput<Label extends ListingLabelEvent> {
+	uri: string;
+	cid: string;
+	labels: readonly Label[];
+	evaluatedAt: Date | string;
+	acceptedSources?: readonly string[];
+}
+
+export interface ReleaseWithdrawalResult {
+	withdrawn: boolean;
+	applicableLabels: readonly ListingLabelEvent[];
+}
+
+export function evaluateReleaseWithdrawal(
+	input: ReleaseWithdrawalInput<VerifiedListingLabel>,
+): ReleaseWithdrawalResult {
+	for (const label of input.labels) {
+		if (!isVerifiedListingLabel(label)) {
+			throw new TypeError("withdrawal labels must be verified before evaluation");
+		}
+	}
+	return evaluateReleaseWithdrawalCore(input);
+}
+
+/** Evaluates labels loaded from a store that authenticated them before persistence. */
+export function evaluateHydratedReleaseWithdrawal(
+	input: ReleaseWithdrawalInput<ListingLabelEvent>,
+): ReleaseWithdrawalResult {
+	return evaluateReleaseWithdrawalCore({
+		...input,
+		labels: input.labels.map((label) => parseListingLabel(label)),
+	});
+}
+
+function evaluateReleaseWithdrawalCore(
+	input: ReleaseWithdrawalInput<ListingLabelEvent>,
+): ReleaseWithdrawalResult {
+	const acceptedSources =
+		input.acceptedSources === undefined ? null : new Set(input.acceptedSources);
+	const reduction = reduceListingLabels(input.labels, input.evaluatedAt);
+	const applicableLabels = reduction.states.flatMap((state) => {
+		const candidates =
+			state.collision.length > 0 ? state.collision : state.active ? [state.winner] : [];
+		return candidates.filter(
+			(label) =>
+				RELEASE_WITHDRAWAL_VALUES.has(label.val) &&
+				isListingLabelActive(label, input.evaluatedAt) &&
+				label.uri === input.uri &&
+				(label.cid === undefined || label.cid === input.cid) &&
+				(acceptedSources === null || acceptedSources.has(label.src)),
+		);
+	});
+	return { withdrawn: applicableLabels.length > 0, applicableLabels };
+}

--- a/packages/registry-moderation/tests/evaluate.test.ts
+++ b/packages/registry-moderation/tests/evaluate.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	evaluateHydratedListingVisibility,
+	evaluateListingVisibility,
+	selectLatestHydratedApprovedRevision,
+} from "../src/evaluate.js";
+import {
+	FIXTURE_LABELER_DID,
+	FIXTURE_NEW_PROFILE_CID,
+	FIXTURE_PROFILE_CID,
+	FIXTURE_PROFILE_URI,
+	FIXTURE_PUBLISHER_DID,
+	INITIAL_LISTING_POLICY_FIXTURE,
+	LABEL_TRANSITION_RULES_FIXTURE,
+	LISTING_TRANSITION_FIXTURES,
+} from "../src/fixtures/index.js";
+import { LISTING_LABELS, type ListingLabelEvent } from "../src/labels.js";
+
+const NOW = "2026-08-24T01:00:00.000Z";
+
+describe("listing visibility", () => {
+	it.each(LISTING_TRANSITION_FIXTURES)("applies the $id contract", (fixture) => {
+		const result = evaluateHydratedListingVisibility({
+			subject: fixture.subject,
+			policy: INITIAL_LISTING_POLICY_FIXTURE,
+			labels: fixture.labels,
+			evaluatedAt: NOW,
+		});
+
+		expect(result.state).toBe(fixture.expectedState);
+		expect(result.visible).toBe(fixture.expectedState === "passed");
+	});
+
+	it("freezes transitions for every listing label and operator authority", () => {
+		const issued = new Set(
+			LABEL_TRANSITION_RULES_FIXTURE.flatMap((transition) => transition.issues),
+		);
+		for (const value of Object.values(LISTING_LABELS)) {
+			expect(issued.has(value)).toBe(true);
+		}
+		expect(LABEL_TRANSITION_RULES_FIXTURE).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ actor: "reviewer", action: "approve" }),
+				expect.objectContaining({ actor: "reviewer", action: "block" }),
+				expect.objectContaining({ actor: "admin", action: "takedown" }),
+			]),
+		);
+	});
+
+	it("ignores a positive label from a source that is not required", () => {
+		const result = evaluateHydratedListingVisibility({
+			subject: {
+				uri: FIXTURE_PROFILE_URI,
+				cid: FIXTURE_PROFILE_CID,
+				kind: "profile",
+				publisherDid: FIXTURE_PUBLISHER_DID,
+			},
+			policy: INITIAL_LISTING_POLICY_FIXTURE,
+			labels: [
+				{
+					ver: 1,
+					src: "did:web:untrusted.test",
+					uri: FIXTURE_PROFILE_URI,
+					cid: FIXTURE_PROFILE_CID,
+					val: LISTING_LABELS.passed,
+					cts: "2026-08-24T00:00:00.000Z",
+				},
+			],
+			evaluatedAt: NOW,
+		});
+
+		expect(result).toMatchObject({
+			visible: false,
+			state: "unavailable",
+			missingPositiveSources: [FIXTURE_LABELER_DID],
+		});
+	});
+
+	it("selects the previous approved revision while a newer revision is pending", () => {
+		const pass: ListingLabelEvent = {
+			ver: 1,
+			src: FIXTURE_LABELER_DID,
+			uri: FIXTURE_PROFILE_URI,
+			cid: FIXTURE_PROFILE_CID,
+			val: LISTING_LABELS.passed,
+			cts: "2026-08-24T00:00:00.000Z",
+		};
+		const pending: ListingLabelEvent = {
+			...pass,
+			cid: FIXTURE_NEW_PROFILE_CID,
+			val: LISTING_LABELS.pending,
+			cts: "2026-08-24T00:00:01.000Z",
+		};
+		const selected = selectLatestHydratedApprovedRevision({
+			revisions: [
+				{
+					uri: FIXTURE_PROFILE_URI,
+					cid: FIXTURE_PROFILE_CID,
+					kind: "profile",
+					publisherDid: FIXTURE_PUBLISHER_DID,
+					observedAt: "2026-08-23T00:00:00.000Z",
+				},
+				{
+					uri: FIXTURE_PROFILE_URI,
+					cid: FIXTURE_NEW_PROFILE_CID,
+					kind: "profile",
+					publisherDid: FIXTURE_PUBLISHER_DID,
+					observedAt: "2026-08-24T00:00:00.000Z",
+				},
+			],
+			policy: INITIAL_LISTING_POLICY_FIXTURE,
+			labels: [pass, pending],
+			evaluatedAt: NOW,
+		});
+
+		expect(selected?.cid).toBe(FIXTURE_PROFILE_CID);
+	});
+
+	it("does not revive the historical pass after a newer pass is negated", () => {
+		const labels: ListingLabelEvent[] = [
+			{
+				ver: 1,
+				src: FIXTURE_LABELER_DID,
+				uri: FIXTURE_PROFILE_URI,
+				cid: FIXTURE_PROFILE_CID,
+				val: LISTING_LABELS.passed,
+				cts: "2026-08-24T00:00:00.000Z",
+			},
+			{
+				ver: 1,
+				src: FIXTURE_LABELER_DID,
+				uri: FIXTURE_PROFILE_URI,
+				cid: FIXTURE_NEW_PROFILE_CID,
+				val: LISTING_LABELS.passed,
+				cts: "2026-08-24T00:00:01.000Z",
+			},
+			{
+				ver: 1,
+				src: FIXTURE_LABELER_DID,
+				uri: FIXTURE_PROFILE_URI,
+				cid: FIXTURE_NEW_PROFILE_CID,
+				val: LISTING_LABELS.passed,
+				neg: true,
+				cts: "2026-08-24T00:00:02.000Z",
+			},
+		];
+
+		for (const cid of [FIXTURE_PROFILE_CID, FIXTURE_NEW_PROFILE_CID]) {
+			expect(
+				evaluateHydratedListingVisibility({
+					subject: {
+						uri: FIXTURE_PROFILE_URI,
+						cid,
+						kind: "profile",
+						publisherDid: FIXTURE_PUBLISHER_DID,
+					},
+					policy: INITIAL_LISTING_POLICY_FIXTURE,
+					labels,
+					evaluatedAt: NOW,
+				}).visible,
+			).toBe(false);
+		}
+	});
+
+	it("applies exact-CID blocks before a colliding label state", () => {
+		const block: ListingLabelEvent = {
+			ver: 1,
+			src: FIXTURE_LABELER_DID,
+			uri: FIXTURE_PROFILE_URI,
+			cid: FIXTURE_PROFILE_CID,
+			val: LISTING_LABELS.blocked,
+			cts: "2026-08-24T00:00:00.000Z",
+		};
+		const result = evaluateHydratedListingVisibility({
+			subject: {
+				uri: FIXTURE_PROFILE_URI,
+				cid: FIXTURE_PROFILE_CID,
+				kind: "profile",
+				publisherDid: FIXTURE_PUBLISHER_DID,
+			},
+			policy: INITIAL_LISTING_POLICY_FIXTURE,
+			labels: [block, { ...block, neg: true }],
+			evaluatedAt: NOW,
+		});
+
+		expect(result.state).toBe("blocked");
+	});
+
+	it("does not revive a block when every colliding event is inactive", () => {
+		const pass: ListingLabelEvent = {
+			ver: 1,
+			src: FIXTURE_LABELER_DID,
+			uri: FIXTURE_PROFILE_URI,
+			cid: FIXTURE_PROFILE_CID,
+			val: LISTING_LABELS.passed,
+			cts: "2026-08-24T00:00:00.000Z",
+		};
+		const negatedBlock: ListingLabelEvent = {
+			...pass,
+			val: LISTING_LABELS.blocked,
+			neg: true,
+			cts: "2026-08-24T00:00:01.000Z",
+		};
+		const result = evaluateHydratedListingVisibility({
+			subject: {
+				uri: FIXTURE_PROFILE_URI,
+				cid: FIXTURE_PROFILE_CID,
+				kind: "profile",
+				publisherDid: FIXTURE_PUBLISHER_DID,
+			},
+			policy: INITIAL_LISTING_POLICY_FIXTURE,
+			labels: [pass, negatedBlock, { ...negatedBlock, exp: "2026-08-25T00:00:00.000Z" }],
+			evaluatedAt: NOW,
+		});
+
+		expect(result.state).toBe("passed");
+	});
+
+	it("rejects a cast-forged verified label on the authoritative path", () => {
+		const fabricated = {
+			ver: 1,
+			src: FIXTURE_LABELER_DID,
+			uri: FIXTURE_PROFILE_URI,
+			cid: FIXTURE_PROFILE_CID,
+			val: LISTING_LABELS.passed,
+			cts: "2026-08-24T00:00:00.000Z",
+		} as unknown as Parameters<typeof evaluateListingVisibility>[0]["labels"][number];
+
+		expect(() =>
+			evaluateListingVisibility({
+				subject: {
+					uri: FIXTURE_PROFILE_URI,
+					cid: FIXTURE_PROFILE_CID,
+					kind: "profile",
+					publisherDid: FIXTURE_PUBLISHER_DID,
+				},
+				policy: INITIAL_LISTING_POLICY_FIXTURE,
+				labels: [fabricated],
+				evaluatedAt: NOW,
+			}),
+		).toThrow("must be verified");
+	});
+
+	it("fails closed when pass and pending are both active for the exact CID", () => {
+		const pass: ListingLabelEvent = {
+			ver: 1,
+			src: FIXTURE_LABELER_DID,
+			uri: FIXTURE_PROFILE_URI,
+			cid: FIXTURE_PROFILE_CID,
+			val: LISTING_LABELS.passed,
+			cts: "2026-08-24T00:00:00.000Z",
+		};
+		const result = evaluateHydratedListingVisibility({
+			subject: {
+				uri: FIXTURE_PROFILE_URI,
+				cid: FIXTURE_PROFILE_CID,
+				kind: "profile",
+				publisherDid: FIXTURE_PUBLISHER_DID,
+			},
+			policy: INITIAL_LISTING_POLICY_FIXTURE,
+			labels: [
+				pass,
+				{
+					...pass,
+					val: LISTING_LABELS.pending,
+					cts: "2026-08-24T00:00:01.000Z",
+				},
+			],
+			evaluatedAt: NOW,
+		});
+
+		expect(result).toMatchObject({ visible: false, state: "conflict" });
+	});
+
+	it("rejects malformed subject identifiers before evaluating labels", () => {
+		expect(() =>
+			evaluateHydratedListingVisibility({
+				subject: {
+					uri: `https://${FIXTURE_PUBLISHER_DID}/${FIXTURE_PROFILE_URI}`,
+					cid: FIXTURE_PROFILE_CID,
+					kind: "profile",
+					publisherDid: FIXTURE_PUBLISHER_DID,
+				},
+				policy: INITIAL_LISTING_POLICY_FIXTURE,
+				labels: [],
+				evaluatedAt: NOW,
+			}),
+		).toThrow("at:// record URI");
+	});
+});

--- a/packages/registry-moderation/tests/fixtures/label-crypto.json
+++ b/packages/registry-moderation/tests/fixtures/label-crypto.json
@@ -1,0 +1,15 @@
+{
+	"privateKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+	"multikey": "zDnaepsL7AXenJkVYdkh5KuKsSU7Ykh7kyXaLLU7auN9FWSiZ",
+	"otherMultikey": "zDnaer52RTwabaBeMkKYYwZmEFqPabLW78cRK62iovMUQhFif",
+	"nonP256Multikey": "zQ3shVc2UkAfJCdc1TR8E66J85h48P43r93q8jGPkPpjF9Ef9",
+	"label": {
+		"ver": 1,
+		"src": "did:example:labeler",
+		"uri": "at://did:example:publisher/com.emdashcms.experimental.package.profile/plugin",
+		"cid": "bafkreif4oaymum54i5qefbwoblrt5zasfjhpyhyvacpseqtehi3queew5m",
+		"val": "listing-passed",
+		"neg": false,
+		"cts": "2026-07-10T12:00:00.000Z"
+	}
+}

--- a/packages/registry-moderation/tests/fixtures/p256-label-v1.json
+++ b/packages/registry-moderation/tests/fixtures/p256-label-v1.json
@@ -1,0 +1,43 @@
+{
+	"description": "ATProto label v1 P-256 cross-implementation interoperability vector",
+	"label": {
+		"ver": 1,
+		"src": "did:web:labeller.test",
+		"uri": "at://did:plc:z72i7hdynmk6r22z27h6tvur/com.emdashcms.experimental.package.release/crypto-interop",
+		"cid": "bafyreigh2akiscaildc4mscz4uzpcbap5jxg26eecmrf6cmnvkzkjmoixe",
+		"val": "assessment-passed",
+		"cts": "2026-07-10T12:34:56.000Z",
+		"exp": "2026-08-09T12:34:56.000Z"
+	},
+	"canonicalCborHex": "a763636964783b62616679726569676832616b69736361696c6463346d73637a34757a7063626170356a786732366565636d726636636d6e766b7a6b6a6d6f697865636374737818323032362d30372d31305431323a33343a35362e3030305a636578707818323032362d30382d30395431323a33343a35362e3030305a63737263756469643a7765623a6c6162656c6c65722e7465737463757269785f61743a2f2f6469643a706c633a7a373269376864796e6d6b367232327a32376836747675722f636f6d2e656d64617368636d732e6578706572696d656e74616c2e7061636b6167652e72656c656173652f63727970746f2d696e7465726f706376616c716173736573736d656e742d7061737365646376657201",
+	"sha256Hex": "4ac798323da266b2a68caf3caf769a930bafc4403dd4f5921aeb33d2a1a26631",
+	"key": {
+		"curve": "P-256",
+		"publicKeyDid": "did:key:zDnaepsL7AXenJkVYdkh5KuKsSU7Ykh7kyXaLLU7auN9FWSiZ",
+		"publicKeyMultikey": "zDnaepsL7AXenJkVYdkh5KuKsSU7Ykh7kyXaLLU7auN9FWSiZ",
+		"publicKeyRawHex": "036b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
+		"testPrivateKeyRawBase64Url": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE"
+	},
+	"didDocument": {
+		"id": "did:web:labeller.test",
+		"verificationMethod": [
+			{
+				"id": "did:web:labeller.test#atproto_label",
+				"type": "Multikey",
+				"controller": "did:web:labeller.test",
+				"publicKeyMultibase": "zDnaepsL7AXenJkVYdkh5KuKsSU7Ykh7kyXaLLU7auN9FWSiZ"
+			}
+		]
+	},
+	"signatures": {
+		"atcuteWebcryptoHex": "884bc6f1dabf7da026d8c7fcf20dfb0395eb5e9dce09958f54e00b64644af7950244e3d1ada5ef60d0eec8e6b3e0721fad27b555b48291893acc9ba6db4238de",
+		"atprotoReferenceHex": "183823d83ada5cb73cf29ada84cadeb4ffe76b6f5c65245f820fbe163ab4482b5d7e9f9bd7bf206dcebefe3877c7f547d34279235fe4efde497bbb5655685200"
+	},
+	"provenance": {
+		"payloadCodec": "@atcute/cbor 2.3.3",
+		"workerdSigner": "@atcute/crypto 2.4.1 P256PrivateKey.sign",
+		"independentSignerAndVerifier": "@atproto/crypto 0.4.5 P256Keypair.sign/verifySignature",
+		"independentSource": "https://github.com/bluesky-social/atproto/tree/main/packages/crypto",
+		"independentLicense": "MIT OR Apache-2.0"
+	}
+}

--- a/packages/registry-moderation/tests/inputs.test.ts
+++ b/packages/registry-moderation/tests/inputs.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+
+import { NormalizedModerationFindingSchema } from "../src/findings.js";
+import {
+	MODERATION_INPUT_FIELDS_FIXTURE,
+	PROFILE_MODERATION_INPUT_FIXTURE,
+	PROHIBITED_ASSESSMENT_INPUTS_FIXTURE,
+	RELEASE_MODERATION_INPUT_FIXTURE,
+} from "../src/fixtures/index.js";
+import {
+	CanonicalProfileModerationInputSchema,
+	CanonicalReleaseModerationInputSchema,
+} from "../src/inputs.js";
+
+describe("canonical moderation inputs", () => {
+	it("accepts every rendered profile and release field in the frozen fixtures", () => {
+		expect(CanonicalProfileModerationInputSchema.parse(PROFILE_MODERATION_INPUT_FIXTURE)).toEqual(
+			PROFILE_MODERATION_INPUT_FIXTURE,
+		);
+		expect(CanonicalReleaseModerationInputSchema.parse(RELEASE_MODERATION_INPUT_FIXTURE)).toEqual(
+			RELEASE_MODERATION_INPUT_FIXTURE,
+		);
+		expect(MODERATION_INPUT_FIELDS_FIXTURE.profile).toContain("slug");
+		expect(MODERATION_INPUT_FIELDS_FIXTURE.release).toEqual(
+			expect.arrayContaining([
+				"version",
+				"repositoryUrl",
+				"requires.constraints",
+				"sbom.url",
+				"media.screenshot",
+			]),
+		);
+	});
+
+	it.each([
+		["package artifact", { artifacts: { package: { url: "https://trap.invalid/package" } } }],
+		["manifest", { manifest: { backend: "backend.js" } }],
+		["declared access", { declaredAccess: { network: true } }],
+		["provenance", { provenance: { url: "https://trap.invalid/provenance" } }],
+		["source archive", { sourceArchive: { url: "https://trap.invalid/source" } }],
+	] as const)("rejects %s from the model input boundary", (_name, extra) => {
+		expect(() =>
+			CanonicalReleaseModerationInputSchema.parse({
+				...RELEASE_MODERATION_INPUT_FIXTURE,
+				...extra,
+			}),
+		).toThrow(/unsupported field/);
+	});
+
+	it("allows only SBOM display descriptors", () => {
+		expect(() =>
+			CanonicalReleaseModerationInputSchema.parse({
+				...RELEASE_MODERATION_INPUT_FIXTURE,
+				sbom: {
+					...RELEASE_MODERATION_INPUT_FIXTURE.sbom,
+					checksum: "trap-checksum",
+					document: { components: [] },
+				},
+			}),
+		).toThrow(/unsupported field/);
+	});
+
+	it("rejects profile sections and media entries that official clients do not render", () => {
+		expect(() =>
+			CanonicalProfileModerationInputSchema.parse({
+				...PROFILE_MODERATION_INPUT_FIXTURE,
+				sections: { hiddenPublisherHeading: "This is not rendered" },
+			}),
+		).toThrow(/do not render/);
+		expect(() =>
+			CanonicalReleaseModerationInputSchema.parse({
+				...RELEASE_MODERATION_INPUT_FIXTURE,
+				media: [
+					...RELEASE_MODERATION_INPUT_FIXTURE.media,
+					{
+						kind: "documentation",
+						index: 0,
+						url: "https://trap.invalid/docs",
+						checksum: "bafydocs",
+					},
+				],
+			}),
+		).toThrow(/not display media/);
+	});
+
+	it("binds the canonical subject URI and CID to the publisher identity", () => {
+		for (const subject of [
+			{ ...PROFILE_MODERATION_INPUT_FIXTURE.subject, uri: "not-an-at-uri" },
+			{ ...PROFILE_MODERATION_INPUT_FIXTURE.subject, cid: "not-a-cid" },
+			{
+				...PROFILE_MODERATION_INPUT_FIXTURE.subject,
+				uri: PROFILE_MODERATION_INPUT_FIXTURE.subject.uri.replace(
+					PROFILE_MODERATION_INPUT_FIXTURE.publisherDid,
+					"did:plc:anotherpublisher",
+				),
+			},
+		]) {
+			expect(() =>
+				CanonicalProfileModerationInputSchema.parse({
+					...PROFILE_MODERATION_INPUT_FIXTURE,
+					subject,
+				}),
+			).toThrow();
+		}
+		expect(() =>
+			CanonicalProfileModerationInputSchema.parse({
+				...PROFILE_MODERATION_INPUT_FIXTURE,
+				slug: "different-package",
+			}),
+		).toThrow();
+		expect(() =>
+			CanonicalReleaseModerationInputSchema.parse({
+				...RELEASE_MODERATION_INPUT_FIXTURE,
+				version: "9.9.9",
+			}),
+		).toThrow();
+	});
+
+	it("enumerates package, SBOM, provenance, and source-content prohibitions", () => {
+		expect(PROHIBITED_ASSESSMENT_INPUTS_FIXTURE.neverFetch).toEqual(
+			expect.arrayContaining([
+				"release.artifacts.package.url",
+				"release.sbom.url",
+				"release.provenance.url",
+				"release.sourceArchive.url",
+			]),
+		);
+		expect(PROHIBITED_ASSESSMENT_INPUTS_FIXTURE.neverModel).toEqual(
+			expect.arrayContaining([
+				"release.artifacts.package",
+				"release.sbom.document",
+				"release.provenance",
+				"release.sourceRepository.content",
+			]),
+		);
+	});
+
+	it("rejects unknown finding categories and label-shaped model output", () => {
+		expect(
+			NormalizedModerationFindingSchema.safeParse({
+				category: "malware",
+				recommendation: "review",
+				confidence: 0.9,
+				summary: "Unexpected category",
+				evidenceRefs: ["profile.name"],
+			}),
+		).toMatchObject({ success: false });
+		expect(
+			NormalizedModerationFindingSchema.safeParse({
+				category: "scam-or-spam",
+				recommendation: "review",
+				confidence: 0.9,
+				summary: "Review this listing",
+				evidenceRefs: ["profile.name"],
+				label: "listing-blocked",
+			}),
+		).toMatchObject({ success: false });
+	});
+});

--- a/packages/registry-moderation/tests/label-crypto.test.ts
+++ b/packages/registry-moderation/tests/label-crypto.test.ts
@@ -70,6 +70,7 @@ describe("listing label verification", () => {
 		for (const label of [
 			{ ...signed, sig: alteredSignature },
 			{ ...signed, val: "listing-pending" },
+			{ ...signed, cid: "bafyreihf4k3kf5j7dmvclqmk3ypfopgcrf5jm5k4mls3tcbnkj2xszc3da" },
 		]) {
 			await expect(
 				verifyListingLabel({ label, resolveDid: async () => document() }),

--- a/packages/registry-moderation/tests/label-crypto.test.ts
+++ b/packages/registry-moderation/tests/label-crypto.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+	createListingLabelSigner,
+	InvalidListingLabelSignatureError,
+	isVerifiedListingLabel,
+	parseListingLabel,
+	verifyListingLabel,
+	type LabelDidDocument,
+	type ListingLabelEvent,
+	type SignedListingLabel,
+} from "../src/index.js";
+
+const fixture = JSON.parse(
+	readFileSync(new URL("./fixtures/label-crypto.json", import.meta.url), "utf8"),
+) as {
+	privateKey: string;
+	multikey: string;
+	label: ListingLabelEvent;
+};
+
+function document(): LabelDidDocument {
+	return {
+		id: fixture.label.src,
+		verificationMethod: [
+			{
+				id: "#atproto_label",
+				type: "Multikey",
+				controller: fixture.label.src,
+				publicKeyMultibase: fixture.multikey,
+			},
+		],
+	};
+}
+
+async function signedLabel(): Promise<SignedListingLabel> {
+	const signer = await createListingLabelSigner({
+		issuerDid: fixture.label.src,
+		privateKey: fixture.privateKey,
+		resolveDid: async () => document(),
+	});
+	const { src: _src, ...unsigned } = fixture.label;
+	return signer.sign(unsigned);
+}
+
+describe("listing label verification", () => {
+	it("signs, verifies, freezes, and non-enumerably brands a canonical label", async () => {
+		const verified = await verifyListingLabel({
+			label: await signedLabel(),
+			resolveDid: async () => document(),
+		});
+
+		const { neg: _neg, ...canonicalFixture } = fixture.label;
+		expect(verified).toEqual(expect.objectContaining(canonicalFixture));
+		expect(isVerifiedListingLabel(verified)).toBe(true);
+		expect(Object.isFrozen(verified)).toBe(true);
+		const symbols = Object.getOwnPropertySymbols(verified);
+		expect(symbols).toHaveLength(1);
+		expect(Object.getOwnPropertyDescriptor(verified, symbols[0]!)?.enumerable).toBe(false);
+		expect(isVerifiedListingLabel({ ...verified })).toBe(false);
+	});
+
+	it("rejects signature and signed-field tampering", async () => {
+		const signed = await signedLabel();
+		const alteredSignature = Uint8Array.from(signed.sig);
+		alteredSignature[0] ^= 0xff;
+
+		for (const label of [
+			{ ...signed, sig: alteredSignature },
+			{ ...signed, val: "listing-pending" },
+		]) {
+			await expect(
+				verifyListingLabel({ label, resolveDid: async () => document() }),
+			).rejects.toBeInstanceOf(InvalidListingLabelSignatureError);
+		}
+	});
+
+	it("rejects wrong URI schemes, malformed record URIs, CIDs, DIDs, and timestamps", () => {
+		for (const label of [
+			{ ...fixture.label, uri: "https://publisher.test/plugin" },
+			{
+				...fixture.label,
+				uri: "at://did:example:publisher/com.emdashcms.experimental.package.profile",
+			},
+			{
+				...fixture.label,
+				uri: "at://did:example:publisher/com.emdashcms.experimental.package.profile/..",
+			},
+			{ ...fixture.label, cid: "bafy-not-a-cid" },
+			{ ...fixture.label, src: "did:Example:labeler" },
+			{ ...fixture.label, cts: "2026-02-30T12:00:00Z" },
+		]) {
+			expect(() => parseListingLabel(label)).toThrow(TypeError);
+		}
+	});
+
+	it("rejects unsupported fields and accessor-backed label fields", () => {
+		expect(() => parseListingLabel({ ...fixture.label, extra: true })).toThrow("unsupported field");
+		let accessed = false;
+		const accessor = { ...fixture.label };
+		Object.defineProperty(accessor, "val", {
+			enumerable: true,
+			get() {
+				accessed = true;
+				return fixture.label.val;
+			},
+		});
+		expect(() => parseListingLabel(accessor)).toThrow("label.val");
+		expect(accessed).toBe(false);
+	});
+});

--- a/packages/registry-moderation/tests/labels.test.ts
+++ b/packages/registry-moderation/tests/labels.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { LISTING_LABELS, listingLabelKey, reduceListingLabels } from "../src/labels.js";
+import type { ListingLabelEvent } from "../src/labels.js";
+
+const URI = "at://did:plc:test/com.emdashcms.experimental.package.profile/plugin";
+
+function label(overrides: Partial<ListingLabelEvent> = {}): ListingLabelEvent {
+	return {
+		ver: 1,
+		src: "did:web:labeler.test",
+		uri: URI,
+		cid: "bafyold",
+		val: LISTING_LABELS.passed,
+		cts: "2026-08-24T00:00:00.000Z",
+		...overrides,
+	};
+}
+
+describe("listing label reduction", () => {
+	it("keys standard label state by source, URI, and value rather than CID", () => {
+		expect(listingLabelKey(label({ cid: "one" }))).toBe(listingLabelKey(label({ cid: "two" })));
+	});
+
+	it("retains the winning event CID for applicability", () => {
+		const reduction = reduceListingLabels(
+			[label({ cid: "bafyold" }), label({ cid: "bafynew", cts: "2026-08-24T00:00:01.000Z" })],
+			"2026-08-24T00:00:02.000Z",
+		);
+
+		expect(reduction.states).toHaveLength(1);
+		expect(reduction.states[0]?.winner.cid).toBe("bafynew");
+		expect(reduction.states[0]?.active).toBe(true);
+	});
+
+	it("does not revive an older event after a winning negation or expiry", () => {
+		const negated = reduceListingLabels(
+			[
+				label({ cid: "bafyold" }),
+				label({ cid: "bafynew", neg: true, cts: "2026-08-24T00:00:01.000Z" }),
+			],
+			"2026-08-24T00:00:02.000Z",
+		);
+		const expired = reduceListingLabels(
+			[
+				label({ cid: "bafyold" }),
+				label({
+					cid: "bafynew",
+					cts: "2026-08-24T00:00:01.000Z",
+					exp: "2026-08-24T00:00:02.000Z",
+				}),
+			],
+			"2026-08-24T00:00:02.000Z",
+		);
+
+		expect(negated.states[0]).toMatchObject({ active: false, winner: { cid: "bafynew" } });
+		expect(expired.states[0]).toMatchObject({ active: false, winner: { cid: "bafynew" } });
+	});
+
+	it("fails closed when different events collide at the winning timestamp", () => {
+		const reduction = reduceListingLabels(
+			[label({ cid: "one" }), label({ cid: "two" })],
+			"2026-08-24T00:00:02.000Z",
+		);
+
+		expect(reduction.states[0]?.active).toBe(false);
+		expect(reduction.states[0]?.collision).toHaveLength(2);
+	});
+});

--- a/packages/registry-moderation/tests/policy.test.ts
+++ b/packages/registry-moderation/tests/policy.test.ts
@@ -1,0 +1,58 @@
+import { createHash, createPublicKey, verify } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { INITIAL_LISTING_POLICY_FIXTURE } from "../src/fixtures/index.js";
+import { ListingModerationPolicySchema } from "../src/policy.js";
+import cryptoVector from "./fixtures/p256-label-v1.json" with { type: "json" };
+
+describe("listing policy contract", () => {
+	it("keeps positive, state, and redaction authorities independent", () => {
+		const policy = ListingModerationPolicySchema.parse(INITIAL_LISTING_POLICY_FIXTURE);
+
+		expect(policy.requiredPositiveSources).not.toEqual(policy.acceptedStateSources);
+		expect(policy.redactionSources).not.toEqual(policy.requiredPositiveSources);
+	});
+
+	it("rejects a policy without a required positive source", () => {
+		expect(() =>
+			ListingModerationPolicySchema.parse({
+				...INITIAL_LISTING_POLICY_FIXTURE,
+				requiredPositiveSources: [],
+			}),
+		).toThrow(/must not be empty/);
+	});
+
+	it("rejects duplicate prohibited categories", () => {
+		expect(() =>
+			ListingModerationPolicySchema.parse({
+				...INITIAL_LISTING_POLICY_FIXTURE,
+				prohibitedCategories: ["scam-or-spam", "scam-or-spam"],
+			}),
+		).toThrow(/must not contain duplicates/);
+	});
+
+	it("retains the independently generated P-256 interoperability vector", () => {
+		const canonical = Buffer.from(cryptoVector.canonicalCborHex, "hex");
+		const spki = Buffer.from(
+			`3039301306072a8648ce3d020106082a8648ce3d030107032200${cryptoVector.key.publicKeyRawHex}`,
+			"hex",
+		);
+		const publicKey = createPublicKey({ key: spki, format: "der", type: "spki" });
+		expect(cryptoVector.provenance.independentSource).toContain("bluesky-social/atproto");
+		expect(createHash("sha256").update(canonical).digest("hex")).toBe(cryptoVector.sha256Hex);
+		for (const signature of Object.values(cryptoVector.signatures)) {
+			expect(
+				verify(
+					"sha256",
+					canonical,
+					{ key: publicKey, dsaEncoding: "ieee-p1363" },
+					Buffer.from(signature, "hex"),
+				),
+			).toBe(true);
+		}
+		expect(cryptoVector.signatures.atcuteWebcryptoHex).not.toBe(
+			cryptoVector.signatures.atprotoReferenceHex,
+		);
+	});
+});

--- a/packages/registry-moderation/tests/withdrawal.test.ts
+++ b/packages/registry-moderation/tests/withdrawal.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	evaluateHydratedReleaseWithdrawal,
+	LEGACY_RELEASE_WITHDRAWAL_LABEL,
+	RELEASE_WITHDRAWAL_LABEL,
+	type ListingLabelEvent,
+} from "../src/index.js";
+
+const URI = "at://did:plc:publisher/com.emdashcms.experimental.package.release/gallery:1.0.0";
+const CID = "bafyreig6yhf7b3q2jy5vsxawhsq7knfr5h5xj4vl7jrmqpm5m7agj2yp4u";
+const SOURCE = "did:web:labels.example.com";
+const NOW = "2026-08-24T12:00:00.000Z";
+
+function label(overrides: Partial<ListingLabelEvent> = {}): ListingLabelEvent {
+	return {
+		ver: 1,
+		src: SOURCE,
+		uri: URI,
+		cid: CID,
+		val: RELEASE_WITHDRAWAL_LABEL,
+		cts: "2026-08-24T10:00:00.000Z",
+		...overrides,
+	};
+}
+
+function evaluate(labels: ListingLabelEvent[], acceptedSources?: string[]) {
+	return evaluateHydratedReleaseWithdrawal({
+		uri: URI,
+		cid: CID,
+		labels,
+		evaluatedAt: NOW,
+		acceptedSources,
+	});
+}
+
+describe("release withdrawal", () => {
+	it.each([LEGACY_RELEASE_WITHDRAWAL_LABEL, RELEASE_WITHDRAWAL_LABEL])("recognizes %s", (value) => {
+		expect(evaluate([label({ val: value })]).withdrawn).toBe(true);
+	});
+
+	it("honors current negation, expiry, CID, and accepted source", () => {
+		expect(
+			evaluate([label(), label({ neg: true, cts: "2026-08-24T11:00:00.000Z" })]).withdrawn,
+		).toBe(false);
+		expect(evaluate([label({ exp: NOW })]).withdrawn).toBe(false);
+		expect(
+			evaluate([label({ cid: "bafyreihf4k3kf5j7dmvclqmk3ypfopgcrf5jm5k4mls3tcbnkj2xszc3da" })])
+				.withdrawn,
+		).toBe(false);
+		expect(evaluate([label()], ["did:web:other.example.com"]).withdrawn).toBe(false);
+	});
+
+	it("fails closed on a same-time positive and negation collision", () => {
+		expect(evaluate([label(), label({ neg: true })]).withdrawn).toBe(true);
+	});
+
+	it("does not withdraw on a collision containing only inactive events", () => {
+		expect(
+			evaluate([label({ neg: true }), label({ neg: true, exp: "2026-08-25T00:00:00.000Z" })])
+				.withdrawn,
+		).toBe(false);
+		expect(
+			evaluate([label({ exp: "2026-08-24T11:00:00.000Z" }), label({ exp: NOW })]).withdrawn,
+		).toBe(false);
+	});
+});

--- a/packages/registry-moderation/tsconfig.json
+++ b/packages/registry-moderation/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"lib": ["es2023"]
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/registry-moderation/tsdown.config.ts
+++ b/packages/registry-moderation/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["src/index.ts", "src/fixtures/index.ts"],
+	format: ["esm"],
+	dts: true,
+	clean: true,
+	platform: "neutral",
+	target: "es2023",
+});

--- a/packages/registry-moderation/vitest.config.ts
+++ b/packages/registry-moderation/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2349,6 +2349,9 @@ importers:
       '@atcute/lex-cli':
         specifier: 'catalog:'
         version: 2.8.1
+      '@emdash-cms/registry-moderation':
+        specifier: workspace:*
+        version: link:../registry-moderation
       publint:
         specifier: 'catalog:'
         version: 0.3.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,8 +274,8 @@ catalogs:
       specifier: ^4.1.5
       version: 4.1.5
     wrangler:
-      specifier: ^4.125.0
-      version: 4.125.0
+      specifier: ^4.124.0
+      version: 4.124.0
     y-protocols:
       specifier: ^1.0.7
       version: 1.0.7
@@ -406,7 +406,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
-        version: 1.36.3(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.125.0)
+        version: 1.36.3(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.124.0)
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
         version: 0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
@@ -427,13 +427,13 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   demos/cloudflare:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@24.10.13)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@24.10.13)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@24.10.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -482,13 +482,13 @@ importers:
         version: 24.10.13
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   demos/playground:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -516,7 +516,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   demos/plugins-demo:
     dependencies:
@@ -605,7 +605,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@24.10.13)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@24.10.13)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@24.10.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -642,7 +642,7 @@ importers:
         version: 24.10.13
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   demos/simple:
     dependencies:
@@ -694,22 +694,22 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: ^13.1.7
-        version: 13.1.7(@types/node@26.1.1)(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(wrangler@4.125.0)(yaml@2.9.0)
+        version: 13.1.7(@types/node@25.9.1)(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(wrangler@4.124.0)(yaml@2.9.0)
       '@astrojs/starlight':
         specifier: ^0.38.2
-        version: 0.38.2(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
+        version: 0.38.2(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
       '@astrojs/starlight-tailwind':
         specifier: ^5.0.0
-        version: 5.0.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)))(tailwindcss@4.2.1)
+        version: 5.0.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)))(tailwindcss@4.2.1)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
       agents:
         specifier: ^0.12.0
-        version: 0.12.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.3)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
+        version: 0.12.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
       astro:
         specifier: ^6.1.3
-        version: 6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
+        version: 6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -721,7 +721,7 @@ importers:
         version: 4.2.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
       zod:
         specifier: ^4.4.1
         version: 4.4.1
@@ -760,7 +760,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -791,13 +791,13 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   fixtures/perf-site:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/node':
         specifier: 'catalog:'
         version: 11.0.0(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))
@@ -834,7 +834,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   i18n:
     devDependencies:
@@ -843,13 +843,13 @@ importers:
         version: 24.10.13
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/blog-demo:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -886,13 +886,13 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/cache-demo:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -929,7 +929,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/discord-bot:
     devDependencies:
@@ -938,13 +938,13 @@ importers:
         version: 6.0.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/do-demo:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -981,13 +981,13 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/do-solo-demo:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -1024,25 +1024,25 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/emdash-bot:
     dependencies:
       '@cloudflare/codemode':
         specifier: ^0.4.1
-        version: 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)
+        version: 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
       '@cloudflare/sandbox':
         specifier: 0.12.3
         version: 0.12.3
       '@cloudflare/shell':
         specifier: ^0.4.0
-        version: 0.4.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)
+        version: 0.4.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
       '@flue/runtime':
         specifier: 2.0.3
-        version: 2.0.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@6.0.3)(ws@8.21.1)(zod@4.4.3)
+        version: 2.0.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(typescript@6.0.3)(ws@8.21.1)(zod@4.4.1)
       agents:
         specifier: ^0.20.1
-        version: 0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
+        version: 0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
       hono:
         specifier: 4.12.27
         version: 4.12.27
@@ -1052,40 +1052,40 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.53.0
-        version: 1.53.0(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0)
+        version: 1.53.0(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0)
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
-        version: 0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@flue/vite':
         specifier: 2.0.3
-        version: 2.0.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(hono@4.12.27)(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(ws@8.21.1)(zod@4.4.3)
+        version: 2.0.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(hono@4.12.27)(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(ws@8.21.1)(zod@4.4.1)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vite:
         specifier: 8.0.11
-        version: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/flue-review:
     dependencies:
       '@cloudflare/codemode':
         specifier: ^0.4.1
-        version: 0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)
+        version: 0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
       '@cloudflare/shell':
         specifier: ^0.4.0
-        version: 0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.3)
+        version: 0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
       '@flue/runtime':
         specifier: 1.0.0-beta.9
-        version: 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.3.7)(typescript@6.0.3)(ws@8.21.1)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
+        version: 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.3.7)(typescript@6.0.3)(ws@8.21.1)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
       agents:
         specifier: ^0.14.5
-        version: 0.14.5(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(react@19.2.4)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
+        version: 0.14.5(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
       hono:
         specifier: ^4.12.23
         version: 4.12.23
@@ -1095,37 +1095,37 @@ importers:
     devDependencies:
       '@flue/cli':
         specifier: 1.0.0-beta.9
-        version: 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@26.1.1)(esbuild@0.28.1)(hono@4.12.23)(jiti@2.7.0)(tsx@4.21.0)(typebox@1.3.7)(typescript@6.0.3)(wrangler@4.125.0)(ws@8.21.1)(yaml@2.9.0)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
+        version: 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@25.9.1)(esbuild@0.28.1)(hono@4.12.23)(jiti@2.7.0)(tsx@4.21.0)(typebox@1.3.7)(typescript@6.0.3)(wrangler@4.124.0)(ws@8.21.1)(yaml@2.9.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/perf-monitor:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.0.0
-        version: 1.26.1(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.125.0)
+        version: 1.26.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.124.0)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/plugins-site:
     devDependencies:
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   packages/admin:
     dependencies:
@@ -1321,10 +1321,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.7.0(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.7.0(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/browser-playwright':
         specifier: ^4.1.10
-        version: 4.1.10(playwright@1.61.1)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)
+        version: 4.1.10(playwright@1.61.1)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -1345,10 +1345,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^7.0.0
-        version: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.5)
@@ -1477,7 +1477,7 @@ importers:
         version: 19.2.14
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/blocks:
     dependencies:
@@ -1532,7 +1532,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/blocks/playground:
     dependencies:
@@ -1554,7 +1554,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.3
-        version: 4.3.3(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.3.3(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -1563,7 +1563,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.7.0(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.7.0(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.1.11
         version: 4.2.1
@@ -1572,7 +1572,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^6.3.5
-        version: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       wrangler:
         specifier: ^4.63.0
         version: 4.71.0(@cloudflare/workers-types@4.20260305.1)
@@ -1609,7 +1609,7 @@ importers:
         version: 0.18.2
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@cloudflare/kumo':
         specifier: 'catalog:'
         version: 2.6.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
@@ -1639,7 +1639,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/contentful-to-portable-text:
     dependencies:
@@ -1664,13 +1664,13 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core:
     dependencies:
       '@astrojs/react':
         specifier: '>=5.0.0-beta.0'
-        version: 5.0.0-beta.4(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
+        version: 5.0.0-beta.4(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
       '@atcute/client':
         specifier: 'catalog:'
         version: 5.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
@@ -1875,10 +1875,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       zod-openapi:
         specifier: ^5.4.6
         version: 5.4.6(zod@4.4.1)
@@ -1938,7 +1938,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/marketplace:
     dependencies:
@@ -1972,7 +1972,7 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jsdom@26.1.0)(vite@8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   packages/plugin-cli:
     dependencies:
@@ -2070,7 +2070,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/ai-moderation:
     dependencies:
@@ -2095,7 +2095,7 @@ importers:
         version: 19.2.14
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/api-test:
     dependencies:
@@ -2129,7 +2129,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/audit-log:
     dependencies:
@@ -2210,7 +2210,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/forms:
     dependencies:
@@ -2222,7 +2222,7 @@ importers:
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       astro:
         specifier: '>=6.0.0-beta.0'
-        version: 6.0.0-beta.20(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.9.0)
+        version: 6.0.0-beta.20(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.9.0)
       emdash:
         specifier: workspace:>=0.11.0
         version: link:../../core
@@ -2235,7 +2235,7 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/marketplace-test:
     dependencies:
@@ -2360,7 +2360,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/registry-moderation:
     dependencies:
@@ -2391,7 +2391,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/registry-verification:
     dependencies:
@@ -2410,7 +2410,7 @@ importers:
         version: 0.18.2
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
-        version: 0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@sigstore/bundle':
         specifier: 5.0.0
         version: 5.0.0
@@ -2434,7 +2434,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/workerd:
     dependencies:
@@ -2465,7 +2465,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
       miniflare:
         specifier: ^4.20250408.0
@@ -2497,7 +2497,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
       '@x402/svm':
         specifier: ^2.8.0
@@ -2566,7 +2566,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -2600,7 +2600,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   templates/marketing:
     dependencies:
@@ -2640,7 +2640,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -2674,7 +2674,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   templates/portfolio:
     dependencies:
@@ -2708,7 +2708,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -2736,7 +2736,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
   templates/starter:
     dependencies:
@@ -2770,7 +2770,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -2798,7 +2798,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
 
 packages:
 
@@ -2855,7 +2855,6 @@ packages:
   '@arethetypeswrong/cli@0.18.2':
     resolution: {integrity: sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==}
     engines: {node: '>=20'}
-    hasBin: true
 
   '@arethetypeswrong/core@0.18.2':
     resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
@@ -3106,6 +3105,9 @@ packages:
     peerDependencies:
       '@atcute/cbor': ^2.0.0
       '@atcute/cid': ^2.0.0
+
+  '@atcute/cbor@2.3.2':
+    resolution: {integrity: sha512-xP2SORSau/VVI00x2V4BjwIkHr6EQ7l/MXEOPaa4LGYtePFc4gnD4L1yN10dT5NEuUnvGEuCh6arLB7gz1smVQ==}
 
   '@atcute/cbor@2.3.3':
     resolution: {integrity: sha512-zZ4nHOK837zTMWJtta35YD7pcukrTzDc8jkpIGlSgoDYzu3l4BX3WVgpPJtRn3K6h2v97uyiWfiVjSpM7JSFzQ==}
@@ -3994,12 +3996,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20260820.1':
-    resolution: {integrity: sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
   '@cloudflare/workerd-darwin-arm64@1.20260301.1':
     resolution: {integrity: sha512-PPIetY3e67YBr9O4UhILK8nbm5TqUDl14qx4rwFNrRSBOvlzuczzbd4BqgpAtbGVFxKp1PWpjAnBvGU/OI/tLQ==}
     engines: {node: '>=16'}
@@ -4014,12 +4010,6 @@ packages:
 
   '@cloudflare/workerd-darwin-arm64@1.20260815.1':
     resolution: {integrity: sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-arm64@1.20260820.1':
-    resolution: {integrity: sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -4042,12 +4032,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20260820.1':
-    resolution: {integrity: sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
   '@cloudflare/workerd-linux-arm64@1.20260301.1':
     resolution: {integrity: sha512-igL1pkyCXW6GiGpjdOAvqMi87UW0LMc/+yIQe/CSzuZJm5GzXoAMrwVTkCFnikk6JVGELrM5x0tGYlxa0sk5Iw==}
     engines: {node: '>=16'}
@@ -4066,12 +4050,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260820.1':
-    resolution: {integrity: sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
   '@cloudflare/workerd-windows-64@1.20260301.1':
     resolution: {integrity: sha512-Q0wMJ4kcujXILwQKQFc1jaYamVsNvjuECzvRrTI8OxGFMx2yq9aOsswViE4X1gaS2YQQ5u0JGwuGi5WdT1Lt7A==}
     engines: {node: '>=16'}
@@ -4086,12 +4064,6 @@ packages:
 
   '@cloudflare/workerd-windows-64@1.20260815.1':
     resolution: {integrity: sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
-
-  '@cloudflare/workerd-windows-64@1.20260820.1':
-    resolution: {integrity: sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -7917,6 +7889,9 @@ packages:
   '@types/node@24.10.13':
     resolution: {integrity: sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==}
 
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
@@ -10111,12 +10086,10 @@ packages:
   marked@17.0.3:
     resolution: {integrity: sha512-jt1v2ObpyOKR8p4XaUJVk3YWRJ5n+i4+rjQopxvV32rSndTJXvIzuUdWWIy/1pFQMkQmvTXawzDNqOH/CUmx6A==}
     engines: {node: '>= 20'}
-    hasBin: true
 
   marked@9.1.6:
     resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
     engines: {node: '>= 16'}
-    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -10350,10 +10323,6 @@ packages:
 
   miniflare@5.20260815.0-alpha:
     resolution: {integrity: sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ==}
-    engines: {node: '>=22.0.0'}
-
-  miniflare@5.20260820.0-alpha:
-    resolution: {integrity: sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==}
     engines: {node: '>=22.0.0'}
 
   minimatch@10.2.5:
@@ -11103,7 +11072,6 @@ packages:
   publint@0.3.17:
     resolution: {integrity: sha512-Q3NLegA9XM6usW+dYQRG1g9uEHiYUzcCVBJDJ7yMcWRqVU9LYZUWdqbwMZfmTCFC5PZLQpLAmhvRcQRl3exqkw==}
     engines: {node: '>=18'}
-    hasBin: true
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
@@ -11959,6 +11927,9 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   undici-types@7.28.0:
     resolution: {integrity: sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==}
 
@@ -12623,17 +12594,12 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20260820.1:
-    resolution: {integrity: sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w==}
-    engines: {node: '>=16'}
-    hasBin: true
-
-  wrangler@4.125.0:
-    resolution: {integrity: sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg==}
+  wrangler@4.124.0:
+    resolution: {integrity: sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^5.20260820.1
+      '@cloudflare/workers-types': ^5.20260815.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -12807,9 +12773,6 @@ packages:
   zod@4.4.1:
     resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
-
   zrender@6.0.0:
     resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
 
@@ -12827,26 +12790,12 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.1
 
-  '@ai-sdk/gateway@3.0.107(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.25(zod@4.4.3)
-      '@vercel/oidc': 3.2.0
-      zod: 4.4.3
-
   '@ai-sdk/provider-utils@4.0.25(zod@4.4.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.1
-
-  '@ai-sdk/provider-utils@4.0.25(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
 
   '@ai-sdk/provider@3.0.10':
     dependencies:
@@ -12859,11 +12808,11 @@ snapshots:
       package-manager-detector: 1.7.0
       tinyexec: 1.0.4
 
-  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.91.1(zod@4.4.1)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.4.3
+      zod: 4.4.1
 
   '@apidevtools/json-schema-ref-parser@14.0.1':
     dependencies:
@@ -12974,16 +12923,16 @@ snapshots:
       - prettier
       - prettier-plugin-astro
 
-  '@astrojs/cloudflare@13.1.7(@types/node@26.1.1)(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(wrangler@4.125.0)(yaml@2.9.0)':
+  '@astrojs/cloudflare@13.1.7(@types/node@25.9.1)(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(wrangler@4.124.0)(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0
       '@astrojs/underscore-redirects': 1.0.3
-      '@cloudflare/vite-plugin': 1.53.0(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0)
-      astro: 6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
+      '@cloudflare/vite-plugin': 1.53.0(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0)
+      astro: 6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
       piccolore: 0.1.3
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
-      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
@@ -12999,16 +12948,16 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@astrojs/cloudflare@14.0.0(@types/node@24.10.13)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)':
+  '@astrojs/cloudflare@14.0.0(@types/node@24.10.13)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/underscore-redirects': 1.0.3
-      '@cloudflare/vite-plugin': 1.53.0(vite@8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))
+      '@cloudflare/vite-plugin': 1.53.0(vite@8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))
       astro: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
       piccolore: 0.1.3
       tinyglobby: 0.2.17
       vite: 8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
-      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -13025,16 +12974,16 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@astrojs/cloudflare@14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)':
+  '@astrojs/cloudflare@14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/underscore-redirects': 1.0.3
-      '@cloudflare/vite-plugin': 1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))
+      '@cloudflare/vite-plugin': 1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))
       astro: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
       piccolore: 0.1.3
       tinyglobby: 0.2.17
       vite: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
-      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -13239,12 +13188,12 @@ snapshots:
       github-slugger: 2.0.0
       satteri: 0.9.1
 
-  '@astrojs/mdx@5.0.3(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))':
+  '@astrojs/mdx@5.0.3(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.17.0
-      astro: 6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
+      astro: 6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -13292,17 +13241,17 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@5.0.0-beta.4(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)':
+  '@astrojs/react@5.0.0-beta.4(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0-beta.3
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react': 5.1.4(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitejs/plugin-react': 5.1.4(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       devalue: 5.6.3
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       ultrahtml: 1.6.0
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13375,22 +13324,22 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.1
 
-  '@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)))(tailwindcss@4.2.1)':
+  '@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)))(tailwindcss@4.2.1)':
     dependencies:
-      '@astrojs/starlight': 0.38.2(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
+      '@astrojs/starlight': 0.38.2(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
       tailwindcss: 4.2.1
 
-  '@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))':
+  '@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))':
     dependencies:
       '@astrojs/markdown-remark': 7.0.0
-      '@astrojs/mdx': 5.0.3(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
+      '@astrojs/mdx': 5.0.3(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
-      astro-expressive-code: 0.41.6(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
+      astro: 6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
+      astro-expressive-code: 0.41.6(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -13446,7 +13395,7 @@ snapshots:
 
   '@atcute/car@5.1.1':
     dependencies:
-      '@atcute/cbor': 2.3.3(@atcute/cid@2.4.1)
+      '@atcute/cbor': 2.3.2
       '@atcute/cid': 2.4.1
       '@atcute/uint8array': 1.1.1
       '@atcute/varint': 2.0.0
@@ -13457,6 +13406,12 @@ snapshots:
       '@atcute/cid': 2.4.1
       '@atcute/uint8array': 1.1.1
       '@atcute/varint': 2.0.0
+
+  '@atcute/cbor@2.3.2':
+    dependencies:
+      '@atcute/cid': 2.4.1
+      '@atcute/multibase': 1.2.0
+      '@atcute/uint8array': 1.1.1
 
   '@atcute/cbor@2.3.3(@atcute/cid@2.4.1)':
     dependencies:
@@ -13606,7 +13561,7 @@ snapshots:
 
   '@atcute/mst@1.0.0':
     dependencies:
-      '@atcute/cbor': 2.3.3(@atcute/cid@2.4.1)
+      '@atcute/cbor': 2.3.2
       '@atcute/cid': 2.4.1
       '@atcute/uint8array': 1.1.1
 
@@ -13701,7 +13656,7 @@ snapshots:
   '@atcute/repo@0.1.4':
     dependencies:
       '@atcute/car': 5.1.1
-      '@atcute/cbor': 2.3.3(@atcute/cid@2.4.1)
+      '@atcute/cbor': 2.3.2
       '@atcute/cid': 2.4.1
       '@atcute/crypto': 2.4.1
       '@atcute/lexicons': 1.3.0
@@ -14723,13 +14678,13 @@ snapshots:
 
   '@cloudflare/ai-search-snippet@0.0.42': {}
 
-  '@cloudflare/codemode@0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)':
+  '@cloudflare/codemode@0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)':
     dependencies:
       '@types/json-schema': 7.0.15
       acorn: 8.17.0
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
-      ai: 6.0.172(zod@4.4.3)
+      ai: 6.0.172(zod@4.4.1)
       zod: 4.4.1
 
   '@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)':
@@ -14740,33 +14695,14 @@ snapshots:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
       ai: 6.0.172(zod@4.4.1)
       zod: 4.4.1
-    optional: true
 
-  '@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)':
+  '@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)':
     dependencies:
       '@types/json-schema': 7.0.15
       acorn: 8.17.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
-      ai: 6.0.172(zod@4.4.3)
-      zod: 4.4.1
-
-  '@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.3)':
-    dependencies:
-      '@types/json-schema': 7.0.15
-      acorn: 8.17.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
-      ai: 6.0.172(zod@4.4.3)
-      zod: 4.4.3
-
-  '@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)':
-    dependencies:
-      '@types/json-schema': 7.0.15
-      acorn: 8.17.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
-      ai: 6.0.172(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
+      ai: 6.0.172(zod@4.4.1)
       zod: 4.4.1
 
   '@cloudflare/containers@0.3.7': {}
@@ -14804,9 +14740,9 @@ snapshots:
       capnweb: 0.8.0
       hono: 4.12.30
 
-  '@cloudflare/shell@0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.3)':
+  '@cloudflare/shell@0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)':
     dependencies:
-      '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.3)
+      '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
       isomorphic-git: 1.38.5
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -14814,9 +14750,9 @@ snapshots:
       - ai
       - zod
 
-  '@cloudflare/shell@0.4.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)':
+  '@cloudflare/shell@0.4.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)':
     dependencies:
-      '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)
+      '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
       isomorphic-git: 1.38.5
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -14848,98 +14784,92 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260815.1
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260820.1)':
-    dependencies:
-      unenv: 2.0.0-rc.24
-    optionalDependencies:
-      workerd: 1.20260820.1
-
-  '@cloudflare/vite-plugin@1.26.1(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.125.0)':
+  '@cloudflare/vite-plugin@1.26.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.124.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.15.0(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 4.20260301.1
       unenv: 2.0.0-rc.24
-      vite: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
-      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+      vite: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - workerd
 
-  '@cloudflare/vite-plugin@1.36.3(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.125.0)':
+  '@cloudflare/vite-plugin@1.36.3(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.124.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 4.20260507.1
       unenv: 2.0.0-rc.24
       vite: 8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
-      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - workerd
 
-  '@cloudflare/vite-plugin@1.53.0(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0)':
+  '@cloudflare/vite-plugin@1.53.0(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 5.20260815.0-alpha
       unenv: 2.0.0-rc.24
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       workerd: 1.20260815.1
-      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vite-plugin@1.53.0(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0)':
+  '@cloudflare/vite-plugin@1.53.0(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 5.20260815.0-alpha
       unenv: 2.0.0-rc.24
-      vite: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       workerd: 1.20260815.1
-      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vite-plugin@1.53.0(vite@8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))':
+  '@cloudflare/vite-plugin@1.53.0(vite@8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 5.20260815.0-alpha
       unenv: 2.0.0-rc.24
       vite: 8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       workerd: 1.20260815.1
-      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vite-plugin@1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))':
+  '@cloudflare/vite-plugin@1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 5.20260815.0-alpha
       unenv: 2.0.0-rc.24
       vite: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       workerd: 1.20260815.1
-      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vite-plugin@1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0)':
+  '@cloudflare/vite-plugin@1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 5.20260815.0-alpha
       unenv: 2.0.0-rc.24
       vite: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       workerd: 1.20260815.1
-      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -14960,14 +14890,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vitest-pool-workers@0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@cloudflare/vitest-pool-workers@0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
       cjs-module-lexer: 1.4.0
       esbuild: 0.27.3
       miniflare: 4.20260507.1
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler: 4.90.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -14975,14 +14905,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vitest-pool-workers@0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@cloudflare/vitest-pool-workers@0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
       cjs-module-lexer: 1.4.0
       esbuild: 0.27.3
       miniflare: 4.20260507.1
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler: 4.90.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -14997,7 +14927,7 @@ snapshots:
       cjs-module-lexer: 1.4.0
       esbuild: 0.27.3
       miniflare: 4.20260507.1
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler: 4.90.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -15014,9 +14944,6 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260815.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260820.1':
-    optional: true
-
   '@cloudflare/workerd-darwin-arm64@1.20260301.1':
     optional: true
 
@@ -15024,9 +14951,6 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260815.1':
-    optional: true
-
-  '@cloudflare/workerd-darwin-arm64@1.20260820.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260301.1':
@@ -15038,9 +14962,6 @@ snapshots:
   '@cloudflare/workerd-linux-64@1.20260815.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260820.1':
-    optional: true
-
   '@cloudflare/workerd-linux-arm64@1.20260301.1':
     optional: true
 
@@ -15050,9 +14971,6 @@ snapshots:
   '@cloudflare/workerd-linux-arm64@1.20260815.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260820.1':
-    optional: true
-
   '@cloudflare/workerd-windows-64@1.20260301.1':
     optional: true
 
@@ -15060,9 +14978,6 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260815.1':
-    optional: true
-
-  '@cloudflare/workerd-windows-64@1.20260820.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260305.1': {}
@@ -15142,9 +15057,9 @@ snapshots:
     optionalDependencies:
       oxlint: 1.74.0(oxlint-tsgolint@0.25.0)
 
-  '@earendil-works/pi-agent-core@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)':
     dependencies:
-      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -15156,9 +15071,9 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-agent-core@0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.1)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)':
     dependencies:
-      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)
       diff: 8.0.4
       ignore: 7.0.5
       typebox: 1.3.7
@@ -15171,9 +15086,9 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)':
     dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.1)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))
       '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
@@ -15181,7 +15096,7 @@ snapshots:
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.21.1)(zod@4.4.3)
+      openai: 6.26.0(ws@8.21.1)(zod@4.4.1)
       partial-json: 0.1.7
       typebox: 1.1.38
     transitivePeerDependencies:
@@ -15192,17 +15107,17 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.1)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)':
     dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.1)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))
       '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.21.1)(zod@4.4.3)
+      openai: 6.26.0(ws@8.21.1)(zod@4.4.1)
       partial-json: 0.1.7
       typebox: 1.3.7
     transitivePeerDependencies:
@@ -15653,10 +15568,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@flue/cli@1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@26.1.1)(esbuild@0.28.1)(hono@4.12.23)(jiti@2.7.0)(tsx@4.21.0)(typebox@1.3.7)(typescript@6.0.3)(wrangler@4.125.0)(ws@8.21.1)(yaml@2.9.0)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)':
+  '@flue/cli@1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@25.9.1)(esbuild@0.28.1)(hono@4.12.23)(jiti@2.7.0)(tsx@4.21.0)(typebox@1.3.7)(typescript@6.0.3)(wrangler@4.124.0)(ws@8.21.1)(yaml@2.9.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)':
     dependencies:
-      '@cloudflare/vite-plugin': 1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0)
-      '@flue/runtime': 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.3.7)(typescript@6.0.3)(ws@8.21.1)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
+      '@cloudflare/vite-plugin': 1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0)
+      '@flue/runtime': 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.3.7)(typescript@6.0.3)(ws@8.21.1)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
       '@flue/sdk': 1.0.0-beta.9
       '@hono/node-server': 2.0.4(hono@4.12.23)
       '@vercel/detect-agent': 1.2.3
@@ -15666,7 +15581,7 @@ snapshots:
       picocolors: 1.1.1
       ulidx: 2.4.1
       valibot: 1.4.1(typescript@6.0.3)
-      vite: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@standard-schema/spec'
@@ -15698,18 +15613,18 @@ snapshots:
       - zod-openapi
       - zod-to-json-schema
 
-  '@flue/runtime@1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.3.7)(typescript@6.0.3)(ws@8.21.1)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)':
+  '@flue/runtime@1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.3.7)(typescript@6.0.3)(ws@8.21.1)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-agent-core': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)
+      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)
       '@hono/node-server': 2.0.4(hono@4.12.27)
       '@hono/standard-validator': 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.27)
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
-      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
+      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
+      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.1)
       '@valibot/to-json-schema': 1.7.1(valibot@1.4.1(typescript@6.0.3))
       hono: 4.12.27
-      hono-openapi: 1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.27))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.27)(openapi-types@12.1.3)
+      hono-openapi: 1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.27))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.1))(@types/json-schema@7.0.15)(hono@4.12.27)(openapi-types@12.1.3)
       js-yaml: 4.2.0
       just-bash: 3.0.1
       openapi-types: 12.1.3
@@ -15733,10 +15648,10 @@ snapshots:
       - zod-openapi
       - zod-to-json-schema
 
-  '@flue/runtime@2.0.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@6.0.3)(ws@8.21.1)(zod@4.4.3)':
+  '@flue/runtime@2.0.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(typescript@6.0.3)(ws@8.21.1)(zod@4.4.1)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.1)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-agent-core': 0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)
+      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)
       '@hono/node-server': 2.0.4(hono@4.12.27)
       '@modelcontextprotocol/client': 2.0.0
       '@valibot/to-json-schema': 1.7.1(valibot@1.4.1(typescript@6.0.3))
@@ -15757,15 +15672,15 @@ snapshots:
     dependencies:
       '@durable-streams/client': 0.2.6
 
-  '@flue/vite@2.0.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(hono@4.12.27)(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(ws@8.21.1)(zod@4.4.3)':
+  '@flue/vite@2.0.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(hono@4.12.27)(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(ws@8.21.1)(zod@4.4.1)':
     dependencies:
-      '@flue/runtime': 2.0.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@6.0.3)(ws@8.21.1)(zod@4.4.3)
+      '@flue/runtime': 2.0.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(typescript@6.0.3)(ws@8.21.1)(zod@4.4.1)
       '@hono/node-server': 2.0.4(hono@4.12.27)
-      agents: 0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
+      agents: 0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
       magic-string: 1.1.0
       tinyglobby: 0.2.17
       ulidx: 2.4.1
-      vite: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@ai-sdk/react'
       - '@babel/core'
@@ -15805,14 +15720,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))':
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.6.1
       ws: 8.21.1
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16408,11 +16323,11 @@ snapshots:
       eventsource-parser: 3.1.0
       jose: 6.1.3
       pkce-challenge: 5.0.1
-      zod: 4.4.3
+      zod: 4.4.1
 
   '@modelcontextprotocol/core@2.0.0':
     dependencies:
-      zod: 4.4.3
+      zod: 4.4.1
 
   '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)':
     dependencies:
@@ -16462,7 +16377,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.27)
       ajv: 8.17.1
@@ -16479,32 +16394,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.1(zod@4.4.3)
-    optionalDependencies:
-      '@cfworker/json-schema': 4.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
-    dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.27)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.12.27
-      jose: 6.1.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.1(zod@4.4.3)
+      zod: 4.4.1
+      zod-to-json-schema: 3.25.1(zod@4.4.1)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
@@ -16513,7 +16404,7 @@ snapshots:
   '@modelcontextprotocol/server@2.0.0':
     dependencies:
       '@modelcontextprotocol/core': 2.0.0
-      zod: 4.4.3
+      zod: 4.4.1
 
   '@mongodb-js/zstd@7.0.0':
     dependencies:
@@ -17174,23 +17065,23 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.3':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       picomatch: 4.0.4
       rolldown: 1.0.3
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       picomatch: 4.0.4
       rolldown: 1.0.3
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      vite: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -17977,7 +17868,7 @@ snapshots:
 
   '@speed-highlight/core@1.2.14': {}
 
-  '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)':
+  '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/json-schema': 7.0.15
@@ -17986,18 +17877,18 @@ snapshots:
       '@valibot/to-json-schema': 1.7.1(valibot@1.4.1(typescript@6.0.3))
       typebox: 1.3.7
       valibot: 1.4.1(typescript@6.0.3)
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.1(zod@4.4.3)
+      zod: 4.4.1
+      zod-to-json-schema: 3.25.1(zod@4.4.1)
 
-  '@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3)':
+  '@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.1)':
     dependencies:
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
+      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
       '@standard-schema/spec': 1.1.0
       openapi-types: 12.1.3
     optionalDependencies:
       typebox: 1.3.7
       valibot: 1.4.1(typescript@6.0.3)
-      zod: 4.4.3
+      zod: 4.4.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -18079,12 +17970,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.1
 
-  '@tailwindcss/vite@4.3.3(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.3(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
-      vite: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@tanstack/history@1.161.4': {}
 
@@ -18466,7 +18357,7 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 24.10.13
 
   '@types/chai@5.2.2':
     dependencies:
@@ -18531,13 +18422,17 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
 
   '@types/pg@8.16.0':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 25.9.1
       pg-protocol: 1.11.0
       pg-types: 2.2.0
 
@@ -18557,7 +18452,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 24.10.13
 
   '@types/semver@7.7.1': {}
 
@@ -18626,7 +18521,7 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
@@ -18634,11 +18529,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
@@ -18646,7 +18541,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18662,7 +18557,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
@@ -18670,7 +18565,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18698,29 +18593,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser-playwright@4.1.10(playwright@1.61.1)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)':
+  '@vitest/browser-playwright@4.1.10(playwright@1.61.1)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)':
     dependencies:
-      '@vitest/browser': 4.1.10(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)
-      '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/browser': 4.1.10(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)
+      '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       playwright: 1.61.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)':
+  '@vitest/browser@4.1.10(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -18737,29 +18632,29 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.5(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.5(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.5(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.5(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.5(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -18769,13 +18664,13 @@ snapshots:
     optionalDependencies:
       vite: 8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.5(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.5(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.5(vite@8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -18826,7 +18721,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -18939,12 +18834,12 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agents@0.12.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.3)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1):
+  agents@0.12.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1):
     dependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.7)
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       ai: 6.0.172(zod@4.4.1)
       cron-schedule: 6.0.0
       mimetext: 3.0.28
@@ -18958,7 +18853,7 @@ snapshots:
       '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
       '@x402/core': 2.8.0
       '@x402/evm': 2.8.0(typescript@6.0.3)
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/plugin-transform-runtime'
@@ -18967,14 +18862,14 @@ snapshots:
       - rolldown
       - supports-color
 
-  agents@0.14.5(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(react@19.2.4)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1):
+  agents@0.14.5(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1):
     dependencies:
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
       '@cfworker/json-schema': 4.1.1
-      '@cloudflare/codemode': 0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)
+      '@cloudflare/codemode': 0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
-      ai: 6.0.172(zod@4.4.3)
+      ai: 6.0.172(zod@4.4.1)
       cron-schedule: 6.0.0
       esbuild: 0.28.1
       just-bash: 3.0.1
@@ -18998,14 +18893,14 @@ snapshots:
       - rolldown
       - supports-color
 
-  agents@0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1):
+  agents@0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1):
     dependencies:
       '@babel/plugin-proposal-decorators': 8.0.2(@babel/core@7.29.7)
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/client': 2.0.0
-      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
       '@modelcontextprotocol/server': 2.0.0
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       cron-schedule: 6.0.0
       esbuild: 0.28.1
       mimetext: 3.0.28
@@ -19017,12 +18912,12 @@ snapshots:
       yargs: 18.0.0
       zod: 4.4.1
     optionalDependencies:
-      '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)
+      '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
       '@x402/core': 2.8.0
       '@x402/evm': 2.8.0(typescript@6.0.3)
-      ai: 6.0.172(zod@4.4.3)
+      ai: 6.0.172(zod@4.4.1)
       just-bash: 3.0.1
-      vite: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/plugin-transform-runtime'
@@ -19037,14 +18932,6 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.25(zod@4.4.1)
       '@opentelemetry/api': 1.9.0
       zod: 4.4.1
-
-  ai@6.0.172(zod@4.4.3):
-    dependencies:
-      '@ai-sdk/gateway': 3.0.107(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.25(zod@4.4.3)
-      '@opentelemetry/api': 1.9.0
-      zod: 4.4.3
 
   ajv-draft-04@1.0.0(ajv@8.17.1):
     optionalDependencies:
@@ -19142,9 +19029,9 @@ snapshots:
       '@astro-community/astro-embed-youtube': 0.5.10
       astro: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
 
-  astro-expressive-code@0.41.6(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)):
+  astro-expressive-code@0.41.6(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)):
     dependencies:
-      astro: 6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
+      astro: 6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
       rehype-expressive-code: 0.41.6
 
   astro-iconset@0.0.4(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -19163,7 +19050,7 @@ snapshots:
       '@portabletext/types': 2.0.15
       astro: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
 
-  astro@6.0.0-beta.20(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.9.0):
+  astro@6.0.0-beta.20(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 3.0.0
       '@astrojs/internal-helpers': 0.8.0-beta.3
@@ -19215,8 +19102,102 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.4(aws4fetch@1.0.20)
       vfile: 6.0.3
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
-      vitefu: 1.1.2(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      xxhash-wasm: 1.1.0
+      yargs-parser: 22.0.0
+      zod: 4.4.1
+    optionalDependencies:
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@types/node'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - idb-keyval
+      - ioredis
+      - jiti
+      - less
+      - lightningcss
+      - rollup
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - yaml
+
+  astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0):
+    dependencies:
+      '@astrojs/compiler': 3.0.1
+      '@astrojs/internal-helpers': 0.8.0
+      '@astrojs/markdown-remark': 7.1.0
+      '@astrojs/telemetry': 3.3.0
+      '@capsizecss/unpack': 4.0.0
+      '@clack/prompts': 1.1.0
+      '@oslojs/encoding': 1.1.0
+      '@rollup/pluginutils': 5.3.0(rollup@4.55.2)
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      ci-info: 4.4.0
+      clsx: 2.1.1
+      common-ancestor-path: 2.0.0
+      cookie: 1.1.1
+      devalue: 5.6.3
+      diff: 8.0.3
+      dlv: 1.1.3
+      dset: 3.1.4
+      es-module-lexer: 2.0.0
+      esbuild: 0.27.3
+      flattie: 1.1.1
+      fontace: 0.4.1
+      github-slugger: 2.0.0
+      html-escaper: 3.0.3
+      http-cache-semantics: 4.2.0
+      js-yaml: 4.1.1
+      magic-string: 0.30.21
+      magicast: 0.5.2
+      mrmime: 2.0.1
+      neotraverse: 0.6.18
+      obug: 2.1.1
+      p-limit: 7.3.0
+      p-queue: 9.1.0
+      package-manager-detector: 1.6.0
+      piccolore: 0.1.3
+      picomatch: 4.0.4
+      rehype: 13.0.2
+      semver: 7.7.4
+      shiki: 4.0.2
+      smol-toml: 1.6.0
+      svgo: 4.0.1
+      tinyclip: 0.1.12
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tsconfck: 3.1.6(typescript@6.0.3)
+      ultrahtml: 1.6.0
+      unifont: 0.7.4
+      unist-util-visit: 5.1.0
+      unstorage: 1.17.4(aws4fetch@1.0.20)
+      vfile: 6.0.3
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.1
@@ -19304,100 +19285,6 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tsconfck: 3.1.6(typescript@6.0.0-beta)
-      ultrahtml: 1.6.0
-      unifont: 0.7.4
-      unist-util-visit: 5.1.0
-      unstorage: 1.17.4(aws4fetch@1.0.20)
-      vfile: 6.0.3
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
-      vitefu: 1.1.2(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
-      xxhash-wasm: 1.1.0
-      yargs-parser: 22.0.0
-      zod: 4.4.1
-    optionalDependencies:
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@types/node'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - db0
-      - idb-keyval
-      - ioredis
-      - jiti
-      - less
-      - lightningcss
-      - rollup
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - uploadthing
-      - yaml
-
-  astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0):
-    dependencies:
-      '@astrojs/compiler': 3.0.1
-      '@astrojs/internal-helpers': 0.8.0
-      '@astrojs/markdown-remark': 7.1.0
-      '@astrojs/telemetry': 3.3.0
-      '@capsizecss/unpack': 4.0.0
-      '@clack/prompts': 1.1.0
-      '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.3.0(rollup@4.55.2)
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      ci-info: 4.4.0
-      clsx: 2.1.1
-      common-ancestor-path: 2.0.0
-      cookie: 1.1.1
-      devalue: 5.6.3
-      diff: 8.0.3
-      dlv: 1.1.3
-      dset: 3.1.4
-      es-module-lexer: 2.0.0
-      esbuild: 0.27.3
-      flattie: 1.1.1
-      fontace: 0.4.1
-      github-slugger: 2.0.0
-      html-escaper: 3.0.3
-      http-cache-semantics: 4.2.0
-      js-yaml: 4.1.1
-      magic-string: 0.30.21
-      magicast: 0.5.2
-      mrmime: 2.0.1
-      neotraverse: 0.6.18
-      obug: 2.1.1
-      p-limit: 7.3.0
-      p-queue: 9.1.0
-      package-manager-detector: 1.6.0
-      piccolore: 0.1.3
-      picomatch: 4.0.4
-      rehype: 13.0.2
-      semver: 7.7.4
-      shiki: 4.0.2
-      smol-toml: 1.6.0
-      svgo: 4.0.1
-      tinyclip: 0.1.12
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@6.0.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -20957,10 +20844,10 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono-openapi@1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.27))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.27)(openapi-types@12.1.3):
+  hono-openapi@1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.27))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.1))(@types/json-schema@7.0.15)(hono@4.12.27)(openapi-types@12.1.3):
     dependencies:
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
-      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3)
+      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
+      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.1)
       '@types/json-schema': 7.0.15
       openapi-types: 12.1.3
     optionalDependencies:
@@ -22022,18 +21909,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  miniflare@5.20260820.0-alpha:
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.35.2
-      undici: 7.29.0
-      workerd: 1.20260820.1
-      ws: 8.21.0
-      youch: 4.1.0-beta.10
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -22233,10 +22108,10 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@6.26.0(ws@8.21.1)(zod@4.4.3):
+  openai@6.26.0(ws@8.21.1)(zod@4.4.1):
     optionalDependencies:
       ws: 8.21.1
-      zod: 4.4.3
+      zod: 4.4.1
 
   openapi-types@12.1.3: {}
 
@@ -23962,6 +23837,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  undici-types@7.24.6: {}
+
   undici-types@7.28.0:
     optional: true
 
@@ -24155,7 +24032,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
+  vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -24164,7 +24041,23 @@ snapshots:
       rollup: 4.55.2
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 26.1.1
+      '@types/node': 25.9.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      tsx: 4.21.0
+      yaml: 2.9.0
+
+  vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.6
+      rollup: 4.55.2
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
@@ -24202,7 +24095,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
+  vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -24210,7 +24103,7 @@ snapshots:
       rolldown: 1.0.0-rc.18
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 26.1.1
+      '@types/node': 25.9.1
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
@@ -24232,6 +24125,21 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
+  vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.20
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.1
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.21.0
+      yaml: 2.9.0
+
   vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -24246,6 +24154,10 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.21.0
       yaml: 2.9.0
+
+  vitefu@1.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
   vitefu@1.1.2(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
@@ -24263,7 +24175,7 @@ snapshots:
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -24326,10 +24238,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.5(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -24346,20 +24258,20 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 26.1.1
-      '@vitest/browser-playwright': 4.1.10(playwright@1.61.1)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)
+      '@types/node': 25.9.1
+      '@vitest/browser-playwright': 4.1.10(playwright@1.61.1)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.5(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -24376,20 +24288,20 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 26.1.1
+      '@types/node': 25.9.1
       '@vitest/ui': 4.1.10(vitest@4.1.5)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -24406,16 +24318,16 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 26.1.1
+      '@types/node': 25.9.1
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -24439,7 +24351,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 26.1.1
+      '@types/node': 25.9.1
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
@@ -24622,24 +24534,16 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260815.1
       '@cloudflare/workerd-windows-64': 1.20260815.1
 
-  workerd@1.20260820.1:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260820.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260820.1
-      '@cloudflare/workerd-linux-64': 1.20260820.1
-      '@cloudflare/workerd-linux-arm64': 1.20260820.1
-      '@cloudflare/workerd-windows-64': 1.20260820.1
-
-  wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1):
+  wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260820.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 5.20260820.0-alpha
+      miniflare: 5.20260815.0-alpha
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260820.1
+      workerd: 1.20260815.1
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260305.1
       fsevents: 2.3.3
@@ -24802,15 +24706,9 @@ snapshots:
     dependencies:
       zod: 4.4.1
 
-  zod-to-json-schema@3.25.1(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
-
   zod@3.25.76: {}
 
   zod@4.4.1: {}
-
-  zod@4.4.3: {}
 
   zrender@6.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,8 +274,8 @@ catalogs:
       specifier: ^4.1.5
       version: 4.1.5
     wrangler:
-      specifier: ^4.124.0
-      version: 4.124.0
+      specifier: ^4.125.0
+      version: 4.125.0
     y-protocols:
       specifier: ^1.0.7
       version: 1.0.7
@@ -406,7 +406,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
-        version: 1.36.3(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.124.0)
+        version: 1.36.3(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.125.0)
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
         version: 0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
@@ -427,13 +427,13 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   demos/cloudflare:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@24.10.13)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@24.10.13)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@24.10.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -482,13 +482,13 @@ importers:
         version: 24.10.13
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   demos/playground:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -516,7 +516,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   demos/plugins-demo:
     dependencies:
@@ -605,7 +605,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@24.10.13)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@24.10.13)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@24.10.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -642,7 +642,7 @@ importers:
         version: 24.10.13
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   demos/simple:
     dependencies:
@@ -694,22 +694,22 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: ^13.1.7
-        version: 13.1.7(@types/node@25.9.1)(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(wrangler@4.124.0)(yaml@2.9.0)
+        version: 13.1.7(@types/node@26.1.1)(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(wrangler@4.125.0)(yaml@2.9.0)
       '@astrojs/starlight':
         specifier: ^0.38.2
-        version: 0.38.2(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
+        version: 0.38.2(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
       '@astrojs/starlight-tailwind':
         specifier: ^5.0.0
-        version: 5.0.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)))(tailwindcss@4.2.1)
+        version: 5.0.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)))(tailwindcss@4.2.1)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
       agents:
         specifier: ^0.12.0
-        version: 0.12.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
+        version: 0.12.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.3)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
       astro:
         specifier: ^6.1.3
-        version: 6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
+        version: 6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -721,7 +721,7 @@ importers:
         version: 4.2.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
       zod:
         specifier: ^4.4.1
         version: 4.4.1
@@ -760,7 +760,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -791,13 +791,13 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   fixtures/perf-site:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/node':
         specifier: 'catalog:'
         version: 11.0.0(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))
@@ -834,7 +834,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   i18n:
     devDependencies:
@@ -843,13 +843,13 @@ importers:
         version: 24.10.13
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/blog-demo:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -886,13 +886,13 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/cache-demo:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -929,7 +929,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/discord-bot:
     devDependencies:
@@ -938,13 +938,13 @@ importers:
         version: 6.0.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/do-demo:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -981,13 +981,13 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/do-solo-demo:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -1024,25 +1024,25 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/emdash-bot:
     dependencies:
       '@cloudflare/codemode':
         specifier: ^0.4.1
-        version: 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
+        version: 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)
       '@cloudflare/sandbox':
         specifier: 0.12.3
         version: 0.12.3
       '@cloudflare/shell':
         specifier: ^0.4.0
-        version: 0.4.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
+        version: 0.4.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)
       '@flue/runtime':
         specifier: 2.0.3
-        version: 2.0.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(typescript@6.0.3)(ws@8.21.1)(zod@4.4.1)
+        version: 2.0.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@6.0.3)(ws@8.21.1)(zod@4.4.3)
       agents:
         specifier: ^0.20.1
-        version: 0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
+        version: 0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
       hono:
         specifier: 4.12.27
         version: 4.12.27
@@ -1052,40 +1052,40 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.53.0
-        version: 1.53.0(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0)
+        version: 1.53.0(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0)
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
-        version: 0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@flue/vite':
         specifier: 2.0.3
-        version: 2.0.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(hono@4.12.27)(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(ws@8.21.1)(zod@4.4.1)
+        version: 2.0.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(hono@4.12.27)(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(ws@8.21.1)(zod@4.4.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vite:
         specifier: 8.0.11
-        version: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/flue-review:
     dependencies:
       '@cloudflare/codemode':
         specifier: ^0.4.1
-        version: 0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
+        version: 0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)
       '@cloudflare/shell':
         specifier: ^0.4.0
-        version: 0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
+        version: 0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.3)
       '@flue/runtime':
         specifier: 1.0.0-beta.9
-        version: 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.3.7)(typescript@6.0.3)(ws@8.21.1)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
+        version: 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.3.7)(typescript@6.0.3)(ws@8.21.1)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
       agents:
         specifier: ^0.14.5
-        version: 0.14.5(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
+        version: 0.14.5(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(react@19.2.4)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
       hono:
         specifier: ^4.12.23
         version: 4.12.23
@@ -1095,37 +1095,37 @@ importers:
     devDependencies:
       '@flue/cli':
         specifier: 1.0.0-beta.9
-        version: 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@25.9.1)(esbuild@0.28.1)(hono@4.12.23)(jiti@2.7.0)(tsx@4.21.0)(typebox@1.3.7)(typescript@6.0.3)(wrangler@4.124.0)(ws@8.21.1)(yaml@2.9.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
+        version: 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@26.1.1)(esbuild@0.28.1)(hono@4.12.23)(jiti@2.7.0)(tsx@4.21.0)(typebox@1.3.7)(typescript@6.0.3)(wrangler@4.125.0)(ws@8.21.1)(yaml@2.9.0)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/perf-monitor:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.0.0
-        version: 1.26.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.124.0)
+        version: 1.26.1(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.125.0)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   infra/plugins-site:
     devDependencies:
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   packages/admin:
     dependencies:
@@ -1321,10 +1321,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.7.0(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.7.0(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/browser-playwright':
         specifier: ^4.1.10
-        version: 4.1.10(playwright@1.61.1)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)
+        version: 4.1.10(playwright@1.61.1)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -1345,10 +1345,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^7.0.0
-        version: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest-browser-react:
         specifier: ^2.2.0
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.5)
@@ -1477,7 +1477,7 @@ importers:
         version: 19.2.14
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/blocks:
     dependencies:
@@ -1532,7 +1532,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/blocks/playground:
     dependencies:
@@ -1554,7 +1554,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.3
-        version: 4.3.3(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.3.3(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -1563,7 +1563,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.7.0(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.7.0(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.1.11
         version: 4.2.1
@@ -1572,7 +1572,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^6.3.5
-        version: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       wrangler:
         specifier: ^4.63.0
         version: 4.71.0(@cloudflare/workers-types@4.20260305.1)
@@ -1609,7 +1609,7 @@ importers:
         version: 0.18.2
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@cloudflare/kumo':
         specifier: 'catalog:'
         version: 2.6.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
@@ -1639,7 +1639,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/contentful-to-portable-text:
     dependencies:
@@ -1664,13 +1664,13 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core:
     dependencies:
       '@astrojs/react':
         specifier: '>=5.0.0-beta.0'
-        version: 5.0.0-beta.4(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
+        version: 5.0.0-beta.4(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
       '@atcute/client':
         specifier: 'catalog:'
         version: 5.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
@@ -1875,10 +1875,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       zod-openapi:
         specifier: ^5.4.6
         version: 5.4.6(zod@4.4.1)
@@ -1938,7 +1938,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/marketplace:
     dependencies:
@@ -1972,7 +1972,7 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jsdom@26.1.0)(vite@8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   packages/plugin-cli:
     dependencies:
@@ -2070,7 +2070,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/ai-moderation:
     dependencies:
@@ -2095,7 +2095,7 @@ importers:
         version: 19.2.14
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/api-test:
     dependencies:
@@ -2129,7 +2129,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/audit-log:
     dependencies:
@@ -2210,7 +2210,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/forms:
     dependencies:
@@ -2222,7 +2222,7 @@ importers:
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       astro:
         specifier: '>=6.0.0-beta.0'
-        version: 6.0.0-beta.20(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.9.0)
+        version: 6.0.0-beta.20(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.9.0)
       emdash:
         specifier: workspace:>=0.11.0
         version: link:../../core
@@ -2235,7 +2235,7 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/marketplace-test:
     dependencies:
@@ -2360,7 +2360,38 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
+  packages/registry-moderation:
+    dependencies:
+      '@atcute/cbor':
+        specifier: 'catalog:'
+        version: 2.3.3(@atcute/cid@2.4.1)
+      '@atcute/cid':
+        specifier: 'catalog:'
+        version: 2.4.1
+      '@atcute/crypto':
+        specifier: 'catalog:'
+        version: 2.4.1
+      '@atcute/multibase':
+        specifier: 'catalog:'
+        version: 1.2.0
+    devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: 'catalog:'
+        version: 0.18.2
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.17
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.16.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3))(publint@0.3.17)(typescript@6.0.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/registry-verification:
     dependencies:
@@ -2379,7 +2410,7 @@ importers:
         version: 0.18.2
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
-        version: 0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@sigstore/bundle':
         specifier: 5.0.0
         version: 5.0.0
@@ -2403,7 +2434,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/workerd:
     dependencies:
@@ -2434,7 +2465,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
       miniflare:
         specifier: ^4.20250408.0
@@ -2466,7 +2497,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
       '@x402/svm':
         specifier: ^2.8.0
@@ -2535,7 +2566,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -2569,7 +2600,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   templates/marketing:
     dependencies:
@@ -2609,7 +2640,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -2643,7 +2674,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   templates/portfolio:
     dependencies:
@@ -2677,7 +2708,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -2705,7 +2736,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
   templates/starter:
     dependencies:
@@ -2739,7 +2770,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
+        version: 14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)
@@ -2767,7 +2798,7 @@ importers:
         version: 4.20260305.1
       wrangler:
         specifier: 'catalog:'
-        version: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+        version: 4.125.0(@cloudflare/workers-types@4.20260305.1)
 
 packages:
 
@@ -2824,6 +2855,7 @@ packages:
   '@arethetypeswrong/cli@0.18.2':
     resolution: {integrity: sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==}
     engines: {node: '>=20'}
+    hasBin: true
 
   '@arethetypeswrong/core@0.18.2':
     resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
@@ -3074,9 +3106,6 @@ packages:
     peerDependencies:
       '@atcute/cbor': ^2.0.0
       '@atcute/cid': ^2.0.0
-
-  '@atcute/cbor@2.3.2':
-    resolution: {integrity: sha512-xP2SORSau/VVI00x2V4BjwIkHr6EQ7l/MXEOPaa4LGYtePFc4gnD4L1yN10dT5NEuUnvGEuCh6arLB7gz1smVQ==}
 
   '@atcute/cbor@2.3.3':
     resolution: {integrity: sha512-zZ4nHOK837zTMWJtta35YD7pcukrTzDc8jkpIGlSgoDYzu3l4BX3WVgpPJtRn3K6h2v97uyiWfiVjSpM7JSFzQ==}
@@ -3965,6 +3994,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-64@1.20260820.1':
+    resolution: {integrity: sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-arm64@1.20260301.1':
     resolution: {integrity: sha512-PPIetY3e67YBr9O4UhILK8nbm5TqUDl14qx4rwFNrRSBOvlzuczzbd4BqgpAtbGVFxKp1PWpjAnBvGU/OI/tLQ==}
     engines: {node: '>=16'}
@@ -3979,6 +4014,12 @@ packages:
 
   '@cloudflare/workerd-darwin-arm64@1.20260815.1':
     resolution: {integrity: sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260820.1':
+    resolution: {integrity: sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -4001,6 +4042,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-64@1.20260820.1':
+    resolution: {integrity: sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-arm64@1.20260301.1':
     resolution: {integrity: sha512-igL1pkyCXW6GiGpjdOAvqMi87UW0LMc/+yIQe/CSzuZJm5GzXoAMrwVTkCFnikk6JVGELrM5x0tGYlxa0sk5Iw==}
     engines: {node: '>=16'}
@@ -4019,6 +4066,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260820.1':
+    resolution: {integrity: sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20260301.1':
     resolution: {integrity: sha512-Q0wMJ4kcujXILwQKQFc1jaYamVsNvjuECzvRrTI8OxGFMx2yq9aOsswViE4X1gaS2YQQ5u0JGwuGi5WdT1Lt7A==}
     engines: {node: '>=16'}
@@ -4033,6 +4086,12 @@ packages:
 
   '@cloudflare/workerd-windows-64@1.20260815.1':
     resolution: {integrity: sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260820.1':
+    resolution: {integrity: sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -7858,9 +7917,6 @@ packages:
   '@types/node@24.10.13':
     resolution: {integrity: sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==}
 
-  '@types/node@25.9.1':
-    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
-
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
@@ -10055,10 +10111,12 @@ packages:
   marked@17.0.3:
     resolution: {integrity: sha512-jt1v2ObpyOKR8p4XaUJVk3YWRJ5n+i4+rjQopxvV32rSndTJXvIzuUdWWIy/1pFQMkQmvTXawzDNqOH/CUmx6A==}
     engines: {node: '>= 20'}
+    hasBin: true
 
   marked@9.1.6:
     resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
     engines: {node: '>= 16'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -10292,6 +10350,10 @@ packages:
 
   miniflare@5.20260815.0-alpha:
     resolution: {integrity: sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ==}
+    engines: {node: '>=22.0.0'}
+
+  miniflare@5.20260820.0-alpha:
+    resolution: {integrity: sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==}
     engines: {node: '>=22.0.0'}
 
   minimatch@10.2.5:
@@ -11041,6 +11103,7 @@ packages:
   publint@0.3.17:
     resolution: {integrity: sha512-Q3NLegA9XM6usW+dYQRG1g9uEHiYUzcCVBJDJ7yMcWRqVU9LYZUWdqbwMZfmTCFC5PZLQpLAmhvRcQRl3exqkw==}
     engines: {node: '>=18'}
+    hasBin: true
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
@@ -11896,9 +11959,6 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
-
   undici-types@7.28.0:
     resolution: {integrity: sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==}
 
@@ -12563,12 +12623,17 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.124.0:
-    resolution: {integrity: sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==}
+  workerd@1.20260820.1:
+    resolution: {integrity: sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.125.0:
+    resolution: {integrity: sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^5.20260815.1
+      '@cloudflare/workers-types': ^5.20260820.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -12742,6 +12807,9 @@ packages:
   zod@4.4.1:
     resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zrender@6.0.0:
     resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
 
@@ -12759,12 +12827,26 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.1
 
+  '@ai-sdk/gateway@3.0.107(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.25(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@4.0.25(zod@4.4.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.1
+
+  '@ai-sdk/provider-utils@4.0.25(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
 
   '@ai-sdk/provider@3.0.10':
     dependencies:
@@ -12777,11 +12859,11 @@ snapshots:
       package-manager-detector: 1.7.0
       tinyexec: 1.0.4
 
-  '@anthropic-ai/sdk@0.91.1(zod@4.4.1)':
+  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.4.1
+      zod: 4.4.3
 
   '@apidevtools/json-schema-ref-parser@14.0.1':
     dependencies:
@@ -12892,16 +12974,16 @@ snapshots:
       - prettier
       - prettier-plugin-astro
 
-  '@astrojs/cloudflare@13.1.7(@types/node@25.9.1)(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(wrangler@4.124.0)(yaml@2.9.0)':
+  '@astrojs/cloudflare@13.1.7(@types/node@26.1.1)(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(wrangler@4.125.0)(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0
       '@astrojs/underscore-redirects': 1.0.3
-      '@cloudflare/vite-plugin': 1.53.0(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0)
-      astro: 6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
+      '@cloudflare/vite-plugin': 1.53.0(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0)
+      astro: 6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
       piccolore: 0.1.3
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
-      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
@@ -12917,16 +12999,16 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@astrojs/cloudflare@14.0.0(@types/node@24.10.13)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)':
+  '@astrojs/cloudflare@14.0.0(@types/node@24.10.13)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/underscore-redirects': 1.0.3
-      '@cloudflare/vite-plugin': 1.53.0(vite@8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))
+      '@cloudflare/vite-plugin': 1.53.0(vite@8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))
       astro: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
       piccolore: 0.1.3
       tinyglobby: 0.2.17
       vite: 8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
-      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -12943,16 +13025,16 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@astrojs/cloudflare@14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)':
+  '@astrojs/cloudflare@14.0.0(@types/node@26.1.1)(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/underscore-redirects': 1.0.3
-      '@cloudflare/vite-plugin': 1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))
+      '@cloudflare/vite-plugin': 1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))
       astro: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
       piccolore: 0.1.3
       tinyglobby: 0.2.17
       vite: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
-      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -13157,12 +13239,12 @@ snapshots:
       github-slugger: 2.0.0
       satteri: 0.9.1
 
-  '@astrojs/mdx@5.0.3(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))':
+  '@astrojs/mdx@5.0.3(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.17.0
-      astro: 6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
+      astro: 6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -13210,17 +13292,17 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@5.0.0-beta.4(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)':
+  '@astrojs/react@5.0.0-beta.4(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0-beta.3
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react': 5.1.4(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitejs/plugin-react': 5.1.4(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       devalue: 5.6.3
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       ultrahtml: 1.6.0
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13293,22 +13375,22 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.1
 
-  '@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)))(tailwindcss@4.2.1)':
+  '@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)))(tailwindcss@4.2.1)':
     dependencies:
-      '@astrojs/starlight': 0.38.2(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
+      '@astrojs/starlight': 0.38.2(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
       tailwindcss: 4.2.1
 
-  '@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))':
+  '@astrojs/starlight@0.38.2(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))':
     dependencies:
       '@astrojs/markdown-remark': 7.0.0
-      '@astrojs/mdx': 5.0.3(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
+      '@astrojs/mdx': 5.0.3(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
-      astro-expressive-code: 0.41.6(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
+      astro: 6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
+      astro-expressive-code: 0.41.6(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -13364,7 +13446,7 @@ snapshots:
 
   '@atcute/car@5.1.1':
     dependencies:
-      '@atcute/cbor': 2.3.2
+      '@atcute/cbor': 2.3.3(@atcute/cid@2.4.1)
       '@atcute/cid': 2.4.1
       '@atcute/uint8array': 1.1.1
       '@atcute/varint': 2.0.0
@@ -13375,12 +13457,6 @@ snapshots:
       '@atcute/cid': 2.4.1
       '@atcute/uint8array': 1.1.1
       '@atcute/varint': 2.0.0
-
-  '@atcute/cbor@2.3.2':
-    dependencies:
-      '@atcute/cid': 2.4.1
-      '@atcute/multibase': 1.2.0
-      '@atcute/uint8array': 1.1.1
 
   '@atcute/cbor@2.3.3(@atcute/cid@2.4.1)':
     dependencies:
@@ -13530,7 +13606,7 @@ snapshots:
 
   '@atcute/mst@1.0.0':
     dependencies:
-      '@atcute/cbor': 2.3.2
+      '@atcute/cbor': 2.3.3(@atcute/cid@2.4.1)
       '@atcute/cid': 2.4.1
       '@atcute/uint8array': 1.1.1
 
@@ -13625,7 +13701,7 @@ snapshots:
   '@atcute/repo@0.1.4':
     dependencies:
       '@atcute/car': 5.1.1
-      '@atcute/cbor': 2.3.2
+      '@atcute/cbor': 2.3.3(@atcute/cid@2.4.1)
       '@atcute/cid': 2.4.1
       '@atcute/crypto': 2.4.1
       '@atcute/lexicons': 1.3.0
@@ -14647,13 +14723,13 @@ snapshots:
 
   '@cloudflare/ai-search-snippet@0.0.42': {}
 
-  '@cloudflare/codemode@0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)':
+  '@cloudflare/codemode@0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)':
     dependencies:
       '@types/json-schema': 7.0.15
       acorn: 8.17.0
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
-      ai: 6.0.172(zod@4.4.1)
+      ai: 6.0.172(zod@4.4.3)
       zod: 4.4.1
 
   '@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)':
@@ -14664,14 +14740,33 @@ snapshots:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
       ai: 6.0.172(zod@4.4.1)
       zod: 4.4.1
+    optional: true
 
-  '@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)':
+  '@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)':
     dependencies:
       '@types/json-schema': 7.0.15
       acorn: 8.17.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
-      ai: 6.0.172(zod@4.4.1)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
+      ai: 6.0.172(zod@4.4.3)
+      zod: 4.4.1
+
+  '@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      acorn: 8.17.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
+      ai: 6.0.172(zod@4.4.3)
+      zod: 4.4.3
+
+  '@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      acorn: 8.17.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      ai: 6.0.172(zod@4.4.3)
       zod: 4.4.1
 
   '@cloudflare/containers@0.3.7': {}
@@ -14709,9 +14804,9 @@ snapshots:
       capnweb: 0.8.0
       hono: 4.12.30
 
-  '@cloudflare/shell@0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)':
+  '@cloudflare/shell@0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
+      '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.3)
       isomorphic-git: 1.38.5
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -14719,9 +14814,9 @@ snapshots:
       - ai
       - zod
 
-  '@cloudflare/shell@0.4.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)':
+  '@cloudflare/shell@0.4.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)':
     dependencies:
-      '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
+      '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)
       isomorphic-git: 1.38.5
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -14753,92 +14848,98 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260815.1
 
-  '@cloudflare/vite-plugin@1.26.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.124.0)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260820.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260820.1
+
+  '@cloudflare/vite-plugin@1.26.1(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.125.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.15.0(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 4.20260301.1
       unenv: 2.0.0-rc.24
-      vite: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
-      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+      vite: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - workerd
 
-  '@cloudflare/vite-plugin@1.36.3(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.124.0)':
+  '@cloudflare/vite-plugin@1.36.3(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260815.1)(wrangler@4.125.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 4.20260507.1
       unenv: 2.0.0-rc.24
       vite: 8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
-      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - workerd
 
-  '@cloudflare/vite-plugin@1.53.0(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0)':
+  '@cloudflare/vite-plugin@1.53.0(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 5.20260815.0-alpha
       unenv: 2.0.0-rc.24
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       workerd: 1.20260815.1
-      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vite-plugin@1.53.0(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0)':
+  '@cloudflare/vite-plugin@1.53.0(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 5.20260815.0-alpha
       unenv: 2.0.0-rc.24
-      vite: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       workerd: 1.20260815.1
-      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vite-plugin@1.53.0(vite@8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))':
+  '@cloudflare/vite-plugin@1.53.0(vite@8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 5.20260815.0-alpha
       unenv: 2.0.0-rc.24
       vite: 8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       workerd: 1.20260815.1
-      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vite-plugin@1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1))':
+  '@cloudflare/vite-plugin@1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 5.20260815.0-alpha
       unenv: 2.0.0-rc.24
       vite: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       workerd: 1.20260815.1
-      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vite-plugin@1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0)':
+  '@cloudflare/vite-plugin@1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
       miniflare: 5.20260815.0-alpha
       unenv: 2.0.0-rc.24
       vite: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       workerd: 1.20260815.1
-      wrangler: 4.124.0(@cloudflare/workers-types@4.20260305.1)
+      wrangler: 4.125.0(@cloudflare/workers-types@4.20260305.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -14859,14 +14960,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vitest-pool-workers@0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@cloudflare/vitest-pool-workers@0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
       cjs-module-lexer: 1.4.0
       esbuild: 0.27.3
       miniflare: 4.20260507.1
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler: 4.90.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -14874,14 +14975,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vitest-pool-workers@0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@cloudflare/vitest-pool-workers@0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
       cjs-module-lexer: 1.4.0
       esbuild: 0.27.3
       miniflare: 4.20260507.1
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler: 4.90.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -14896,7 +14997,7 @@ snapshots:
       cjs-module-lexer: 1.4.0
       esbuild: 0.27.3
       miniflare: 4.20260507.1
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       wrangler: 4.90.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -14913,6 +15014,9 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260815.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-64@1.20260820.1':
+    optional: true
+
   '@cloudflare/workerd-darwin-arm64@1.20260301.1':
     optional: true
 
@@ -14920,6 +15024,9 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260815.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260820.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260301.1':
@@ -14931,6 +15038,9 @@ snapshots:
   '@cloudflare/workerd-linux-64@1.20260815.1':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20260820.1':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20260301.1':
     optional: true
 
@@ -14940,6 +15050,9 @@ snapshots:
   '@cloudflare/workerd-linux-arm64@1.20260815.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260820.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20260301.1':
     optional: true
 
@@ -14947,6 +15060,9 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260815.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260820.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260305.1': {}
@@ -15026,9 +15142,9 @@ snapshots:
     optionalDependencies:
       oxlint: 1.74.0(oxlint-tsgolint@0.25.0)
 
-  '@earendil-works/pi-agent-core@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)':
+  '@earendil-works/pi-agent-core@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)
+      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -15040,9 +15156,9 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-agent-core@0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)':
+  '@earendil-works/pi-agent-core@0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)
+      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.1)(zod@4.4.3)
       diff: 8.0.4
       ignore: 7.0.5
       typebox: 1.3.7
@@ -15055,9 +15171,9 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)':
+  '@earendil-works/pi-ai@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.1)
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))
       '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
@@ -15065,7 +15181,7 @@ snapshots:
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.21.1)(zod@4.4.1)
+      openai: 6.26.0(ws@8.21.1)(zod@4.4.3)
       partial-json: 0.1.7
       typebox: 1.1.38
     transitivePeerDependencies:
@@ -15076,17 +15192,17 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)':
+  '@earendil-works/pi-ai@0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.1)(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.1)
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
       '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.21.1)(zod@4.4.1)
+      openai: 6.26.0(ws@8.21.1)(zod@4.4.3)
       partial-json: 0.1.7
       typebox: 1.3.7
     transitivePeerDependencies:
@@ -15537,10 +15653,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@flue/cli@1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@25.9.1)(esbuild@0.28.1)(hono@4.12.23)(jiti@2.7.0)(tsx@4.21.0)(typebox@1.3.7)(typescript@6.0.3)(wrangler@4.124.0)(ws@8.21.1)(yaml@2.9.0)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)':
+  '@flue/cli@1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@types/node@26.1.1)(esbuild@0.28.1)(hono@4.12.23)(jiti@2.7.0)(tsx@4.21.0)(typebox@1.3.7)(typescript@6.0.3)(wrangler@4.125.0)(ws@8.21.1)(yaml@2.9.0)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@cloudflare/vite-plugin': 1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.124.0)
-      '@flue/runtime': 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.3.7)(typescript@6.0.3)(ws@8.21.1)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
+      '@cloudflare/vite-plugin': 1.53.0(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.125.0)
+      '@flue/runtime': 1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.3.7)(typescript@6.0.3)(ws@8.21.1)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
       '@flue/sdk': 1.0.0-beta.9
       '@hono/node-server': 2.0.4(hono@4.12.23)
       '@vercel/detect-agent': 1.2.3
@@ -15550,7 +15666,7 @@ snapshots:
       picocolors: 1.1.1
       ulidx: 2.4.1
       valibot: 1.4.1(typescript@6.0.3)
-      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@standard-schema/spec'
@@ -15582,18 +15698,18 @@ snapshots:
       - zod-openapi
       - zod-to-json-schema
 
-  '@flue/runtime@1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.3.7)(typescript@6.0.3)(ws@8.21.1)(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)':
+  '@flue/runtime@1.0.0-beta.9(@cfworker/json-schema@4.1.1)(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(typebox@1.3.7)(typescript@6.0.3)(ws@8.21.1)(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)
-      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)
+      '@earendil-works/pi-agent-core': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.3)
       '@hono/node-server': 2.0.4(hono@4.12.27)
       '@hono/standard-validator': 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.27)
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
-      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.1)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
+      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3)
       '@valibot/to-json-schema': 1.7.1(valibot@1.4.1(typescript@6.0.3))
       hono: 4.12.27
-      hono-openapi: 1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.27))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.1))(@types/json-schema@7.0.15)(hono@4.12.27)(openapi-types@12.1.3)
+      hono-openapi: 1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.27))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.27)(openapi-types@12.1.3)
       js-yaml: 4.2.0
       just-bash: 3.0.1
       openapi-types: 12.1.3
@@ -15617,10 +15733,10 @@ snapshots:
       - zod-openapi
       - zod-to-json-schema
 
-  '@flue/runtime@2.0.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(typescript@6.0.3)(ws@8.21.1)(zod@4.4.1)':
+  '@flue/runtime@2.0.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@6.0.3)(ws@8.21.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)
-      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ws@8.21.1)(zod@4.4.1)
+      '@earendil-works/pi-agent-core': 0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.83.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.1)(zod@4.4.3)
       '@hono/node-server': 2.0.4(hono@4.12.27)
       '@modelcontextprotocol/client': 2.0.0
       '@valibot/to-json-schema': 1.7.1(valibot@1.4.1(typescript@6.0.3))
@@ -15641,15 +15757,15 @@ snapshots:
     dependencies:
       '@durable-streams/client': 0.2.6
 
-  '@flue/vite@2.0.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(hono@4.12.27)(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(ws@8.21.1)(zod@4.4.1)':
+  '@flue/vite@2.0.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(hono@4.12.27)(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(ws@8.21.1)(zod@4.4.3)':
     dependencies:
-      '@flue/runtime': 2.0.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(typescript@6.0.3)(ws@8.21.1)(zod@4.4.1)
+      '@flue/runtime': 2.0.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(typescript@6.0.3)(ws@8.21.1)(zod@4.4.3)
       '@hono/node-server': 2.0.4(hono@4.12.27)
-      agents: 0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
+      agents: 0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1)
       magic-string: 1.1.0
       tinyglobby: 0.2.17
       ulidx: 2.4.1
-      vite: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@ai-sdk/react'
       - '@babel/core'
@@ -15689,14 +15805,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))':
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.6.1
       ws: 8.21.1
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16292,11 +16408,11 @@ snapshots:
       eventsource-parser: 3.1.0
       jose: 6.1.3
       pkce-challenge: 5.0.1
-      zod: 4.4.1
+      zod: 4.4.3
 
   '@modelcontextprotocol/core@2.0.0':
     dependencies:
-      zod: 4.4.1
+      zod: 4.4.3
 
   '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)':
     dependencies:
@@ -16346,7 +16462,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)':
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.27)
       ajv: 8.17.1
@@ -16363,8 +16479,32 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.4.1
-      zod-to-json-schema: 3.25.1(zod@4.4.1)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.27)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
@@ -16373,7 +16513,7 @@ snapshots:
   '@modelcontextprotocol/server@2.0.0':
     dependencies:
       '@modelcontextprotocol/core': 2.0.0
-      zod: 4.4.1
+      zod: 4.4.3
 
   '@mongodb-js/zstd@7.0.0':
     dependencies:
@@ -17034,23 +17174,23 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.3':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       picomatch: 4.0.4
       rolldown: 1.0.3
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       picomatch: 4.0.4
       rolldown: 1.0.3
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      vite: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -17837,7 +17977,7 @@ snapshots:
 
   '@speed-highlight/core@1.2.14': {}
 
-  '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)':
+  '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/json-schema': 7.0.15
@@ -17846,18 +17986,18 @@ snapshots:
       '@valibot/to-json-schema': 1.7.1(valibot@1.4.1(typescript@6.0.3))
       typebox: 1.3.7
       valibot: 1.4.1(typescript@6.0.3)
-      zod: 4.4.1
-      zod-to-json-schema: 3.25.1(zod@4.4.1)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
 
-  '@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.1)':
+  '@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3)':
     dependencies:
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
+      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
       '@standard-schema/spec': 1.1.0
       openapi-types: 12.1.3
     optionalDependencies:
       typebox: 1.3.7
       valibot: 1.4.1(typescript@6.0.3)
-      zod: 4.4.1
+      zod: 4.4.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -17939,12 +18079,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.1
 
-  '@tailwindcss/vite@4.3.3(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.3(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
-      vite: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@tanstack/history@1.161.4': {}
 
@@ -18326,7 +18466,7 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 26.1.1
 
   '@types/chai@5.2.2':
     dependencies:
@@ -18391,17 +18531,13 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@25.9.1':
-    dependencies:
-      undici-types: 7.24.6
-
   '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
 
   '@types/pg@8.16.0':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.1
       pg-protocol: 1.11.0
       pg-types: 2.2.0
 
@@ -18421,7 +18557,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 26.1.1
 
   '@types/semver@7.7.1': {}
 
@@ -18490,7 +18626,7 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
@@ -18498,11 +18634,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
@@ -18510,7 +18646,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18526,7 +18662,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
@@ -18534,7 +18670,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18562,29 +18698,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser-playwright@4.1.10(playwright@1.61.1)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)':
+  '@vitest/browser-playwright@4.1.10(playwright@1.61.1)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)':
     dependencies:
-      '@vitest/browser': 4.1.10(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)
-      '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/browser': 4.1.10(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)
+      '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       playwright: 1.61.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)':
+  '@vitest/browser@4.1.10(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -18601,29 +18737,29 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.5(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.5(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.5(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.5(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.5(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -18633,13 +18769,13 @@ snapshots:
     optionalDependencies:
       vite: 8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.5(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.5(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.5(vite@8.0.16(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -18690,7 +18826,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -18803,12 +18939,12 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agents@0.12.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1):
+  agents@0.12.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.3)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1):
     dependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.7)
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       ai: 6.0.172(zod@4.4.1)
       cron-schedule: 6.0.0
       mimetext: 3.0.28
@@ -18822,7 +18958,7 @@ snapshots:
       '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
       '@x402/core': 2.8.0
       '@x402/evm': 2.8.0(typescript@6.0.3)
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/plugin-transform-runtime'
@@ -18831,14 +18967,14 @@ snapshots:
       - rolldown
       - supports-color
 
-  agents@0.14.5(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1):
+  agents@0.14.5(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(react@19.2.4)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1):
     dependencies:
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
       '@cfworker/json-schema': 4.1.1
-      '@cloudflare/codemode': 0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
+      '@cloudflare/codemode': 0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
-      ai: 6.0.172(zod@4.4.1)
+      ai: 6.0.172(zod@4.4.3)
       cron-schedule: 6.0.0
       esbuild: 0.28.1
       just-bash: 3.0.1
@@ -18862,14 +18998,14 @@ snapshots:
       - rolldown
       - supports-color
 
-  agents@0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1):
+  agents@0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1))(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.3))(just-bash@3.0.1)(react@19.2.4)(rolldown@1.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.1):
     dependencies:
       '@babel/plugin-proposal-decorators': 8.0.2(@babel/core@7.29.7)
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/client': 2.0.0
-      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@modelcontextprotocol/server': 2.0.0
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       cron-schedule: 6.0.0
       esbuild: 0.28.1
       mimetext: 3.0.28
@@ -18881,12 +19017,12 @@ snapshots:
       yargs: 18.0.0
       zod: 4.4.1
     optionalDependencies:
-      '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(ai@6.0.172(zod@4.4.1))(zod@4.4.1)
+      '@cloudflare/codemode': 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.172(zod@4.4.3))(zod@4.4.1)
       '@x402/core': 2.8.0
       '@x402/evm': 2.8.0(typescript@6.0.3)
-      ai: 6.0.172(zod@4.4.1)
+      ai: 6.0.172(zod@4.4.3)
       just-bash: 3.0.1
-      vite: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/plugin-transform-runtime'
@@ -18901,6 +19037,14 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.25(zod@4.4.1)
       '@opentelemetry/api': 1.9.0
       zod: 4.4.1
+
+  ai@6.0.172(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.107(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.25(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
 
   ajv-draft-04@1.0.0(ajv@8.17.1):
     optionalDependencies:
@@ -18998,9 +19142,9 @@ snapshots:
       '@astro-community/astro-embed-youtube': 0.5.10
       astro: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
 
-  astro-expressive-code@0.41.6(astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)):
+  astro-expressive-code@0.41.6(astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)):
     dependencies:
-      astro: 6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
+      astro: 6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
       rehype-expressive-code: 0.41.6
 
   astro-iconset@0.0.4(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -19019,7 +19163,7 @@ snapshots:
       '@portabletext/types': 2.0.15
       astro: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
 
-  astro@6.0.0-beta.20(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.9.0):
+  astro@6.0.0-beta.20(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 3.0.0
       '@astrojs/internal-helpers': 0.8.0-beta.3
@@ -19071,102 +19215,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.4(aws4fetch@1.0.20)
       vfile: 6.0.3
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
-      vitefu: 1.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
-      xxhash-wasm: 1.1.0
-      yargs-parser: 22.0.0
-      zod: 4.4.1
-    optionalDependencies:
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@types/node'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - db0
-      - idb-keyval
-      - ioredis
-      - jiti
-      - less
-      - lightningcss
-      - rollup
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - uploadthing
-      - yaml
-
-  astro@6.1.3(@types/node@25.9.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0):
-    dependencies:
-      '@astrojs/compiler': 3.0.1
-      '@astrojs/internal-helpers': 0.8.0
-      '@astrojs/markdown-remark': 7.1.0
-      '@astrojs/telemetry': 3.3.0
-      '@capsizecss/unpack': 4.0.0
-      '@clack/prompts': 1.1.0
-      '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.3.0(rollup@4.55.2)
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      ci-info: 4.4.0
-      clsx: 2.1.1
-      common-ancestor-path: 2.0.0
-      cookie: 1.1.1
-      devalue: 5.6.3
-      diff: 8.0.3
-      dlv: 1.1.3
-      dset: 3.1.4
-      es-module-lexer: 2.0.0
-      esbuild: 0.27.3
-      flattie: 1.1.1
-      fontace: 0.4.1
-      github-slugger: 2.0.0
-      html-escaper: 3.0.3
-      http-cache-semantics: 4.2.0
-      js-yaml: 4.1.1
-      magic-string: 0.30.21
-      magicast: 0.5.2
-      mrmime: 2.0.1
-      neotraverse: 0.6.18
-      obug: 2.1.1
-      p-limit: 7.3.0
-      p-queue: 9.1.0
-      package-manager-detector: 1.6.0
-      piccolore: 0.1.3
-      picomatch: 4.0.4
-      rehype: 13.0.2
-      semver: 7.7.4
-      shiki: 4.0.2
-      smol-toml: 1.6.0
-      svgo: 4.0.1
-      tinyclip: 0.1.12
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@6.0.3)
-      ultrahtml: 1.6.0
-      unifont: 0.7.4
-      unist-util-visit: 5.1.0
-      unstorage: 1.17.4(aws4fetch@1.0.20)
-      vfile: 6.0.3
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
-      vitefu: 1.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.2(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.1
@@ -19254,6 +19304,100 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tsconfck: 3.1.6(typescript@6.0.0-beta)
+      ultrahtml: 1.6.0
+      unifont: 0.7.4
+      unist-util-visit: 5.1.0
+      unstorage: 1.17.4(aws4fetch@1.0.20)
+      vfile: 6.0.3
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.2(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      xxhash-wasm: 1.1.0
+      yargs-parser: 22.0.0
+      zod: 4.4.1
+    optionalDependencies:
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@types/node'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - idb-keyval
+      - ioredis
+      - jiti
+      - less
+      - lightningcss
+      - rollup
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - yaml
+
+  astro@6.1.3(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0):
+    dependencies:
+      '@astrojs/compiler': 3.0.1
+      '@astrojs/internal-helpers': 0.8.0
+      '@astrojs/markdown-remark': 7.1.0
+      '@astrojs/telemetry': 3.3.0
+      '@capsizecss/unpack': 4.0.0
+      '@clack/prompts': 1.1.0
+      '@oslojs/encoding': 1.1.0
+      '@rollup/pluginutils': 5.3.0(rollup@4.55.2)
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      ci-info: 4.4.0
+      clsx: 2.1.1
+      common-ancestor-path: 2.0.0
+      cookie: 1.1.1
+      devalue: 5.6.3
+      diff: 8.0.3
+      dlv: 1.1.3
+      dset: 3.1.4
+      es-module-lexer: 2.0.0
+      esbuild: 0.27.3
+      flattie: 1.1.1
+      fontace: 0.4.1
+      github-slugger: 2.0.0
+      html-escaper: 3.0.3
+      http-cache-semantics: 4.2.0
+      js-yaml: 4.1.1
+      magic-string: 0.30.21
+      magicast: 0.5.2
+      mrmime: 2.0.1
+      neotraverse: 0.6.18
+      obug: 2.1.1
+      p-limit: 7.3.0
+      p-queue: 9.1.0
+      package-manager-detector: 1.6.0
+      piccolore: 0.1.3
+      picomatch: 4.0.4
+      rehype: 13.0.2
+      semver: 7.7.4
+      shiki: 4.0.2
+      smol-toml: 1.6.0
+      svgo: 4.0.1
+      tinyclip: 0.1.12
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tsconfck: 3.1.6(typescript@6.0.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -20813,10 +20957,10 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono-openapi@1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.27))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.1))(@types/json-schema@7.0.15)(hono@4.12.27)(openapi-types@12.1.3):
+  hono-openapi@1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.27))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.27)(openapi-types@12.1.3):
     dependencies:
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1)
-      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.1))(zod@4.4.1))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.1)
+      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
+      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(quansync@0.2.11)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.3.7)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3)
       '@types/json-schema': 7.0.15
       openapi-types: 12.1.3
     optionalDependencies:
@@ -21878,6 +22022,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  miniflare@5.20260820.0-alpha:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.2
+      undici: 7.29.0
+      workerd: 1.20260820.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -22077,10 +22233,10 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@6.26.0(ws@8.21.1)(zod@4.4.1):
+  openai@6.26.0(ws@8.21.1)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.1
-      zod: 4.4.1
+      zod: 4.4.3
 
   openapi-types@12.1.3: {}
 
@@ -23806,8 +23962,6 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.24.6: {}
-
   undici-types@7.28.0:
     optional: true
 
@@ -24001,7 +24155,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
+  vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -24010,23 +24164,7 @@ snapshots:
       rollup: 4.55.2
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.9.1
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      lightningcss: 1.32.0
-      tsx: 4.21.0
-      yaml: 2.9.0
-
-  vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.6
-      rollup: 4.55.2
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.1
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
@@ -24064,7 +24202,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
+  vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -24072,7 +24210,7 @@ snapshots:
       rolldown: 1.0.0-rc.18
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.1
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
@@ -24094,21 +24232,6 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.5
-      postcss: 8.5.20
-      rolldown: 1.0.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 25.9.1
-      esbuild: 0.28.1
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      tsx: 4.21.0
-      yaml: 2.9.0
-
   vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -24123,10 +24246,6 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.21.0
       yaml: 2.9.0
-
-  vitefu@1.1.2(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
-    optionalDependencies:
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
   vitefu@1.1.2(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
@@ -24144,7 +24263,7 @@ snapshots:
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -24207,10 +24326,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@26.1.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.5(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -24227,20 +24346,20 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 25.9.1
-      '@vitest/browser-playwright': 4.1.10(playwright@1.61.1)(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)
+      '@types/node': 26.1.1
+      '@vitest/browser-playwright': 4.1.10(playwright@1.61.1)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.5)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/ui@4.1.10)(jsdom@26.1.0)(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.5(vite@6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -24257,20 +24376,20 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 25.9.1
+      '@types/node': 26.1.1
       '@vitest/ui': 4.1.10(vitest@4.1.5)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -24287,16 +24406,16 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.11(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 25.9.1
+      '@types/node': 26.1.1
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -24320,7 +24439,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 25.9.1
+      '@types/node': 26.1.1
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
@@ -24503,16 +24622,24 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260815.1
       '@cloudflare/workerd-windows-64': 1.20260815.1
 
-  wrangler@4.124.0(@cloudflare/workers-types@4.20260305.1):
+  workerd@1.20260820.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260820.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260820.1
+      '@cloudflare/workerd-linux-64': 1.20260820.1
+      '@cloudflare/workerd-linux-arm64': 1.20260820.1
+      '@cloudflare/workerd-windows-64': 1.20260820.1
+
+  wrangler@4.125.0(@cloudflare/workers-types@4.20260305.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260820.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 5.20260815.0-alpha
+      miniflare: 5.20260820.0-alpha
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260815.1
+      workerd: 1.20260820.1
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260305.1
       fsevents: 2.3.3
@@ -24675,9 +24802,15 @@ snapshots:
     dependencies:
       zod: 4.4.1
 
+  zod-to-json-schema@3.25.1(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
   zod@3.25.76: {}
 
   zod@4.4.1: {}
+
+  zod@4.4.3: {}
 
   zrender@6.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,6 +99,7 @@ catalog:
   # Kumo identical: bump this version deliberately and rebuild admin.
   "@cloudflare/kumo": 2.6.0
   "@cloudflare/vite-plugin": ^1.36.3
+  "@cloudflare/vitest-plugin": ^1.0.0
   "@cloudflare/vitest-pool-workers": ^0.16.3
   "@cloudflare/workers-types": ^4.20260305.1
   "@iconify-json/ph": ^1.2.2
@@ -162,7 +163,7 @@ catalog:
   typescript: ^6.0.3
   vite: ^8.0.11
   vitest: ^4.1.5
-  wrangler: ^4.124.0
+  wrangler: ^4.125.0
   "y-protocols": ^1.0.7
   yjs: ^13.6.0
   zod: ^4.4.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,7 +99,6 @@ catalog:
   # Kumo identical: bump this version deliberately and rebuild admin.
   "@cloudflare/kumo": 2.6.0
   "@cloudflare/vite-plugin": ^1.36.3
-  "@cloudflare/vitest-plugin": ^1.0.0
   "@cloudflare/vitest-pool-workers": ^0.16.3
   "@cloudflare/workers-types": ^4.20260305.1
   "@iconify-json/ph": ^1.2.2
@@ -163,7 +162,7 @@ catalog:
   typescript: ^6.0.3
   vite: ^8.0.11
   vitest: ^4.1.5
-  wrangler: ^4.125.0
+  wrangler: ^4.124.0
   "y-protocols": ^1.0.7
   yjs: ^13.6.0
   zod: ^4.4.1


### PR DESCRIPTION
## What does this PR do?

Adds the shared contracts for metadata-only plugin-listing moderation. It defines exact-CID signed label verification and reduction, fail-closed visibility evaluation, both release-withdrawal spellings, executable policy fixtures, and experimental public assessment/policy Lexicons. Public label arrays require signatures, and the contract identifies the signed label query/subscription state as moderation authority.

This is the bottom PR in the replacement stack for #1909. The existing #1909 branch remains a donor reference and is not adopted into this stack.

Related to the approved registry RFC #694.

> **Stack deployment note:** This PR is a review slice, not a deployable milestone. Deploy and migrate only the complete four-PR stack; intermediate PR heads do not define supported runtime or database upgrade boundaries.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/pull/694

`.changeset/quiet-listings-pass.md` is included in this PR for the two published packages. Admin localization is not applicable to this contracts-only PR.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- Normal `pnpm install`: passed on this branch
- Registry moderation: 56 tests
- Registry Lexicons: 27 tests
- Package typechecks and builds: passed
- Quick and type-aware lint: zero diagnostics
