### PR TITLE
feat(release-service): verify GitHub workload identity

### DIFF
--- a/apps/release-service/src/workload/github-oidc.ts
+++ b/apps/release-service/src/workload/github-oidc.ts
@@ -1,0 +1,185 @@
+import { createRemoteJWKSet, jwtVerify, type JWTVerifyGetKey, type JWTPayload } from "jose";
+
+import { WorkloadIdentityError, type VerifiedWorkloadIdentity } from "./types.js";
+
+export const GITHUB_ACTIONS_ISSUER = "https://token.actions.githubusercontent.com";
+const GITHUB_ACTIONS_JWKS = `${GITHUB_ACTIONS_ISSUER}/.well-known/jwks`;
+const GITHUB_JWKS_CACHE_SYMBOL = Symbol.for("@emdash-cms/release-service/github-oidc-jwks");
+const MAX_TOKEN_CHARS = 16 * 1024;
+const DECIMAL_ID_PATTERN = /^[1-9][0-9]*$/;
+const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const LOGIN_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$/;
+const ACTOR_PATTERN = /^(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})|[A-Za-z0-9-]{1,39}\[bot\])$/;
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const REF_PATTERN = /^refs\/[A-Za-z0-9._/-]{1,507}$/;
+const WORKFLOW_REF_PATTERN =
+	/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/\.github\/workflows\/[A-Za-z0-9_./-]+\.ya?ml@refs\/[A-Za-z0-9._/-]+$/;
+
+function getGitHubJwks(): JWTVerifyGetKey {
+	const target = globalThis as typeof globalThis & {
+		[GITHUB_JWKS_CACHE_SYMBOL]?: JWTVerifyGetKey;
+	};
+	return (target[GITHUB_JWKS_CACHE_SYMBOL] ??= createRemoteJWKSet(new URL(GITHUB_ACTIONS_JWKS)));
+}
+
+function requiredString(
+	payload: JWTPayload,
+	claim: string,
+	maximum: number,
+	pattern?: RegExp,
+): string {
+	const value = payload[claim];
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		value.length > maximum ||
+		(pattern && !pattern.test(value))
+	) {
+		throw new WorkloadIdentityError("WORKLOAD_TOKEN_INVALID");
+	}
+	return value;
+}
+
+function optionalString(payload: JWTPayload, claim: string, maximum: number): string | null {
+	const value = payload[claim];
+	if (value === undefined) return null;
+	if (typeof value !== "string" || value.length === 0 || value.length > maximum) {
+		throw new WorkloadIdentityError("WORKLOAD_TOKEN_INVALID");
+	}
+	return value;
+}
+
+function normalizeClaims(payload: JWTPayload): VerifiedWorkloadIdentity {
+	const subject = requiredString(payload, "sub", 2048);
+	const tokenId = requiredString(payload, "jti", 255);
+	const repository = requiredString(payload, "repository", 256, REPOSITORY_PATTERN);
+	const repositoryId = requiredString(payload, "repository_id", 32, DECIMAL_ID_PATTERN);
+	const repositoryOwner = requiredString(payload, "repository_owner", 64, LOGIN_PATTERN);
+	const repositoryOwnerId = requiredString(payload, "repository_owner_id", 32, DECIMAL_ID_PATTERN);
+	const workflowRef = requiredString(payload, "workflow_ref", 1024, WORKFLOW_REF_PATTERN);
+	const workflowSha = requiredString(payload, "workflow_sha", 40, SHA_PATTERN);
+	const jobRef = optionalString(payload, "job_workflow_ref", 1024);
+	const jobSha = optionalString(payload, "job_workflow_sha", 40);
+	const runId = requiredString(payload, "run_id", 32, DECIMAL_ID_PATTERN);
+	const runAttemptValue = requiredString(payload, "run_attempt", 10, DECIMAL_ID_PATTERN);
+	const actor = requiredString(payload, "actor", 64, ACTOR_PATTERN);
+	const actorId = requiredString(payload, "actor_id", 32, DECIMAL_ID_PATTERN);
+	const eventName = requiredString(payload, "event_name", 128);
+	const ref = requiredString(payload, "ref", 512, REF_PATTERN);
+	const refType = requiredString(payload, "ref_type", 16);
+	const commitSha = requiredString(payload, "sha", 40, SHA_PATTERN);
+	const environment = optionalString(payload, "environment", 255);
+	const visibility = requiredString(payload, "repository_visibility", 16);
+	const runnerEnvironment = requiredString(payload, "runner_environment", 32);
+	const runAttempt = Number(runAttemptValue);
+	const issuedAt = payload.iat;
+	const expiresAt = payload.exp;
+	const [owner] = repository.split("/", 1);
+	if (
+		owner?.toLowerCase() !== repositoryOwner.toLowerCase() ||
+		!workflowRef.toLowerCase().startsWith(`${repository.toLowerCase()}/.github/workflows/`) ||
+		(jobRef === null) !== (jobSha === null) ||
+		(jobRef !== null && !WORKFLOW_REF_PATTERN.test(jobRef)) ||
+		(jobSha !== null && !SHA_PATTERN.test(jobSha)) ||
+		!Number.isSafeInteger(runAttempt) ||
+		runAttempt < 1 ||
+		(refType !== "branch" && refType !== "tag") ||
+		(visibility !== "public" && visibility !== "private" && visibility !== "internal") ||
+		(runnerEnvironment !== "github-hosted" && runnerEnvironment !== "self-hosted") ||
+		typeof issuedAt !== "number" ||
+		!Number.isSafeInteger(issuedAt) ||
+		typeof expiresAt !== "number" ||
+		!Number.isSafeInteger(expiresAt) ||
+		issuedAt > expiresAt
+	) {
+		throw new WorkloadIdentityError("WORKLOAD_TOKEN_INVALID");
+	}
+	return {
+		issuer: "github-actions",
+		subject,
+		tokenId,
+		repository: {
+			name: repository.toLowerCase(),
+			id: repositoryId,
+			owner: repositoryOwner.toLowerCase(),
+			ownerId: repositoryOwnerId,
+			visibility,
+		},
+		workflow: { ref: workflowRef, sha: workflowSha, jobRef, jobSha },
+		run: {
+			id: runId,
+			attempt: runAttempt,
+			actor,
+			actorId,
+			eventName,
+			ref,
+			refType,
+			commitSha,
+			environment,
+			runnerEnvironment,
+		},
+		issuedAt,
+		expiresAt,
+	};
+}
+
+export async function verifyGitHubActionsToken(
+	token: string,
+	expectedAudience: string,
+	keyResolver: JWTVerifyGetKey = getGitHubJwks(),
+): Promise<VerifiedWorkloadIdentity> {
+	let validAudience = false;
+	try {
+		const audienceUrl = new URL(expectedAudience);
+		validAudience = audienceUrl.protocol === "https:" && audienceUrl.origin === expectedAudience;
+	} catch {
+		validAudience = false;
+	}
+	if (
+		typeof token !== "string" ||
+		token.length === 0 ||
+		token.length > MAX_TOKEN_CHARS ||
+		!validAudience
+	) {
+		throw new WorkloadIdentityError(
+			validAudience ? "WORKLOAD_TOKEN_INVALID" : "WORKLOAD_CONFIGURATION_INVALID",
+		);
+	}
+	try {
+		const { payload } = await jwtVerify(token, keyResolver, {
+			algorithms: ["RS256"],
+			audience: expectedAudience,
+			issuer: GITHUB_ACTIONS_ISSUER,
+			typ: "JWT",
+			clockTolerance: 5,
+			maxTokenAge: "10 minutes",
+			requiredClaims: [
+				"exp",
+				"iat",
+				"nbf",
+				"jti",
+				"sub",
+				"repository",
+				"repository_id",
+				"repository_owner",
+				"repository_owner_id",
+				"workflow_ref",
+				"workflow_sha",
+				"run_id",
+				"run_attempt",
+				"actor",
+				"actor_id",
+				"event_name",
+				"ref",
+				"ref_type",
+				"sha",
+				"repository_visibility",
+				"runner_environment",
+			],
+		});
+		return normalizeClaims(payload);
+	} catch (error) {
+		if (error instanceof WorkloadIdentityError) throw error;
+		throw new WorkloadIdentityError("WORKLOAD_TOKEN_INVALID");
+	}
+}

--- a/apps/release-service/src/workload/types.ts
+++ b/apps/release-service/src/workload/types.ts
@@ -1,0 +1,44 @@
+export type WorkloadIdentityErrorCode = "WORKLOAD_CONFIGURATION_INVALID" | "WORKLOAD_TOKEN_INVALID";
+
+export class WorkloadIdentityError extends Error {
+	readonly code: WorkloadIdentityErrorCode;
+
+	constructor(code: WorkloadIdentityErrorCode) {
+		super(code);
+		this.name = "WorkloadIdentityError";
+		this.code = code;
+	}
+}
+
+export interface VerifiedWorkloadIdentity {
+	issuer: "github-actions";
+	subject: string;
+	tokenId: string;
+	repository: {
+		name: string;
+		id: string;
+		owner: string;
+		ownerId: string;
+		visibility: "public" | "private" | "internal";
+	};
+	workflow: {
+		ref: string;
+		sha: string;
+		jobRef: string | null;
+		jobSha: string | null;
+	};
+	run: {
+		id: string;
+		attempt: number;
+		actor: string;
+		actorId: string;
+		eventName: string;
+		ref: string;
+		refType: "branch" | "tag";
+		commitSha: string;
+		environment: string | null;
+		runnerEnvironment: "github-hosted" | "self-hosted";
+	};
+	issuedAt: number;
+	expiresAt: number;
+}

--- a/apps/release-service/test/github-oidc.test.ts
+++ b/apps/release-service/test/github-oidc.test.ts
@@ -1,0 +1,226 @@
+import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT, type JWTVerifyGetKey } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { GITHUB_ACTIONS_ISSUER, verifyGitHubActionsToken } from "../src/workload/github-oidc.js";
+
+const AUDIENCE = "https://release.example.invalid";
+const KEY_ID = "github-actions-test-key";
+const SHA = "a".repeat(40);
+const WORKFLOW_SHA = "b".repeat(40);
+
+let privateKey: CryptoKey;
+let keyResolver: JWTVerifyGetKey;
+
+beforeAll(async () => {
+	const keys = await generateKeyPair("RS256", { extractable: true });
+	privateKey = keys.privateKey;
+	const publicJwk = await exportJWK(keys.publicKey);
+	publicJwk.kid = KEY_ID;
+	publicJwk.alg = "RS256";
+	publicJwk.use = "sig";
+	keyResolver = createLocalJWKSet({ keys: [publicJwk] });
+});
+
+function claims(): Record<string, unknown> {
+	return {
+		jti: "f4b4a3d2-1111-4222-8333-abcdefabcdef",
+		repository: "EmDash-CMS/EmDash",
+		repository_id: "123456789",
+		repository_owner: "EmDash-CMS",
+		repository_owner_id: "987654321",
+		workflow_ref: "EmDash-CMS/EmDash/.github/workflows/release.yml@refs/heads/main",
+		workflow_sha: WORKFLOW_SHA,
+		run_id: "10000000001",
+		run_attempt: "2",
+		actor: "release-bot",
+		actor_id: "11223344",
+		event_name: "workflow_dispatch",
+		ref: "refs/heads/main",
+		ref_type: "branch",
+		sha: SHA,
+		repository_visibility: "public",
+		runner_environment: "github-hosted",
+	};
+}
+
+async function token(
+	options: {
+		claims?: Record<string, unknown>;
+		issuer?: string;
+		audience?: string;
+		issuedAt?: number;
+		notBefore?: number;
+		expiresAt?: number;
+		subject?: string;
+	} = {},
+): Promise<string> {
+	const now = Math.floor(Date.now() / 1000);
+	return new SignJWT(options.claims ?? claims())
+		.setProtectedHeader({ alg: "RS256", kid: KEY_ID, typ: "JWT" })
+		.setIssuer(options.issuer ?? GITHUB_ACTIONS_ISSUER)
+		.setAudience(options.audience ?? AUDIENCE)
+		.setSubject(
+			options.subject ??
+				"repo:EmDash-CMS/EmDash:owner_id:987654321:repo_id:123456789:ref:refs/heads/main",
+		)
+		.setIssuedAt(options.issuedAt ?? now)
+		.setNotBefore(options.notBefore ?? now - 1)
+		.setExpirationTime(options.expiresAt ?? now + 300)
+		.sign(privateKey);
+}
+
+describe("GitHub Actions OIDC verification", () => {
+	it("verifies and normalizes a workload identity without retaining the token", async () => {
+		const rawToken = await token();
+		const identity = await verifyGitHubActionsToken(rawToken, AUDIENCE, keyResolver);
+
+		expect(identity).toEqual({
+			issuer: "github-actions",
+			subject: "repo:EmDash-CMS/EmDash:owner_id:987654321:repo_id:123456789:ref:refs/heads/main",
+			tokenId: "f4b4a3d2-1111-4222-8333-abcdefabcdef",
+			repository: {
+				name: "emdash-cms/emdash",
+				id: "123456789",
+				owner: "emdash-cms",
+				ownerId: "987654321",
+				visibility: "public",
+			},
+			workflow: {
+				ref: "EmDash-CMS/EmDash/.github/workflows/release.yml@refs/heads/main",
+				sha: WORKFLOW_SHA,
+				jobRef: null,
+				jobSha: null,
+			},
+			run: {
+				id: "10000000001",
+				attempt: 2,
+				actor: "release-bot",
+				actorId: "11223344",
+				eventName: "workflow_dispatch",
+				ref: "refs/heads/main",
+				refType: "branch",
+				commitSha: SHA,
+				environment: null,
+				runnerEnvironment: "github-hosted",
+			},
+			issuedAt: expect.any(Number),
+			expiresAt: expect.any(Number),
+		});
+		expect(JSON.stringify(identity)).not.toContain(rawToken);
+	});
+
+	it("normalizes optional environment and reusable-workflow claims", async () => {
+		const value = claims();
+		value["environment"] = "production";
+		value["job_workflow_ref"] =
+			"EmDash-CMS/release-automation/.github/workflows/publish.yml@refs/tags/v1";
+		value["job_workflow_sha"] = "c".repeat(40);
+
+		await expect(
+			verifyGitHubActionsToken(await token({ claims: value }), AUDIENCE, keyResolver),
+		).resolves.toMatchObject({
+			workflow: {
+				jobRef: "EmDash-CMS/release-automation/.github/workflows/publish.yml@refs/tags/v1",
+				jobSha: "c".repeat(40),
+			},
+			run: { environment: "production" },
+		});
+	});
+
+	it("accepts GitHub App bot actor names", async () => {
+		await expect(
+			verifyGitHubActionsToken(
+				await token({ claims: { ...claims(), actor: "dependabot[bot]" } }),
+				AUDIENCE,
+				keyResolver,
+			),
+		).resolves.toMatchObject({ run: { actor: "dependabot[bot]" } });
+	});
+
+	it.each([
+		["repository owner mismatch", { repository_owner: "attacker" }],
+		[
+			"workflow repository mismatch",
+			{ workflow_ref: "attacker/repo/.github/workflows/release.yml@refs/heads/main" },
+		],
+		["invalid workflow SHA", { workflow_sha: "not-a-sha" }],
+		["zero run attempt", { run_attempt: "0" }],
+		["invalid ref", { ref: "main" }],
+		["invalid ref type", { ref_type: "pull_request" }],
+		["invalid visibility", { repository_visibility: "secret" }],
+		["invalid runner", { runner_environment: "unknown" }],
+		[
+			"invalid reusable workflow ref",
+			{ job_workflow_ref: "not-a-workflow", job_workflow_sha: SHA },
+		],
+	] satisfies ReadonlyArray<readonly [string, Record<string, unknown>]>)(
+		"rejects %s",
+		async (_name, replacement) => {
+			await expect(
+				verifyGitHubActionsToken(
+					await token({ claims: { ...claims(), ...replacement } }),
+					AUDIENCE,
+					keyResolver,
+				),
+			).rejects.toMatchObject({ code: "WORKLOAD_TOKEN_INVALID" });
+		},
+	);
+
+	it("rejects a reusable workflow ref without its matching SHA", async () => {
+		await expect(
+			verifyGitHubActionsToken(
+				await token({
+					claims: {
+						...claims(),
+						job_workflow_ref:
+							"EmDash-CMS/release-automation/.github/workflows/publish.yml@refs/heads/main",
+					},
+				}),
+				AUDIENCE,
+				keyResolver,
+			),
+		).rejects.toMatchObject({ code: "WORKLOAD_TOKEN_INVALID" });
+	});
+
+	it("rejects missing required normalized claims", async () => {
+		const value = claims();
+		delete value["repository_id"];
+
+		await expect(
+			verifyGitHubActionsToken(await token({ claims: value }), AUDIENCE, keyResolver),
+		).rejects.toMatchObject({ code: "WORKLOAD_TOKEN_INVALID" });
+	});
+
+	it.each([
+		["wrong issuer", { issuer: "https://issuer.example" }],
+		["wrong audience", { audience: "https://other.example" }],
+		["expired token", { expiresAt: 1 }],
+		["future token", { notBefore: Math.floor(Date.now() / 1000) + 3600 }],
+		["stale token", { issuedAt: Math.floor(Date.now() / 1000) - 3600 }],
+	] satisfies ReadonlyArray<readonly [string, Parameters<typeof token>[0]]>)(
+		"rejects a %s",
+		async (_name, options) => {
+			await expect(
+				verifyGitHubActionsToken(await token(options), AUDIENCE, keyResolver),
+			).rejects.toMatchObject({ code: "WORKLOAD_TOKEN_INVALID" });
+		},
+	);
+
+	it("rejects invalid verifier configuration separately from the token", async () => {
+		await expect(verifyGitHubActionsToken(await token(), "", keyResolver)).rejects.toMatchObject({
+			code: "WORKLOAD_CONFIGURATION_INVALID",
+		});
+	});
+
+	it("rejects a modified signature", async () => {
+		const value = await token();
+		const segments = value.split(".");
+		const signature = segments[2];
+		if (!signature) throw new Error("Expected JWT signature");
+		segments[2] = `${signature.startsWith("A") ? "B" : "A"}${signature.slice(1)}`;
+
+		await expect(
+			verifyGitHubActionsToken(segments.join("."), AUDIENCE, keyResolver),
+		).rejects.toMatchObject({ code: "WORKLOAD_TOKEN_INVALID" });
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds issuer-neutral verified-workload types and strict GitHub Actions OpenID Connect verification. The verifier uses GitHub's live RS256 JWKS, requires the service audience and GitHub issuer, bounds token age and size, validates the complete repository/workflow/run identity, and cross-checks repository ownership and workflow location. It accepts GitHub's current opaque immutable or customized subject formats without deriving authority from the subject string.

Only normalized claims leave the verifier. The raw JWT is never included in the result, errors, storage model, or fixtures. This is the first layer of the workload identity/admission stack, based on `feat/drs-confidential-oauth-callback`. Related to RFC #1870 and Discussion #1590.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1590

Admin i18n and a changeset are not applicable; this changes a private Worker app and adds no UI strings.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 (Codex)

## Screenshots / test output

- Twenty-one focused Workerd cases cover normalization, bot actors, reusable workflows, environments, missing/malformed claims, repository/workflow substitution, wrong issuer/audience, token time limits, invalid configuration, and signature tampering.
- The branch passes 119 release-service tests, typecheck, production build, quick lint, and type-aware lint.
- Live issuer metadata confirms `https://token.actions.githubusercontent.com`, its current JWKS endpoint, supported claims, and RS256 signing algorithm.
