### PR TITLE
feat(registry): enforce release provenance

### DIFF
--- a/.changeset/verify-registry-bundles.md
+++ b/.changeset/verify-registry-bundles.md
@@ -1,10 +1,13 @@
 ---
 "emdash": patch
 "@emdash-cms/registry-client": minor
+"@emdash-cms/registry-verification": minor
 ---
 
 Adds `DirectPdsClient` for reading package profiles and releases with AT Protocol repository proofs, and updates experimental decentralized registry installs and updates to verify current signed records directly from the publisher's PDS.
 
-The installer applies the signed profile's release policy and binds moderation labels to the exact profile or release CID. Artifact checksums, archive paths, bundle limits, manifest identity, and version use the same verification rules as the registry release tooling.
+The installer applies the signed profile's release policy, independently fetches and verifies supplied Sigstore/SLSA provenance, and binds moderation labels to the exact profile or release CID. Missing required provenance and any supplied provenance that is unavailable, malformed, mismatched, or unsupported block installation and updates. Artifact checksums, archive paths, bundle limits, manifest identity, and version use the same verification rules as the registry release tooling.
+
+The verification package also exports `inspectPackageReleaseRecords` for validating signed records and policy before artifact and provenance evidence is available.
 
 Release records must contain a lowercase base32 multibase `sha2-256` multihash. Existing releases produced by the EmDash plugin CLI already use this format; nonconforming bare hexadecimal checksums are rejected.

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -57,9 +57,11 @@ import {
 } from "../../registry/artifact-verification.js";
 import {
 	readAuthoritativePackageRelease,
+	verifyAuthoritativePackageRelease,
 	type AuthoritativeRecordErrorCode,
 	type AuthoritativeRecordReader,
 	type AuthoritativeRecordReadOptions,
+	type VerifiedAuthoritativeReleaseReport,
 	type VerifiedAuthoritativeRecords,
 } from "../../registry/authoritative-records.js";
 import {
@@ -213,12 +215,13 @@ function registryRecordError(
 
 function recordVerificationSummary(
 	records: VerifiedAuthoritativeRecords,
+	report: VerifiedAuthoritativeReleaseReport,
 ): RegistryRecordVerificationSummary {
 	return {
 		profileCid: records.profile.cid,
 		releaseCid: records.release.cid,
-		provenance: records.report.provenance.status,
-		policy: records.report.value.policy,
+		provenance: report.provenance.status,
+		policy: report.value.policy,
 	};
 }
 
@@ -710,7 +713,7 @@ export async function handleRegistryInstall(
 			return registryRecordError(authoritative.error.code, authoritative.error.message);
 		}
 		const records = authoritative.value;
-		const { release } = records.report.value;
+		const { profile, release } = records.inspection.value;
 
 		const packageYanked =
 			hasCurrentRecordLabel(packageView.labels ?? [], "security:yanked", records.profile) ||
@@ -860,7 +863,7 @@ export async function handleRegistryInstall(
 			};
 		}
 
-		// Step 4: fetch bytes from an aggregator mirror or the URL in the
+		// Step 5: fetch bytes from an aggregator mirror or the URL in the
 		// authoritative signed release. Mirror bytes remain untrusted.
 		const declaredUrl = release.artifacts.package.url;
 		const declaredChecksum = release.artifacts.package.checksum;
@@ -878,7 +881,7 @@ export async function handleRegistryInstall(
 		const mirrors = releaseView.mirrors ?? [];
 		const artifactBytes = await fetchArtifact(mirrors, declaredUrl);
 
-		// Steps 5-6: verify the signed checksum, archive, manifest, and
+		// Steps 6-7: verify the signed checksum, archive, manifest, and
 		// expected package identity with the runtime-neutral verifier used
 		// by the release service.
 		const artifactReport = await validateRegistryArtifact(
@@ -894,7 +897,18 @@ export async function handleRegistryInstall(
 				"install",
 			);
 		}
-		const bundle = artifactReport.value;
+		const { bundle, artifactDigest } = artifactReport.value;
+		const recordReport = await verifyAuthoritativePackageRelease(
+			records,
+			artifactDigest,
+			opts?.authoritativeRecords,
+		);
+		if (!recordReport.success) {
+			return registryRecordError(
+				recordReport.code,
+				recordReport.reasons[0]?.message ?? "The release provenance is invalid.",
+			);
+		}
 
 		// Rewrite the manifest's id to the derived opaque pluginId before
 		// it reaches R2 storage or the sandbox loader. The sandbox uses
@@ -913,10 +927,7 @@ export async function handleRegistryInstall(
 		// is blind to constraint content (host scope), so compare the full
 		// enforced access of record vs bundle here and refuse on any difference.
 		if (
-			!verifiedAccessEqual(
-				records.report.value.declaredAccess,
-				bundle.manifest.declaredAccess ?? {},
-			)
+			!verifiedAccessEqual(recordReport.value.declaredAccess, bundle.manifest.declaredAccess ?? {})
 		) {
 			return {
 				success: false,
@@ -1066,7 +1077,7 @@ export async function handleRegistryInstall(
 				slug,
 				version,
 				capabilities: bundle.manifest.capabilities,
-				verification: recordVerificationSummary(records),
+				verification: recordVerificationSummary(records, recordReport),
 			},
 		};
 	} catch (err) {
@@ -1386,7 +1397,7 @@ export async function handleRegistryUpdate(
 			return registryRecordError(authoritative.error.code, authoritative.error.message);
 		}
 		const records = authoritative.value;
-		const { release } = records.report.value;
+		const { profile, release } = records.inspection.value;
 
 		const authoritativeReleaseWithdrawal = evaluateRegistryReleaseWithdrawal(
 			{
@@ -1447,7 +1458,18 @@ export async function handleRegistryUpdate(
 				"update",
 			);
 		}
-		const bundle = artifactReport.value;
+		const { bundle, artifactDigest } = artifactReport.value;
+		const recordReport = await verifyAuthoritativePackageRelease(
+			records,
+			artifactDigest,
+			opts?.authoritativeRecords,
+		);
+		if (!recordReport.success) {
+			return registryRecordError(
+				recordReport.code,
+				recordReport.reasons[0]?.message ?? "The release provenance is invalid.",
+			);
+		}
 
 		// Rewrite manifest.id to the opaque pluginId so the sandbox loader
 		// and R2 layout stay in sync across install and update.
@@ -1459,10 +1481,7 @@ export async function handleRegistryUpdate(
 		// the capability set identical, sails through the escalation diff below,
 		// and installs a bundle enforcing a scope the record never showed.
 		if (
-			!verifiedAccessEqual(
-				records.report.value.declaredAccess,
-				bundle.manifest.declaredAccess ?? {},
-			)
+			!verifiedAccessEqual(recordReport.value.declaredAccess, bundle.manifest.declaredAccess ?? {})
 		) {
 			return {
 				success: false,
@@ -1556,7 +1575,7 @@ export async function handleRegistryUpdate(
 				newVersion,
 				capabilityChanges,
 				routeVisibilityChanges: hasNewPublicRoutes ? routeVisibilityChanges : undefined,
-				verification: recordVerificationSummary(records),
+				verification: recordVerificationSummary(records, recordReport),
 			},
 		};
 	} catch (err) {

--- a/packages/core/src/registry/artifact-verification.ts
+++ b/packages/core/src/registry/artifact-verification.ts
@@ -1,6 +1,6 @@
 import type { VerificationErrorCode } from "@emdash-cms/registry-verification";
 import { validatePluginBundle } from "@emdash-cms/registry-verification/bundle";
-import { verifyMultihash } from "@emdash-cms/registry-verification/checksum";
+import { decodeMultihash, verifyMultihash } from "@emdash-cms/registry-verification/checksum";
 
 import { pluginManifestSchema, reconcileManifestAccess } from "../plugins/manifest-schema.js";
 import type { PluginBundle } from "../plugins/marketplace.js";
@@ -13,7 +13,10 @@ export type RegistryArtifactVerificationCode =
 	| "BUNDLE_RUNTIME_UNSUPPORTED";
 
 export type RegistryArtifactVerificationResult =
-	| { success: true; value: PluginBundle }
+	| {
+			success: true;
+			value: { bundle: PluginBundle; artifactDigest: Uint8Array };
+	  }
 	| {
 			success: false;
 			error: { code: RegistryArtifactVerificationCode; message: string };
@@ -27,6 +30,8 @@ export async function validateRegistryArtifact(
 ): Promise<RegistryArtifactVerificationResult> {
 	const checksumReport = await verifyMultihash(bytes, checksum);
 	if (!checksumReport.success) return checksumReport;
+	const decodedChecksum = decodeMultihash(checksum);
+	if (!decodedChecksum.success) return decodedChecksum;
 
 	const bundleReport = await validatePluginBundle(bytes, {
 		expectedSlug: slug,
@@ -49,13 +54,16 @@ export async function validateRegistryArtifact(
 		return {
 			success: true,
 			value: {
-				manifest: reconcileManifestAccess(manifest.data),
-				backendCode: bundleDecoder.decode(bundleReport.value.backend),
-				adminCode:
-					bundleReport.value.admin === undefined
-						? undefined
-						: bundleDecoder.decode(bundleReport.value.admin),
-				checksum,
+				bundle: {
+					manifest: reconcileManifestAccess(manifest.data),
+					backendCode: bundleDecoder.decode(bundleReport.value.backend),
+					adminCode:
+						bundleReport.value.admin === undefined
+							? undefined
+							: bundleDecoder.decode(bundleReport.value.admin),
+					checksum,
+				},
+				artifactDigest: decodedChecksum.value.digest,
 			},
 		};
 	} catch {

--- a/packages/core/src/registry/authoritative-records.ts
+++ b/packages/core/src/registry/authoritative-records.ts
@@ -6,13 +6,22 @@ import type {
 } from "@emdash-cms/registry-client/direct-pds";
 import { DirectPdsClient, DirectPdsReadError } from "@emdash-cms/registry-client/direct-pds";
 import {
+	fetchVerifiedResource,
+	inspectPackageReleaseRecords,
+	verifyMultihash,
 	verifyPackageReleaseRecords,
-	type ProvenanceEvidence,
+	type FetchImplementation,
+	type HostnameResolver,
+	type ProvenanceVerifier,
+	type RecordInspectionReport,
+	type RecordVerificationFailure,
 	type RecordVerificationReport,
 	type VerificationErrorCode,
 } from "@emdash-cms/registry-verification";
 
-import { ssrfSafeFetch } from "../security/ssrf.js";
+import { cloudflareDohResolver, ssrfSafeFetch } from "../security/ssrf.js";
+
+const MAX_PROVENANCE_BYTES = 5 * 1024 * 1024;
 
 export type AuthoritativeRecordErrorCode =
 	| DirectPdsReadErrorCode
@@ -22,14 +31,24 @@ export type AuthoritativeRecordErrorCode =
 export interface AuthoritativeRecordReadOptions {
 	fetch?: typeof fetch;
 	didDocumentResolver?: DirectPdsDidDocumentResolver;
-	provenance?: ProvenanceEvidence;
+	provenanceFetch?: FetchImplementation;
+	resolveHostname?: HostnameResolver;
+	provenanceVerifier?: ProvenanceVerifier;
 }
 
 export interface VerifiedAuthoritativeRecords {
+	publisherDid: string;
+	packageSlug: string;
+	version: string;
 	profile: DirectPdsProfileRecord;
 	release: DirectPdsReleaseRecord;
-	report: Extract<RecordVerificationReport, { success: true }>;
+	inspection: Extract<RecordInspectionReport, { success: true }>;
 }
+
+export type VerifiedAuthoritativeReleaseReport = Extract<
+	RecordVerificationReport,
+	{ success: true }
+>;
 
 export type AuthoritativeRecordReadResult =
 	| { success: true; value: VerifiedAuthoritativeRecords }
@@ -61,25 +80,27 @@ export async function readAuthoritativePackageRelease(
 			client.getPackageProfile(packageSlug),
 			client.getPackageRelease(packageSlug, version),
 		]);
-		const report = await verifyPackageReleaseRecords({
+		const inspection = await inspectPackageReleaseRecords({
 			publisherDid,
 			package: packageSlug,
 			version,
 			rkey: release.rkey,
 			profile: profile.value,
 			release: release.value,
-			provenance: options.provenance,
 		});
-		if (!report.success) {
+		if (!inspection.success) {
 			return {
 				success: false,
 				error: {
-					code: report.code,
-					message: report.reasons[0]?.message ?? "The signed package records are invalid.",
+					code: inspection.code,
+					message: inspection.reasons[0]?.message ?? "The signed package records are invalid.",
 				},
 			};
 		}
-		return { success: true, value: { profile, release, report } };
+		return {
+			success: true,
+			value: { publisherDid, packageSlug, version, profile, release, inspection },
+		};
 	} catch (error) {
 		if (error instanceof DirectPdsReadError) {
 			return { success: false, error: { code: error.code, message: error.message } };
@@ -94,7 +115,64 @@ export async function readAuthoritativePackageRelease(
 	}
 }
 
+export async function verifyAuthoritativePackageRelease(
+	records: VerifiedAuthoritativeRecords,
+	artifactDigest: Uint8Array,
+	options: AuthoritativeRecordReadOptions = {},
+): Promise<RecordVerificationReport> {
+	const context = records.inspection.value;
+	const provenanceReference = context.releaseExtension.provenance;
+	let document: Uint8Array | undefined;
+	if (provenanceReference) {
+		const fetched = await fetchVerifiedResource(provenanceReference.url, {
+			fetch: options.provenanceFetch ?? defaultProvenanceFetch,
+			resolveHostname: options.resolveHostname ?? cloudflareDohResolver,
+			maxBytes: MAX_PROVENANCE_BYTES,
+		});
+		if (!fetched.success) {
+			return verificationFailure(fetched.error.code, fetched.error.message);
+		}
+		const checksum = await verifyMultihash(fetched.value.bytes, provenanceReference.checksum);
+		if (!checksum.success) {
+			return verificationFailure(checksum.error.code, checksum.error.message);
+		}
+		document = fetched.value.bytes;
+	}
+
+	return verifyPackageReleaseRecords({
+		publisherDid: records.publisherDid,
+		package: records.packageSlug,
+		version: records.version,
+		rkey: records.release.rkey,
+		profile: records.profile.value,
+		release: records.release.value,
+		provenance:
+			document === undefined
+				? undefined
+				: {
+						document,
+						artifactDigest,
+						verifier: options.provenanceVerifier,
+					},
+	});
+}
+
+function verificationFailure(
+	code: VerificationErrorCode,
+	message: string,
+): RecordVerificationFailure {
+	return {
+		success: false,
+		status: "failed",
+		code,
+		reasons: [{ code, message }],
+		provenance: { status: "failed" },
+	};
+}
+
 const guardedFetch: typeof fetch = async (input, init) => {
 	const url = input instanceof Request ? input.url : String(input);
 	return ssrfSafeFetch(url, init, { httpsOnly: true });
 };
+
+const defaultProvenanceFetch: FetchImplementation = (input, init) => globalThis.fetch(input, init);

--- a/packages/core/tests/unit/api/registry-env-gate-handler.test.ts
+++ b/packages/core/tests/unit/api/registry-env-gate-handler.test.ts
@@ -8,7 +8,7 @@
  * `ENV_INCOMPATIBLE` result aborts *before* any artifact fetch.
  */
 
-import { verifyPackageReleaseRecords } from "@emdash-cms/registry-verification";
+import { inspectPackageReleaseRecords } from "@emdash-cms/registry-verification";
 import BetterSqlite3 from "better-sqlite3";
 import { Kysely, SqliteDialect } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -119,7 +119,7 @@ function authoritativeReader(requires: Record<string, string>): AuthoritativeRec
 			},
 		};
 		const rkey = packageSlug + ":" + version;
-		const report = await verifyPackageReleaseRecords({
+		const inspection = await inspectPackageReleaseRecords({
 			publisherDid,
 			package: packageSlug,
 			version,
@@ -127,10 +127,13 @@ function authoritativeReader(requires: Record<string, string>): AuthoritativeRec
 			profile,
 			release,
 		});
-		if (!report.success) throw new Error(report.reasons[0]?.message);
+		if (!inspection.success) throw new Error(inspection.reasons[0]?.message);
 		return {
 			success: true,
 			value: {
+				publisherDid,
+				packageSlug,
+				version,
 				profile: {
 					uri: profile.id,
 					cid: "bafy-profile",
@@ -143,7 +146,7 @@ function authoritativeReader(requires: Record<string, string>): AuthoritativeRec
 					rkey,
 					value: release,
 				},
-				report,
+				inspection,
 			},
 		};
 	};

--- a/packages/core/tests/unit/registry/artifact-verification.test.ts
+++ b/packages/core/tests/unit/registry/artifact-verification.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { gzipSync } from "node:zlib";
 
-import { computeMultihash } from "@emdash-cms/registry-verification/checksum";
+import { computeMultihash, decodeMultihash } from "@emdash-cms/registry-verification/checksum";
 import { packTar, type TarEntry } from "modern-tar";
 import { describe, expect, it } from "vitest";
 
@@ -52,21 +52,23 @@ async function checksum(bytes: Uint8Array): Promise<string> {
 describe("validateRegistryArtifact", () => {
 	it("returns a runtime bundle after shared checksum, archive, and manifest validation", async () => {
 		const bytes = await createBundle(pluginManifest());
-		const result = await validateRegistryArtifact(
-			bytes,
-			await checksum(bytes),
-			"test-plugin",
-			"1.0.0",
-		);
+		const expectedChecksum = await checksum(bytes);
+		const result = await validateRegistryArtifact(bytes, expectedChecksum, "test-plugin", "1.0.0");
 
 		expect(result).toMatchObject({
 			success: true,
 			value: {
-				manifest: { id: "test-plugin", version: "1.0.0" },
-				backendCode: "export default {};",
-				adminCode: "export default {};",
+				bundle: {
+					manifest: { id: "test-plugin", version: "1.0.0" },
+					backendCode: "export default {};",
+					adminCode: "export default {};",
+				},
+				artifactDigest: expect.any(Uint8Array),
 			},
 		});
+		const decoded = decodeMultihash(expectedChecksum);
+		if (!decoded.success || !result.success) throw new Error("expected valid checksum and bundle");
+		expect(result.value.artifactDigest).toEqual(decoded.value.digest);
 	});
 
 	it("rejects legacy bare-hex checksums at the installer boundary", async () => {

--- a/packages/core/tests/unit/registry/authoritative-records.test.ts
+++ b/packages/core/tests/unit/registry/authoritative-records.test.ts
@@ -3,11 +3,13 @@ import {
 	type FakePublisher,
 	type FakePublisherFixture,
 } from "@emdash-cms/atproto-test-utils";
-import { computeMultihash } from "@emdash-cms/registry-verification/checksum";
-import { describe, expect, it } from "vitest";
+import type { ProvenanceVerifier } from "@emdash-cms/registry-verification";
+import { computeMultihash, decodeMultihash } from "@emdash-cms/registry-verification/checksum";
+import { describe, expect, it, vi } from "vitest";
 
 import {
 	readAuthoritativePackageRelease,
+	verifyAuthoritativePackageRelease,
 	type AuthoritativeRecordReadOptions,
 } from "../../../src/registry/authoritative-records.js";
 import { hasCurrentRecordLabel } from "../../../src/registry/record-labels.js";
@@ -15,6 +17,11 @@ import { hasCurrentRecordLabel } from "../../../src/registry/record-labels.js";
 const PUBLISHER_DID = "did:plc:records0000000000000000";
 const PROFILE_NSID = "com.emdashcms.experimental.package.profile";
 const RELEASE_NSID = "com.emdashcms.experimental.package.release";
+const PROVENANCE_URL = "https://artifacts.example.test/provenance.json";
+const REPOSITORY = "https://github.com/example/gallery";
+const BUILDER_ID =
+	"https://github.com/example/gallery/.github/workflows/release.yml@refs/heads/main";
+const encoder = new TextEncoder();
 
 interface RecordHarness {
 	fixture: FakePublisherFixture;
@@ -93,6 +100,45 @@ function releaseRecord(overrides: Record<string, unknown> = {}): Record<string, 
 	};
 }
 
+async function checksumAndDigest(bytes: Uint8Array): Promise<{
+	checksum: string;
+	digest: Uint8Array;
+}> {
+	const computed = await computeMultihash(bytes);
+	if (!computed.success) throw new Error(computed.error.message);
+	const decoded = decodeMultihash(computed.value);
+	if (!decoded.success) throw new Error(decoded.error.message);
+	return { checksum: computed.value, digest: decoded.value.digest };
+}
+
+function releaseWithProvenance(
+	artifactChecksum: string,
+	provenanceChecksum: string,
+	provenanceUrl = PROVENANCE_URL,
+): Record<string, unknown> {
+	return releaseRecord({
+		artifacts: {
+			package: {
+				url: "https://artifacts.example.test/gallery-1.0.0.tar.gz",
+				checksum: artifactChecksum,
+			},
+		},
+		extensions: {
+			"com.emdashcms.experimental.package.releaseExtension": {
+				$type: "com.emdashcms.experimental.package.releaseExtension",
+				declaredAccess: {},
+				provenance: {
+					predicateType: "https://slsa.dev/provenance/v1",
+					url: provenanceUrl,
+					checksum: provenanceChecksum,
+					sourceRepository: REPOSITORY,
+					builderId: BUILDER_ID,
+				},
+			},
+		},
+	});
+}
+
 describe("readAuthoritativePackageRelease", () => {
 	it("verifies signed PDS records and returns their exact CIDs and normalized policy", async () => {
 		const harness = await createHarness({
@@ -111,9 +157,9 @@ describe("readAuthoritativePackageRelease", () => {
 			value: {
 				profile: { rkey: "gallery", cid: expect.stringMatching(/^b/) },
 				release: { rkey: "gallery:1.0.0", cid: expect.stringMatching(/^b/) },
-				report: {
-					status: "unattested",
-					provenance: { status: "absent-optional" },
+				inspection: {
+					status: "inspected",
+					provenance: { status: "not-checked" },
 					value: {
 						repository: "https://github.com/example/gallery",
 						policy: {
@@ -132,11 +178,19 @@ describe("readAuthoritativePackageRelease", () => {
 			profile: profileRecord({}, { requireProvenance: true }),
 		});
 
+		const records = await readAuthoritativePackageRelease(
+			PUBLISHER_DID,
+			"gallery",
+			"1.0.0",
+			harness.options,
+		);
+		expect(records.success).toBe(true);
+		if (!records.success) return;
 		await expect(
-			readAuthoritativePackageRelease(PUBLISHER_DID, "gallery", "1.0.0", harness.options),
+			verifyAuthoritativePackageRelease(records.value, new Uint8Array(), harness.options),
 		).resolves.toMatchObject({
 			success: false,
-			error: { code: "PROVENANCE_REQUIRED" },
+			code: "PROVENANCE_REQUIRED",
 		});
 	});
 
@@ -168,34 +222,165 @@ describe("readAuthoritativePackageRelease", () => {
 		});
 	});
 
-	it("reports supplied provenance as unverifiable until evidence is fetched", async () => {
-		const provenanceChecksum = await computeMultihash(new TextEncoder().encode("{}"));
-		if (!provenanceChecksum.success) throw new Error(provenanceChecksum.error.message);
+	it("fetches and verifies supplied provenance against the artifact digest", async () => {
+		const artifact = await checksumAndDigest(encoder.encode("artifact"));
+		const provenanceDocument = encoder.encode("{}");
+		const provenance = await checksumAndDigest(provenanceDocument);
 		const harness = await createHarness({
-			release: releaseRecord({
-				extensions: {
-					"com.emdashcms.experimental.package.releaseExtension": {
-						$type: "com.emdashcms.experimental.package.releaseExtension",
-						declaredAccess: {},
-						provenance: {
-							predicateType: "https://slsa.dev/provenance/v1",
-							url: "https://artifacts.example.test/provenance.json",
-							checksum: provenanceChecksum.value,
-							sourceRepository: "https://github.com/example/gallery",
-							builderId:
-								"https://github.com/example/gallery/.github/workflows/release.yml@refs/heads/main",
-						},
-					},
-				},
-			}),
+			release: releaseWithProvenance(artifact.checksum, provenance.checksum),
+		});
+		const records = await readAuthoritativePackageRelease(
+			PUBLISHER_DID,
+			"gallery",
+			"1.0.0",
+			harness.options,
+		);
+		expect(records.success).toBe(true);
+		if (!records.success) return;
+		const verify = vi.fn<ProvenanceVerifier["verify"]>(async (input) => ({
+			success: true,
+			value: {
+				predicateType: "https://slsa.dev/provenance/v1",
+				artifactDigest: input.artifactDigest,
+				sourceRepository: REPOSITORY,
+				builderId: BUILDER_ID,
+			},
+		}));
+		const provenanceFetch = vi.fn(() =>
+			Promise.resolve(new Response(provenanceDocument, { status: 200 })),
+		);
+
+		const report = await verifyAuthoritativePackageRelease(records.value, artifact.digest, {
+			...harness.options,
+			provenanceFetch,
+			resolveHostname: async () => ["93.184.216.34"],
+			provenanceVerifier: { verify },
 		});
 
-		await expect(
-			readAuthoritativePackageRelease(PUBLISHER_DID, "gallery", "1.0.0", harness.options),
-		).resolves.toMatchObject({
-			success: false,
-			error: { code: "PROVENANCE_UNVERIFIABLE" },
+		expect(report).toMatchObject({
+			success: true,
+			status: "verified",
+			provenance: { status: "verified" },
 		});
+		expect(provenanceFetch).toHaveBeenCalledOnce();
+		expect(verify).toHaveBeenCalledOnce();
+	});
+
+	it("rejects a provenance document whose bytes do not match its signed checksum", async () => {
+		const artifact = await checksumAndDigest(encoder.encode("artifact"));
+		const expectedProvenance = await checksumAndDigest(encoder.encode("expected"));
+		const harness = await createHarness({
+			release: releaseWithProvenance(artifact.checksum, expectedProvenance.checksum),
+		});
+		const records = await readAuthoritativePackageRelease(
+			PUBLISHER_DID,
+			"gallery",
+			"1.0.0",
+			harness.options,
+		);
+		expect(records.success).toBe(true);
+		if (!records.success) return;
+		const verify = vi.fn<ProvenanceVerifier["verify"]>();
+
+		const report = await verifyAuthoritativePackageRelease(records.value, artifact.digest, {
+			...harness.options,
+			provenanceFetch: () =>
+				Promise.resolve(new Response(encoder.encode("substituted"), { status: 200 })),
+			resolveHostname: async () => ["93.184.216.34"],
+			provenanceVerifier: { verify },
+		});
+
+		expect(report).toMatchObject({ success: false, code: "CHECKSUM_MISMATCH" });
+		expect(verify).not.toHaveBeenCalled();
+	});
+
+	it("rejects an unavailable supplied provenance document even when policy makes it optional", async () => {
+		const artifact = await checksumAndDigest(encoder.encode("artifact"));
+		const provenance = await checksumAndDigest(encoder.encode("{}"));
+		const harness = await createHarness({
+			release: releaseWithProvenance(artifact.checksum, provenance.checksum),
+		});
+		const records = await readAuthoritativePackageRelease(
+			PUBLISHER_DID,
+			"gallery",
+			"1.0.0",
+			harness.options,
+		);
+		expect(records.success).toBe(true);
+		if (!records.success) return;
+
+		const report = await verifyAuthoritativePackageRelease(records.value, artifact.digest, {
+			...harness.options,
+			provenanceFetch: () => Promise.resolve(new Response(null, { status: 404 })),
+			resolveHostname: async () => ["93.184.216.34"],
+		});
+
+		expect(report).toMatchObject({ success: false, code: "RESOURCE_STATUS_ERROR" });
+	});
+
+	it("rejects a supplied provenance URL targeting a local host", async () => {
+		const artifact = await checksumAndDigest(encoder.encode("artifact"));
+		const provenance = await checksumAndDigest(encoder.encode("{}"));
+		const harness = await createHarness({
+			release: releaseWithProvenance(
+				artifact.checksum,
+				provenance.checksum,
+				"https://localhost/provenance.json",
+			),
+		});
+		const records = await readAuthoritativePackageRelease(
+			PUBLISHER_DID,
+			"gallery",
+			"1.0.0",
+			harness.options,
+		);
+		expect(records.success).toBe(true);
+		if (!records.success) return;
+
+		const report = await verifyAuthoritativePackageRelease(records.value, artifact.digest, {
+			...harness.options,
+			provenanceFetch: () => {
+				throw new Error("local provenance must not be fetched");
+			},
+			resolveHostname: async () => ["127.0.0.1"],
+		});
+
+		expect(report).toMatchObject({ success: false, code: "HOST_REJECTED" });
+	});
+
+	it("rejects provenance whose source or builder evidence cannot be verified", async () => {
+		const artifact = await checksumAndDigest(encoder.encode("artifact"));
+		const provenanceDocument = encoder.encode("{}");
+		const provenance = await checksumAndDigest(provenanceDocument);
+		const harness = await createHarness({
+			release: releaseWithProvenance(artifact.checksum, provenance.checksum),
+		});
+		const records = await readAuthoritativePackageRelease(
+			PUBLISHER_DID,
+			"gallery",
+			"1.0.0",
+			harness.options,
+		);
+		expect(records.success).toBe(true);
+		if (!records.success) return;
+		const provenanceVerifier: ProvenanceVerifier = {
+			verify: async () => ({
+				success: false,
+				error: {
+					code: "PROVENANCE_UNVERIFIABLE",
+					message: "The provenance source or builder does not match the signed release.",
+				},
+			}),
+		};
+
+		const report = await verifyAuthoritativePackageRelease(records.value, artifact.digest, {
+			...harness.options,
+			provenanceFetch: () => Promise.resolve(new Response(provenanceDocument, { status: 200 })),
+			resolveHostname: async () => ["93.184.216.34"],
+			provenanceVerifier,
+		});
+
+		expect(report).toMatchObject({ success: false, code: "PROVENANCE_UNVERIFIABLE" });
 	});
 });
 

--- a/packages/registry-verification/src/index.ts
+++ b/packages/registry-verification/src/index.ts
@@ -17,7 +17,7 @@ export {
 export { validatePluginBundle } from "./bundle.js";
 export { GitHubProvenanceVerifier } from "./provenance.js";
 export { canonicalizeRepositoryUrl } from "./repository.js";
-export { verifyPackageReleaseRecords } from "./records.js";
+export { inspectPackageReleaseRecords, verifyPackageReleaseRecords } from "./records.js";
 export type { DecodedMultihash, MultihashAlgorithm } from "./checksum.js";
 export type {
 	FetchImplementation,
@@ -37,7 +37,10 @@ export type {
 	NormalizedReleasePolicy,
 	ProvenanceEvidence,
 	ProvenanceStatus,
+	RecordInspectionInput,
+	RecordInspectionReport,
 	RecordVerificationCode,
+	RecordVerificationFailure,
 	RecordVerificationInput,
 	RecordVerificationReason,
 	RecordVerificationReport,

--- a/packages/registry-verification/src/records.ts
+++ b/packages/registry-verification/src/records.ts
@@ -40,6 +40,8 @@ export interface RecordVerificationInput {
 	provenance?: ProvenanceEvidence;
 }
 
+export type RecordInspectionInput = Omit<RecordVerificationInput, "provenance">;
+
 export type RecordVerificationCode =
 	| VerificationErrorCode
 	| "PROVENANCE_ABSENT_OPTIONAL"
@@ -68,6 +70,14 @@ export interface VerifiedRecordContext {
 	verifiedProvenance?: VerifiedProvenance;
 }
 
+export type RecordVerificationFailure = {
+	success: false;
+	status: "failed";
+	code: VerificationErrorCode;
+	reasons: RecordVerificationReason[];
+	provenance: { status: ProvenanceStatus };
+};
+
 export type RecordVerificationReport =
 	| {
 			success: true;
@@ -77,13 +87,18 @@ export type RecordVerificationReport =
 			provenance: { status: "verified" | "absent-optional" };
 			value: VerifiedRecordContext;
 	  }
+	| RecordVerificationFailure;
+
+export type RecordInspectionReport =
 	| {
-			success: false;
-			status: "failed";
-			code: VerificationErrorCode;
+			success: true;
+			status: "inspected";
+			code: "VERIFIED";
 			reasons: RecordVerificationReason[];
-			provenance: { status: ProvenanceStatus };
-	  };
+			provenance: { status: "not-checked" };
+			value: VerifiedRecordContext;
+	  }
+	| RecordVerificationFailure;
 
 const DEFAULT_POLICY: NormalizedReleasePolicy = {
 	requireProvenance: false,
@@ -91,10 +106,10 @@ const DEFAULT_POLICY: NormalizedReleasePolicy = {
 	approvers: [],
 };
 
-/** Validate signed profile/release records and apply the complete provenance policy. */
-export async function verifyPackageReleaseRecords(
-	input: RecordVerificationInput,
-): Promise<RecordVerificationReport> {
+/** Validate signed profile/release records without evaluating provenance evidence. */
+export async function inspectPackageReleaseRecords(
+	input: RecordInspectionInput,
+): Promise<RecordInspectionReport> {
 	const profile = await parseLexicon(PackageProfile.mainSchema, input.profile);
 	if (!profile) return failed("PROFILE_LEXICON_INVALID", "The package profile is malformed.");
 
@@ -184,6 +199,33 @@ export async function verifyPackageReleaseRecords(
 	}
 	const declaredAccess = canonicalizeDeclaredAccess(releaseExtension.declaredAccess);
 
+	return {
+		success: true,
+		status: "inspected",
+		code: "VERIFIED",
+		reasons: [{ code: "VERIFIED", message: "The signed package records are valid." }],
+		provenance: { status: "not-checked" },
+		value: {
+			profile,
+			release,
+			profileExtension,
+			releaseExtension,
+			repository,
+			policy,
+			declaredAccess,
+		},
+	};
+}
+
+/** Validate signed records and apply the complete provenance policy. */
+export async function verifyPackageReleaseRecords(
+	input: RecordVerificationInput,
+): Promise<RecordVerificationReport> {
+	const inspection = await inspectPackageReleaseRecords(input);
+	if (!inspection.success) return inspection;
+	const context = inspection.value;
+	const { policy, release, releaseExtension, repository } = context;
+
 	if (!releaseExtension.provenance) {
 		if (policy.requireProvenance) {
 			return failed(
@@ -203,15 +245,7 @@ export async function verifyPackageReleaseRecords(
 				},
 			],
 			provenance: { status: "absent-optional" },
-			value: {
-				profile,
-				release,
-				profileExtension,
-				releaseExtension,
-				repository,
-				policy,
-				declaredAccess,
-			},
+			value: context,
 		};
 	}
 
@@ -260,13 +294,7 @@ export async function verifyPackageReleaseRecords(
 		reasons: [{ code: "VERIFIED", message: "The signed records and provenance are valid." }],
 		provenance: { status: "verified" },
 		value: {
-			profile,
-			release,
-			profileExtension,
-			releaseExtension,
-			repository,
-			policy,
-			declaredAccess,
+			...context,
 			verifiedProvenance: provenanceResult.value,
 		},
 	};
@@ -302,7 +330,7 @@ function failed(
 	code: VerificationErrorCode,
 	message: string,
 	provenance: ProvenanceStatus = "not-checked",
-): RecordVerificationReport {
+): RecordVerificationFailure {
 	return {
 		success: false,
 		status: "failed",

--- a/packages/registry-verification/tests/records.test.ts
+++ b/packages/registry-verification/tests/records.test.ts
@@ -9,7 +9,7 @@ import type {
 	ReleaseProvenance,
 	VerifiedProvenance,
 } from "../src/index.js";
-import { verifyPackageReleaseRecords } from "../src/index.js";
+import { inspectPackageReleaseRecords, verifyPackageReleaseRecords } from "../src/index.js";
 
 const publisherDid = "did:plc:publisher";
 const packageSlug = "gallery";
@@ -161,6 +161,28 @@ describe("verifyPackageReleaseRecords", () => {
 			success: false,
 			code: "PROVENANCE_REQUIRED",
 			provenance: { status: "absent-required" },
+		});
+	});
+
+	it("inspects signed policy before provenance evidence is available", async () => {
+		const profile = cloneProfile();
+		profile.extensions["com.emdashcms.experimental.package.profileExtension"].releasePolicy = {
+			requireProvenance: true,
+		};
+		expect(
+			await inspectPackageReleaseRecords({
+				publisherDid,
+				package: packageSlug,
+				version,
+				rkey,
+				profile,
+				release: cloneRelease(),
+			}),
+		).toMatchObject({
+			success: true,
+			status: "inspected",
+			provenance: { status: "not-checked" },
+			value: { policy: { requireProvenance: true } },
 		});
 	});
 


### PR DESCRIPTION
## What does this PR do?

Completes installer-side provenance enforcement for experimental decentralized registry installs and updates.

The shared verifier now exposes `inspectPackageReleaseRecords`, allowing the installer to validate signed profile/release records and policy before artifact bytes are available. After the artifact passes checksum and bundle validation, the installer independently fetches the signed provenance URL with HTTPS, DNS, redirect, timeout, and byte-limit guards; verifies the provenance multihash; binds it to the verified artifact digest; and runs the Sigstore/SLSA source and builder checks.

A profile that requires provenance cannot install a release without it. Any release that supplies provenance fails closed when the document is unavailable, oversized, malformed, checksum-mismatched, unsupported, or inconsistent with the artifact, signed source repository, or builder identity—even when provenance is optional in the profile policy.

No release-service endpoint or state participates in the decision.

Related: #1870 and #2643

Stack: #2662 → #2663 → this PR (W9.3 provenance enforcement).

## Type of change

- [ ] Bug fix
- [x] Feature (approved through RFC #1870 and implementation spec #2643)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). N/A: no admin UI strings changed.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion. This work is approved through RFC #1870 and implementation spec #2643.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- `pnpm typecheck` — 31 package typechecks passed
- `pnpm lint:json` — 0 diagnostics
- Core Node suite — 6,042 passed, 9 skipped
- Registry verification Node suite — 94 passed
- Registry verification workerd suite — 36 passed
- Core workerd suite — 8 passed
- Registry verification packed-output check — passed
- `pnpm --filter emdash build` — passed
