### PR TITLE
feat(release-service): serialize publication operations

### DIFF
--- a/apps/release-service/src/publisher-do/publication-operation.ts
+++ b/apps/release-service/src/publisher-do/publication-operation.ts
@@ -1,0 +1,452 @@
+import { base64url } from "jose";
+
+const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
+const ULID_PATTERN = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const DIGEST_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const AT_URI_PATTERN =
+	/^at:\/\/did:[a-z0-9]+:[A-Za-z0-9._:%-]+\/[a-zA-Z0-9.-]+\/[A-Za-z0-9._:~-]+$/;
+const CID_PATTERN = /^[A-Za-z0-9]+$/;
+const MAX_LEASE_MS = 5 * 60_000;
+
+export interface PublicationOperationLease {
+	intentId: string;
+	generation: number;
+	token: string;
+	expectedIntentGeneration: number;
+	expiresAt: number;
+}
+
+export type BeginPublicationOperationResult =
+	| { ok: true; lease: PublicationOperationLease }
+	| {
+			ok: false;
+			code: "INTENT_UNAVAILABLE" | "INTENT_CAS_REQUIRED" | "PUBLICATION_RECOVERY_REQUIRED";
+	  }
+	| { ok: false; code: "PUBLICATION_BUSY"; retryAt: number };
+
+export type PublicationOutcome = "published" | "ambiguous" | "conflict";
+
+export interface CompletePublicationOperationInput {
+	publisherDid: string;
+	intentId: string;
+	generation: number;
+	token: string;
+	expectedIntentGeneration: number;
+	completionDigest: string;
+	outcome: PublicationOutcome;
+	resultUri: string | null;
+	resultCid: string | null;
+	now?: number;
+}
+
+export type CompletePublicationOperationResult =
+	| {
+			ok: true;
+			state: "published" | "reconciling" | "conflict";
+			stateGeneration: number;
+			replayed: boolean;
+	  }
+	| { ok: false; code: "PUBLICATION_CAS_REQUIRED" };
+
+interface OperationRow {
+	[key: string]: string | number | ArrayBuffer | null;
+	generation: number;
+	token_hash: string | null;
+	intent_generation: number;
+	status: "active" | "completed";
+	expires_at: number;
+	completion_digest: string | null;
+	outcome: PublicationOutcome | null;
+	completed_at: number | null;
+}
+
+interface IntentRow {
+	[key: string]: string | number | ArrayBuffer | null;
+	state: string;
+	state_generation: number;
+}
+
+export class PublicationOperationError extends Error {
+	readonly code = "PUBLICATION_OPERATION_INVALID";
+
+	constructor() {
+		super("PUBLICATION_OPERATION_INVALID");
+		this.name = "PublicationOperationError";
+	}
+}
+
+async function hashToken(token: string): Promise<string> {
+	return base64url.encode(
+		new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token))),
+	);
+}
+
+function hashesEqual(left: string, right: string): boolean {
+	try {
+		const leftBytes = base64url.decode(left);
+		const rightBytes = base64url.decode(right);
+		return (
+			leftBytes.length === rightBytes.length && crypto.subtle.timingSafeEqual(leftBytes, rightBytes)
+		);
+	} catch {
+		return false;
+	}
+}
+
+function readIntent(storage: DurableObjectStorage, intentId: string): IntentRow | null {
+	return (
+		storage.sql
+			.exec<IntentRow>("SELECT state, state_generation FROM intents WHERE id = ?", intentId)
+			.toArray()[0] ?? null
+	);
+}
+
+export function initializePublicationOperationSchema(storage: DurableObjectStorage): void {
+	storage.sql.exec(`
+		CREATE TABLE IF NOT EXISTS publication_operations (
+			intent_id TEXT PRIMARY KEY,
+			generation INTEGER NOT NULL CHECK (generation >= 1),
+			token_hash TEXT,
+			intent_generation INTEGER NOT NULL CHECK (intent_generation >= 1),
+			status TEXT NOT NULL CHECK (status IN ('active', 'completed')),
+			expires_at INTEGER NOT NULL,
+			completion_digest TEXT,
+			outcome TEXT CHECK (outcome IN ('published', 'ambiguous', 'conflict')),
+			started_at INTEGER NOT NULL,
+			completed_at INTEGER
+		);
+		CREATE INDEX IF NOT EXISTS idx_publication_operations_expiry
+			ON publication_operations(status, expires_at);
+		CREATE TABLE IF NOT EXISTS deadlines (
+			kind TEXT NOT NULL CHECK (kind IN ('publication-operation')),
+			subject_id TEXT NOT NULL,
+			generation INTEGER NOT NULL CHECK (generation >= 1),
+			scheduled_at INTEGER NOT NULL,
+			PRIMARY KEY (kind, subject_id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_deadlines_schedule
+			ON deadlines(scheduled_at, kind, subject_id);
+	`);
+}
+
+export class PublicationOperationStore {
+	readonly #storage: DurableObjectStorage;
+
+	constructor(storage: DurableObjectStorage) {
+		this.#storage = storage;
+	}
+
+	async begin(
+		publisherDid: string,
+		intentId: string,
+		expectedIntentGeneration: number,
+		leaseMs: number,
+		now = Date.now(),
+	): Promise<BeginPublicationOperationResult> {
+		if (
+			!DID_PATTERN.test(publisherDid) ||
+			!ULID_PATTERN.test(intentId) ||
+			!Number.isSafeInteger(expectedIntentGeneration) ||
+			expectedIntentGeneration < 1 ||
+			!Number.isSafeInteger(leaseMs) ||
+			leaseMs < 1 ||
+			leaseMs > MAX_LEASE_MS ||
+			!Number.isSafeInteger(now) ||
+			now < 0 ||
+			now > Number.MAX_SAFE_INTEGER - leaseMs
+		) {
+			throw new PublicationOperationError();
+		}
+		const token = base64url.encode(crypto.getRandomValues(new Uint8Array(32)));
+		const tokenHash = await hashToken(token);
+		return this.#storage.transactionSync(() => {
+			const intent = readIntent(this.#storage, intentId);
+			if (!intent || intent.state !== "publishing") {
+				return { ok: false, code: "INTENT_UNAVAILABLE" } as const;
+			}
+			if (intent.state_generation !== expectedIntentGeneration) {
+				return { ok: false, code: "INTENT_CAS_REQUIRED" } as const;
+			}
+			const current = this.#storage.sql
+				.exec<OperationRow>(
+					`SELECT generation, token_hash, intent_generation, status, expires_at,
+					        completion_digest, outcome, completed_at
+					 FROM publication_operations WHERE intent_id = ?`,
+					intentId,
+				)
+				.toArray()[0];
+			if (current?.status === "active" && current.expires_at > now) {
+				return { ok: false, code: "PUBLICATION_BUSY", retryAt: current.expires_at } as const;
+			}
+			if (current?.status === "active") {
+				return { ok: false, code: "PUBLICATION_RECOVERY_REQUIRED" } as const;
+			}
+			const generation = (current?.generation ?? 0) + 1;
+			const expiresAt = now + leaseMs;
+			this.#storage.sql.exec(
+				`INSERT INTO publication_operations (
+					intent_id, generation, token_hash, intent_generation, status,
+					expires_at, completion_digest, outcome, started_at, completed_at
+				) VALUES (?, ?, ?, ?, 'active', ?, NULL, NULL, ?, NULL)
+				ON CONFLICT(intent_id) DO UPDATE SET
+					generation = excluded.generation,
+					token_hash = excluded.token_hash,
+					intent_generation = excluded.intent_generation,
+					status = 'active',
+					expires_at = excluded.expires_at,
+					completion_digest = NULL,
+					outcome = NULL,
+					started_at = excluded.started_at,
+					completed_at = NULL`,
+				intentId,
+				generation,
+				tokenHash,
+				expectedIntentGeneration,
+				expiresAt,
+				now,
+			);
+			this.#storage.sql.exec(
+				`INSERT INTO deadlines (kind, subject_id, generation, scheduled_at)
+				 VALUES ('publication-operation', ?, ?, ?)
+				 ON CONFLICT(kind, subject_id) DO UPDATE SET
+					generation = excluded.generation, scheduled_at = excluded.scheduled_at`,
+				intentId,
+				generation,
+				expiresAt,
+			);
+			this.#storage.sql.exec(
+				`INSERT INTO audit_events (
+					event_type, actor_realm, actor_identity, subject,
+					reason_code, public_payload, created_at
+				) VALUES ('publication-operation-started', 'system',
+				          'release-service', ?, NULL, '{}', ?)`,
+				intentId,
+				now,
+			);
+			return {
+				ok: true,
+				lease: { intentId, generation, token, expectedIntentGeneration, expiresAt },
+			} as const;
+		});
+	}
+
+	async complete(
+		input: CompletePublicationOperationInput,
+	): Promise<CompletePublicationOperationResult> {
+		const now = input.now ?? Date.now();
+		if (
+			!DID_PATTERN.test(input.publisherDid) ||
+			!ULID_PATTERN.test(input.intentId) ||
+			!Number.isSafeInteger(input.generation) ||
+			input.generation < 1 ||
+			!TOKEN_PATTERN.test(input.token) ||
+			!Number.isSafeInteger(input.expectedIntentGeneration) ||
+			input.expectedIntentGeneration < 1 ||
+			!DIGEST_PATTERN.test(input.completionDigest) ||
+			(input.outcome !== "published" &&
+				input.outcome !== "ambiguous" &&
+				input.outcome !== "conflict") ||
+			(input.outcome === "published" &&
+				(typeof input.resultUri !== "string" ||
+					!AT_URI_PATTERN.test(input.resultUri) ||
+					typeof input.resultCid !== "string" ||
+					!CID_PATTERN.test(input.resultCid))) ||
+			(input.outcome !== "published" && (input.resultUri !== null || input.resultCid !== null)) ||
+			!Number.isSafeInteger(now) ||
+			now < 0
+		) {
+			throw new PublicationOperationError();
+		}
+		const tokenHash = await hashToken(input.token);
+		return this.#storage.transactionSync(() => {
+			const operation = this.#storage.sql
+				.exec<OperationRow>(
+					`SELECT generation, token_hash, intent_generation, status, expires_at,
+					        completion_digest, outcome, completed_at
+					 FROM publication_operations WHERE intent_id = ?`,
+					input.intentId,
+				)
+				.toArray()[0];
+			const intent = readIntent(this.#storage, input.intentId);
+			const replayState =
+				input.outcome === "published"
+					? "published"
+					: input.outcome === "ambiguous"
+						? "reconciling"
+						: "conflict";
+			if (
+				operation?.status === "completed" &&
+				operation.generation === input.generation &&
+				operation.token_hash !== null &&
+				hashesEqual(operation.token_hash, tokenHash) &&
+				operation.completion_digest === input.completionDigest &&
+				operation.outcome === input.outcome &&
+				intent?.state === replayState &&
+				intent.state_generation === input.expectedIntentGeneration + 1
+			) {
+				return {
+					ok: true,
+					state: replayState,
+					stateGeneration: intent.state_generation,
+					replayed: true,
+				} as const;
+			}
+			if (
+				!operation ||
+				operation.status !== "active" ||
+				operation.generation !== input.generation ||
+				operation.token_hash === null ||
+				!hashesEqual(operation.token_hash, tokenHash) ||
+				operation.intent_generation !== input.expectedIntentGeneration ||
+				operation.expires_at <= now ||
+				!intent ||
+				intent.state !== "publishing" ||
+				intent.state_generation !== input.expectedIntentGeneration
+			) {
+				return { ok: false, code: "PUBLICATION_CAS_REQUIRED" } as const;
+			}
+			const nextState =
+				input.outcome === "published"
+					? "published"
+					: input.outcome === "ambiguous"
+						? "reconciling"
+						: "conflict";
+			const reasonCode =
+				input.outcome === "ambiguous"
+					? "PDS_AMBIGUOUS"
+					: input.outcome === "conflict"
+						? "RELEASE_CONFLICT"
+						: null;
+			const nextGeneration = intent.state_generation + 1;
+			const stateData = JSON.stringify({ resultUri: input.resultUri, resultCid: input.resultCid });
+			this.#storage.sql.exec(
+				`UPDATE intents SET state = ?, state_generation = ?, state_data_json = ?, updated_at = ?
+				 WHERE id = ?`,
+				nextState,
+				nextGeneration,
+				stateData,
+				now,
+				input.intentId,
+			);
+			this.#storage.sql.exec(
+				`INSERT INTO audit_events (
+					event_type, actor_realm, actor_identity, subject,
+					reason_code, public_payload, created_at
+				) VALUES ('publication-operation-completed', 'system',
+				          'release-service', ?, ?, '{}', ?)`,
+				input.intentId,
+				reasonCode,
+				now,
+			);
+			this.#storage.sql.exec(
+				`INSERT INTO intent_transitions (
+					intent_id, sequence, from_state, to_state, state_generation,
+					transition_digest, actor_realm, actor_identity, reason_code,
+					state_data_json, created_at
+				) VALUES (?, ?, 'publishing', ?, ?, ?, 'system', 'release-service', ?, ?, ?)`,
+				input.intentId,
+				nextGeneration,
+				nextState,
+				nextGeneration,
+				input.completionDigest,
+				reasonCode,
+				stateData,
+				now,
+			);
+			this.#storage.sql.exec(
+				`UPDATE publication_operations SET
+					status = 'completed', completion_digest = ?, outcome = ?, completed_at = ?
+				 WHERE intent_id = ?`,
+				input.completionDigest,
+				input.outcome,
+				now,
+				input.intentId,
+			);
+			this.#storage.sql.exec(
+				"DELETE FROM deadlines WHERE kind = 'publication-operation' AND subject_id = ?",
+				input.intentId,
+			);
+			return {
+				ok: true,
+				state: nextState,
+				stateGeneration: nextGeneration,
+				replayed: false,
+			} as const;
+		});
+	}
+
+	recoverExpired(now = Date.now()): number {
+		if (!Number.isSafeInteger(now) || now < 0) throw new PublicationOperationError();
+		return this.#storage.transactionSync(() => {
+			const expired = this.#storage.sql
+				.exec<{ intent_id: string; generation: number; token_hash: string }>(
+					`SELECT intent_id, generation, token_hash FROM publication_operations
+					 WHERE status = 'active' AND expires_at <= ? AND token_hash IS NOT NULL`,
+					now,
+				)
+				.toArray();
+			let recovered = 0;
+			for (const operation of expired) {
+				const intent = readIntent(this.#storage, operation.intent_id);
+				if (intent?.state === "publishing") {
+					const nextGeneration = intent.state_generation + 1;
+					const stateData = '{"recovery":"operation-expired"}';
+					this.#storage.sql.exec(
+						`UPDATE intents SET state = 'reconciling', state_generation = ?,
+							state_data_json = ?, updated_at = ? WHERE id = ?`,
+						nextGeneration,
+						stateData,
+						now,
+						operation.intent_id,
+					);
+					this.#storage.sql.exec(
+						`INSERT INTO intent_transitions (
+							intent_id, sequence, from_state, to_state, state_generation,
+							transition_digest, actor_realm, actor_identity, reason_code,
+							state_data_json, created_at
+						) VALUES (?, ?, 'publishing', 'reconciling', ?, ?, 'system',
+						          'release-service', 'PDS_AMBIGUOUS', ?, ?)`,
+						operation.intent_id,
+						nextGeneration,
+						nextGeneration,
+						operation.token_hash,
+						stateData,
+						now,
+					);
+					this.#storage.sql.exec(
+						`INSERT INTO audit_events (
+							event_type, actor_realm, actor_identity, subject,
+							reason_code, public_payload, created_at
+						) VALUES ('publication-operation-recovery-required', 'system',
+						          'release-service', ?, 'PDS_AMBIGUOUS', '{}', ?)`,
+						operation.intent_id,
+						now,
+					);
+					recovered += 1;
+				}
+				this.#storage.sql.exec(
+					`UPDATE publication_operations SET status = 'completed',
+						completion_digest = token_hash, outcome = 'ambiguous', completed_at = ?
+					 WHERE intent_id = ? AND generation = ?`,
+					now,
+					operation.intent_id,
+					operation.generation,
+				);
+				this.#storage.sql.exec(
+					"DELETE FROM deadlines WHERE kind = 'publication-operation' AND subject_id = ?",
+					operation.intent_id,
+				);
+			}
+			return recovered;
+		});
+	}
+
+	nextDeadline(): number | null {
+		return this.#storage.sql
+			.exec<{ scheduled_at: number | null }>(
+				"SELECT MIN(scheduled_at) AS scheduled_at FROM deadlines",
+			)
+			.one().scheduled_at;
+	}
+}

--- a/apps/release-service/src/publisher-do/publisher-do.ts
+++ b/apps/release-service/src/publisher-do/publisher-do.ts
@@ -11,6 +11,13 @@ import {
 	type TransitionIntentResult,
 } from "./intent-state.js";
 import {
+	initializePublicationOperationSchema,
+	PublicationOperationStore,
+	type BeginPublicationOperationResult,
+	type CompletePublicationOperationInput,
+	type CompletePublicationOperationResult,
+} from "./publication-operation.js";
+import {
 	initializeWorkloadPolicySchema,
 	WorkloadPolicyStore,
 	type PutWorkloadPolicyInput,
@@ -32,6 +39,13 @@ export type {
 	TransitionIntentInput,
 	TransitionIntentResult,
 } from "./intent-state.js";
+export type {
+	BeginPublicationOperationResult,
+	CompletePublicationOperationInput,
+	CompletePublicationOperationResult,
+	PublicationOperationLease,
+	PublicationOutcome,
+} from "./publication-operation.js";
 
 const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
 const HASH_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
@@ -280,12 +294,14 @@ export class PublisherDurableObject extends DurableObject<Env> {
 	readonly #objectName: string | undefined;
 	readonly #workloadPolicies: WorkloadPolicyStore;
 	readonly #intents: IntentStateStore;
+	readonly #publicationOperations: PublicationOperationStore;
 
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env);
 		this.#objectName = ctx.id.name;
 		this.#workloadPolicies = new WorkloadPolicyStore(ctx.storage);
 		this.#intents = new IntentStateStore(ctx.storage);
+		this.#publicationOperations = new PublicationOperationStore(ctx.storage);
 		void ctx.blockConcurrencyWhile(async () => {
 			this.#initializeSchema();
 		});
@@ -363,6 +379,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		`);
 		initializeWorkloadPolicySchema(this.ctx.storage);
 		initializeIntentStateSchema(this.ctx.storage);
+		initializePublicationOperationSchema(this.ctx.storage);
 	}
 
 	#assertPublisherObjectName(publisherDid: string): void {
@@ -454,6 +471,34 @@ export class PublisherDurableObject extends DurableObject<Env> {
 	listIntentTransitions(publisherDid: string, intentId: string): readonly IntentTransition[] {
 		this.#assertPublisherDid(publisherDid);
 		return this.#intents.listTransitions(intentId);
+	}
+
+	async beginPublicationOperation(
+		publisherDid: string,
+		intentId: string,
+		expectedIntentGeneration: number,
+		leaseMs: number,
+		now = Date.now(),
+	): Promise<BeginPublicationOperationResult> {
+		this.#assertPublisherDid(publisherDid);
+		const result = await this.#publicationOperations.begin(
+			publisherDid,
+			intentId,
+			expectedIntentGeneration,
+			leaseMs,
+			now,
+		);
+		if (result.ok) await this.#scheduleNextAlarm(now);
+		return result;
+	}
+
+	async completePublicationOperation(
+		input: CompletePublicationOperationInput,
+	): Promise<CompletePublicationOperationResult> {
+		this.#assertPublisherDid(input.publisherDid);
+		const result = await this.#publicationOperations.complete(input);
+		await this.#scheduleNextAlarm(input.now ?? Date.now());
+		return result;
 	}
 
 	createPublisherSession(input: CreatePublisherSessionInput): CreatePublisherSessionResult {
@@ -1049,6 +1094,26 @@ export class PublisherDurableObject extends DurableObject<Env> {
 				)
 				.toArray()[0] ?? null
 		);
+	}
+
+	async #scheduleNextAlarm(now: number): Promise<void> {
+		const deadline = this.#publicationOperations.nextDeadline();
+		if (deadline === null) {
+			await this.ctx.storage.deleteAlarm();
+			return;
+		}
+		await this.ctx.storage.setAlarm(Math.max(now + 1, deadline));
+	}
+
+	override async alarm(): Promise<void> {
+		const now = Date.now();
+		this.#publicationOperations.recoverExpired(now);
+		this.ctx.storage.transactionSync(() => {
+			this.ctx.storage.sql.exec("DELETE FROM oauth_states WHERE expires_at <= ?", now);
+			this.ctx.storage.sql.exec("DELETE FROM publisher_sessions WHERE expires_at <= ?", now);
+			this.ctx.storage.sql.exec("DELETE FROM intent_idempotency WHERE expires_at <= ?", now);
+		});
+		await this.#scheduleNextAlarm(now);
 	}
 
 	#clearRefreshOperation(now: number): void {

--- a/apps/release-service/test/publication-operation.test.ts
+++ b/apps/release-service/test/publication-operation.test.ts
@@ -1,0 +1,214 @@
+import { reset, runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { IntentState, PutWorkloadPolicyInput } from "../src/publisher-do/publisher-do.js";
+
+const DID = "did:plc:publisher";
+const INTENT_ID = "01JABCDEFGHJKMNPQRSTVWXYZ0";
+const NOW = 1_800_000_000_000;
+
+function publisher() {
+	return env.PUBLISHER_DO.getByName(DID);
+}
+
+function policy(): PutWorkloadPolicyInput {
+	return {
+		publisherDid: DID,
+		packageSlug: "gallery",
+		repository: "emdash-cms/gallery",
+		repositoryId: "123",
+		repositoryOwnerId: "456",
+		workflowRef: "emdash-cms/gallery/.github/workflows/release.yml@refs/heads/main",
+		allowedRefs: [],
+		allowedEnvironments: [],
+		active: true,
+		expectedVersion: null,
+		now: NOW,
+	};
+}
+
+async function preparePublishing() {
+	const stub = publisher();
+	await stub.putWorkloadPolicy(policy());
+	await stub.createIntent({
+		publisherDid: DID,
+		intentId: INTENT_ID,
+		packageSlug: "gallery",
+		version: "1.2.3",
+		workloadPolicyVersion: 1,
+		workloadIdentityDigest: "A".repeat(43),
+		idempotencyKey: "github-run-100-attempt-1",
+		requestDigest: "B".repeat(43),
+		workloadIdentityJson: '{"issuer":"github-actions"}',
+		releaseInputJson: '{"package":"gallery","version":"1.2.3"}',
+		expiresAt: NOW + 60_000,
+		now: NOW + 1,
+	});
+	const path = ["verifying", "verified", "ready", "publishing"] as const;
+	let state: IntentState = "received";
+	let generation = 1;
+	for (const next of path) {
+		await stub.transitionIntent({
+			publisherDid: DID,
+			intentId: INTENT_ID,
+			expectedState: state,
+			expectedGeneration: generation,
+			toState: next,
+			transitionDigest: String.fromCharCode(66 + generation).repeat(43),
+			actorRealm: "system",
+			actorIdentity: "release-service",
+			reasonCode: null,
+			stateDataJson: JSON.stringify({ step: next }),
+			...(next === "verifying" ? { workflowId: "workflow-1" } : {}),
+			now: NOW + 1 + generation,
+		});
+		state = next;
+		generation += 1;
+	}
+	return stub;
+}
+
+afterEach(async () => {
+	await reset();
+});
+
+describe("publisher publication operations", () => {
+	it("serializes publication with a generation-bound hashed lease", async () => {
+		const stub = await preparePublishing();
+		const first = await stub.beginPublicationOperation(DID, INTENT_ID, 5, 5_000, NOW + 10);
+		expect(first).toMatchObject({
+			ok: true,
+			lease: { intentId: INTENT_ID, generation: 1, expectedIntentGeneration: 5 },
+		});
+		if (!first.ok) return;
+		await expect(
+			stub.beginPublicationOperation(DID, INTENT_ID, 5, 5_000, NOW + 11),
+		).resolves.toEqual({
+			ok: false,
+			code: "PUBLICATION_BUSY",
+			retryAt: first.lease.expiresAt,
+		});
+
+		const persisted = await runInDurableObject(stub, (_instance, state) =>
+			state.storage.sql
+				.exec<{ token_hash: string }>(
+					"SELECT token_hash FROM publication_operations WHERE intent_id = ?",
+					INTENT_ID,
+				)
+				.one(),
+		);
+		expect(persisted.token_hash).not.toBe(first.lease.token);
+	});
+
+	it("completes a confirmed write atomically and replays the exact completion", async () => {
+		const stub = await preparePublishing();
+		const started = await stub.beginPublicationOperation(DID, INTENT_ID, 5, 5_000, NOW + 10);
+		expect(started.ok).toBe(true);
+		if (!started.ok) return;
+		const completion = {
+			publisherDid: DID,
+			intentId: INTENT_ID,
+			generation: started.lease.generation,
+			token: started.lease.token,
+			expectedIntentGeneration: 5,
+			completionDigest: "Z".repeat(43),
+			outcome: "published" as const,
+			resultUri: "at://did:plc:publisher/com.emdashcms.experimental.package.release/gallery:1.2.3",
+			resultCid: "bafybeigdyrzt",
+			now: NOW + 11,
+		};
+
+		await expect(stub.completePublicationOperation(completion)).resolves.toEqual({
+			ok: true,
+			state: "published",
+			stateGeneration: 6,
+			replayed: false,
+		});
+		await expect(stub.completePublicationOperation(completion)).resolves.toEqual({
+			ok: true,
+			state: "published",
+			stateGeneration: 6,
+			replayed: true,
+		});
+		await expect(stub.getIntent(DID, INTENT_ID)).resolves.toMatchObject({
+			state: "published",
+			stateGeneration: 6,
+			stateDataJson: JSON.stringify({
+				resultUri: completion.resultUri,
+				resultCid: completion.resultCid,
+			}),
+		});
+	});
+
+	it("rejects stale tokens and records ambiguous outcomes for reconciliation", async () => {
+		const stub = await preparePublishing();
+		const started = await stub.beginPublicationOperation(DID, INTENT_ID, 5, 5_000, NOW + 10);
+		expect(started.ok).toBe(true);
+		if (!started.ok) return;
+
+		await expect(
+			stub.completePublicationOperation({
+				publisherDid: DID,
+				intentId: INTENT_ID,
+				generation: started.lease.generation,
+				token: `${"A".repeat(42)}B`,
+				expectedIntentGeneration: 5,
+				completionDigest: "Y".repeat(43),
+				outcome: "ambiguous",
+				resultUri: null,
+				resultCid: null,
+				now: NOW + 11,
+			}),
+		).resolves.toEqual({ ok: false, code: "PUBLICATION_CAS_REQUIRED" });
+		await expect(
+			stub.completePublicationOperation({
+				publisherDid: DID,
+				intentId: INTENT_ID,
+				generation: started.lease.generation,
+				token: started.lease.token,
+				expectedIntentGeneration: 5,
+				completionDigest: "Y".repeat(43),
+				outcome: "ambiguous",
+				resultUri: null,
+				resultCid: null,
+				now: NOW + 12,
+			}),
+		).resolves.toMatchObject({ ok: true, state: "reconciling", stateGeneration: 6 });
+	});
+
+	it("requires reconciliation instead of superseding an expired write lease", async () => {
+		const stub = await preparePublishing();
+		await stub.beginPublicationOperation(DID, INTENT_ID, 5, 1, NOW + 10);
+
+		await expect(
+			stub.beginPublicationOperation(DID, INTENT_ID, 5, 5_000, NOW + 12),
+		).resolves.toEqual({ ok: false, code: "PUBLICATION_RECOVERY_REQUIRED" });
+	});
+
+	it("recovers an expired in-flight write into reconciliation via the alarm", async () => {
+		const stub = await preparePublishing();
+		const alarmNow = Date.now() - 1_000;
+		await stub.beginPublicationOperation(DID, INTENT_ID, 5, 1, alarmNow);
+
+		await runDurableObjectAlarm(stub);
+		await expect(stub.getIntent(DID, INTENT_ID)).resolves.toMatchObject({
+			state: "reconciling",
+			stateGeneration: 6,
+			stateDataJson: '{"recovery":"operation-expired"}',
+		});
+		const transitions = await stub.listIntentTransitions(DID, INTENT_ID);
+		expect(transitions.at(-1)).toMatchObject({
+			fromState: "publishing",
+			toState: "reconciling",
+			reasonCode: "PDS_AMBIGUOUS",
+		});
+		const audit = await runInDurableObject(stub, (_instance, state) =>
+			state.storage.sql
+				.exec<{ event_type: string }>("SELECT event_type FROM audit_events ORDER BY sequence")
+				.toArray()
+				.map((row) => row.event_type),
+		);
+		expect(audit).toContain("publication-operation-recovery-required");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds generation-bound publication operation leases and the publisher alarm recovery path. Capability tokens are random, persisted only as SHA-256 hashes, and bound to one intent generation. Confirmed, ambiguous, and conflicting PDS outcomes atomically complete the operation and transition the intent with an append-only record.

An expired lease can never be superseded while the write outcome is unknown. The alarm moves the intent from `publishing` to `reconciling`, records `PDS_AMBIGUOUS`, and clears its deadline. Exact completion retries are bounded to the immediately produced state. This is layer 5 of the workload identity/admission merge unit, based on `feat/drs-workload-admission-policy`. Related to RFC #1870 and Discussion #1590.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (not applicable: no UI)
- [ ] I have added and reviewed the user-facing changeset (not applicable: private Worker app)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1590

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 (Codex)

## Screenshots / test output

- Workerd covers lease serialization, token-hash persistence, stale capabilities, confirmed and ambiguous completion, bounded replay, no-supersede expiry, alarm reconciliation, and audit.
- The top branch passes 144 release-service tests, production build, quick lint, and type-aware lint.
