### PR TITLE
feat(registry): show verified install evidence

### DIFF
--- a/.changeset/verify-registry-bundles.md
+++ b/.changeset/verify-registry-bundles.md
@@ -1,5 +1,6 @@
 ---
 "emdash": patch
+"@emdash-cms/admin": patch
 "@emdash-cms/registry-client": minor
 "@emdash-cms/registry-verification": minor
 ---
@@ -9,5 +10,7 @@ Adds `DirectPdsClient` for reading package profiles and releases with AT Protoco
 The installer applies the signed profile's release policy, independently fetches and verifies supplied Sigstore/SLSA provenance, and binds moderation labels to the exact profile or release CID. Missing required provenance and any supplied provenance that is unavailable, malformed, mismatched, or unsupported block installation and updates. Artifact checksums, archive paths, bundle limits, manifest identity, and version use the same verification rules as the registry release tooling.
 
 The verification package also exports `inspectPackageReleaseRecords` for validating signed records and policy before artifact and provenance evidence is available.
+
+Registry install and update consent now show the exact verified profile and release CIDs, signed publisher policy, and provenance status. Install consent uses permissions and MCP tools read from the verified bundle rather than the aggregator's record copy.
 
 Release records must contain a lowercase base32 multibase `sha2-256` multihash. Existing releases produced by the EmDash plugin CLI already use this format; nonconforming bare hexadecimal checksums are rejected.

--- a/packages/admin/src/components/CapabilityConsentDialog.tsx
+++ b/packages/admin/src/components/CapabilityConsentDialog.tsx
@@ -13,6 +13,7 @@ import * as React from "react";
 
 import { describeCapability } from "../lib/api/marketplace.js";
 import type { PluginMcpConsentTool } from "../lib/api/marketplace.js";
+import type { RegistryRecordVerificationSummary } from "../lib/api/registry.js";
 import { cn } from "../lib/utils.js";
 import { DialogError } from "./DialogError.js";
 
@@ -33,6 +34,8 @@ export interface CapabilityConsentDialogProps {
 	mcpTools?: PluginMcpConsentTool[];
 	/** Audit verdict badge */
 	auditVerdict?: "pass" | "warn" | "fail";
+	/** Independent signed-record and provenance evidence for registry plugins. */
+	verification?: RegistryRecordVerificationSummary;
 	/** Whether the action is in progress */
 	isPending?: boolean;
 	/** Error message to display inline */
@@ -52,6 +55,7 @@ export function CapabilityConsentDialog({
 	newlyPublicRoutes = [],
 	mcpTools = [],
 	auditVerdict,
+	verification,
 	isPending = false,
 	error,
 	onConfirm,
@@ -72,21 +76,81 @@ export function CapabilityConsentDialog({
 			<div className="absolute inset-0 bg-black/50" onClick={() => !isPending && onCancel()} />
 
 			{/* Dialog */}
-			<div className="relative w-full max-w-md rounded-lg border bg-kumo-base shadow-lg">
+			<div className="relative w-full max-w-lg rounded-lg border bg-kumo-base shadow-lg">
 				{/* Header */}
 				<div className="border-b px-6 py-4">
 					<h2 className="text-lg font-semibold">
-						{isUpdate ? t`Review New Permissions` : t`Plugin Permissions`}
+						{verification
+							? isUpdate
+								? t`Review Verified Update`
+								: t`Review Verified Plugin`
+							: isUpdate
+								? t`Review New Permissions`
+								: t`Plugin Permissions`}
 					</h2>
 					<p className="mt-1 text-sm text-kumo-subtle">
-						{isUpdate
-							? t`${pluginName} is requesting additional permissions:`
-							: t`${pluginName} requires the following permissions:`}
+						{verification
+							? t`Review the independently verified release evidence and permissions for ${pluginName} before continuing.`
+							: isUpdate
+								? t`${pluginName} is requesting additional permissions:`
+								: t`${pluginName} requires the following permissions:`}
 					</p>
 				</div>
 
 				{/* Capabilities list */}
-				<div className="px-6 py-4 space-y-3">
+				<div className="max-h-[70vh] space-y-3 overflow-y-auto px-6 py-4">
+					{verification ? (
+						<div className="rounded-md border border-kumo-success/30 bg-kumo-success/10 p-3 text-sm">
+							<div className="flex items-start gap-2">
+								<ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-kumo-success" />
+								<div>
+									<div className="font-medium">{t`Independent verification`}</div>
+									<p className="mt-1 text-xs text-kumo-subtle">
+										{verification.provenance === "verified"
+											? t`Provenance is verified against the signed release and artifact.`
+											: t`No provenance was supplied; the signed publisher policy permits this.`}
+									</p>
+								</div>
+							</div>
+							<dl className="mt-3 space-y-2 text-xs">
+								<div>
+									<dt className="font-medium text-kumo-subtle">{t`Profile CID`}</dt>
+									<dd className="break-all font-mono">
+										<bdi dir="ltr">{verification.profileCid}</bdi>
+									</dd>
+								</div>
+								<div>
+									<dt className="font-medium text-kumo-subtle">{t`Release CID`}</dt>
+									<dd className="break-all font-mono">
+										<bdi dir="ltr">{verification.releaseCid}</bdi>
+									</dd>
+								</div>
+								<div>
+									<dt className="font-medium text-kumo-subtle">{t`Publisher release policy`}</dt>
+									<dd>
+										{verification.policy.requireProvenance
+											? t`Provenance required`
+											: t`Provenance optional`}
+										{" · "}
+										{verification.policy.confirmation === "always"
+											? t`Publisher approval required for every delegated release`
+											: t`Publisher approval required only for permission escalation`}
+									</dd>
+								</div>
+								{verification.policy.approvers.length > 0 ? (
+									<div>
+										<dt className="font-medium text-kumo-subtle">{t`Authorized approvers`}</dt>
+										{verification.policy.approvers.map((approver) => (
+											<dd key={approver} className="break-all font-mono">
+												<bdi dir="ltr">{approver}</bdi>
+											</dd>
+										))}
+									</div>
+								) : null}
+							</dl>
+						</div>
+					) : null}
+
 					{capabilities.map((cap) => {
 						const isNew = newSet.has(cap);
 						return (

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -43,10 +43,12 @@ import {
 	type PluginMcpConsentTool,
 } from "../lib/api/marketplace.js";
 import {
+	RegistryMcpConsentRequiredError,
 	RegistryUpdateEscalationError,
 	uninstallRegistryPlugin,
 	updateRegistryPlugin,
 	type RegistryUpdateOpts,
+	type RegistryRecordVerificationSummary,
 } from "../lib/api/registry.js";
 import { safeIconUrl } from "../lib/url.js";
 import { cn } from "../lib/utils";
@@ -242,6 +244,8 @@ function PluginCard({
 	const [showUninstallConfirm, setShowUninstallConfirm] = React.useState(false);
 	const [registryEscalation, setRegistryEscalation] =
 		React.useState<RegistryUpdateEscalationError | null>(null);
+	const [registryVerification, setRegistryVerification] =
+		React.useState<RegistryRecordVerificationSummary | null>(null);
 	const queryClient = useQueryClient();
 	const toastManager = Toast.useToastManager();
 
@@ -261,6 +265,7 @@ function PluginCard({
 		onSuccess: () => {
 			setShowUpdateConsent(false);
 			setRegistryEscalation(null);
+			setRegistryVerification(null);
 			setMcpUpdateTools([]);
 			void queryClient.invalidateQueries({ queryKey: ["plugins"] });
 			void queryClient.invalidateQueries({ queryKey: ["plugin-updates"] });
@@ -273,9 +278,14 @@ function PluginCard({
 		onError: (err) => {
 			if (err instanceof RegistryUpdateEscalationError) {
 				setRegistryEscalation(err);
+				setRegistryVerification(err.verification ?? null);
 				setShowUpdateConsent(true);
 			}
-			if (err instanceof PluginMcpConsentRequiredError) {
+			if (err instanceof RegistryMcpConsentRequiredError) {
+				setMcpUpdateTools(err.tools);
+				setRegistryVerification(err.verification ?? null);
+				setShowUpdateConsent(true);
+			} else if (err instanceof PluginMcpConsentRequiredError) {
 				setMcpUpdateTools(err.tools);
 				setShowUpdateConsent(true);
 			}
@@ -289,6 +299,7 @@ function PluginCard({
 			// is none); `onError` opens the consent dialog populated with
 			// the actual diff.
 			setRegistryEscalation(null);
+			setRegistryVerification(null);
 			updateMutation.mutate({});
 		} else {
 			setShowUpdateConsent(true);
@@ -300,6 +311,8 @@ function PluginCard({
 			const opts: RegistryUpdateOpts = {
 				confirmCapabilityChanges: true,
 				confirmMcpTools: mcpUpdateTools.length > 0,
+				acknowledgedProfileCid: registryVerification?.profileCid,
+				acknowledgedReleaseCid: registryVerification?.releaseCid,
 			};
 			if (registryEscalation?.code === "ROUTE_VISIBILITY_ESCALATION") {
 				opts.confirmRouteVisibilityChanges = true;
@@ -644,6 +657,7 @@ function PluginCard({
 					newCapabilities={registryEscalation?.capabilityChanges.added ?? []}
 					newlyPublicRoutes={registryEscalation?.routeVisibilityChanges?.newlyPublic ?? []}
 					mcpTools={mcpUpdateTools}
+					verification={registryVerification ?? undefined}
 					isPending={updateMutation.isPending}
 					error={
 						updateMutation.error instanceof RegistryUpdateEscalationError
@@ -654,6 +668,7 @@ function PluginCard({
 					onCancel={() => {
 						setShowUpdateConsent(false);
 						setRegistryEscalation(null);
+						setRegistryVerification(null);
 						setMcpUpdateTools([]);
 						updateMutation.reset();
 					}}

--- a/packages/admin/src/components/RegistryPluginDetail.tsx
+++ b/packages/admin/src/components/RegistryPluginDetail.tsx
@@ -3,9 +3,9 @@
  *
  * Detail view for a plugin from the experimental decentralized plugin
  * registry. Resolves `(handle, slug)` directly against the configured
- * aggregator; install routes through the EmDash server's
- * `/_emdash/api/admin/plugins/registry/install` endpoint, which
- * re-resolves and re-verifies before writing the install.
+ * aggregator. Consent and installation route through the EmDash server,
+ * which independently verifies publisher records, artifact, manifest, and
+ * provenance before any write.
  *
  * Identified in the URL by a `pluginId` that is `${handle}/${slug}`.
  * The router wraps this component when `manifest.registry` is set on
@@ -46,7 +46,9 @@ import {
 	releasePassesPolicy,
 	resolveRegistryPackageStatus,
 	sbomDownloadHref,
+	verifyRegistryPlugin,
 	type RegistryClientConfig,
+	type RegistryInstallResult,
 	type RegistryReleaseView,
 	type SectionKey,
 } from "../lib/api/registry.js";
@@ -68,6 +70,8 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 	const queryClient = useQueryClient();
 	const [showConsent, setShowConsent] = React.useState(false);
 	const [mcpConsentTools, setMcpConsentTools] = React.useState<PluginMcpConsentTool[]>([]);
+	const [verificationPreview, setVerificationPreview] =
+		React.useState<RegistryInstallResult | null>(null);
 
 	// Plugins list — used to compute whether this package is already
 	// installed. Same query key as elsewhere so the install mutation's
@@ -223,17 +227,10 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 	const isPreRelease = release ? isPreReleaseVersion(release.version) : false;
 
 	// `release.extensions[com.emdashcms.experimental.package.releaseExtension]`
-	// carries the structured `declaredAccess` -- the trust contract. The sandbox
-	// enforces the legacy `capabilities: string[]` shape, so we derive that list
-	// from declaredAccess using the SAME total converter the bundler and runtime
-	// use (`@emdash-cms/plugin-types`). Deriving via the shared converter -- not
-	// a component-local reimplementation -- is what keeps the consent list equal
-	// to what the install handler enforces; an earlier divergent local flattener
-	// dropped hook-registration capabilities and broke every such install.
-	//
-	// `canonicalCapabilitiesForDriftCheck` filters non-strings, dedupes, and
-	// sorts so an aggregator-supplied array with unstable order can't trigger a
-	// spurious server-side drift rejection later.
+	// carries the aggregator's copy of `declaredAccess`. This list is only a
+	// preliminary detail-page preview. The consent dialog uses the server's
+	// direct-PDS verification response and the manifest extracted from the
+	// checksum-verified bundle.
 	//
 	// NSID is exact-matched, not prefix-matched. RFC 0001 fixes the NSID for
 	// this extension; accepting variants like `…releaseExtensionV2` would let a
@@ -376,38 +373,52 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 		);
 	}, [pkg, installedPlugins, slug]);
 	const isInstalled = Boolean(installedEntry);
+	const activeVerification =
+		verificationPreview !== null &&
+		verificationPreview.publisherDid === pkg?.did &&
+		verificationPreview.slug === slug &&
+		verificationPreview.version === release?.version
+			? verificationPreview
+			: null;
+
+	const verificationMutation = useMutation({
+		mutationFn: () => {
+			if (!pkg || !release) throw new Error(t`Select a release before verifying it`);
+			return verifyRegistryPlugin({
+				did: pkg.did,
+				slug,
+				version: release.version,
+			});
+		},
+		onSuccess: (result) => {
+			setVerificationPreview(result);
+			setMcpConsentTools(result.mcpTools);
+			setShowConsent(true);
+		},
+	});
 
 	const installMutation = useMutation({
 		mutationFn: () => {
 			if (!pkg) throw new Error("Package not loaded");
+			if (!activeVerification) throw new Error(t`Verify the plugin before installing it`);
 			return installRegistryPlugin({
 				did: pkg.did,
 				slug,
-				version: release?.version,
-				// Always send the acknowledgement, even when the dialog
-				// showed no permissions. The server compares this list
-				// against the bundle's actual `manifest.capabilities`
-				// after download:
-				//
-				//   - If the bundle has capabilities, the server
-				//     requires us to send a matching list (the consent
-				//     dialog is the only place the admin sees what
-				//     they're agreeing to).
-				//   - If the bundle has no capabilities, no consent is
-				//     required and the server ignores this field.
-				//
-				// Sending the empty list when the release extension was
-				// missing means a publisher who ships a bundle with
-				// permissions but no extension block can't sneak the
-				// permissions past an empty consent dialog -- the
-				// server will refuse with `DECLARED_ACCESS_REQUIRED`.
-				acknowledgedDeclaredAccess: capabilities,
+				version: activeVerification.version,
+				// The server re-fetches the signed records and bundle, then
+				// requires these permissions, tools, and CIDs to match the
+				// evidence shown in the dialog.
+				acknowledgedDeclaredAccess: activeVerification.capabilities,
 				acknowledgedMcpTools: mcpConsentTools,
+				acknowledgedProfileCid: activeVerification.verification.profileCid,
+				acknowledgedReleaseCid: activeVerification.verification.releaseCid,
 			});
 		},
 		onSuccess: () => {
 			setShowConsent(false);
 			setMcpConsentTools([]);
+			setVerificationPreview(null);
+			verificationMutation.reset();
 			void queryClient.invalidateQueries({ queryKey: ["plugins"] });
 			void queryClient.invalidateQueries({ queryKey: ["manifest"] });
 			void queryClient.invalidateQueries({ queryKey: ["registry"] });
@@ -585,16 +596,44 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 					) : (
 						<Button
 							variant="primary"
-							disabled={!release || !policyOk || !envOk}
-							onClick={() => setShowConsent(true)}
+							disabled={
+								!release ||
+								!policyOk ||
+								!envOk ||
+								handleResult.status === "invalid" ||
+								verificationMutation.isPending
+							}
+							onClick={() => verificationMutation.mutate()}
 						>
-							{t`Install`}
+							{verificationMutation.isPending ? t`Verifying...` : t`Install`}
 						</Button>
 					)}
 				</div>
 			</div>
+			{verificationMutation.error ? (
+				<div
+					className="rounded-md border border-kumo-error bg-kumo-error/10 p-4 text-sm text-kumo-error"
+					role="alert"
+				>
+					{getMutationError(verificationMutation.error)}
+				</div>
+			) : null}
 
-			{/* The aggregator returned records but none passed lexicon validation. */}
+			{handleResult.status === "invalid" ? (
+				<div
+					className="flex items-start gap-3 rounded-md border border-kumo-error bg-kumo-error/10 p-4 text-kumo-error"
+					role="alert"
+				>
+					<Warning className="mt-0.5 h-5 w-5 shrink-0" />
+					<div>
+						<p className="font-medium">{t`We couldn't verify this publisher's identity`}</p>
+						<p className="mt-1 text-sm text-kumo-default">
+							{t`This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying.`}
+						</p>
+					</div>
+				</div>
+			) : null}
+
 			{hasFilteredAllReleases ? (
 				<div
 					className="flex items-start gap-3 rounded-md border border-kumo-warning bg-kumo-warning/10 p-4 text-kumo-warning"
@@ -792,18 +831,23 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 			) : null}
 
 			{/* Consent dialog */}
-			{showConsent && release ? (
+			{showConsent && release && activeVerification ? (
 				<CapabilityConsentDialog
 					mode="install"
 					pluginName={displayName ?? slug}
-					capabilities={capabilities}
+					capabilities={activeVerification.capabilities}
+					allowedHosts={
+						declaredAccessToCapabilities(activeVerification.declaredAccess).allowedHosts
+					}
 					mcpTools={mcpConsentTools}
+					verification={activeVerification.verification}
 					isPending={installMutation.isPending}
 					error={getMutationError(installMutation.error)}
 					onConfirm={() => installMutation.mutate()}
 					onCancel={() => {
 						setShowConsent(false);
 						setMcpConsentTools([]);
+						setVerificationPreview(null);
 						installMutation.reset();
 					}}
 				/>

--- a/packages/admin/src/lib/api/registry.ts
+++ b/packages/admin/src/lib/api/registry.ts
@@ -7,11 +7,10 @@
  *     via `@emdash-cms/registry-client`'s `DiscoveryClient`. The
  *     aggregator is a public, CORS-enabled atproto AppView; no server
  *     proxy is needed.
- *   - **Install**: POST to the EmDash server (which holds the sandbox,
- *     R2, and `_plugin_state` table). The server re-resolves the same
- *     `(handle, slug)` against the aggregator, re-verifies the bundle,
- *     and writes the install. The browser is the consent UI; the server
- *     is the install actor.
+ *   - **Verify / install**: POST to the EmDash server. The server reads
+ *     signed records directly from the publisher PDS, verifies the bundle
+ *     and provenance, returns consent evidence, then repeats those checks
+ *     against acknowledged CIDs when installing.
  *
  * The discovery client is constructed lazily so we only pull
  * `@atcute/client` into the admin bundle when the registry path is
@@ -20,6 +19,7 @@
  */
 
 import type { Did, Handle } from "@atcute/lexicons";
+import type { DeclaredAccess } from "@emdash-cms/plugin-types";
 import type {
 	ListingStatusResult,
 	ValidatedListReleases,
@@ -91,6 +91,8 @@ export interface RegistryInstallRequest {
 	version?: string;
 	acknowledgedDeclaredAccess?: unknown;
 	acknowledgedMcpTools?: PluginMcpConsentTool[];
+	acknowledgedProfileCid?: string;
+	acknowledgedReleaseCid?: string;
 }
 
 export interface RegistryInstallResult {
@@ -99,6 +101,20 @@ export interface RegistryInstallResult {
 	slug: string;
 	version: string;
 	capabilities: string[];
+	declaredAccess: DeclaredAccess;
+	mcpTools: PluginMcpConsentTool[];
+	verification: RegistryRecordVerificationSummary;
+}
+
+export interface RegistryRecordVerificationSummary {
+	profileCid: string;
+	releaseCid: string;
+	provenance: "verified" | "absent-optional";
+	policy: {
+		requireProvenance: boolean;
+		confirmation: "escalation-only" | "always";
+		approvers: string[];
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -730,13 +746,24 @@ export function extractMediaArtifacts(artifacts: unknown): MediaArtifacts {
 // ---------------------------------------------------------------------------
 
 const INSTALL_ENDPOINT = `${API_BASE}/admin/plugins/registry/install`;
+const VERIFY_ENDPOINT = `${API_BASE}/admin/plugins/registry/verify`;
+
+export async function verifyRegistryPlugin(
+	body: Pick<RegistryInstallRequest, "did" | "slug" | "version">,
+): Promise<RegistryInstallResult> {
+	const response = await apiFetch(VERIFY_ENDPOINT, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+	return parseApiResponse<RegistryInstallResult>(response, i18n._(msg`Failed to verify plugin`));
+}
 
 /**
  * Install a plugin from the registry.
  *
- * Posts to the EmDash server, which re-resolves the same `(handle,
- * slug)` against the aggregator, re-verifies the bundle's checksum
- * against the signed release record, and writes the install. Surfaces
+ * Posts to the EmDash server, which re-fetches the acknowledged signed
+ * records, bundle, and provenance before writing the install. Surfaces
  * structured error codes (`RELEASE_YANKED`, `CHECKSUM_MISMATCH`,
  * `DECLARED_ACCESS_DRIFT`, etc.) that callers map to localized
  * messages.
@@ -769,6 +796,8 @@ export interface RegistryUpdateOpts {
 	confirmCapabilityChanges?: boolean;
 	confirmRouteVisibilityChanges?: boolean;
 	confirmMcpTools?: boolean;
+	acknowledgedProfileCid?: string;
+	acknowledgedReleaseCid?: string;
 }
 
 export interface RegistryUninstallOpts {
@@ -785,17 +814,30 @@ export class RegistryUpdateEscalationError extends Error {
 	readonly code: "CAPABILITY_ESCALATION" | "ROUTE_VISIBILITY_ESCALATION";
 	readonly capabilityChanges: { added: string[]; removed: string[] };
 	readonly routeVisibilityChanges?: { newlyPublic: string[] };
+	readonly verification?: RegistryRecordVerificationSummary;
 	constructor(
 		code: "CAPABILITY_ESCALATION" | "ROUTE_VISIBILITY_ESCALATION",
 		message: string,
 		capabilityChanges: { added: string[]; removed: string[] },
 		routeVisibilityChanges?: { newlyPublic: string[] },
+		verification?: RegistryRecordVerificationSummary,
 	) {
 		super(message);
 		this.name = "RegistryUpdateEscalationError";
 		this.code = code;
 		this.capabilityChanges = capabilityChanges;
 		this.routeVisibilityChanges = routeVisibilityChanges;
+		this.verification = verification;
+	}
+}
+
+export class RegistryMcpConsentRequiredError extends PluginMcpConsentRequiredError {
+	constructor(
+		tools: PluginMcpConsentTool[],
+		readonly verification?: RegistryRecordVerificationSummary,
+	) {
+		super(tools);
+		this.name = "RegistryMcpConsentRequiredError";
 	}
 }
 
@@ -834,7 +876,7 @@ export async function updateRegistryPlugin(
 	await throwResponseError(response, i18n._(msg`Failed to update plugin`));
 }
 
-function parseMcpConsent(body: unknown): PluginMcpConsentRequiredError | null {
+function parseMcpConsent(body: unknown): RegistryMcpConsentRequiredError | null {
 	if (!body || typeof body !== "object" || !("error" in body)) return null;
 	const error = body.error;
 	if (!error || typeof error !== "object" || !("code" in error)) return null;
@@ -844,7 +886,10 @@ function parseMcpConsent(body: unknown): PluginMcpConsentRequiredError | null {
 			? (error.details as { mcpTools?: PluginMcpConsentTool[] })
 			: {};
 	return details.mcpTools && details.mcpTools.length > 0
-		? new PluginMcpConsentRequiredError(details.mcpTools)
+		? new RegistryMcpConsentRequiredError(
+				details.mcpTools,
+				normaliseRegistryVerification("verification" in details ? details.verification : undefined),
+			)
 		: null;
 }
 
@@ -862,6 +907,9 @@ function parseEscalation(body: unknown): RegistryUpdateEscalationError | null {
 	const routeVisibilityChanges = normaliseRouteVisibilityChanges(
 		"routeVisibilityChanges" in details ? details.routeVisibilityChanges : undefined,
 	);
+	const verification = normaliseRegistryVerification(
+		"verification" in details ? details.verification : undefined,
+	);
 	const message =
 		"message" in error && typeof error.message === "string"
 			? error.message
@@ -871,7 +919,44 @@ function parseEscalation(body: unknown): RegistryUpdateEscalationError | null {
 		message,
 		capabilityChanges,
 		routeVisibilityChanges,
+		verification,
 	);
+}
+
+function normaliseRegistryVerification(
+	value: unknown,
+): RegistryRecordVerificationSummary | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const profileCid = Reflect.get(value, "profileCid");
+	const releaseCid = Reflect.get(value, "releaseCid");
+	const provenance = Reflect.get(value, "provenance");
+	const policy = Reflect.get(value, "policy");
+	if (
+		typeof profileCid !== "string" ||
+		typeof releaseCid !== "string" ||
+		(provenance !== "verified" && provenance !== "absent-optional") ||
+		!policy ||
+		typeof policy !== "object"
+	) {
+		return undefined;
+	}
+	const requireProvenance = Reflect.get(policy, "requireProvenance");
+	const confirmation = Reflect.get(policy, "confirmation");
+	const approvers = Reflect.get(policy, "approvers");
+	if (
+		typeof requireProvenance !== "boolean" ||
+		(confirmation !== "always" && confirmation !== "escalation-only") ||
+		!Array.isArray(approvers) ||
+		!approvers.every((approver) => typeof approver === "string")
+	) {
+		return undefined;
+	}
+	return {
+		profileCid,
+		releaseCid,
+		provenance,
+		policy: { requireProvenance, confirmation, approvers },
+	};
 }
 
 function normaliseCapabilityChanges(value: unknown): { added: string[]; removed: string[] } {

--- a/packages/admin/tests/components/CapabilityConsentDialog.test.tsx
+++ b/packages/admin/tests/components/CapabilityConsentDialog.test.tsx
@@ -1,3 +1,4 @@
+import { i18n } from "@lingui/core";
 import * as React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -252,5 +253,103 @@ describe("CapabilityConsentDialog", () => {
 
 		const dialog = screen.getByRole("dialog");
 		await expect.element(dialog).toBeInTheDocument();
+	});
+
+	it("shows verified provenance, exact record CIDs, and signed policy", async () => {
+		const screen = await render(
+			<CapabilityConsentDialog
+				pluginName="Test"
+				capabilities={[]}
+				verification={{
+					profileCid: "bafy-profile",
+					releaseCid: "bafy-release",
+					provenance: "verified",
+					policy: {
+						requireProvenance: true,
+						confirmation: "always",
+						approvers: ["did:plc:approver"],
+					},
+				}}
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+
+		await expect.element(screen.getByText("Independent verification")).toBeInTheDocument();
+		await expect
+			.element(screen.getByText("Provenance is verified against the signed release and artifact."))
+			.toBeInTheDocument();
+		await expect.element(screen.getByText("bafy-profile")).toBeInTheDocument();
+		await expect.element(screen.getByText("bafy-release")).toBeInTheDocument();
+		await expect.element(screen.getByText("Provenance required")).toBeInTheDocument();
+		await expect
+			.element(screen.getByText("Publisher approval required for every delegated release"))
+			.toBeInTheDocument();
+		await expect.element(screen.getByText("did:plc:approver")).toBeInTheDocument();
+	});
+
+	it("explains when absent provenance is permitted by signed policy", async () => {
+		const screen = await render(
+			<CapabilityConsentDialog
+				pluginName="Test"
+				capabilities={[]}
+				verification={{
+					profileCid: "bafy-profile",
+					releaseCid: "bafy-release",
+					provenance: "absent-optional",
+					policy: {
+						requireProvenance: false,
+						confirmation: "escalation-only",
+						approvers: [],
+					},
+				}}
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+
+		await expect
+			.element(
+				screen.getByText("No provenance was supplied; the signed publisher policy permits this."),
+			)
+			.toBeInTheDocument();
+		await expect.element(screen.getByText("Provenance optional")).toBeInTheDocument();
+		await expect
+			.element(screen.getByText("Publisher approval required only for permission escalation"))
+			.toBeInTheDocument();
+	});
+
+	it("keeps CIDs and DIDs readable in Arabic RTL mode", async () => {
+		const previousLocale = i18n.locale;
+		i18n.load("ar", {});
+		i18n.activate("ar");
+		try {
+			const screen = await render(
+				<div dir="rtl">
+					<CapabilityConsentDialog
+						pluginName="Test"
+						capabilities={[]}
+						verification={{
+							profileCid: "bafy-profile",
+							releaseCid: "bafy-release",
+							provenance: "verified",
+							policy: {
+								requireProvenance: true,
+								confirmation: "always",
+								approvers: ["did:plc:approver"],
+							},
+						}}
+						onConfirm={onConfirm}
+						onCancel={onCancel}
+					/>
+				</div>,
+			);
+
+			expect(screen.getByText("bafy-profile").element().getAttribute("dir")).toBe("ltr");
+			expect(screen.getByText("bafy-release").element().getAttribute("dir")).toBe("ltr");
+			expect(screen.getByText("did:plc:approver").element().getAttribute("dir")).toBe("ltr");
+		} finally {
+			i18n.activate(previousLocale);
+		}
 	});
 });

--- a/packages/admin/tests/components/RegistryPluginDetail.test.tsx
+++ b/packages/admin/tests/components/RegistryPluginDetail.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
 	RegistryClientConfig,
+	RegistryInstallResult,
 	RegistryPackageView,
 	RegistryReleaseView,
 } from "../../src/lib/api/registry";
@@ -26,6 +27,8 @@ vi.mock("@tanstack/react-router", async () => {
 const mockGetRegistryPackageStatus = vi.fn();
 const mockResolveRegistryPackageStatus = vi.fn();
 const mockListRegistryReleases = vi.fn();
+const mockVerifyRegistryPlugin = vi.fn();
+const mockInstallRegistryPlugin = vi.fn();
 
 vi.mock("../../src/lib/api/registry", async () => {
 	const actual = await vi.importActual<typeof import("../../src/lib/api/registry")>(
@@ -36,6 +39,9 @@ vi.mock("../../src/lib/api/registry", async () => {
 		getRegistryPackageStatus: (...a: unknown[]) => mockGetRegistryPackageStatus(...a),
 		resolveRegistryPackageStatus: (...a: unknown[]) => mockResolveRegistryPackageStatus(...a),
 		listRegistryReleases: (...a: unknown[]) => mockListRegistryReleases(...a),
+		verifyRegistryPlugin: (...a: unknown[]) => mockVerifyRegistryPlugin(...a),
+		installRegistryPlugin: (...a: unknown[]) => mockInstallRegistryPlugin(...a),
+		resolveDidToHandle: vi.fn(async () => ({ status: "ok", handle: "acme.dev" })),
 	};
 });
 
@@ -120,6 +126,28 @@ function setup(pkg: RegistryPackageView, releases: RegistryReleaseView[]) {
 	mockGetRegistryPackageStatus.mockResolvedValue({ status: "passed", value: pkg });
 	mockResolveRegistryPackageStatus.mockResolvedValue({ status: "passed", value: pkg });
 	mockListRegistryReleases.mockResolvedValue({ releases });
+}
+
+function verificationPreview(): RegistryInstallResult {
+	return {
+		pluginId: "r_verified",
+		publisherDid: "did:plc:acme",
+		slug: "myplugin",
+		version: "1.2.3",
+		capabilities: ["users:read"],
+		declaredAccess: { users: { read: {} } },
+		mcpTools: [],
+		verification: {
+			profileCid: "bafy-profile",
+			releaseCid: "bafy-release",
+			provenance: "verified",
+			policy: {
+				requireProvenance: true,
+				confirmation: "always",
+				approvers: ["did:plc:approver"],
+			},
+		},
+	};
 }
 
 describe("RegistryPluginDetail sections", () => {
@@ -283,7 +311,66 @@ describe("RegistryPluginDetail release withdrawal", () => {
 	});
 });
 
-describe("RegistryPluginDetail approved publisher identity", () => {
+describe("RegistryPluginDetail independent install consent", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("opens consent from the server's verified bundle and provenance report", async () => {
+		setup(makePackage(), [
+			makeRelease({
+				extensions: {
+					[RELEASE_EXTENSION_NSID]: {
+						declaredAccess: { content: { read: {} } },
+					},
+				},
+			}),
+		]);
+		mockVerifyRegistryPlugin.mockResolvedValue(verificationPreview());
+		mockInstallRegistryPlugin.mockResolvedValue(verificationPreview());
+		const screen = await render(
+			<Wrapper>
+				<RegistryPluginDetail pluginId="acme.dev/myplugin" config={CONFIG} />
+			</Wrapper>,
+		);
+
+		await screen.getByRole("button", { name: "Install" }).click();
+
+		expect(mockVerifyRegistryPlugin).toHaveBeenCalledWith({
+			did: "did:plc:acme",
+			slug: "myplugin",
+			version: "1.2.3",
+		});
+		await expect.element(screen.getByText("Independent verification")).toBeInTheDocument();
+		await expect.element(screen.getByText("Read user accounts")).toBeInTheDocument();
+		await expect.element(screen.getByText("bafy-profile")).toBeInTheDocument();
+		await expect.element(screen.getByText("bafy-release")).toBeInTheDocument();
+		await screen.getByRole("button", { name: "Accept & Install" }).click();
+		expect(mockInstallRegistryPlugin).toHaveBeenCalledWith(
+			expect.objectContaining({
+				acknowledgedProfileCid: "bafy-profile",
+				acknowledgedReleaseCid: "bafy-release",
+			}),
+		);
+	});
+
+	it("shows a verification failure without opening consent", async () => {
+		setup(makePackage(), [makeRelease()]);
+		mockVerifyRegistryPlugin.mockRejectedValue(new Error("Repository proof invalid"));
+		const screen = await render(
+			<Wrapper>
+				<RegistryPluginDetail pluginId="acme.dev/myplugin" config={CONFIG} />
+			</Wrapper>,
+		);
+
+		await screen.getByRole("button", { name: "Install" }).click();
+
+		await expect.element(screen.getByRole("alert")).toHaveTextContent("Repository proof invalid");
+		expect(screen.getByRole("dialog").query()).toBeNull();
+	});
+});
+
+describe("RegistryPluginDetail lastUpdated and approved publisher identity", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});

--- a/packages/admin/tests/lib/registry-consent.test.ts
+++ b/packages/admin/tests/lib/registry-consent.test.ts
@@ -1,7 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PluginMcpConsentRequiredError } from "../../src/lib/api/marketplace";
-import { updateRegistryPlugin } from "../../src/lib/api/registry";
+import {
+	RegistryMcpConsentRequiredError,
+	RegistryUpdateEscalationError,
+	updateRegistryPlugin,
+} from "../../src/lib/api/registry";
+
+const verification = {
+	profileCid: "bafy-profile",
+	releaseCid: "bafy-release",
+	provenance: "verified",
+	policy: {
+		requireProvenance: true,
+		confirmation: "always",
+		approvers: ["did:plc:approver"],
+	},
+} as const;
 
 describe("registry MCP consent errors", () => {
 	let fetchSpy: ReturnType<typeof vi.fn>;
@@ -51,7 +66,7 @@ describe("registry MCP consent errors", () => {
 				JSON.stringify({
 					error: {
 						code: "MCP_TOOL_CONSENT_REQUIRED",
-						details: { mcpTools: [tool] },
+						details: { mcpTools: [tool], verification },
 					},
 				}),
 				{ status: 409 },
@@ -61,5 +76,29 @@ describe("registry MCP consent errors", () => {
 		const error = await updateRegistryPlugin("my-plugin").catch((reason: unknown) => reason);
 		expect(error).toBeInstanceOf(PluginMcpConsentRequiredError);
 		expect((error as PluginMcpConsentRequiredError).tools).toEqual([tool]);
+		expect(error).toBeInstanceOf(RegistryMcpConsentRequiredError);
+		expect((error as RegistryMcpConsentRequiredError).verification).toEqual(verification);
+	});
+
+	it("preserves verification evidence on capability escalation", async () => {
+		fetchSpy.mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					error: {
+						code: "CAPABILITY_ESCALATION",
+						message: "Plugin update requires new capabilities",
+						details: {
+							capabilityChanges: { added: ["users:read"], removed: [] },
+							verification,
+						},
+					},
+				}),
+				{ status: 409 },
+			),
+		);
+
+		const error = await updateRegistryPlugin("my-plugin").catch((reason: unknown) => reason);
+		expect(error).toBeInstanceOf(RegistryUpdateEscalationError);
+		expect((error as RegistryUpdateEscalationError).verification).toEqual(verification);
 	});
 });

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -139,6 +139,8 @@ export interface RegistryInstallInput {
 	 */
 	acknowledgedDeclaredAccess?: unknown;
 	acknowledgedMcpTools?: unknown;
+	acknowledgedProfileCid?: string;
+	acknowledgedReleaseCid?: string;
 }
 
 export interface RegistryInstallResult {
@@ -152,7 +154,17 @@ export interface RegistryInstallResult {
 	version: string;
 	/** Capabilities surfaced from the bundle's manifest. */
 	capabilities: string[];
+	declaredAccess: DeclaredAccess;
+	mcpTools: RegistryMcpConsentTool[];
 	verification: RegistryRecordVerificationSummary;
+}
+
+export interface RegistryMcpConsentTool {
+	name: string;
+	description: string;
+	route: string;
+	permission: string;
+	destructive: boolean;
 }
 
 export interface RegistryRecordVerificationSummary {
@@ -211,6 +223,31 @@ function registryRecordError(
 			details: { verificationCode: code },
 		},
 	};
+}
+
+function recordConsentError(
+	input: { profileCid?: string; releaseCid?: string },
+	records: VerifiedAuthoritativeRecords,
+): ApiResult<never> | null {
+	if (!input.profileCid || !input.releaseCid) {
+		return {
+			success: false,
+			error: {
+				code: "RECORD_CONSENT_REQUIRED",
+				message: "Verify the signed package records before confirming this action.",
+			},
+		};
+	}
+	if (input.profileCid !== records.profile.cid || input.releaseCid !== records.release.cid) {
+		return {
+			success: false,
+			error: {
+				code: "RECORD_VERIFICATION_DRIFT",
+				message: "The signed package records changed after review. Verify them again.",
+			},
+		};
+	}
+	return null;
 }
 
 function recordVerificationSummary(
@@ -514,6 +551,7 @@ export async function handleRegistryInstall(
 		hostEnv?: HostEnv;
 		authoritativeRecords?: AuthoritativeRecordReadOptions;
 		readAuthoritativeRecords?: AuthoritativeRecordReader;
+		verifyOnly?: boolean;
 	},
 ): Promise<ApiResult<RegistryInstallResult>> {
 	// Accept either the bare-string shorthand or the full
@@ -714,6 +752,16 @@ export async function handleRegistryInstall(
 		}
 		const records = authoritative.value;
 		const { profile, release } = records.inspection.value;
+		if (!opts?.verifyOnly) {
+			const consentError = recordConsentError(
+				{
+					profileCid: input.acknowledgedProfileCid,
+					releaseCid: input.acknowledgedReleaseCid,
+				},
+				records,
+			);
+			if (consentError) return consentError;
+		}
 
 		const packageYanked =
 			hasCurrentRecordLabel(packageView.labels ?? [], "security:yanked", records.profile) ||
@@ -909,6 +957,7 @@ export async function handleRegistryInstall(
 				recordReport.reasons[0]?.message ?? "The release provenance is invalid.",
 			);
 		}
+		const verification = recordVerificationSummary(records, recordReport);
 
 		// Rewrite the manifest's id to the derived opaque pluginId before
 		// it reaches R2 storage or the sandbox loader. The sandbox uses
@@ -960,7 +1009,7 @@ export async function handleRegistryInstall(
 		// the runtime starts enforcing `declaredAccess` natively, this
 		// comparison switches to that shape.
 		const actualCapabilities = canonicalCapabilitiesForDriftCheck(bundle.manifest.capabilities);
-		if (actualCapabilities.length > 0) {
+		if (!opts?.verifyOnly && actualCapabilities.length > 0) {
 			if (input.acknowledgedDeclaredAccess === undefined) {
 				return {
 					success: false,
@@ -990,18 +1039,30 @@ export async function handleRegistryInstall(
 		const actualMcpTools = (bundle.manifest.mcp?.tools ?? []).map(
 			({ inputSchema: _, outputSchema: __, ...tool }) => tool,
 		);
-		if (actualMcpTools.length > 0) {
+		if (!opts?.verifyOnly && actualMcpTools.length > 0) {
 			if (JSON.stringify(input.acknowledgedMcpTools) !== JSON.stringify(actualMcpTools)) {
 				return {
 					success: false,
 					error: {
 						code: "MCP_TOOL_CONSENT_REQUIRED",
 						message: "Plugin MCP tools require explicit consent",
-						details: { mcpTools: actualMcpTools },
+						details: { mcpTools: actualMcpTools, verification },
 					},
 				};
 			}
 		}
+
+		const result: RegistryInstallResult = {
+			pluginId,
+			publisherDid,
+			slug,
+			version,
+			capabilities: bundle.manifest.capabilities,
+			declaredAccess: recordReport.value.releaseExtension.declaredAccess,
+			mcpTools: actualMcpTools,
+			verification,
+		};
+		if (opts?.verifyOnly) return { success: true, data: result };
 
 		// Step 7: store in R2 under the registry prefix.
 		await storeBundleInR2(storage, pluginId, version, bundle, "registry");
@@ -1071,14 +1132,7 @@ export async function handleRegistryInstall(
 
 		return {
 			success: true,
-			data: {
-				pluginId,
-				publisherDid,
-				slug,
-				version,
-				capabilities: bundle.manifest.capabilities,
-				verification: recordVerificationSummary(records, recordReport),
-			},
+			data: result,
 		};
 	} catch (err) {
 		if (err instanceof ClientValidationError) {
@@ -1241,6 +1295,8 @@ export async function handleRegistryUpdate(
 		confirmCapabilityChanges?: boolean;
 		confirmRouteVisibilityChanges?: boolean;
 		confirmMcpTools?: boolean;
+		acknowledgedProfileCid?: string;
+		acknowledgedReleaseCid?: string;
 		hostEnv?: HostEnv;
 		authoritativeRecords?: AuthoritativeRecordReadOptions;
 		readAuthoritativeRecords?: AuthoritativeRecordReader;
@@ -1398,6 +1454,20 @@ export async function handleRegistryUpdate(
 		}
 		const records = authoritative.value;
 		const { profile, release } = records.inspection.value;
+		if (
+			opts?.confirmCapabilityChanges ||
+			opts?.confirmRouteVisibilityChanges ||
+			opts?.confirmMcpTools
+		) {
+			const consentError = recordConsentError(
+				{
+					profileCid: opts.acknowledgedProfileCid,
+					releaseCid: opts.acknowledgedReleaseCid,
+				},
+				records,
+			);
+			if (consentError) return consentError;
+		}
 
 		const authoritativeReleaseWithdrawal = evaluateRegistryReleaseWithdrawal(
 			{
@@ -1470,6 +1540,7 @@ export async function handleRegistryUpdate(
 				recordReport.reasons[0]?.message ?? "The release provenance is invalid.",
 			);
 		}
+		const verification = recordVerificationSummary(records, recordReport);
 
 		// Rewrite manifest.id to the opaque pluginId so the sandbox loader
 		// and R2 layout stay in sync across install and update.
@@ -1507,7 +1578,7 @@ export async function handleRegistryUpdate(
 				error: {
 					code: "CAPABILITY_ESCALATION",
 					message: "Plugin update requires new capabilities",
-					details: { capabilityChanges },
+					details: { capabilityChanges, verification },
 				},
 			};
 		}
@@ -1520,7 +1591,7 @@ export async function handleRegistryUpdate(
 				error: {
 					code: "ROUTE_VISIBILITY_ESCALATION",
 					message: "Plugin update exposes new public (unauthenticated) routes",
-					details: { routeVisibilityChanges, capabilityChanges },
+					details: { routeVisibilityChanges, capabilityChanges, verification },
 				},
 			};
 		}
@@ -1539,6 +1610,7 @@ export async function handleRegistryUpdate(
 					message: "Plugin update changes its MCP tools",
 					details: {
 						mcpTools: newMcpTools.map(({ inputSchema: _, outputSchema: __, ...tool }) => tool),
+						verification,
 					},
 				},
 			};
@@ -1575,7 +1647,7 @@ export async function handleRegistryUpdate(
 				newVersion,
 				capabilityChanges,
 				routeVisibilityChanges: hasNewPublicRoutes ? routeVisibilityChanges : undefined,
-				verification: recordVerificationSummary(records, recordReport),
+				verification,
 			},
 		};
 	} catch (err) {

--- a/packages/core/src/astro/routes/api/admin/plugins/registry/[id]/update.ts
+++ b/packages/core/src/astro/routes/api/admin/plugins/registry/[id]/update.ts
@@ -38,6 +38,8 @@ const updateBodySchema = z.object({
 	 */
 	confirmRouteVisibilityChanges: z.boolean().optional(),
 	confirmMcpTools: z.boolean().optional(),
+	acknowledgedProfileCid: z.string().min(1).max(256).optional(),
+	acknowledgedReleaseCid: z.string().min(1).max(256).optional(),
 });
 
 export const POST: APIRoute = async ({ params, request, locals }) => {
@@ -73,6 +75,8 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 				confirmCapabilityChanges: body.confirmCapabilityChanges,
 				confirmRouteVisibilityChanges: body.confirmRouteVisibilityChanges,
 				confirmMcpTools: body.confirmMcpTools,
+				acknowledgedProfileCid: body.acknowledgedProfileCid,
+				acknowledgedReleaseCid: body.acknowledgedReleaseCid,
 				hostEnv: hostEnvFromVersions(VERSION, emdash.config.astroVersion),
 			},
 		);

--- a/packages/core/src/astro/routes/api/admin/plugins/registry/install.ts
+++ b/packages/core/src/astro/routes/api/admin/plugins/registry/install.ts
@@ -59,6 +59,8 @@ const installBodySchema = z.object({
 	 */
 	acknowledgedDeclaredAccess: z.unknown().optional(),
 	acknowledgedMcpTools: z.unknown().optional(),
+	acknowledgedProfileCid: z.string().min(1).max(256).optional(),
+	acknowledgedReleaseCid: z.string().min(1).max(256).optional(),
 });
 
 export const POST: APIRoute = async ({ request, locals }) => {
@@ -99,6 +101,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 				version: body.version,
 				acknowledgedDeclaredAccess: body.acknowledgedDeclaredAccess,
 				acknowledgedMcpTools: body.acknowledgedMcpTools,
+				acknowledgedProfileCid: body.acknowledgedProfileCid,
+				acknowledgedReleaseCid: body.acknowledgedReleaseCid,
 			},
 			{
 				configuredPluginIds: reservedPluginIds,

--- a/packages/core/src/astro/routes/api/admin/plugins/registry/verify.ts
+++ b/packages/core/src/astro/routes/api/admin/plugins/registry/verify.ts
@@ -1,0 +1,60 @@
+import { hostEnvFromVersions } from "@emdash-cms/registry-client/env";
+import type { APIRoute } from "astro";
+import { z } from "zod";
+
+import { requirePerm } from "#api/authorize.js";
+import { apiError, handleError, unwrapResult } from "#api/error.js";
+import { handleRegistryInstall } from "#api/index.js";
+import { isParseError, parseBody } from "#api/parse.js";
+
+import { VERSION } from "../../../../../../version.js";
+
+export const prerender = false;
+
+const verifyBodySchema = z.object({
+	did: z
+		.string()
+		.min(1)
+		.max(2048)
+		.regex(/^did:[a-z]+:/, "Invalid DID"),
+	slug: z
+		.string()
+		.min(1)
+		.max(64)
+		.regex(/^[a-zA-Z][a-zA-Z0-9_-]*$/, "Invalid slug"),
+	version: z.string().min(1).max(64).optional(),
+});
+
+export const POST: APIRoute = async ({ request, locals }) => {
+	try {
+		const { emdash, user } = locals;
+		if (!emdash?.db) {
+			return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
+		}
+		const denied = requirePerm(user, "plugins:manage");
+		if (denied) return denied;
+		const body = await parseBody(request, verifyBodySchema);
+		if (isParseError(body)) return body;
+
+		const reservedPluginIds = new Set<string>([
+			...emdash.configuredPlugins.map((plugin: { id: string }) => plugin.id),
+			...(emdash.config.sandboxed ?? []).map((plugin: { id: string }) => plugin.id),
+		]);
+		const result = await handleRegistryInstall(
+			emdash.db,
+			emdash.storage,
+			emdash.getSandboxRunner(),
+			emdash.config.experimental?.registry,
+			body,
+			{
+				configuredPluginIds: reservedPluginIds,
+				hostEnv: hostEnvFromVersions(VERSION, emdash.config.astroVersion),
+				verifyOnly: true,
+			},
+		);
+		return unwrapResult(result);
+	} catch (error) {
+		console.error("[registry-verify] Unhandled error:", error);
+		return handleError(error, "Failed to verify registry plugin", "VERIFICATION_FAILED");
+	}
+};

--- a/packages/core/tests/unit/api/registry-verify-only.test.ts
+++ b/packages/core/tests/unit/api/registry-verify-only.test.ts
@@ -1,0 +1,256 @@
+import { gzipSync } from "node:zlib";
+
+import { inspectPackageReleaseRecords } from "@emdash-cms/registry-verification";
+import { computeMultihash } from "@emdash-cms/registry-verification/checksum";
+import BetterSqlite3 from "better-sqlite3";
+import { Kysely, SqliteDialect } from "kysely";
+import { packTar, type TarEntry } from "modern-tar";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { handleRegistryInstall } from "../../../src/api/handlers/registry.js";
+import { runMigrations } from "../../../src/database/migrations/runner.js";
+import type { Database } from "../../../src/database/types.js";
+import type { SandboxRunner } from "../../../src/plugins/sandbox/types.js";
+import { PluginStateRepository } from "../../../src/plugins/state.js";
+import type { AuthoritativeRecordReader } from "../../../src/registry/authoritative-records.js";
+import { setDefaultDnsResolver } from "../../../src/security/ssrf.js";
+import type { Storage } from "../../../src/storage/types.js";
+
+const PUBLISHER_DID = "did:plc:verify00000000000000000";
+const SLUG = "gallery";
+const VERSION = "1.0.0";
+const ARTIFACT_URL = "https://artifacts.example.test/gallery.tar.gz";
+const PROFILE_NSID = "com.emdashcms.experimental.package.profile";
+const RELEASE_NSID = "com.emdashcms.experimental.package.release";
+const encoder = new TextEncoder();
+
+const getPackage = vi.fn();
+const getLatestRelease = vi.fn();
+const listReleases = vi.fn();
+
+vi.mock("@emdash-cms/registry-client/discovery", () => ({
+	DiscoveryClient: class {
+		getPackage = getPackage;
+		getLatestRelease = getLatestRelease;
+		listReleases = listReleases;
+	},
+}));
+
+function file(name: string, body: string): TarEntry {
+	const bytes = encoder.encode(body);
+	return { header: { name, size: bytes.byteLength, type: "file" }, body: bytes };
+}
+
+async function pluginBundle(): Promise<Uint8Array> {
+	const manifest = {
+		id: SLUG,
+		version: VERSION,
+		declaredAccess: { users: { read: {} } },
+		capabilities: ["users:read"],
+		allowedHosts: [],
+		storage: {},
+		hooks: [],
+		routes: [],
+		admin: {},
+	};
+	return new Uint8Array(
+		gzipSync(
+			await packTar([
+				file("manifest.json", JSON.stringify(manifest)),
+				file("backend.js", "export default {};"),
+			]),
+		),
+	);
+}
+
+async function authoritativeReader(checksum: string): Promise<AuthoritativeRecordReader> {
+	const profile = {
+		$type: PROFILE_NSID,
+		id: `at://${PUBLISHER_DID}/${PROFILE_NSID}/${SLUG}`,
+		slug: SLUG,
+		type: "emdash-plugin",
+		name: "Verified Gallery",
+		license: "MIT",
+		authors: [{ name: "Publisher" }],
+		security: [{ email: "security@example.test" }],
+		extensions: {
+			"com.emdashcms.experimental.package.profileExtension": {
+				$type: "com.emdashcms.experimental.package.profileExtension",
+				repository: "https://github.com/example/gallery",
+			},
+		},
+	};
+	const release = {
+		$type: RELEASE_NSID,
+		package: SLUG,
+		version: VERSION,
+		artifacts: { package: { url: ARTIFACT_URL, checksum } },
+		extensions: {
+			"com.emdashcms.experimental.package.releaseExtension": {
+				$type: "com.emdashcms.experimental.package.releaseExtension",
+				declaredAccess: { users: { read: {} } },
+			},
+		},
+	};
+	const inspection = await inspectPackageReleaseRecords({
+		publisherDid: PUBLISHER_DID,
+		package: SLUG,
+		version: VERSION,
+		rkey: `${SLUG}:${VERSION}`,
+		profile,
+		release,
+	});
+	if (!inspection.success) throw new Error(inspection.reasons[0]?.message);
+	return async () => ({
+		success: true,
+		value: {
+			publisherDid: PUBLISHER_DID,
+			packageSlug: SLUG,
+			version: VERSION,
+			profile: {
+				uri: profile.id,
+				cid: "bafy-profile",
+				rkey: SLUG,
+				value: profile,
+			},
+			release: {
+				uri: `at://${PUBLISHER_DID}/${RELEASE_NSID}/${SLUG}:${VERSION}`,
+				cid: "bafy-release",
+				rkey: `${SLUG}:${VERSION}`,
+				value: release,
+			},
+			inspection,
+		},
+	});
+}
+
+describe("handleRegistryInstall verifyOnly", () => {
+	let db: Kysely<Database>;
+	let previousResolver: ReturnType<typeof setDefaultDnsResolver>;
+
+	beforeEach(async () => {
+		db = new Kysely<Database>({
+			dialect: new SqliteDialect({ database: new BetterSqlite3(":memory:") }),
+		});
+		await runMigrations(db);
+		previousResolver = setDefaultDnsResolver(async () => ["93.184.216.34"]);
+		getPackage.mockReset();
+		getLatestRelease.mockReset();
+		listReleases.mockReset();
+	});
+
+	afterEach(async () => {
+		setDefaultDnsResolver(previousResolver);
+		vi.unstubAllGlobals();
+		await db.destroy();
+	});
+
+	it("returns authoritative consent evidence without writing storage or plugin state", async () => {
+		const bytes = await pluginBundle();
+		const checksum = await computeMultihash(bytes);
+		if (!checksum.success) throw new Error(checksum.error.message);
+		getPackage.mockResolvedValue({
+			did: PUBLISHER_DID,
+			slug: SLUG,
+			labels: [],
+			profile: { name: "Untrusted aggregator copy" },
+		});
+		const releaseView = {
+			did: PUBLISHER_DID,
+			package: SLUG,
+			version: VERSION,
+			indexedAt: "2026-01-01T00:00:00.000Z",
+			labels: [],
+			mirrors: [],
+			release: {
+				package: SLUG,
+				version: VERSION,
+				artifacts: { package: { url: "https://evil.example/bundle", checksum: "wrong" } },
+			},
+		};
+		getLatestRelease.mockResolvedValue(releaseView);
+		listReleases.mockResolvedValue({ releases: [releaseView] });
+		const fetch = vi.fn(() => Promise.resolve(new Response(bytes, { status: 200 })));
+		vi.stubGlobal("fetch", fetch);
+		const upload = vi.fn();
+		const storage = { upload } as unknown as Storage;
+		const sandbox = { isAvailable: () => true } as unknown as SandboxRunner;
+
+		const result = await handleRegistryInstall(
+			db,
+			storage,
+			sandbox,
+			{ aggregatorUrl: "https://aggregator.test" },
+			{ did: PUBLISHER_DID, slug: SLUG, version: VERSION },
+			{
+				verifyOnly: true,
+				readAuthoritativeRecords: await authoritativeReader(checksum.value),
+			},
+		);
+
+		expect(result).toMatchObject({
+			success: true,
+			data: {
+				capabilities: ["users:read"],
+				declaredAccess: { users: { read: {} } },
+				verification: {
+					profileCid: "bafy-profile",
+					releaseCid: "bafy-release",
+					provenance: "absent-optional",
+				},
+			},
+		});
+		expect(fetch).toHaveBeenCalledWith(
+			ARTIFACT_URL,
+			expect.objectContaining({ redirect: "manual" }),
+		);
+		expect(upload).not.toHaveBeenCalled();
+		if (!result.success) return;
+		expect(await new PluginStateRepository(db).get(result.data.pluginId)).toBeNull();
+	});
+
+	it.each([
+		["missing", {}, "RECORD_CONSENT_REQUIRED"],
+		[
+			"stale",
+			{ acknowledgedProfileCid: "bafy-old-profile", acknowledgedReleaseCid: "bafy-old-release" },
+			"RECORD_VERIFICATION_DRIFT",
+		],
+	] as const)(
+		"rejects %s record consent before fetching artifact bytes",
+		async (_case, cids, code) => {
+			const releaseView = {
+				did: PUBLISHER_DID,
+				package: SLUG,
+				version: VERSION,
+				indexedAt: "2026-01-01T00:00:00.000Z",
+				labels: [],
+				mirrors: [],
+				release: null,
+			};
+			getPackage.mockResolvedValue({
+				did: PUBLISHER_DID,
+				slug: SLUG,
+				labels: [],
+				profile: null,
+			});
+			listReleases.mockResolvedValue({ releases: [releaseView] });
+			const fetch = vi.fn(() => {
+				throw new Error("artifact fetch must not run before record consent");
+			});
+			vi.stubGlobal("fetch", fetch);
+
+			const result = await handleRegistryInstall(
+				db,
+				{} as Storage,
+				{ isAvailable: () => true } as unknown as SandboxRunner,
+				{ aggregatorUrl: "https://aggregator.test" },
+				{ did: PUBLISHER_DID, slug: SLUG, version: VERSION, ...cids },
+				{ readAuthoritativeRecords: await authoritativeReader("bciqexample") },
+			);
+
+			expect(result).toMatchObject({ success: false, error: { code } });
+			expect(fetch).not.toHaveBeenCalled();
+		},
+	);
+});


### PR DESCRIPTION
## What does this PR do?

Adds independently verified registry evidence to install and update consent.

Clicking Install first calls a non-mutating server verification route. That route repeats direct-PDS record proof, artifact, manifest, declared-access, and provenance checks, then returns exact profile/release CIDs, normalized signed policy, bundle permissions, and MCP tools. The dialog displays that evidence; the subsequent install must acknowledge the same CIDs, permissions, and tools or it fails closed.

Update capability, public-route, and MCP consent errors carry the same verification evidence. Confirmation requests are bound to the displayed CIDs, so a profile or release change between preview and confirmation requires a fresh review.

All new strings use Lingui. CID and DID values use bidi isolation and were exercised under Arabic RTL.

Related: #1870 and #2643

Stack: #2662 → #2663 → #2665 → this PR (W9.4 verified consent).

## Type of change

- [ ] Bug fix
- [x] Feature (approved through RFC #1870 and implementation spec #2643)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Arabic RTL behavior was verified; no `messages.po` files are included.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion. This work is approved through RFC #1870 and implementation spec #2643.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- `pnpm typecheck` — 31 package typechecks passed
- `pnpm lint:json` — 0 diagnostics
- Admin browser suite — 1,522 passed
- Core Node suite — 6,045 passed, 9 skipped
- Core workerd suite — 8 passed
- Admin and core builds — passed
- Focused verified-consent suite — 33 admin browser tests and 3 core handler tests passed
