### PR TITLE
feat(release-service): evaluate workload admission policy

### DIFF
--- a/apps/release-service/src/workload/policy.ts
+++ b/apps/release-service/src/workload/policy.ts
@@ -1,0 +1,102 @@
+import { base64url } from "jose";
+
+import type { StoredWorkloadPolicy } from "../publisher-do/workload-policy.js";
+import type { VerifiedWorkloadIdentity } from "./types.js";
+
+export type WorkloadPolicyRejectionCode =
+	| "WORKLOAD_POLICY_INACTIVE"
+	| "WORKLOAD_REPOSITORY_MISMATCH"
+	| "WORKLOAD_WORKFLOW_MISMATCH"
+	| "WORKLOAD_REF_MISMATCH"
+	| "WORKLOAD_ENVIRONMENT_MISMATCH";
+
+export type WorkloadPolicyDecision =
+	| { ok: true }
+	| { ok: false; code: WorkloadPolicyRejectionCode };
+
+export function evaluateWorkloadPolicy(
+	identity: VerifiedWorkloadIdentity,
+	policy: StoredWorkloadPolicy,
+): WorkloadPolicyDecision {
+	if (!policy.active) return { ok: false, code: "WORKLOAD_POLICY_INACTIVE" };
+	if (
+		identity.repository.name !== policy.repository ||
+		identity.repository.id !== policy.repositoryId ||
+		identity.repository.ownerId !== policy.repositoryOwnerId
+	) {
+		return { ok: false, code: "WORKLOAD_REPOSITORY_MISMATCH" };
+	}
+	if (identity.workflow.ref !== policy.workflowRef) {
+		return { ok: false, code: "WORKLOAD_WORKFLOW_MISMATCH" };
+	}
+	if (policy.allowedRefs.length > 0 && !policy.allowedRefs.includes(identity.run.ref)) {
+		return { ok: false, code: "WORKLOAD_REF_MISMATCH" };
+	}
+	if (
+		policy.allowedEnvironments.length > 0 &&
+		(identity.run.environment === null ||
+			!policy.allowedEnvironments.includes(identity.run.environment))
+	) {
+		return { ok: false, code: "WORKLOAD_ENVIRONMENT_MISMATCH" };
+	}
+	return { ok: true };
+}
+
+async function digest(parts: readonly unknown[]): Promise<string> {
+	const bytes = new TextEncoder().encode(JSON.stringify(parts));
+	return base64url.encode(new Uint8Array(await crypto.subtle.digest("SHA-256", bytes)));
+}
+
+export function digestWorkloadIdentity(identity: VerifiedWorkloadIdentity): Promise<string> {
+	return digest([
+		"emdash-release-service",
+		"workload-identity",
+		1,
+		identity.issuer,
+		identity.subject,
+		identity.tokenId,
+		identity.repository.name,
+		identity.repository.id,
+		identity.repository.owner,
+		identity.repository.ownerId,
+		identity.repository.visibility,
+		identity.workflow.ref,
+		identity.workflow.sha,
+		identity.workflow.jobRef,
+		identity.workflow.jobSha,
+		identity.run.id,
+		identity.run.attempt,
+		identity.run.actor,
+		identity.run.actorId,
+		identity.run.eventName,
+		identity.run.ref,
+		identity.run.refType,
+		identity.run.commitSha,
+		identity.run.environment,
+		identity.run.runnerEnvironment,
+		identity.issuedAt,
+		identity.expiresAt,
+	]);
+}
+
+export function digestWorkloadIdempotencyIdentity(
+	identity: VerifiedWorkloadIdentity,
+	publisherDid: string,
+	packageSlug: string,
+	version: string,
+): Promise<string> {
+	return digest([
+		"emdash-release-service",
+		"workload-idempotency",
+		1,
+		publisherDid,
+		packageSlug,
+		version,
+		identity.issuer,
+		identity.repository.id,
+		identity.repository.ownerId,
+		identity.workflow.ref,
+		identity.run.id,
+		identity.run.attempt,
+	]);
+}

--- a/apps/release-service/test/workload-policy-evaluation.test.ts
+++ b/apps/release-service/test/workload-policy-evaluation.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import type { StoredWorkloadPolicy } from "../src/publisher-do/workload-policy.js";
+import {
+	digestWorkloadIdempotencyIdentity,
+	digestWorkloadIdentity,
+	evaluateWorkloadPolicy,
+	type WorkloadPolicyRejectionCode,
+} from "../src/workload/policy.js";
+import type { VerifiedWorkloadIdentity } from "../src/workload/types.js";
+
+const identity: VerifiedWorkloadIdentity = {
+	issuer: "github-actions",
+	subject: "opaque-subject",
+	tokenId: "token-id",
+	repository: {
+		name: "emdash-cms/gallery",
+		id: "123456789",
+		owner: "emdash-cms",
+		ownerId: "987654321",
+		visibility: "public",
+	},
+	workflow: {
+		ref: "emdash-cms/gallery/.github/workflows/release.yml@refs/heads/main",
+		sha: "a".repeat(40),
+		jobRef: null,
+		jobSha: null,
+	},
+	run: {
+		id: "100",
+		attempt: 2,
+		actor: "release-bot",
+		actorId: "200",
+		eventName: "workflow_dispatch",
+		ref: "refs/heads/main",
+		refType: "branch",
+		commitSha: "b".repeat(40),
+		environment: "production",
+		runnerEnvironment: "github-hosted",
+	},
+	issuedAt: 1_800_000_000,
+	expiresAt: 1_800_000_300,
+};
+
+const policy: StoredWorkloadPolicy = {
+	packageSlug: "gallery",
+	repository: "emdash-cms/gallery",
+	repositoryId: "123456789",
+	repositoryOwnerId: "987654321",
+	workflowRef: "emdash-cms/gallery/.github/workflows/release.yml@refs/heads/main",
+	allowedRefs: ["refs/heads/main"],
+	allowedEnvironments: ["production"],
+	active: true,
+	stateVersion: 1,
+	authorizedBy: "did:plc:publisher",
+	createdAt: 1_800_000_000_000,
+	updatedAt: 1_800_000_000_000,
+};
+
+interface Replacement {
+	identity?: {
+		repository?: Partial<VerifiedWorkloadIdentity["repository"]>;
+		workflow?: Partial<VerifiedWorkloadIdentity["workflow"]>;
+		run?: Partial<VerifiedWorkloadIdentity["run"]>;
+	};
+	policy?: Partial<StoredWorkloadPolicy>;
+}
+
+const rejectionCases: ReadonlyArray<readonly [WorkloadPolicyRejectionCode, Replacement]> = [
+	["WORKLOAD_POLICY_INACTIVE", { policy: { active: false } }],
+	["WORKLOAD_REPOSITORY_MISMATCH", { identity: { repository: { id: "999" } } }],
+	["WORKLOAD_WORKFLOW_MISMATCH", { identity: { workflow: { ref: "other" } } }],
+	["WORKLOAD_REF_MISMATCH", { identity: { run: { ref: "refs/heads/dev" } } }],
+	["WORKLOAD_ENVIRONMENT_MISMATCH", { identity: { run: { environment: "staging" } } }],
+];
+
+describe("workload policy evaluation", () => {
+	it("accepts the exact immutable repository, workflow, ref, and environment", () => {
+		expect(evaluateWorkloadPolicy(identity, policy)).toEqual({ ok: true });
+	});
+
+	it.each(rejectionCases)("rejects %s", (code, replacement) => {
+		const changedIdentity = {
+			...identity,
+			repository: {
+				...identity.repository,
+				...replacement.identity?.repository,
+			},
+			workflow: {
+				...identity.workflow,
+				...replacement.identity?.workflow,
+			},
+			run: {
+				...identity.run,
+				...replacement.identity?.run,
+			},
+		};
+		expect(evaluateWorkloadPolicy(changedIdentity, { ...policy, ...replacement.policy })).toEqual({
+			ok: false,
+			code,
+		});
+	});
+
+	it("treats empty ref and environment restrictions as wildcards", () => {
+		expect(
+			evaluateWorkloadPolicy(
+				{ ...identity, run: { ...identity.run, ref: "refs/tags/v1", environment: null } },
+				{ ...policy, allowedRefs: [], allowedEnvironments: [] },
+			),
+		).toEqual({ ok: true });
+	});
+
+	it("produces stable, domain-separated workload digests", async () => {
+		const identityDigest = await digestWorkloadIdentity(identity);
+		const idempotencyDigest = await digestWorkloadIdempotencyIdentity(
+			identity,
+			"did:plc:publisher",
+			"gallery",
+			"1.2.3",
+		);
+
+		expect(identityDigest).toMatch(/^[A-Za-z0-9_-]{43}$/);
+		expect(idempotencyDigest).toMatch(/^[A-Za-z0-9_-]{43}$/);
+		expect(identityDigest).not.toBe(idempotencyDigest);
+		expect(await digestWorkloadIdentity({ ...identity })).toBe(identityDigest);
+		expect(
+			await digestWorkloadIdempotencyIdentity(
+				{ ...identity, run: { ...identity.run, attempt: 3 } },
+				"did:plc:publisher",
+				"gallery",
+				"1.2.3",
+			),
+		).not.toBe(idempotencyDigest);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds exact workload-policy evaluation and canonical digest construction for intent admission. Admission binds normalized GitHub identity to canonical repository name, immutable repository/owner IDs, exact workflow, configured refs, and configured environments. Empty ref/environment lists are explicit wildcards.

Domain-separated SHA-256 digests separately identify the complete verified workload and the publisher/package/version/run idempotency identity. This is layer 4 of the workload identity/admission merge unit, based on `feat/drs-publisher-intent-state`. Related to RFC #1870 and Discussion #1590.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (not applicable: no UI)
- [ ] I have added and reviewed the user-facing changeset (not applicable: private Worker app)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1590

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 (Codex)

## Screenshots / test output

- Tests cover every policy rejection dimension, wildcard behavior, stable digesting, domain separation, and run-attempt identity changes.
- The top branch passes 139 release-service tests, typecheck, quick lint, and type-aware lint.
