### PR TITLE
feat(release-service): add publisher intent state machine

### DIFF
--- a/apps/release-service/src/publisher-do/intent-state.ts
+++ b/apps/release-service/src/publisher-do/intent-state.ts
@@ -1,0 +1,561 @@
+const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
+const PACKAGE_SLUG_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+const VERSION_PATTERN = /^[0-9A-Za-z][0-9A-Za-z.-]{0,127}$/;
+const ULID_PATTERN = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const DIGEST_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$/;
+const ACTOR_IDENTITY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,255}$/;
+const REASON_CODE_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
+const WORKFLOW_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+const MAX_WORKLOAD_JSON_CHARS = 16 * 1024;
+const MAX_RELEASE_INPUT_JSON_CHARS = 64 * 1024;
+const MAX_STATE_DATA_JSON_CHARS = 64 * 1024;
+const MAX_INTENT_LIFETIME_MS = 7 * 24 * 60 * 60_000;
+
+export type IntentState =
+	| "received"
+	| "verifying"
+	| "verified"
+	| "awaiting_approval"
+	| "ready"
+	| "publishing"
+	| "reconciling"
+	| "published"
+	| "invalid"
+	| "rejected"
+	| "cancelled"
+	| "expired"
+	| "failed"
+	| "conflict";
+
+export type IntentActorRealm = "oidc" | "publisher" | "approver" | "access" | "system";
+
+const ALLOWED_TRANSITIONS: Readonly<Record<IntentState, ReadonlySet<IntentState>>> = {
+	received: new Set(["verifying", "cancelled", "expired"]),
+	verifying: new Set(["verified", "invalid", "failed", "cancelled", "expired"]),
+	verified: new Set(["ready", "awaiting_approval", "invalid", "failed", "cancelled", "expired"]),
+	awaiting_approval: new Set(["ready", "rejected", "invalid", "cancelled", "expired"]),
+	ready: new Set(["publishing", "invalid", "cancelled", "expired"]),
+	publishing: new Set(["published", "reconciling", "failed", "conflict"]),
+	reconciling: new Set(["published", "failed", "conflict"]),
+	published: new Set(),
+	invalid: new Set(),
+	rejected: new Set(),
+	cancelled: new Set(),
+	expired: new Set(),
+	failed: new Set(),
+	conflict: new Set(),
+};
+
+export interface StoredIntent {
+	id: string;
+	packageSlug: string;
+	version: string;
+	state: IntentState;
+	stateGeneration: number;
+	workloadPolicyVersion: number;
+	requestDigest: string;
+	workloadIdentityJson: string;
+	releaseInputJson: string;
+	stateDataJson: string;
+	workflowId: string | null;
+	expiresAt: number;
+	createdAt: number;
+	updatedAt: number;
+}
+
+export interface CreateIntentInput {
+	publisherDid: string;
+	intentId: string;
+	packageSlug: string;
+	version: string;
+	workloadPolicyVersion: number;
+	workloadIdentityDigest: string;
+	idempotencyKey: string;
+	requestDigest: string;
+	workloadIdentityJson: string;
+	releaseInputJson: string;
+	expiresAt: number;
+	now?: number;
+}
+
+export type CreateIntentResult =
+	| { ok: true; intent: StoredIntent; replayed: boolean }
+	| { ok: false; code: "IDEMPOTENCY_CONFLICT" }
+	| { ok: false; code: "RESERVATION_CONFLICT"; existingIntentId: string }
+	| { ok: false; code: "WORKLOAD_POLICY_UNAVAILABLE" }
+	| { ok: false; code: "PUBLISHER_SUSPENDED" };
+
+export interface TransitionIntentInput {
+	publisherDid: string;
+	intentId: string;
+	expectedState: IntentState;
+	expectedGeneration: number;
+	toState: IntentState;
+	transitionDigest: string;
+	actorRealm: IntentActorRealm;
+	actorIdentity: string;
+	reasonCode: string | null;
+	stateDataJson: string;
+	workflowId?: string;
+	now?: number;
+}
+
+export type TransitionIntentResult =
+	| { ok: true; intent: StoredIntent; replayed: boolean }
+	| { ok: false; code: "INTENT_NOT_FOUND" }
+	| { ok: false; code: "INTENT_CAS_REQUIRED" }
+	| { ok: false; code: "INTENT_TRANSITION_INVALID" };
+
+export interface IntentTransition {
+	sequence: number;
+	fromState: IntentState | null;
+	toState: IntentState;
+	stateGeneration: number;
+	transitionDigest: string;
+	actorRealm: IntentActorRealm;
+	actorIdentity: string;
+	reasonCode: string | null;
+	stateDataJson: string;
+	createdAt: number;
+}
+
+interface IntentRow {
+	[key: string]: string | number | ArrayBuffer | null;
+	id: string;
+	package_slug: string;
+	version: string;
+	state: IntentState;
+	state_generation: number;
+	workload_policy_version: number;
+	request_digest: string;
+	workload_identity_json: string;
+	release_input_json: string;
+	state_data_json: string;
+	workflow_id: string | null;
+	expires_at: number;
+	created_at: number;
+	updated_at: number;
+}
+
+interface IdempotencyRow {
+	[key: string]: string | number | ArrayBuffer | null;
+	request_digest: string;
+	intent_id: string;
+	expires_at: number;
+}
+
+interface TransitionRow {
+	[key: string]: string | number | ArrayBuffer | null;
+	sequence: number;
+	from_state: IntentState | null;
+	to_state: IntentState;
+	state_generation: number;
+	transition_digest: string;
+	actor_realm: IntentActorRealm;
+	actor_identity: string;
+	reason_code: string | null;
+	state_data_json: string;
+	created_at: number;
+}
+
+export class IntentStateError extends Error {
+	readonly code = "INTENT_INPUT_INVALID";
+
+	constructor() {
+		super("INTENT_INPUT_INVALID");
+		this.name = "IntentStateError";
+	}
+}
+
+function validCanonicalObjectJson(value: unknown, maximum: number): value is string {
+	if (typeof value !== "string" || value.length < 2 || value.length > maximum) return false;
+	try {
+		const parsed: unknown = JSON.parse(value);
+		return (
+			parsed !== null &&
+			typeof parsed === "object" &&
+			!Array.isArray(parsed) &&
+			JSON.stringify(parsed) === value
+		);
+	} catch {
+		return false;
+	}
+}
+
+function validState(value: unknown): value is IntentState {
+	return typeof value === "string" && Object.hasOwn(ALLOWED_TRANSITIONS, value);
+}
+
+function validReason(value: unknown): value is string | null {
+	return value === null || (typeof value === "string" && REASON_CODE_PATTERN.test(value));
+}
+
+function rowToIntent(row: IntentRow): StoredIntent {
+	return {
+		id: row.id,
+		packageSlug: row.package_slug,
+		version: row.version,
+		state: row.state,
+		stateGeneration: row.state_generation,
+		workloadPolicyVersion: row.workload_policy_version,
+		requestDigest: row.request_digest,
+		workloadIdentityJson: row.workload_identity_json,
+		releaseInputJson: row.release_input_json,
+		stateDataJson: row.state_data_json,
+		workflowId: row.workflow_id,
+		expiresAt: row.expires_at,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+export function initializeIntentStateSchema(storage: DurableObjectStorage): void {
+	storage.sql.exec(`
+		CREATE TABLE IF NOT EXISTS intents (
+			id TEXT PRIMARY KEY,
+			package_slug TEXT NOT NULL,
+			version TEXT NOT NULL,
+			state TEXT NOT NULL,
+			state_generation INTEGER NOT NULL CHECK (state_generation >= 1),
+			workload_policy_version INTEGER NOT NULL CHECK (workload_policy_version >= 1),
+			request_digest TEXT NOT NULL,
+			workload_identity_json TEXT NOT NULL,
+			release_input_json TEXT NOT NULL,
+			state_data_json TEXT NOT NULL,
+			workflow_id TEXT,
+			expires_at INTEGER NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_intents_state ON intents(state, id);
+		CREATE INDEX IF NOT EXISTS idx_intents_expiry ON intents(expires_at, id);
+		CREATE TABLE IF NOT EXISTS intent_transitions (
+			intent_id TEXT NOT NULL,
+			sequence INTEGER NOT NULL,
+			from_state TEXT,
+			to_state TEXT NOT NULL,
+			state_generation INTEGER NOT NULL,
+			transition_digest TEXT NOT NULL,
+			actor_realm TEXT NOT NULL,
+			actor_identity TEXT NOT NULL,
+			reason_code TEXT,
+			state_data_json TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			PRIMARY KEY (intent_id, sequence),
+			UNIQUE (intent_id, state_generation)
+		);
+		CREATE TABLE IF NOT EXISTS release_reservations (
+			package_slug TEXT NOT NULL,
+			version TEXT NOT NULL,
+			intent_id TEXT NOT NULL UNIQUE,
+			created_at INTEGER NOT NULL,
+			PRIMARY KEY (package_slug, version)
+		);
+		CREATE TABLE IF NOT EXISTS intent_idempotency (
+			workload_identity_digest TEXT NOT NULL,
+			mutation_key TEXT NOT NULL,
+			request_digest TEXT NOT NULL,
+			intent_id TEXT NOT NULL,
+			expires_at INTEGER NOT NULL,
+			PRIMARY KEY (workload_identity_digest, mutation_key)
+		);
+		CREATE INDEX IF NOT EXISTS idx_intent_idempotency_expiry
+			ON intent_idempotency(expires_at);
+	`);
+}
+
+export class IntentStateStore {
+	readonly #storage: DurableObjectStorage;
+
+	constructor(storage: DurableObjectStorage) {
+		this.#storage = storage;
+	}
+
+	create(input: CreateIntentInput): CreateIntentResult {
+		const now = input.now ?? Date.now();
+		if (
+			!DID_PATTERN.test(input.publisherDid) ||
+			!ULID_PATTERN.test(input.intentId) ||
+			!PACKAGE_SLUG_PATTERN.test(input.packageSlug) ||
+			!VERSION_PATTERN.test(input.version) ||
+			!Number.isSafeInteger(input.workloadPolicyVersion) ||
+			input.workloadPolicyVersion < 1 ||
+			!DIGEST_PATTERN.test(input.workloadIdentityDigest) ||
+			!IDEMPOTENCY_KEY_PATTERN.test(input.idempotencyKey) ||
+			!DIGEST_PATTERN.test(input.requestDigest) ||
+			!validCanonicalObjectJson(input.workloadIdentityJson, MAX_WORKLOAD_JSON_CHARS) ||
+			!validCanonicalObjectJson(input.releaseInputJson, MAX_RELEASE_INPUT_JSON_CHARS) ||
+			!Number.isSafeInteger(now) ||
+			now < 0 ||
+			!Number.isSafeInteger(input.expiresAt) ||
+			input.expiresAt <= now ||
+			input.expiresAt - now > MAX_INTENT_LIFETIME_MS
+		) {
+			throw new IntentStateError();
+		}
+		return this.#storage.transactionSync(() => {
+			const idempotency = this.#storage.sql
+				.exec<IdempotencyRow>(
+					`SELECT request_digest, intent_id, expires_at FROM intent_idempotency
+					 WHERE workload_identity_digest = ? AND mutation_key = ?`,
+					input.workloadIdentityDigest,
+					input.idempotencyKey,
+				)
+				.toArray()[0];
+			if (idempotency && idempotency.expires_at > now) {
+				if (idempotency.request_digest !== input.requestDigest) {
+					return { ok: false, code: "IDEMPOTENCY_CONFLICT" } as const;
+				}
+				const intent = this.get(idempotency.intent_id);
+				if (!intent) throw new IntentStateError();
+				return { ok: true, intent, replayed: true } as const;
+			}
+			if (idempotency) {
+				this.#storage.sql.exec(
+					`DELETE FROM intent_idempotency
+					 WHERE workload_identity_digest = ? AND mutation_key = ?`,
+					input.workloadIdentityDigest,
+					input.idempotencyKey,
+				);
+			}
+			const publisher = this.#storage.sql
+				.exec<{ status: string }>("SELECT status FROM publisher WHERE id = 1")
+				.toArray()[0];
+			if (!publisher || publisher.status !== "active") {
+				return { ok: false, code: "PUBLISHER_SUSPENDED" } as const;
+			}
+			const policy = this.#storage.sql
+				.exec<{ active: number; state_version: number }>(
+					`SELECT active, state_version FROM workload_policies WHERE package_slug = ?`,
+					input.packageSlug,
+				)
+				.toArray()[0];
+			if (!policy || policy.active !== 1 || policy.state_version !== input.workloadPolicyVersion) {
+				return { ok: false, code: "WORKLOAD_POLICY_UNAVAILABLE" } as const;
+			}
+			const reservation = this.#storage.sql
+				.exec<{ intent_id: string }>(
+					`SELECT intent_id FROM release_reservations
+					 WHERE package_slug = ? AND version = ?`,
+					input.packageSlug,
+					input.version,
+				)
+				.toArray()[0];
+			if (reservation) {
+				return {
+					ok: false,
+					code: "RESERVATION_CONFLICT",
+					existingIntentId: reservation.intent_id,
+				} as const;
+			}
+			this.#storage.sql.exec(
+				`INSERT INTO intents (
+					id, package_slug, version, state, state_generation,
+					workload_policy_version, request_digest, workload_identity_json,
+					release_input_json, state_data_json, workflow_id,
+					expires_at, created_at, updated_at
+				) VALUES (?, ?, ?, 'received', 1, ?, ?, ?, ?, '{}', NULL, ?, ?, ?)`,
+				input.intentId,
+				input.packageSlug,
+				input.version,
+				input.workloadPolicyVersion,
+				input.requestDigest,
+				input.workloadIdentityJson,
+				input.releaseInputJson,
+				input.expiresAt,
+				now,
+				now,
+			);
+			this.#storage.sql.exec(
+				`INSERT INTO release_reservations (package_slug, version, intent_id, created_at)
+				 VALUES (?, ?, ?, ?)`,
+				input.packageSlug,
+				input.version,
+				input.intentId,
+				now,
+			);
+			this.#storage.sql.exec(
+				`INSERT INTO intent_idempotency (
+					workload_identity_digest, mutation_key, request_digest, intent_id, expires_at
+				) VALUES (?, ?, ?, ?, ?)`,
+				input.workloadIdentityDigest,
+				input.idempotencyKey,
+				input.requestDigest,
+				input.intentId,
+				input.expiresAt,
+			);
+			this.#storage.sql.exec(
+				`INSERT INTO intent_transitions (
+					intent_id, sequence, from_state, to_state, state_generation,
+					transition_digest, actor_realm, actor_identity, reason_code,
+					state_data_json, created_at
+				) VALUES (?, 1, NULL, 'received', 1, ?, 'oidc', ?, NULL, '{}', ?)`,
+				input.intentId,
+				input.requestDigest,
+				input.workloadIdentityDigest,
+				now,
+			);
+			this.#storage.sql.exec(
+				`INSERT INTO audit_events (
+					event_type, actor_realm, actor_identity, subject,
+					reason_code, public_payload, created_at
+				) VALUES ('intent-received', 'oidc', ?, ?, NULL, '{}', ?)`,
+				input.workloadIdentityDigest,
+				input.intentId,
+				now,
+			);
+			return { ok: true, intent: this.get(input.intentId)!, replayed: false } as const;
+		});
+	}
+
+	transition(input: TransitionIntentInput): TransitionIntentResult {
+		const now = input.now ?? Date.now();
+		if (
+			!DID_PATTERN.test(input.publisherDid) ||
+			!ULID_PATTERN.test(input.intentId) ||
+			!validState(input.expectedState) ||
+			!Number.isSafeInteger(input.expectedGeneration) ||
+			input.expectedGeneration < 1 ||
+			!validState(input.toState) ||
+			!DIGEST_PATTERN.test(input.transitionDigest) ||
+			(input.actorRealm !== "oidc" &&
+				input.actorRealm !== "publisher" &&
+				input.actorRealm !== "approver" &&
+				input.actorRealm !== "access" &&
+				input.actorRealm !== "system") ||
+			!ACTOR_IDENTITY_PATTERN.test(input.actorIdentity) ||
+			!validReason(input.reasonCode) ||
+			!validCanonicalObjectJson(input.stateDataJson, MAX_STATE_DATA_JSON_CHARS) ||
+			(input.workflowId !== undefined && !WORKFLOW_ID_PATTERN.test(input.workflowId)) ||
+			!Number.isSafeInteger(now) ||
+			now < 0
+		) {
+			throw new IntentStateError();
+		}
+		return this.#storage.transactionSync(() => {
+			const current = this.get(input.intentId);
+			if (!current) return { ok: false, code: "INTENT_NOT_FOUND" } as const;
+			if (
+				current.state !== input.expectedState ||
+				current.stateGeneration !== input.expectedGeneration
+			) {
+				const replay =
+					current.stateGeneration === input.expectedGeneration + 1
+						? this.#storage.sql
+								.exec<{ transition_digest: string; to_state: IntentState }>(
+									`SELECT transition_digest, to_state FROM intent_transitions
+						 WHERE intent_id = ? AND state_generation = ?`,
+									input.intentId,
+									input.expectedGeneration + 1,
+								)
+								.toArray()[0]
+						: undefined;
+				if (
+					replay?.transition_digest === input.transitionDigest &&
+					replay.to_state === input.toState
+				) {
+					return { ok: true, intent: current, replayed: true } as const;
+				}
+				return { ok: false, code: "INTENT_CAS_REQUIRED" } as const;
+			}
+			if (!ALLOWED_TRANSITIONS[current.state].has(input.toState)) {
+				return { ok: false, code: "INTENT_TRANSITION_INVALID" } as const;
+			}
+			if (
+				(input.workflowId !== undefined &&
+					current.workflowId !== null &&
+					input.workflowId !== current.workflowId) ||
+				(input.workflowId !== undefined &&
+					current.workflowId === null &&
+					(current.state !== "received" || input.toState !== "verifying"))
+			) {
+				return { ok: false, code: "INTENT_TRANSITION_INVALID" } as const;
+			}
+			const nextGeneration = current.stateGeneration + 1;
+			const workflowId = input.workflowId ?? current.workflowId;
+			this.#storage.sql.exec(
+				`UPDATE intents SET
+					state = ?, state_generation = ?, state_data_json = ?,
+					workflow_id = ?, updated_at = ?
+				 WHERE id = ?`,
+				input.toState,
+				nextGeneration,
+				input.stateDataJson,
+				workflowId,
+				now,
+				input.intentId,
+			);
+			this.#storage.sql.exec(
+				`INSERT INTO intent_transitions (
+					intent_id, sequence, from_state, to_state, state_generation,
+					transition_digest, actor_realm, actor_identity, reason_code,
+					state_data_json, created_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				input.intentId,
+				nextGeneration,
+				current.state,
+				input.toState,
+				nextGeneration,
+				input.transitionDigest,
+				input.actorRealm,
+				input.actorIdentity,
+				input.reasonCode,
+				input.stateDataJson,
+				now,
+			);
+			this.#storage.sql.exec(
+				`INSERT INTO audit_events (
+					event_type, actor_realm, actor_identity, subject,
+					reason_code, public_payload, created_at
+				) VALUES ('intent-transitioned', ?, ?, ?, ?, '{}', ?)`,
+				input.actorRealm,
+				input.actorIdentity,
+				input.intentId,
+				input.reasonCode,
+				now,
+			);
+			return { ok: true, intent: this.get(input.intentId)!, replayed: false } as const;
+		});
+	}
+
+	get(intentId: string): StoredIntent | null {
+		if (!ULID_PATTERN.test(intentId)) throw new IntentStateError();
+		const row = this.#storage.sql
+			.exec<IntentRow>(
+				`SELECT id, package_slug, version, state, state_generation,
+				        workload_policy_version, request_digest, workload_identity_json,
+				        release_input_json, state_data_json, workflow_id,
+				        expires_at, created_at, updated_at
+				 FROM intents WHERE id = ?`,
+				intentId,
+			)
+			.toArray()[0];
+		return row ? rowToIntent(row) : null;
+	}
+
+	listTransitions(intentId: string): readonly IntentTransition[] {
+		if (!ULID_PATTERN.test(intentId)) throw new IntentStateError();
+		return this.#storage.sql
+			.exec<TransitionRow>(
+				`SELECT sequence, from_state, to_state, state_generation,
+				        transition_digest, actor_realm, actor_identity,
+				        reason_code, state_data_json, created_at
+				 FROM intent_transitions WHERE intent_id = ? ORDER BY sequence`,
+				intentId,
+			)
+			.toArray()
+			.map((row) => ({
+				sequence: row.sequence,
+				fromState: row.from_state,
+				toState: row.to_state,
+				stateGeneration: row.state_generation,
+				transitionDigest: row.transition_digest,
+				actorRealm: row.actor_realm,
+				actorIdentity: row.actor_identity,
+				reasonCode: row.reason_code,
+				stateDataJson: row.state_data_json,
+				createdAt: row.created_at,
+			}));
+	}
+}

--- a/apps/release-service/src/publisher-do/publisher-do.ts
+++ b/apps/release-service/src/publisher-do/publisher-do.ts
@@ -1,6 +1,16 @@
 import { DurableObject } from "cloudflare:workers";
 
 import {
+	initializeIntentStateSchema,
+	IntentStateStore,
+	type CreateIntentInput,
+	type CreateIntentResult,
+	type IntentTransition,
+	type StoredIntent,
+	type TransitionIntentInput,
+	type TransitionIntentResult,
+} from "./intent-state.js";
+import {
 	initializeWorkloadPolicySchema,
 	WorkloadPolicyStore,
 	type PutWorkloadPolicyInput,
@@ -13,6 +23,15 @@ export type {
 	PutWorkloadPolicyResult,
 	StoredWorkloadPolicy,
 } from "./workload-policy.js";
+export type {
+	CreateIntentInput,
+	CreateIntentResult,
+	IntentState,
+	IntentTransition,
+	StoredIntent,
+	TransitionIntentInput,
+	TransitionIntentResult,
+} from "./intent-state.js";
 
 const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
 const HASH_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
@@ -260,11 +279,13 @@ async function hashRefreshToken(token: string): Promise<string> {
 export class PublisherDurableObject extends DurableObject<Env> {
 	readonly #objectName: string | undefined;
 	readonly #workloadPolicies: WorkloadPolicyStore;
+	readonly #intents: IntentStateStore;
 
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env);
 		this.#objectName = ctx.id.name;
 		this.#workloadPolicies = new WorkloadPolicyStore(ctx.storage);
+		this.#intents = new IntentStateStore(ctx.storage);
 		void ctx.blockConcurrencyWhile(async () => {
 			this.#initializeSchema();
 		});
@@ -341,6 +362,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 			);
 		`);
 		initializeWorkloadPolicySchema(this.ctx.storage);
+		initializeIntentStateSchema(this.ctx.storage);
 	}
 
 	#assertPublisherObjectName(publisherDid: string): void {
@@ -412,6 +434,26 @@ export class PublisherDurableObject extends DurableObject<Env> {
 	): readonly StoredWorkloadPolicy[] {
 		this.#assertPublisherDid(publisherDid);
 		return this.#workloadPolicies.list(afterPackageSlug, limit);
+	}
+
+	createIntent(input: CreateIntentInput): CreateIntentResult {
+		this.#assertPublisherDid(input.publisherDid);
+		return this.#intents.create(input);
+	}
+
+	transitionIntent(input: TransitionIntentInput): TransitionIntentResult {
+		this.#assertPublisherDid(input.publisherDid);
+		return this.#intents.transition(input);
+	}
+
+	getIntent(publisherDid: string, intentId: string): StoredIntent | null {
+		this.#assertPublisherDid(publisherDid);
+		return this.#intents.get(intentId);
+	}
+
+	listIntentTransitions(publisherDid: string, intentId: string): readonly IntentTransition[] {
+		this.#assertPublisherDid(publisherDid);
+		return this.#intents.listTransitions(intentId);
 	}
 
 	createPublisherSession(input: CreatePublisherSessionInput): CreatePublisherSessionResult {

--- a/apps/release-service/test/publisher-intent-state.test.ts
+++ b/apps/release-service/test/publisher-intent-state.test.ts
@@ -1,0 +1,243 @@
+import { reset, runInDurableObject } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type {
+	CreateIntentInput,
+	IntentState,
+	PutWorkloadPolicyInput,
+	TransitionIntentInput,
+} from "../src/publisher-do/publisher-do.js";
+
+const DID = "did:plc:publisher";
+const INTENT_1 = "01JABCDEFGHJKMNPQRSTVWXYZ0";
+const INTENT_2 = "01JABCDEFGHJKMNPQRSTVWXYZ1";
+const NOW = 1_800_000_000_000;
+
+function publisher() {
+	return env.PUBLISHER_DO.getByName(DID);
+}
+
+function policy(): PutWorkloadPolicyInput {
+	return {
+		publisherDid: DID,
+		packageSlug: "gallery",
+		repository: "emdash-cms/gallery",
+		repositoryId: "123456789",
+		repositoryOwnerId: "987654321",
+		workflowRef: "emdash-cms/gallery/.github/workflows/release.yml@refs/heads/main",
+		allowedRefs: ["refs/heads/main"],
+		allowedEnvironments: [],
+		active: true,
+		expectedVersion: null,
+		now: NOW,
+	};
+}
+
+function intent(overrides: Partial<CreateIntentInput> = {}): CreateIntentInput {
+	return {
+		publisherDid: DID,
+		intentId: INTENT_1,
+		packageSlug: "gallery",
+		version: "1.2.3",
+		workloadPolicyVersion: 1,
+		workloadIdentityDigest: "A".repeat(43),
+		idempotencyKey: "github-run-100-attempt-1",
+		requestDigest: "B".repeat(43),
+		workloadIdentityJson: JSON.stringify({ issuer: "github-actions", runId: "100" }),
+		releaseInputJson: JSON.stringify({ package: "gallery", version: "1.2.3" }),
+		expiresAt: NOW + 60_000,
+		now: NOW + 1,
+		...overrides,
+	};
+}
+
+function transition(
+	expectedState: IntentState,
+	expectedGeneration: number,
+	toState: IntentState,
+	overrides: Partial<TransitionIntentInput> = {},
+): TransitionIntentInput {
+	return {
+		publisherDid: DID,
+		intentId: INTENT_1,
+		expectedState,
+		expectedGeneration,
+		toState,
+		transitionDigest: String.fromCharCode(66 + expectedGeneration).repeat(43),
+		actorRealm: "system",
+		actorIdentity: "release-service",
+		reasonCode: null,
+		stateDataJson: JSON.stringify({ step: toState }),
+		now: NOW + 1 + expectedGeneration,
+		...overrides,
+	};
+}
+
+afterEach(async () => {
+	await reset();
+});
+
+describe("publisher release intents", () => {
+	it("atomically reserves a package version and records the received transition", async () => {
+		const stub = publisher();
+		await stub.putWorkloadPolicy(policy());
+
+		const created = await stub.createIntent(intent());
+		expect(created).toMatchObject({
+			ok: true,
+			replayed: false,
+			intent: {
+				id: INTENT_1,
+				packageSlug: "gallery",
+				version: "1.2.3",
+				state: "received",
+				stateGeneration: 1,
+				workloadPolicyVersion: 1,
+				workflowId: null,
+			},
+		});
+		await expect(stub.listIntentTransitions(DID, INTENT_1)).resolves.toMatchObject([
+			{
+				sequence: 1,
+				fromState: null,
+				toState: "received",
+				stateGeneration: 1,
+				actorRealm: "oidc",
+			},
+		]);
+	});
+
+	it("replays identical workload idempotency and rejects changed input", async () => {
+		const stub = publisher();
+		await stub.putWorkloadPolicy(policy());
+		const first = await stub.createIntent(intent());
+
+		await expect(stub.createIntent(intent({ intentId: INTENT_2 }))).resolves.toEqual({
+			...(first.ok ? first : {}),
+			replayed: true,
+		});
+		await expect(
+			stub.createIntent(intent({ intentId: INTENT_2, requestDigest: "C".repeat(43) })),
+		).resolves.toEqual({ ok: false, code: "IDEMPOTENCY_CONFLICT" });
+	});
+
+	it("returns the existing owner when another identity reserves the same version", async () => {
+		const stub = publisher();
+		await stub.putWorkloadPolicy(policy());
+		await stub.createIntent(intent());
+
+		await expect(
+			stub.createIntent(
+				intent({
+					intentId: INTENT_2,
+					workloadIdentityDigest: "D".repeat(43),
+					idempotencyKey: "github-run-101-attempt-1",
+				}),
+			),
+		).resolves.toEqual({
+			ok: false,
+			code: "RESERVATION_CONFLICT",
+			existingIntentId: INTENT_1,
+		});
+	});
+
+	it("requires the exact active workload policy version", async () => {
+		const stub = publisher();
+		await stub.putWorkloadPolicy(policy());
+
+		await expect(stub.createIntent(intent({ workloadPolicyVersion: 2 }))).resolves.toEqual({
+			ok: false,
+			code: "WORKLOAD_POLICY_UNAVAILABLE",
+		});
+		await stub.putWorkloadPolicy({ ...policy(), active: false, expectedVersion: 1, now: NOW + 1 });
+		await expect(stub.createIntent(intent())).resolves.toEqual({
+			ok: false,
+			code: "WORKLOAD_POLICY_UNAVAILABLE",
+		});
+	});
+
+	it("enforces explicit generation-guarded transitions and idempotent replay", async () => {
+		const stub = publisher();
+		await stub.putWorkloadPolicy(policy());
+		await stub.createIntent(intent());
+		const verifying = transition("received", 1, "verifying", {
+			workflowId: "workflow-01JABCDEFGHJKMNPQRSTVWXYZ",
+		});
+
+		const first = await stub.transitionIntent(verifying);
+		expect(first).toMatchObject({
+			ok: true,
+			replayed: false,
+			intent: { state: "verifying", stateGeneration: 2, workflowId: verifying.workflowId },
+		});
+		await expect(stub.transitionIntent(verifying)).resolves.toMatchObject({
+			ok: true,
+			replayed: true,
+			intent: { state: "verifying", stateGeneration: 2 },
+		});
+		await expect(
+			stub.transitionIntent({ ...verifying, transitionDigest: "Z".repeat(43) }),
+		).resolves.toEqual({ ok: false, code: "INTENT_CAS_REQUIRED" });
+		await expect(
+			stub.transitionIntent(
+				transition("verifying", 2, "verified", {
+					workflowId: "different-workflow-id",
+				}),
+			),
+		).resolves.toEqual({ ok: false, code: "INTENT_TRANSITION_INVALID" });
+		await expect(stub.transitionIntent(transition("verifying", 2, "published"))).resolves.toEqual({
+			ok: false,
+			code: "INTENT_TRANSITION_INVALID",
+		});
+		await stub.transitionIntent(transition("verifying", 2, "verified"));
+		await expect(stub.transitionIntent(verifying)).resolves.toEqual({
+			ok: false,
+			code: "INTENT_CAS_REQUIRED",
+		});
+	});
+
+	it("completes the approval and reconciliation path and closes terminal state", async () => {
+		const stub = publisher();
+		await stub.putWorkloadPolicy(policy());
+		await stub.createIntent(intent());
+		const path: IntentState[] = [
+			"verifying",
+			"verified",
+			"awaiting_approval",
+			"ready",
+			"publishing",
+			"reconciling",
+			"published",
+		];
+		let state: IntentState = "received";
+		let generation = 1;
+		for (const next of path) {
+			const result = await stub.transitionIntent(transition(state, generation, next));
+			expect(result).toMatchObject({ ok: true, intent: { state: next } });
+			state = next;
+			generation += 1;
+		}
+		await expect(
+			stub.transitionIntent(transition("published", generation, "failed")),
+		).resolves.toEqual({ ok: false, code: "INTENT_TRANSITION_INVALID" });
+		expect(await stub.listIntentTransitions(DID, INTENT_1)).toHaveLength(8);
+	});
+
+	it("blocks suspended publishers and rejects noncanonical private input", async () => {
+		const stub = publisher();
+		await stub.putWorkloadPolicy(policy());
+		await runInDurableObject(stub, (_instance, state) => {
+			state.storage.sql.exec("UPDATE publisher SET status = 'suspended' WHERE id = 1");
+		});
+		await expect(stub.createIntent(intent())).resolves.toEqual({
+			ok: false,
+			code: "PUBLISHER_SUSPENDED",
+		});
+		await runInDurableObject(stub, async (instance) => {
+			expect(() =>
+				instance.createIntent(intent({ workloadIdentityJson: '{ "runId": "100" }' })),
+			).toThrowError(expect.objectContaining({ code: "INTENT_INPUT_INVALID" }));
+		});
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds publisher-owned release intents, package/version reservations, workload-scoped request idempotency, and append-only transition history. Intent creation requires the exact active workload-policy version and active publisher. Identical retries return the original intent; changed input conflicts; another workload receives the existing reservation owner.

The explicit state machine uses expected state plus generation CAS. Transition digests allow only the immediately repeated transition to replay, Workflow identity cannot change after attachment, illegal and terminal transitions fail closed, and bounded canonical JSON prevents raw OIDC tokens from entering durable state. This is layer 3 of the workload identity/admission merge unit, based on `feat/drs-workload-policy`. Related to RFC #1870 and Discussion #1590.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (not applicable: no UI)
- [ ] I have added and reviewed the user-facing changeset (not applicable: private Worker app)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1590

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 (Codex)

## Screenshots / test output

- Workerd covers policy binding, reservation ownership, idempotent replay/conflict, explicit transition paths, CAS, replay bounds, Workflow identity, terminal closure, suspension, canonical JSON, and transition history.
- The top branch passes 131 release-service tests, typecheck, production build, quick lint, and type-aware lint.
