### PR TITLE
feat(registry): verify provenance digest candidates

### DIFF
--- a/.changeset/swift-verifiers-match.md
+++ b/.changeset/swift-verifiers-match.md
@@ -1,0 +1,7 @@
+---
+"@emdash-cms/registry-verification": minor
+---
+
+Adds optional artifact digest candidates to `GitHubProvenanceVerifier`, allowing callers that compute several supported digest algorithms in one isolated artifact fetch to verify the digest selected by a signed SLSA provenance subject.
+
+Existing callers can continue passing only `artifactDigest`. Successful results return the candidate that matched the signed subject.

--- a/apps/release-verifier/src/index.ts
+++ b/apps/release-verifier/src/index.ts
@@ -2,12 +2,19 @@ import { WorkerEntrypoint } from "cloudflare:workers";
 
 import {
 	verifyArtifact,
+	verifyRelease,
 	type ArtifactVerificationReport,
+	type ReleaseVerificationReport,
 	type VerifyArtifactInput,
+	type VerifyReleaseInput,
 } from "./verify.js";
 
 export default class ReleaseVerifier extends WorkerEntrypoint<Env> {
 	async verifyArtifact(input: VerifyArtifactInput): Promise<ArtifactVerificationReport> {
 		return verifyArtifact(input);
+	}
+
+	async verifyRelease(input: VerifyReleaseInput): Promise<ReleaseVerificationReport> {
+		return verifyRelease(input);
 	}
 }

--- a/apps/release-verifier/src/verify.ts
+++ b/apps/release-verifier/src/verify.ts
@@ -1,10 +1,13 @@
 import {
 	MAX_BUNDLE_COMPRESSED_BYTES,
+	GitHubProvenanceVerifier,
 	fetchVerifiedResource,
 	validatePluginBundle,
 	verifyMultihash,
 	type FetchImplementation,
 	type HostnameResolver,
+	type ProvenanceVerifier,
+	type ReleaseProvenance,
 	type ValidatedPluginBundle,
 	type VerificationErrorCode,
 } from "@emdash-cms/registry-verification";
@@ -14,6 +17,7 @@ import { resolvePublicHostname } from "./dns.js";
 const PACKAGE_SLUG_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
 const VERSION_PATTERN = /^[0-9A-Za-z][0-9A-Za-z.-]{0,127}$/;
 const CHECKSUM_PATTERN = /^b[a-z2-7]+$/;
+const MAX_PROVENANCE_BYTES = 5 * 1024 * 1024;
 
 export interface VerifyArtifactInput {
 	url: string;
@@ -47,9 +51,34 @@ export type ArtifactVerificationReport =
 			};
 	  };
 
+type VerifierError = ArtifactVerificationReport & { success: false };
+
+export interface VerifyReleaseInput {
+	artifact: VerifyArtifactInput;
+	provenance: ReleaseProvenance;
+	profileRepository: string;
+}
+
+export interface VerifiedReleaseReport {
+	artifact: VerifiedArtifactReport;
+	provenance: {
+		url: string;
+		checksum: string;
+		documentBytes: number;
+		predicateType: string;
+		sourceRepository: string;
+		builderId: string;
+	};
+}
+
+export type ReleaseVerificationReport =
+	| { success: true; value: VerifiedReleaseReport }
+	| VerifierError;
+
 export interface VerifierDependencies {
 	fetch: FetchImplementation;
 	resolveHostname: HostnameResolver;
+	provenanceVerifier?: ProvenanceVerifier;
 }
 
 function validInput(input: VerifyArtifactInput): boolean {
@@ -66,35 +95,64 @@ function validInput(input: VerifyArtifactInput): boolean {
 	);
 }
 
-export async function verifyArtifact(
+function invalidInput(message: string): VerifierError {
+	return { success: false, error: { code: "VERIFIER_INPUT_INVALID", message } };
+}
+
+function internalError(): VerifierError {
+	return {
+		success: false,
+		error: { code: "VERIFIER_INTERNAL_ERROR", message: "Artifact verification failed" },
+	};
+}
+
+function validReleaseInput(input: VerifyReleaseInput): boolean {
+	return (
+		input !== null &&
+		typeof input === "object" &&
+		Object.keys(input).length === 3 &&
+		validInput(input.artifact) &&
+		typeof input.profileRepository === "string" &&
+		input.profileRepository.length <= 2048 &&
+		input.provenance !== null &&
+		typeof input.provenance === "object" &&
+		Object.keys(input.provenance).length === 5 &&
+		typeof input.provenance.url === "string" &&
+		input.provenance.url.length <= 2048 &&
+		typeof input.provenance.checksum === "string" &&
+		CHECKSUM_PATTERN.test(input.provenance.checksum) &&
+		typeof input.provenance.builderId === "string" &&
+		input.provenance.builderId.length <= 2048 &&
+		typeof input.provenance.predicateType === "string" &&
+		input.provenance.predicateType.length <= 256 &&
+		typeof input.provenance.sourceRepository === "string" &&
+		input.provenance.sourceRepository.length <= 2048
+	);
+}
+
+async function loadArtifact(
 	input: VerifyArtifactInput,
-	dependencies: VerifierDependencies = {
-		fetch: (url, init) => fetch(url, init),
-		resolveHostname: resolvePublicHostname,
-	},
-): Promise<ArtifactVerificationReport> {
-	if (!validInput(input)) {
-		return {
-			success: false,
-			error: { code: "VERIFIER_INPUT_INVALID", message: "Artifact request is invalid" },
-		};
-	}
-	try {
-		const resource = await fetchVerifiedResource(input.url, {
-			...dependencies,
-			maxBytes: MAX_BUNDLE_COMPRESSED_BYTES,
-		});
-		if (!resource.success) return resource;
-		const checksum = await verifyMultihash(resource.value.bytes, input.checksum);
-		if (!checksum.success) return checksum;
-		const bundle = await validatePluginBundle(resource.value.bytes, {
-			expectedSlug: input.packageSlug,
-			expectedVersion: input.version,
-		});
-		if (!bundle.success) return bundle;
-		return {
-			success: true,
-			value: {
+	dependencies: VerifierDependencies,
+): Promise<
+	{ success: true; value: { bytes: Uint8Array; report: VerifiedArtifactReport } } | VerifierError
+> {
+	const resource = await fetchVerifiedResource(input.url, {
+		...dependencies,
+		maxBytes: MAX_BUNDLE_COMPRESSED_BYTES,
+	});
+	if (!resource.success) return resource;
+	const checksum = await verifyMultihash(resource.value.bytes, input.checksum);
+	if (!checksum.success) return checksum;
+	const bundle = await validatePluginBundle(resource.value.bytes, {
+		expectedSlug: input.packageSlug,
+		expectedVersion: input.version,
+	});
+	if (!bundle.success) return bundle;
+	return {
+		success: true,
+		value: {
+			bytes: resource.value.bytes,
+			report: {
 				url: resource.value.url.toString(),
 				checksum: input.checksum,
 				compressedBytes: resource.value.bytes.byteLength,
@@ -108,11 +166,77 @@ export async function verifyArtifact(
 					adminBytes: bundle.value.admin?.byteLength ?? null,
 				},
 			},
+		},
+	};
+}
+
+export async function verifyArtifact(
+	input: VerifyArtifactInput,
+	dependencies: VerifierDependencies = {
+		fetch: (url, init) => fetch(url, init),
+		resolveHostname: resolvePublicHostname,
+	},
+): Promise<ArtifactVerificationReport> {
+	if (!validInput(input)) {
+		return invalidInput("Artifact request is invalid");
+	}
+	try {
+		const loaded = await loadArtifact(input, dependencies);
+		return loaded.success ? { success: true, value: loaded.value.report } : loaded;
+	} catch {
+		return internalError();
+	}
+}
+
+export async function verifyRelease(
+	input: VerifyReleaseInput,
+	dependencies: VerifierDependencies = {
+		fetch: (url, init) => fetch(url, init),
+		resolveHostname: resolvePublicHostname,
+	},
+): Promise<ReleaseVerificationReport> {
+	if (!validReleaseInput(input)) return invalidInput("Release verification request is invalid");
+	try {
+		const artifact = await loadArtifact(input.artifact, dependencies);
+		if (!artifact.success) return artifact;
+		const provenanceResource = await fetchVerifiedResource(input.provenance.url, {
+			...dependencies,
+			maxBytes: MAX_PROVENANCE_BYTES,
+		});
+		if (!provenanceResource.success) return provenanceResource;
+		const artifactDigests = await Promise.all(
+			(["SHA-256", "SHA-384", "SHA-512"] as const).map(
+				async (algorithm) =>
+					new Uint8Array(await crypto.subtle.digest(algorithm, artifact.value.bytes)),
+			),
+		);
+		const [artifactDigest, ...additionalDigests] = artifactDigests;
+		if (!artifactDigest) return internalError();
+		const provenance = await (
+			dependencies.provenanceVerifier ?? new GitHubProvenanceVerifier()
+		).verify({
+			document: provenanceResource.value.bytes,
+			reference: input.provenance,
+			artifactDigest,
+			artifactDigests: additionalDigests,
+			profileRepository: input.profileRepository,
+		});
+		if (!provenance.success) return provenance;
+		return {
+			success: true,
+			value: {
+				artifact: artifact.value.report,
+				provenance: {
+					url: provenanceResource.value.url.toString(),
+					checksum: input.provenance.checksum,
+					documentBytes: provenanceResource.value.bytes.byteLength,
+					predicateType: provenance.value.predicateType,
+					sourceRepository: provenance.value.sourceRepository,
+					builderId: provenance.value.builderId,
+				},
+			},
 		};
 	} catch {
-		return {
-			success: false,
-			error: { code: "VERIFIER_INTERNAL_ERROR", message: "Artifact verification failed" },
-		};
+		return internalError();
 	}
 }

--- a/apps/release-verifier/test/verifier.test.ts
+++ b/apps/release-verifier/test/verifier.test.ts
@@ -7,6 +7,7 @@ import { exports } from "cloudflare:workers";
 import { packTar, type TarEntry } from "modern-tar";
 import { describe, expect, it, vi } from "vitest";
 
+import { createDelegatedReleaseConformanceFixture } from "../../../packages/registry-verification/fixtures/conformance/delegated-release.js";
 import { resolvePublicHostname } from "../src/dns.js";
 import { verifyArtifact, verifyRelease } from "../src/verify.js";
 
@@ -143,6 +144,36 @@ describe("isolated release verifier", () => {
 		expect(received?.artifactDigest).toHaveLength(32);
 		expect(received?.artifactDigests?.map((digest) => digest.byteLength)).toEqual([48, 64]);
 		expect(JSON.stringify(result)).not.toContain("export default");
+	});
+
+	it("matches the shared delegated-release service output contract", async () => {
+		const fixture = await createDelegatedReleaseConformanceFixture();
+		const result = await verifyRelease(fixture.serviceInput, {
+			fetch: async (url) =>
+				new Response(
+					url.toString() === fixture.artifactUrl
+						? fixture.artifactBytes
+						: fixture.provenanceDocument,
+				),
+			resolveHostname: async () => ["203.0.113.5"],
+			provenanceVerifier: fixture.provenanceVerifier,
+		});
+
+		expect(result).toMatchObject({
+			success: true,
+			value: {
+				artifact: {
+					checksum: fixture.artifactChecksum,
+					manifest: { id: fixture.packageSlug, version: fixture.version },
+				},
+				provenance: {
+					checksum: fixture.provenanceChecksum,
+					predicateType: fixture.expected.predicateType,
+					sourceRepository: fixture.expected.repository,
+					builderId: fixture.expected.builderId,
+				},
+			},
+		});
 	});
 
 	it("rejects checksum and bundle identity mismatches with stable reports", async () => {

--- a/apps/release-verifier/test/verifier.test.ts
+++ b/apps/release-verifier/test/verifier.test.ts
@@ -1,10 +1,14 @@
-import { computeMultihash } from "@emdash-cms/registry-verification";
+import {
+	computeMultihash,
+	type ProvenanceVerificationInput,
+	type ProvenanceVerifier,
+} from "@emdash-cms/registry-verification";
 import { exports } from "cloudflare:workers";
 import { packTar, type TarEntry } from "modern-tar";
 import { describe, expect, it, vi } from "vitest";
 
 import { resolvePublicHostname } from "../src/dns.js";
-import { verifyArtifact } from "../src/verify.js";
+import { verifyArtifact, verifyRelease } from "../src/verify.js";
 
 const encoder = new TextEncoder();
 const ARTIFACT_URL = "https://artifact.example.test/plugin.tgz";
@@ -78,6 +82,66 @@ describe("isolated release verifier", () => {
 				},
 			},
 		});
+		expect(JSON.stringify(result)).not.toContain("export default");
+	});
+
+	it("verifies artifact and provenance in one isolated invocation with all digest candidates", async () => {
+		const bytes = await validBundle();
+		const provenanceDocument = encoder.encode('{"sigstore":"bundle"}');
+		let received: ProvenanceVerificationInput | undefined;
+		const provenanceVerifier: ProvenanceVerifier = {
+			async verify(input) {
+				received = input;
+				return {
+					success: true,
+					value: {
+						predicateType: "https://slsa.dev/provenance/v1",
+						artifactDigest: input.artifactDigests?.[1] ?? input.artifactDigest,
+						sourceRepository: "https://github.com/emdash-cms/gallery",
+						builderId:
+							"https://github.com/emdash-cms/gallery/.github/workflows/release.yml@refs/heads/main",
+					},
+				};
+			},
+		};
+		const result = await verifyRelease(
+			{
+				artifact: {
+					url: ARTIFACT_URL,
+					checksum: await checksum(bytes),
+					packageSlug: "gallery",
+					version: "1.2.3",
+				},
+				provenance: {
+					url: "https://provenance.example.test/bundle.json",
+					checksum: await checksum(provenanceDocument),
+					predicateType: "https://slsa.dev/provenance/v1",
+					sourceRepository: "https://github.com/emdash-cms/gallery",
+					builderId:
+						"https://github.com/emdash-cms/gallery/.github/workflows/release.yml@refs/heads/main",
+				},
+				profileRepository: "https://github.com/emdash-cms/gallery",
+			},
+			{
+				fetch: async (url) =>
+					new Response(url.hostname === "artifact.example.test" ? bytes : provenanceDocument),
+				resolveHostname: async () => ["203.0.113.5"],
+				provenanceVerifier,
+			},
+		);
+
+		expect(result).toMatchObject({
+			success: true,
+			value: {
+				artifact: { manifest: { id: "gallery", version: "1.2.3" } },
+				provenance: {
+					documentBytes: provenanceDocument.byteLength,
+					predicateType: "https://slsa.dev/provenance/v1",
+				},
+			},
+		});
+		expect(received?.artifactDigest).toHaveLength(32);
+		expect(received?.artifactDigests?.map((digest) => digest.byteLength)).toEqual([48, 64]);
 		expect(JSON.stringify(result)).not.toContain("export default");
 	});
 

--- a/packages/registry-verification/fixtures/conformance/delegated-release.ts
+++ b/packages/registry-verification/fixtures/conformance/delegated-release.ts
@@ -1,0 +1,240 @@
+import { declaredAccessToCapabilities, type DeclaredAccess } from "@emdash-cms/plugin-types";
+import type { PackageProfile, PackageRelease } from "@emdash-cms/registry-lexicons";
+import { packTar, type TarEntry } from "modern-tar";
+
+import {
+	compareDigestBytes,
+	computeMultihash,
+	decodeMultihash,
+	type ProvenanceVerifier,
+	type ReleaseProvenance,
+} from "../../src/index.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export interface DelegatedReleaseFixtureOptions {
+	version?: string;
+	manifestId?: string;
+	manifestVersion?: string;
+	releasePackage?: string;
+	releaseVersion?: string;
+	declaredAccess?: DeclaredAccess;
+	manifestDeclaredAccess?: DeclaredAccess;
+	provenance?: Partial<ReleaseProvenance>;
+}
+
+export interface DelegatedReleaseConformanceFixture {
+	publisherDid: string;
+	packageSlug: string;
+	version: string;
+	profile: PackageProfile.Main;
+	release: PackageRelease.Main;
+	artifactUrl: string;
+	artifactBytes: Uint8Array;
+	artifactChecksum: string;
+	artifactDigest: Uint8Array;
+	provenanceUrl: string;
+	provenanceDocument: Uint8Array;
+	provenanceChecksum: string;
+	provenanceVerifier: ProvenanceVerifier;
+	serviceInput: {
+		artifact: {
+			url: string;
+			checksum: string;
+			packageSlug: string;
+			version: string;
+		};
+		provenance: ReleaseProvenance;
+		profileRepository: string;
+	};
+	expected: {
+		repository: string;
+		builderId: string;
+		predicateType: string;
+	};
+}
+
+export async function createDelegatedReleaseConformanceFixture(
+	options: DelegatedReleaseFixtureOptions = {},
+): Promise<DelegatedReleaseConformanceFixture> {
+	const publisherDid = "did:plc:delegated00000000000000";
+	const packageSlug = "gallery";
+	const version = options.version ?? "1.2.3";
+	const repository = "https://github.com/emdash-cms/gallery";
+	const builderId =
+		"https://github.com/emdash-cms/gallery/.github/workflows/release.yml@refs/heads/main";
+	const predicateType = "https://slsa.dev/provenance/v1";
+	const artifactUrl = "https://artifact.example.test/gallery.tgz";
+	const provenanceUrl = "https://provenance.example.test/gallery.sigstore.json";
+	const declaredAccess = options.declaredAccess ?? { content: { read: {} } };
+	const manifestDeclaredAccess = options.manifestDeclaredAccess ?? declaredAccess;
+	const enforcement = declaredAccessToCapabilities(manifestDeclaredAccess);
+	const artifactBytes = await bundle([
+		file(
+			"manifest.json",
+			JSON.stringify({
+				id: options.manifestId ?? packageSlug,
+				version: options.manifestVersion ?? version,
+				declaredAccess: manifestDeclaredAccess,
+				capabilities: enforcement.capabilities,
+				allowedHosts: enforcement.allowedHosts,
+				storage: {},
+				hooks: [],
+				routes: [],
+				admin: {},
+			}),
+		),
+		file("backend.js", "export default {};"),
+		file("admin.js", "export default {};"),
+	]);
+	const artifact = await checksumAndDigest(artifactBytes);
+	const statement = {
+		predicateType,
+		subject: { sha256: toHex(artifact.digest) },
+		sourceRepository: repository,
+		builderId,
+	};
+	const provenanceDocument = encoder.encode(JSON.stringify(statement));
+	const provenance = await checksumAndDigest(provenanceDocument);
+	const reference: ReleaseProvenance = {
+		predicateType,
+		url: provenanceUrl,
+		checksum: provenance.checksum,
+		sourceRepository: repository,
+		builderId,
+		...options.provenance,
+	};
+	const profile: PackageProfile.Main = {
+		$type: "com.emdashcms.experimental.package.profile",
+		id: `at://${publisherDid}/com.emdashcms.experimental.package.profile/${packageSlug}`,
+		slug: packageSlug,
+		type: "emdash-plugin",
+		name: "Gallery",
+		license: "MIT",
+		authors: [{ name: "EmDash" }],
+		security: [{ email: "security@emdashcms.com" }],
+		extensions: {
+			"com.emdashcms.experimental.package.profileExtension": {
+				$type: "com.emdashcms.experimental.package.profileExtension",
+				repository,
+				releasePolicy: {
+					requireProvenance: true,
+					confirmation: "escalation-only",
+					approvers: [publisherDid],
+				},
+			},
+		},
+	};
+	const release: PackageRelease.Main = {
+		$type: "com.emdashcms.experimental.package.release",
+		package: options.releasePackage ?? packageSlug,
+		version: options.releaseVersion ?? version,
+		artifacts: { package: { url: artifactUrl, checksum: artifact.checksum } },
+		extensions: {
+			"com.emdashcms.experimental.package.releaseExtension": {
+				$type: "com.emdashcms.experimental.package.releaseExtension",
+				declaredAccess,
+				provenance: reference,
+			},
+		},
+	};
+	const provenanceVerifier: ProvenanceVerifier = {
+		async verify(input) {
+			let parsed: typeof statement;
+			try {
+				parsed = JSON.parse(decoder.decode(input.document)) as typeof statement;
+			} catch {
+				return unverifiable();
+			}
+			if (
+				input.reference.predicateType !== predicateType ||
+				input.reference.url !== provenanceUrl ||
+				input.reference.checksum !== provenance.checksum ||
+				input.reference.sourceRepository !== repository ||
+				input.reference.builderId !== builderId ||
+				input.profileRepository !== repository ||
+				!compareDigestBytes(input.artifactDigest, artifact.digest) ||
+				parsed.predicateType !== predicateType ||
+				parsed.subject.sha256 !== toHex(artifact.digest) ||
+				parsed.sourceRepository !== repository ||
+				parsed.builderId !== builderId
+			) {
+				return unverifiable();
+			}
+			return {
+				success: true,
+				value: {
+					predicateType,
+					artifactDigest: input.artifactDigest,
+					sourceRepository: repository,
+					builderId,
+				},
+			};
+		},
+	};
+
+	return {
+		publisherDid,
+		packageSlug,
+		version,
+		profile,
+		release,
+		artifactUrl,
+		artifactBytes,
+		artifactChecksum: artifact.checksum,
+		artifactDigest: artifact.digest,
+		provenanceUrl,
+		provenanceDocument,
+		provenanceChecksum: provenance.checksum,
+		provenanceVerifier,
+		serviceInput: {
+			artifact: {
+				url: artifactUrl,
+				checksum: artifact.checksum,
+				packageSlug,
+				version,
+			},
+			provenance: reference,
+			profileRepository: repository,
+		},
+		expected: { repository, builderId, predicateType },
+	};
+}
+
+function file(name: string, body: string): TarEntry {
+	const bytes = encoder.encode(body);
+	return { header: { name, size: bytes.byteLength, type: "file" }, body: bytes };
+}
+
+async function bundle(entries: TarEntry[]): Promise<Uint8Array> {
+	const tar = await packTar(entries);
+	const compressed = new Blob([new Uint8Array(tar)])
+		.stream()
+		.pipeThrough(new CompressionStream("gzip"));
+	return new Uint8Array(await new Response(compressed).arrayBuffer());
+}
+
+async function checksumAndDigest(
+	bytes: Uint8Array,
+): Promise<{ checksum: string; digest: Uint8Array }> {
+	const checksum = await computeMultihash(bytes);
+	if (!checksum.success) throw new Error(checksum.error.message);
+	const decoded = decodeMultihash(checksum.value);
+	if (!decoded.success) throw new Error(decoded.error.message);
+	return { checksum: checksum.value, digest: decoded.value.digest };
+}
+
+function toHex(bytes: Uint8Array): string {
+	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function unverifiable() {
+	return {
+		success: false as const,
+		error: {
+			code: "PROVENANCE_UNVERIFIABLE" as const,
+			message: "The conformance provenance does not match the delegated release.",
+		},
+	};
+}

--- a/packages/registry-verification/fixtures/conformance/delegated-release.ts
+++ b/packages/registry-verification/fixtures/conformance/delegated-release.ts
@@ -55,6 +55,13 @@ export interface DelegatedReleaseConformanceFixture {
 	};
 }
 
+interface ConformanceProvenanceStatement {
+	predicateType: string;
+	subject: { sha256: string };
+	sourceRepository: string;
+	builderId: string;
+}
+
 export async function createDelegatedReleaseConformanceFixture(
 	options: DelegatedReleaseFixtureOptions = {},
 ): Promise<DelegatedReleaseConformanceFixture> {
@@ -89,7 +96,7 @@ export async function createDelegatedReleaseConformanceFixture(
 		file("admin.js", "export default {};"),
 	]);
 	const artifact = await checksumAndDigest(artifactBytes);
-	const statement = {
+	const statement: ConformanceProvenanceStatement = {
 		predicateType,
 		subject: { sha256: toHex(artifact.digest) },
 		sourceRepository: repository,
@@ -141,12 +148,14 @@ export async function createDelegatedReleaseConformanceFixture(
 	};
 	const provenanceVerifier: ProvenanceVerifier = {
 		async verify(input) {
-			let parsed: typeof statement;
+			let value: unknown;
 			try {
-				parsed = JSON.parse(decoder.decode(input.document)) as typeof statement;
+				value = JSON.parse(decoder.decode(input.document));
 			} catch {
 				return unverifiable();
 			}
+			if (!isConformanceStatement(value)) return unverifiable();
+			const parsed = value;
 			if (
 				input.reference.predicateType !== predicateType ||
 				input.reference.url !== provenanceUrl ||
@@ -227,6 +236,19 @@ async function checksumAndDigest(
 
 function toHex(bytes: Uint8Array): string {
 	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function isConformanceStatement(value: unknown): value is ConformanceProvenanceStatement {
+	if (!value || typeof value !== "object") return false;
+	const subject = Reflect.get(value, "subject");
+	return (
+		typeof Reflect.get(value, "predicateType") === "string" &&
+		typeof Reflect.get(value, "sourceRepository") === "string" &&
+		typeof Reflect.get(value, "builderId") === "string" &&
+		typeof subject === "object" &&
+		subject !== null &&
+		typeof Reflect.get(subject, "sha256") === "string"
+	);
 }
 
 function unverifiable() {

--- a/packages/registry-verification/src/bundle.ts
+++ b/packages/registry-verification/src/bundle.ts
@@ -17,7 +17,7 @@ const TAR_BLOCK_BYTES = 512;
 const TAR_END_BYTES = TAR_BLOCK_BYTES * 2;
 const OCTAL_PATTERN = /^[0-7]+$/;
 const WINDOWS_DRIVE_PATTERN = /^[a-zA-Z]:/;
-const decoder = new TextDecoder("utf-8", { fatal: true });
+const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: false });
 
 export interface ValidatePluginBundleOptions {
 	expectedSlug?: string;

--- a/packages/registry-verification/src/provenance.ts
+++ b/packages/registry-verification/src/provenance.ts
@@ -46,6 +46,7 @@ export interface ProvenanceVerificationInput {
 	document: Uint8Array;
 	reference: ReleaseProvenance;
 	artifactDigest: Uint8Array;
+	artifactDigests?: readonly Uint8Array[];
 	profileRepository: string;
 }
 
@@ -83,7 +84,7 @@ export class GitHubProvenanceVerifier implements ProvenanceVerifier {
 				success: true,
 				value: {
 					predicateType: PREDICATE_TYPE,
-					artifactDigest: snapshot.artifactDigest,
+					artifactDigest: expected.artifactDigest,
 					sourceRepository: expected.repository,
 					builderId: expected.builderId,
 				},
@@ -105,6 +106,7 @@ function snapshotInput(input: ProvenanceVerificationInput): ProvenanceVerificati
 			url: input.reference.url,
 		},
 		artifactDigest: new Uint8Array(input.artifactDigest),
+		artifactDigests: input.artifactDigests?.map((digest) => new Uint8Array(digest)),
 		profileRepository: input.profileRepository,
 	};
 }
@@ -114,6 +116,7 @@ function exactRegexPattern(value: string): string {
 }
 
 interface ExpectedIdentity {
+	artifactDigest: Uint8Array;
 	repository: string;
 	builderId: string;
 	workflowRef: string;
@@ -173,7 +176,10 @@ function validateStatement(
 	if (input.reference.predicateType !== PREDICATE_TYPE) {
 		throw new Error("Provenance predicate reference mismatch");
 	}
-	validateArtifactSubject(statement.subject, input.artifactDigest);
+	const artifactDigest = validateArtifactSubject(statement.subject, [
+		input.artifactDigest,
+		...(input.artifactDigests ?? []),
+	]);
 
 	const profileRepository = requireRepository(input.profileRepository);
 	const referenceRepository = requireRepository(input.reference.sourceRepository);
@@ -220,6 +226,7 @@ function validateStatement(
 	if (!GIT_COMMIT_RE.test(commitSha)) throw new Error("Invalid Git commit digest");
 
 	return {
+		artifactDigest,
 		repository: attestedRepository,
 		builderId,
 		workflowRef,
@@ -229,18 +236,21 @@ function validateStatement(
 	};
 }
 
-function validateArtifactSubject(subjects: unknown[], artifactDigest: Uint8Array): void {
-	let matched = false;
+function validateArtifactSubject(
+	subjects: unknown[],
+	artifactDigests: readonly Uint8Array[],
+): Uint8Array {
 	for (const value of subjects) {
 		const digest = requireObject(requireObject(value).digest);
 		for (const [algorithm, expectedLength] of SUPPORTED_SUBJECT_DIGESTS) {
 			if (!(algorithm in digest)) continue;
 			const bytes = decodeHex(requireString(digest[algorithm]));
 			if (bytes.byteLength !== expectedLength) throw new Error("Invalid subject digest length");
-			matched ||= compareDigestBytes(bytes, artifactDigest);
+			const matched = artifactDigests.find((candidate) => compareDigestBytes(bytes, candidate));
+			if (matched) return new Uint8Array(matched);
 		}
 	}
-	if (!matched) throw new Error("Artifact digest mismatch");
+	throw new Error("Artifact digest mismatch");
 }
 
 function validateSignerIdentity(

--- a/packages/registry-verification/src/provenance.ts
+++ b/packages/registry-verification/src/provenance.ts
@@ -32,7 +32,7 @@ const SUPPORTED_SUBJECT_DIGESTS = new Map([
 	["sha384", 48],
 	["sha512", 64],
 ]);
-const decoder = new TextDecoder("utf-8", { fatal: true });
+const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: false });
 const trustedRoot = TrustedRoot.fromJSON(trustedRootJson);
 const verifier = new Verifier(toTrustMaterial(trustedRoot), {
 	tlogThreshold: 1,

--- a/packages/registry-verification/tests/conformance-fixture.test.ts
+++ b/packages/registry-verification/tests/conformance-fixture.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { createDelegatedReleaseConformanceFixture } from "../fixtures/conformance/delegated-release.js";
+import {
+	validatePluginBundle,
+	verifyMultihash,
+	verifyPackageReleaseRecords,
+} from "../src/index.js";
+
+describe("delegated release conformance fixture", () => {
+	it("passes the shared service and installer verification contracts", async () => {
+		const fixture = await createDelegatedReleaseConformanceFixture();
+		await expect(
+			verifyMultihash(fixture.artifactBytes, fixture.artifactChecksum),
+		).resolves.toMatchObject({ success: true });
+		await expect(
+			validatePluginBundle(fixture.artifactBytes, {
+				expectedSlug: fixture.packageSlug,
+				expectedVersion: fixture.version,
+			}),
+		).resolves.toMatchObject({
+			success: true,
+			value: {
+				declaredAccess: { content: { read: {} } },
+			},
+		});
+		await expect(
+			verifyPackageReleaseRecords({
+				publisherDid: fixture.publisherDid,
+				package: fixture.packageSlug,
+				version: fixture.version,
+				rkey: fixture.packageSlug + ":" + fixture.version,
+				profile: fixture.profile,
+				release: fixture.release,
+				provenance: {
+					document: fixture.provenanceDocument,
+					artifactDigest: fixture.artifactDigest,
+					verifier: fixture.provenanceVerifier,
+				},
+			}),
+		).resolves.toMatchObject({
+			success: true,
+			status: "verified",
+			value: {
+				repository: fixture.expected.repository,
+				verifiedProvenance: {
+					builderId: fixture.expected.builderId,
+					predicateType: fixture.expected.predicateType,
+				},
+			},
+		});
+	});
+
+	it("fails when the signed release substitutes provenance source identity", async () => {
+		const fixture = await createDelegatedReleaseConformanceFixture({
+			provenance: { sourceRepository: "https://github.com/attacker/gallery" },
+		});
+		await expect(
+			verifyPackageReleaseRecords({
+				publisherDid: fixture.publisherDid,
+				package: fixture.packageSlug,
+				version: fixture.version,
+				rkey: fixture.packageSlug + ":" + fixture.version,
+				profile: fixture.profile,
+				release: fixture.release,
+				provenance: {
+					document: fixture.provenanceDocument,
+					artifactDigest: fixture.artifactDigest,
+					verifier: fixture.provenanceVerifier,
+				},
+			}),
+		).resolves.toMatchObject({ success: false, code: "PROVENANCE_UNVERIFIABLE" });
+	});
+});

--- a/packages/registry-verification/tests/provenance-contract.ts
+++ b/packages/registry-verification/tests/provenance-contract.ts
@@ -79,6 +79,27 @@ export function provenanceContract(): void {
 			});
 		});
 
+		it("matches one of the caller's bounded artifact digest candidates", async () => {
+			const document = fixtureDocument();
+			const checksum = await computeMultihash(document);
+			if (!checksum.success) throw new Error("Test fixture checksum could not be computed");
+			const result = await new GitHubProvenanceVerifier().verify({
+				document,
+				reference: {
+					builderId,
+					checksum: checksum.value,
+					predicateType,
+					sourceRepository,
+					url: "https://registry.npmjs.org/-/npm/v1/attestations/@sigstore%2fcore@4.0.1",
+				},
+				artifactDigest: new Uint8Array(32),
+				artifactDigests: [artifactDigest],
+				profileRepository: sourceRepository,
+			});
+
+			expect(result).toMatchObject({ success: true, value: { artifactDigest } });
+		});
+
 		it("snapshots mutable inputs before checksum verification yields", async () => {
 			const document = fixtureDocument();
 			const digest = new Uint8Array(artifactDigest);


### PR DESCRIPTION
## What does this PR do?

Extends `GitHubProvenanceVerifier` with optional artifact digest candidates. Existing callers still pass `artifactDigest`; isolated callers may also provide SHA-384/SHA-512 candidates, and the verified result identifies the digest selected by the signed SLSA subject.

The release-verifier Worker uses this additive API to fetch an artifact once, compute SHA-256/384/512, fetch the Sigstore bundle through the guarded egress path, and return one bounded artifact/provenance report without file or document bytes. It also consumes the shared delegated-release conformance fixture used by the independent installer stack. This is layer 2 of the independent verifier stack, based on `feat/drs-release-verifier`. Related to RFC #1870 and Discussion #1590.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (not applicable: no UI)
- [x] I have added and reviewed the user-facing changeset
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1590

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 (Codex)

## Screenshots / test output

- Registry verification: 96 Node tests, packed-output validation, and 37 Workerd tests pass.
- Release verifier: 8 Workerd RPC tests, typecheck, production build, quick lint, and repository type-aware lint pass.
- The shared delegated-release fixture passes both the service output and installer verification contracts.
- The changeset documents the additive `artifactDigests` API and existing-call compatibility.
