### PR TITLE
feat(release-service): store publisher workload policies

### DIFF
--- a/apps/release-service/src/publisher-do/publisher-do.ts
+++ b/apps/release-service/src/publisher-do/publisher-do.ts
@@ -1,5 +1,19 @@
 import { DurableObject } from "cloudflare:workers";
 
+import {
+	initializeWorkloadPolicySchema,
+	WorkloadPolicyStore,
+	type PutWorkloadPolicyInput,
+	type PutWorkloadPolicyResult,
+	type StoredWorkloadPolicy,
+} from "./workload-policy.js";
+
+export type {
+	PutWorkloadPolicyInput,
+	PutWorkloadPolicyResult,
+	StoredWorkloadPolicy,
+} from "./workload-policy.js";
+
 const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
 const HASH_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
 const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
@@ -245,10 +259,12 @@ async function hashRefreshToken(token: string): Promise<string> {
 
 export class PublisherDurableObject extends DurableObject<Env> {
 	readonly #objectName: string | undefined;
+	readonly #workloadPolicies: WorkloadPolicyStore;
 
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env);
 		this.#objectName = ctx.id.name;
+		this.#workloadPolicies = new WorkloadPolicyStore(ctx.storage);
 		void ctx.blockConcurrencyWhile(async () => {
 			this.#initializeSchema();
 		});
@@ -324,6 +340,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 				created_at INTEGER NOT NULL
 			);
 		`);
+		initializeWorkloadPolicySchema(this.ctx.storage);
 	}
 
 	#assertPublisherObjectName(publisherDid: string): void {
@@ -376,6 +393,25 @@ export class PublisherDurableObject extends DurableObject<Env> {
 
 	initializePublisher(publisherDid: string): void {
 		this.#assertPublisherDid(publisherDid);
+	}
+
+	putWorkloadPolicy(input: PutWorkloadPolicyInput): PutWorkloadPolicyResult {
+		this.#assertPublisherDid(input.publisherDid);
+		return this.#workloadPolicies.put(input);
+	}
+
+	getWorkloadPolicy(publisherDid: string, packageSlug: string): StoredWorkloadPolicy | null {
+		this.#assertPublisherDid(publisherDid);
+		return this.#workloadPolicies.get(packageSlug);
+	}
+
+	listWorkloadPolicies(
+		publisherDid: string,
+		afterPackageSlug: string | null,
+		limit: number,
+	): readonly StoredWorkloadPolicy[] {
+		this.#assertPublisherDid(publisherDid);
+		return this.#workloadPolicies.list(afterPackageSlug, limit);
 	}
 
 	createPublisherSession(input: CreatePublisherSessionInput): CreatePublisherSessionResult {

--- a/apps/release-service/src/publisher-do/workload-policy.ts
+++ b/apps/release-service/src/publisher-do/workload-policy.ts
@@ -1,0 +1,265 @@
+const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
+const PACKAGE_SLUG_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const DECIMAL_ID_PATTERN = /^[1-9][0-9]*$/;
+const REF_PATTERN = /^refs\/[A-Za-z0-9._/-]{1,507}$/;
+const WORKFLOW_REF_PATTERN =
+	/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/\.github\/workflows\/[A-Za-z0-9_./-]+\.ya?ml@refs\/[A-Za-z0-9._/-]+$/;
+const MAX_POLICY_VALUES = 32;
+
+export interface StoredWorkloadPolicy {
+	packageSlug: string;
+	repository: string;
+	repositoryId: string;
+	repositoryOwnerId: string;
+	workflowRef: string;
+	allowedRefs: readonly string[];
+	allowedEnvironments: readonly string[];
+	active: boolean;
+	stateVersion: number;
+	authorizedBy: string;
+	createdAt: number;
+	updatedAt: number;
+}
+
+export interface PutWorkloadPolicyInput {
+	publisherDid: string;
+	packageSlug: string;
+	repository: string;
+	repositoryId: string;
+	repositoryOwnerId: string;
+	workflowRef: string;
+	allowedRefs: readonly string[];
+	allowedEnvironments: readonly string[];
+	active: boolean;
+	expectedVersion: number | null;
+	now?: number;
+}
+
+export type PutWorkloadPolicyResult =
+	| { ok: true; policy: StoredWorkloadPolicy }
+	| { ok: false; code: "WORKLOAD_POLICY_CAS_REQUIRED" };
+
+interface WorkloadPolicyRow {
+	[key: string]: string | number | ArrayBuffer | null;
+	package_slug: string;
+	repository: string;
+	repository_id: string;
+	repository_owner_id: string;
+	workflow_ref: string;
+	allowed_refs: string;
+	allowed_environments: string;
+	active: number;
+	state_version: number;
+	authorized_by: string;
+	created_at: number;
+	updated_at: number;
+}
+
+export class WorkloadPolicyError extends Error {
+	readonly code = "WORKLOAD_POLICY_INVALID";
+
+	constructor() {
+		super("WORKLOAD_POLICY_INVALID");
+		this.name = "WorkloadPolicyError";
+	}
+}
+
+function normalizeValues(
+	values: readonly string[],
+	validate: (value: string) => boolean,
+): readonly string[] {
+	if (!Array.isArray(values) || values.length > MAX_POLICY_VALUES) throw new WorkloadPolicyError();
+	const normalized = [...values];
+	if (normalized.some((value) => typeof value !== "string" || !validate(value))) {
+		throw new WorkloadPolicyError();
+	}
+	normalized.sort();
+	if (new Set(normalized).size !== normalized.length) throw new WorkloadPolicyError();
+	return normalized;
+}
+
+function parseStringArray(value: string, validate: (item: string) => boolean): readonly string[] {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		throw new WorkloadPolicyError();
+	}
+	if (
+		!Array.isArray(parsed) ||
+		parsed.length > MAX_POLICY_VALUES ||
+		parsed.some((item) => typeof item !== "string" || !validate(item))
+	) {
+		throw new WorkloadPolicyError();
+	}
+	return parsed;
+}
+
+function validEnvironment(value: string): boolean {
+	if (value.length === 0 || value.length > 255) return false;
+	for (const character of value) {
+		const codePoint = character.codePointAt(0)!;
+		if (codePoint <= 31 || codePoint === 127) return false;
+	}
+	return true;
+}
+
+function rowToPolicy(row: WorkloadPolicyRow): StoredWorkloadPolicy {
+	return {
+		packageSlug: row.package_slug,
+		repository: row.repository,
+		repositoryId: row.repository_id,
+		repositoryOwnerId: row.repository_owner_id,
+		workflowRef: row.workflow_ref,
+		allowedRefs: parseStringArray(row.allowed_refs, (value) => REF_PATTERN.test(value)),
+		allowedEnvironments: parseStringArray(row.allowed_environments, validEnvironment),
+		active: row.active === 1,
+		stateVersion: row.state_version,
+		authorizedBy: row.authorized_by,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+export function initializeWorkloadPolicySchema(storage: DurableObjectStorage): void {
+	storage.sql.exec(`
+		CREATE TABLE IF NOT EXISTS workload_policies (
+			package_slug TEXT PRIMARY KEY,
+			repository TEXT NOT NULL,
+			repository_id TEXT NOT NULL,
+			repository_owner_id TEXT NOT NULL,
+			workflow_ref TEXT NOT NULL,
+			allowed_refs TEXT NOT NULL,
+			allowed_environments TEXT NOT NULL,
+			active INTEGER NOT NULL CHECK (active IN (0, 1)),
+			state_version INTEGER NOT NULL CHECK (state_version >= 1),
+			authorized_by TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_workload_policies_active
+			ON workload_policies(active, package_slug);
+	`);
+}
+
+export class WorkloadPolicyStore {
+	readonly #storage: DurableObjectStorage;
+
+	constructor(storage: DurableObjectStorage) {
+		this.#storage = storage;
+	}
+
+	put(input: PutWorkloadPolicyInput): PutWorkloadPolicyResult {
+		const now = input.now ?? Date.now();
+		const repository = input.repository.toLowerCase();
+		const allowedRefs = normalizeValues(input.allowedRefs, (value) => REF_PATTERN.test(value));
+		const allowedEnvironments = normalizeValues(input.allowedEnvironments, validEnvironment);
+		if (
+			!DID_PATTERN.test(input.publisherDid) ||
+			!PACKAGE_SLUG_PATTERN.test(input.packageSlug) ||
+			!REPOSITORY_PATTERN.test(repository) ||
+			!DECIMAL_ID_PATTERN.test(input.repositoryId) ||
+			!DECIMAL_ID_PATTERN.test(input.repositoryOwnerId) ||
+			!WORKFLOW_REF_PATTERN.test(input.workflowRef) ||
+			!input.workflowRef.toLowerCase().startsWith(`${repository}/.github/workflows/`) ||
+			typeof input.active !== "boolean" ||
+			(input.expectedVersion !== null &&
+				(!Number.isSafeInteger(input.expectedVersion) || input.expectedVersion < 1)) ||
+			!Number.isSafeInteger(now) ||
+			now < 0
+		) {
+			throw new WorkloadPolicyError();
+		}
+		return this.#storage.transactionSync(() => {
+			const current = this.get(input.packageSlug);
+			if (
+				(current === null && input.expectedVersion !== null) ||
+				(current !== null && current.stateVersion !== input.expectedVersion)
+			) {
+				return { ok: false, code: "WORKLOAD_POLICY_CAS_REQUIRED" } as const;
+			}
+			const stateVersion = (current?.stateVersion ?? 0) + 1;
+			const createdAt = current?.createdAt ?? now;
+			this.#storage.sql.exec(
+				`INSERT INTO workload_policies (
+					package_slug, repository, repository_id, repository_owner_id,
+					workflow_ref, allowed_refs, allowed_environments, active,
+					state_version, authorized_by, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT(package_slug) DO UPDATE SET
+					repository = excluded.repository,
+					repository_id = excluded.repository_id,
+					repository_owner_id = excluded.repository_owner_id,
+					workflow_ref = excluded.workflow_ref,
+					allowed_refs = excluded.allowed_refs,
+					allowed_environments = excluded.allowed_environments,
+					active = excluded.active,
+					state_version = excluded.state_version,
+					authorized_by = excluded.authorized_by,
+					updated_at = excluded.updated_at`,
+				input.packageSlug,
+				repository,
+				input.repositoryId,
+				input.repositoryOwnerId,
+				input.workflowRef,
+				JSON.stringify(allowedRefs),
+				JSON.stringify(allowedEnvironments),
+				input.active ? 1 : 0,
+				stateVersion,
+				input.publisherDid,
+				createdAt,
+				now,
+			);
+			this.#storage.sql.exec(
+				`INSERT INTO audit_events (
+					event_type, actor_realm, actor_identity, subject,
+					reason_code, public_payload, created_at
+				) VALUES ('workload-policy-stored', 'publisher', ?, ?, NULL, '{}', ?)`,
+				input.publisherDid,
+				input.packageSlug,
+				now,
+			);
+			return { ok: true, policy: this.get(input.packageSlug)! } as const;
+		});
+	}
+
+	get(packageSlug: string): StoredWorkloadPolicy | null {
+		if (!PACKAGE_SLUG_PATTERN.test(packageSlug)) throw new WorkloadPolicyError();
+		const row = this.#storage.sql
+			.exec<WorkloadPolicyRow>(
+				`SELECT package_slug, repository, repository_id, repository_owner_id,
+				        workflow_ref, allowed_refs, allowed_environments, active,
+				        state_version, authorized_by, created_at, updated_at
+				 FROM workload_policies WHERE package_slug = ?`,
+				packageSlug,
+			)
+			.toArray()[0];
+		return row ? rowToPolicy(row) : null;
+	}
+
+	list(afterPackageSlug: string | null, limit: number): readonly StoredWorkloadPolicy[] {
+		if (
+			(afterPackageSlug !== null && !PACKAGE_SLUG_PATTERN.test(afterPackageSlug)) ||
+			!Number.isSafeInteger(limit) ||
+			limit < 1 ||
+			limit > 100
+		) {
+			throw new WorkloadPolicyError();
+		}
+		return this.#storage.sql
+			.exec<WorkloadPolicyRow>(
+				`SELECT package_slug, repository, repository_id, repository_owner_id,
+				        workflow_ref, allowed_refs, allowed_environments, active,
+				        state_version, authorized_by, created_at, updated_at
+				 FROM workload_policies
+				 WHERE (? IS NULL OR package_slug > ?)
+				 ORDER BY package_slug LIMIT ?`,
+				afterPackageSlug,
+				afterPackageSlug,
+				limit,
+			)
+			.toArray()
+			.map(rowToPolicy);
+	}
+}

--- a/apps/release-service/src/publisher-do/workload-policy.ts
+++ b/apps/release-service/src/publisher-do/workload-policy.ts
@@ -74,7 +74,7 @@ function normalizeValues(
 	if (normalized.some((value) => typeof value !== "string" || !validate(value))) {
 		throw new WorkloadPolicyError();
 	}
-	normalized.sort();
+	normalized.sort((left, right) => left.localeCompare(right));
 	if (new Set(normalized).size !== normalized.length) throw new WorkloadPolicyError();
 	return normalized;
 }

--- a/apps/release-service/test/workload-policy.test.ts
+++ b/apps/release-service/test/workload-policy.test.ts
@@ -1,0 +1,148 @@
+import { reset, runInDurableObject } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { PutWorkloadPolicyInput } from "../src/publisher-do/publisher-do.js";
+
+const DID = "did:plc:publisher";
+const OTHER_DID = "did:plc:other";
+
+function publisher() {
+	return env.PUBLISHER_DO.getByName(DID);
+}
+
+function input(overrides: Partial<PutWorkloadPolicyInput> = {}): PutWorkloadPolicyInput {
+	return {
+		publisherDid: DID,
+		packageSlug: "Gallery",
+		repository: "EmDash-CMS/Gallery",
+		repositoryId: "123456789",
+		repositoryOwnerId: "987654321",
+		workflowRef: "EmDash-CMS/Gallery/.github/workflows/release.yml@refs/heads/main",
+		allowedRefs: ["refs/tags/v2", "refs/heads/main"],
+		allowedEnvironments: ["staging", "production"],
+		active: true,
+		expectedVersion: null,
+		now: 1_800_000_000_000,
+		...overrides,
+	};
+}
+
+afterEach(async () => {
+	await reset();
+});
+
+describe("publisher workload policies", () => {
+	it("stores canonical immutable repository identity and sorted restrictions", async () => {
+		const stub = publisher();
+		const result = await stub.putWorkloadPolicy(input());
+
+		expect(result).toEqual({
+			ok: true,
+			policy: {
+				packageSlug: "Gallery",
+				repository: "emdash-cms/gallery",
+				repositoryId: "123456789",
+				repositoryOwnerId: "987654321",
+				workflowRef: "EmDash-CMS/Gallery/.github/workflows/release.yml@refs/heads/main",
+				allowedRefs: ["refs/heads/main", "refs/tags/v2"],
+				allowedEnvironments: ["production", "staging"],
+				active: true,
+				stateVersion: 1,
+				authorizedBy: DID,
+				createdAt: 1_800_000_000_000,
+				updatedAt: 1_800_000_000_000,
+			},
+		});
+		if (!result.ok) return;
+		await expect(stub.getWorkloadPolicy(DID, "Gallery")).resolves.toEqual(result.policy);
+	});
+
+	it("requires compare-and-set for replacement and preserves creation time", async () => {
+		const stub = publisher();
+		await stub.putWorkloadPolicy(input());
+
+		await expect(
+			stub.putWorkloadPolicy(input({ expectedVersion: null, now: 1_800_000_000_001 })),
+		).resolves.toEqual({ ok: false, code: "WORKLOAD_POLICY_CAS_REQUIRED" });
+		const updated = await stub.putWorkloadPolicy(
+			input({
+				expectedVersion: 1,
+				active: false,
+				allowedRefs: ["refs/heads/main"],
+				now: 1_800_000_000_002,
+			}),
+		);
+		expect(updated).toMatchObject({
+			ok: true,
+			policy: {
+				active: false,
+				stateVersion: 2,
+				createdAt: 1_800_000_000_000,
+				updatedAt: 1_800_000_000_002,
+			},
+		});
+	});
+
+	it("lists policies with stable package-slug pagination", async () => {
+		const stub = publisher();
+		await stub.putWorkloadPolicy(input({ packageSlug: "Alpha" }));
+		await stub.putWorkloadPolicy(
+			input({ packageSlug: "Beta", expectedVersion: null, now: 1_800_000_000_001 }),
+		);
+
+		await expect(stub.listWorkloadPolicies(DID, null, 1)).resolves.toMatchObject([
+			{ packageSlug: "Alpha" },
+		]);
+		await expect(stub.listWorkloadPolicies(DID, "Alpha", 10)).resolves.toMatchObject([
+			{ packageSlug: "Beta" },
+		]);
+	});
+
+	it("appends publisher-attributed audit without storing token-shaped data", async () => {
+		const stub = publisher();
+		await stub.putWorkloadPolicy(input());
+
+		const audit = await runInDurableObject(stub, (_instance, state) =>
+			state.storage.sql
+				.exec<{
+					event_type: string;
+					actor_realm: string;
+					actor_identity: string;
+					subject: string;
+					public_payload: string;
+				}>(
+					"SELECT event_type, actor_realm, actor_identity, subject, public_payload FROM audit_events",
+				)
+				.toArray(),
+		);
+		expect(audit).toEqual([
+			{
+				event_type: "workload-policy-stored",
+				actor_realm: "publisher",
+				actor_identity: DID,
+				subject: "Gallery",
+				public_payload: "{}",
+			},
+		]);
+	});
+
+	it("rejects invalid workflow ownership, duplicate restrictions, and publisher mismatch", async () => {
+		const stub = publisher();
+		await runInDurableObject(stub, async (instance) => {
+			expect(() =>
+				instance.putWorkloadPolicy(
+					input({
+						workflowRef: "attacker/repo/.github/workflows/release.yml@refs/heads/main",
+					}),
+				),
+			).toThrowError(expect.objectContaining({ code: "WORKLOAD_POLICY_INVALID" }));
+			expect(() =>
+				instance.putWorkloadPolicy(input({ allowedRefs: ["refs/heads/main", "refs/heads/main"] })),
+			).toThrowError(expect.objectContaining({ code: "WORKLOAD_POLICY_INVALID" }));
+			expect(() => instance.putWorkloadPolicy(input({ publisherDid: OTHER_DID }))).toThrowError(
+				expect.objectContaining({ code: "PUBLISHER_DID_MISMATCH" }),
+			);
+		});
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds publisher-owned GitHub workload policies to each publisher Durable Object. A policy binds a package slug to canonical repository name plus immutable repository/owner IDs, an exact workflow reference, optional refs and environments, active state, authorizing publisher DID, and a compare-and-set version. Restrictions are canonicalized before persistence; replacements require the current version and append publisher-attributed audit.

This is layer 2 of the workload identity/admission merge unit, based on `feat/drs-github-oidc-verifier`. Related to RFC #1870 and Discussion #1590.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (not applicable: no UI)
- [ ] I have added and reviewed the user-facing changeset (not applicable: private Worker app)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1590

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 (Codex)

## Screenshots / test output

- Workerd covers canonical storage, immutable repository identity, sorted restrictions, CAS replacement, pagination, audit attribution, workflow substitution, duplicate restrictions, and publisher isolation.
- The top branch passes 124 release-service tests, typecheck, and quick lint.
