### PR TITLE
feat(blocks,admin): portable_text and block_list Block Kit fields + Duplicate on plugin block cards

### DIFF
--- a/.changeset/structured-block-kit-fields.md
+++ b/.changeset/structured-block-kit-fields.md
@@ -23,6 +23,10 @@ An ordered list of registered plugin blocks. In the dialog, authors add an item 
 
 Both element types are also accepted as `repeater` sub-fields, so a repeater row can carry rich text or its own ordered block list.
 
+#### `hidden` on plugin block definitions
+
+A plugin block definition may declare `hidden: true`: the block stays registered — existing blocks of the type render and edit exactly as before — but document-level insert surfaces (the slash menu, and a `block_list` picker without an `allowed_types` list) no longer offer it. A `block_list` whose `allowed_types` names the type still offers it, so a plugin can ship child-only blocks that authors reach exclusively inside the parent blocks that declare them.
+
 #### Duplicate on plugin block cards
 
 Plugin block cards in the document editor gain a Duplicate action beside Edit and Delete that inserts a copy of the block, with identical data, immediately after the original.

--- a/.changeset/structured-block-kit-fields.md
+++ b/.changeset/structured-block-kit-fields.md
@@ -1,0 +1,28 @@
+---
+"@emdash-cms/blocks": minor
+"@emdash-cms/admin": minor
+---
+
+Adds two structured Block Kit elements so plugin blocks can carry rich text and nested block content that stays fully editable in the admin editor, plus a Duplicate action on plugin block cards.
+
+#### `portable_text`
+
+A rich-text field whose value is a Portable Text block array. The plugin block dialog renders it as a nested instance of the standard Portable Text editor, so authors get the familiar writing surface and the stored value keeps its complete structure — blocks, spans, marks, markDefs, and keys. The value is never flattened to a string. Like `repeater`, the runtime `renderElement` returns `null`; the parent block's own component renders the persisted value.
+
+```ts
+{ type: "portable_text", action_id: "content", label: "Content" }
+```
+
+#### `block_list`
+
+An ordered list of registered plugin blocks. In the dialog, authors add an item by choosing from the same registered block catalog the document editor offers and filling that block's own Block Kit form, then edit, duplicate, delete, and drag-to-reorder items. When a form contains several block lists (for example one per column, including lists nested in `repeater` rows), each item also offers "Move to…" the sibling list. Each stored item is an ordinary registered block object — `{ _type, _key, ...fields }` — never serialized HTML or a private document format. `allowed_types` restricts which registered blocks may be added; `min_items`/`max_items` bound the list.
+
+```ts
+{ type: "block_list", action_id: "blocks", label: "Blocks", allowed_types: ["acme.heading"] }
+```
+
+Both element types are also accepted as `repeater` sub-fields, so a repeater row can carry rich text or its own ordered block list.
+
+#### Duplicate on plugin block cards
+
+Plugin block cards in the document editor gain a Duplicate action beside Edit and Delete that inserts a copy of the block, with identical data, immediately after the original.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -139,7 +139,6 @@ import {
 	PluginBlockExtension,
 	registerPluginBlocks,
 	resolveIcon,
-	visiblePluginBlocks,
 } from "./editor/PluginBlockNode";
 import { MediaPickerModal } from "./MediaPickerModal";
 import { SectionPickerModal } from "./SectionPickerModal";
@@ -2151,7 +2150,13 @@ function BlockKitRepeater({
 	// translators see whole, inflectable phrases.
 	const addButtonLabel = field.item_label ? t`Add ${field.item_label}` : t`Add item`;
 
+	// Handlers read the LATEST rows through a ref rather than the render closure: two sub-field
+	// changes can land in one tick (a block moved between two rows' block lists writes the target
+	// row, then the source row), and a closure snapshot would let the second write erase the first.
+	const itemsRef = React.useRef(items);
+	itemsRef.current = items;
 	const emit = (next: RepeaterItem[]) => {
+		itemsRef.current = next;
 		setItems(next);
 		const stripped = stripKeys(next);
 		lastEmittedRef.current = stripped;
@@ -2184,7 +2189,7 @@ function BlockKitRepeater({
 			next.add(newItem._key);
 			return next;
 		});
-		emit([...items, newItem]);
+		emit([...itemsRef.current, newItem]);
 	};
 
 	const handleRemove = (key: string) => {
@@ -2195,11 +2200,11 @@ function BlockKitRepeater({
 			next.delete(key);
 			return next;
 		});
-		emit(items.filter((it) => it._key !== key));
+		emit(itemsRef.current.filter((it) => it._key !== key));
 	};
 
 	const handleItemChange = (key: string, subActionId: string, subValue: unknown) => {
-		emit(items.map((it) => (it._key === key ? { ...it, [subActionId]: subValue } : it)));
+		emit(itemsRef.current.map((it) => (it._key === key ? { ...it, [subActionId]: subValue } : it)));
 	};
 
 	const handleDragEnd = (event: DragEndEvent) => {
@@ -2429,20 +2434,41 @@ function BlockKitPortableTextField({
 	value: unknown;
 	onChange: (actionId: string, value: unknown) => void;
 }) {
-	const initialValue = React.useRef<PortableTextBlock[]>(
-		Array.isArray(value) ? (value as PortableTextBlock[]) : [],
-	).current;
+	// The nested editor is uncontrolled (it owns its document while the author types), so the
+	// value it mounted with is what it shows. A dialog seeds its form values in an effect AFTER
+	// its first render, which means the first mount can see `undefined` and the real value only
+	// arrive a tick later. Until the author has typed, a changed incoming value re-seeds the
+	// editor (the same prop-sync the repeater applies to its rows); once dirty, the author's
+	// document is never replaced from outside.
+	const seededRef = React.useRef<unknown>(value);
+	const dirtyRef = React.useRef(false);
+	const [seedKey, setSeedKey] = React.useState(0);
+	React.useEffect(() => {
+		if (dirtyRef.current || value === seededRef.current) return;
+		seededRef.current = value;
+		setSeedKey((k) => k + 1);
+	}, [value]);
+	const seeded = Array.isArray(seededRef.current) ? (seededRef.current as PortableTextBlock[]) : [];
 	return (
 		<div>
 			<label className="text-sm font-medium mb-1.5 block">{field.label}</label>
 			<PortableTextEditor
-				value={initialValue}
-				onChange={(next) => onChange(field.action_id, next)}
+				key={seedKey}
+				value={seeded}
+				onChange={(next) => {
+					dirtyRef.current = true;
+					onChange(field.action_id, next);
+				}}
 				placeholder={field.placeholder}
 				className="rounded-md border border-kumo-line"
 			/>
 		</div>
 	);
+}
+
+/** The blocks document-level insert surfaces may offer (see `PluginBlockDef.hidden`). */
+function visiblePluginBlocks(blocks: PluginBlockDef[]): PluginBlockDef[] {
+	return blocks.filter((block) => !block.hidden);
 }
 
 const newBlockKey = () => `block-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
@@ -2528,6 +2554,16 @@ function BlockKitBlockListField({
 		null,
 	);
 	const [pickingType, setPickingType] = React.useState(false);
+	// The child dialog re-seeds its form whenever `initialValues` changes identity, so the values
+	// handed to it must be stable across renders: computed once per (child, items) pair, never
+	// inline in JSX.
+	const childInitialValues = React.useMemo(() => {
+		if (!child || child.index === null) return undefined;
+		const current = items[child.index];
+		if (!current) return undefined;
+		const { _type, _key, ...rest } = current;
+		return rest;
+	}, [child, items]);
 
 	const minItems = field.min_items ?? 0;
 	const maxItems = field.max_items;
@@ -2640,11 +2676,7 @@ function BlockKitBlockListField({
 
 			<PluginBlockModal
 				block={child?.def ?? null}
-				initialValues={
-					child && child.index !== null && items[child.index]
-						? (({ _type, _key, ...rest }) => rest)(items[child.index]!)
-						: undefined
-				}
+				initialValues={childInitialValues}
 				onClose={() => setChild(null)}
 				onInsert={handleChildSubmit}
 			/>
@@ -2847,6 +2879,8 @@ export {
 	hasPluginBlockFormData as _hasPluginBlockFormData,
 	BlockKitPortableTextField as _BlockKitPortableTextField,
 	BlockKitBlockListField as _BlockKitBlockListField,
+	BlockKitRepeater as _BlockKitRepeater,
+	visiblePluginBlocks as _visiblePluginBlocks,
 	BlockListSiblingsProvider as _BlockListSiblingsProvider,
 	PluginBlockCatalogContext as _PluginBlockCatalogContext,
 };

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -88,6 +88,8 @@ import {
 	DotsSixVertical,
 	CaretDown,
 	type Icon,
+	CopySimple,
+	Pencil,
 } from "@phosphor-icons/react";
 import { X } from "@phosphor-icons/react";
 import { Extension, type Range } from "@tiptap/core";
@@ -1904,7 +1906,12 @@ function PluginBlockModal({
 	const dialogSize = (() => {
 		if (!hasFields) return "sm";
 		const fields = block?.fields ?? [];
-		if (fields.some((f) => f.type === "repeater")) return "xl";
+		if (
+			fields.some(
+				(f) => f.type === "repeater" || f.type === "block_list" || f.type === "portable_text",
+			)
+		)
+			return "xl";
 		if (fields.length > 3) return "lg";
 		return "base";
 	})();
@@ -1932,38 +1939,40 @@ function PluginBlockModal({
 						)}
 					/>
 				</div>
-				<form onSubmit={handleSubmit}>
-					<div className="py-4 space-y-4 max-h-[70vh] overflow-y-auto -mx-1 px-1">
-						{hasFields ? (
-							block.fields!.map((field) => (
-								<BlockKitField
-									key={field.action_id}
-									field={field}
-									pluginId={block.pluginId}
-									value={formValues[field.action_id]}
-									onChange={handleFieldChange}
+				<BlockListSiblingsProvider>
+					<form onSubmit={handleSubmit}>
+						<div className="py-4 space-y-4 max-h-[70vh] overflow-y-auto -mx-1 px-1">
+							{hasFields ? (
+								block.fields!.map((field) => (
+									<BlockKitField
+										key={field.action_id}
+										field={field}
+										pluginId={block.pluginId}
+										value={formValues[field.action_id]}
+										onChange={handleFieldChange}
+									/>
+								))
+							) : (
+								<Input
+									ref={inputRef}
+									type="url"
+									className="w-full"
+									placeholder={block?.placeholder || "Enter URL..."}
+									value={typeof formValues.id === "string" ? formValues.id : ""}
+									onChange={(e) => handleFieldChange("id", e.target.value)}
 								/>
-							))
-						) : (
-							<Input
-								ref={inputRef}
-								type="url"
-								className="w-full"
-								placeholder={block?.placeholder || "Enter URL..."}
-								value={typeof formValues.id === "string" ? formValues.id : ""}
-								onChange={(e) => handleFieldChange("id", e.target.value)}
-							/>
-						)}
-					</div>
-					<div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-						<Button type="button" variant="ghost" onClick={onClose}>
-							Cancel
-						</Button>
-						<Button type="submit" disabled={!canSubmit}>
-							{isEditing ? "Save" : "Insert"}
-						</Button>
-					</div>
-				</form>
+							)}
+						</div>
+						<div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
+							<Button type="button" variant="ghost" onClick={onClose}>
+								Cancel
+							</Button>
+							<Button type="submit" disabled={!canSubmit}>
+								{isEditing ? "Save" : "Insert"}
+							</Button>
+						</div>
+					</form>
+				</BlockListSiblingsProvider>
 			</Dialog>
 		</Dialog.Root>
 	);
@@ -2058,6 +2067,12 @@ function BlockKitField({
 					onChange={onChange}
 				/>
 			);
+		}
+		case "portable_text": {
+			return <BlockKitPortableTextField field={field} value={value} onChange={onChange} />;
+		}
+		case "block_list": {
+			return <BlockKitBlockListField field={field} value={value} onChange={onChange} />;
 		}
 		default:
 			return <div className="text-sm text-kumo-subtle">Unknown field type: {field.type}</div>;
@@ -2154,6 +2169,10 @@ function BlockKitRepeater({
 					break;
 				case "number_input":
 					newItem[sf.action_id] = undefined;
+					break;
+				case "portable_text":
+				case "block_list":
+					newItem[sf.action_id] = [];
 					break;
 				default:
 					newItem[sf.action_id] = "";
@@ -2342,18 +2361,394 @@ function BlockKitRepeaterItem({
 			</div>
 
 			{!isCollapsed && (
-				<div className="p-3 space-y-3">
-					{fields.map((sf) => (
-						<BlockKitField
-							key={sf.action_id}
-							field={sf}
-							pluginId={pluginId}
-							value={item[sf.action_id]}
-							onChange={(actionId, v) => onChange(actionId, v)}
-						/>
-					))}
-				</div>
+				<BlockListScopeContext.Provider value={{ key: item._key, label: summaryLabel }}>
+					<div className="p-3 space-y-3">
+						{fields.map((sf) => (
+							<BlockKitField
+								key={sf.action_id}
+								field={sf}
+								pluginId={pluginId}
+								value={item[sf.action_id]}
+								onChange={(actionId, v) => onChange(actionId, v)}
+							/>
+						))}
+					</div>
+				</BlockListScopeContext.Provider>
 			)}
+		</div>
+	);
+}
+
+// ── Structured Block Kit fields: portable_text and block_list ────────────────
+
+/** The registered plugin-block catalog, provided around the block modal so a
+ * `block_list` field offers the same blocks the document editor inserts. */
+const PluginBlockCatalogContext = React.createContext<PluginBlockDef[]>([]);
+
+interface BlockListSibling {
+	id: string;
+	label: string;
+	receive: (item: Record<string, unknown>) => void;
+}
+
+/** Lets the block lists in one form offer "move to <sibling>" on their items. */
+const BlockListSiblingsContext = React.createContext<{
+	register: (sibling: BlockListSibling) => () => void;
+	siblings: BlockListSibling[];
+} | null>(null);
+
+function BlockListSiblingsProvider({ children }: { children: React.ReactNode }) {
+	const [siblings, setSiblings] = React.useState<BlockListSibling[]>([]);
+	const register = React.useCallback((sibling: BlockListSibling) => {
+		setSiblings((prev) => [...prev.filter((s) => s.id !== sibling.id), sibling]);
+		return () => setSiblings((prev) => prev.filter((s) => s.id !== sibling.id));
+	}, []);
+	const value = React.useMemo(() => ({ register, siblings }), [register, siblings]);
+	return (
+		<BlockListSiblingsContext.Provider value={value}>{children}</BlockListSiblingsContext.Provider>
+	);
+}
+
+/** Names the repeater item a nested block list lives in, so its move targets
+ * read like the item (e.g. "Column 2") rather than a raw action id. */
+const BlockListScopeContext = React.createContext<{ key: string; label: string } | null>(null);
+
+/**
+ * Rich-text field: a nested instance of the standard Portable Text editor bound
+ * to a Portable Text block array. The value keeps blocks, spans, marks,
+ * markDefs and keys; it is never flattened to a string. Mounted uncontrolled
+ * (initial value at open) so typing never fights a round-tripped prop.
+ */
+function BlockKitPortableTextField({
+	field,
+	value,
+	onChange,
+}: {
+	field: Extract<Element, { type: "portable_text" }>;
+	value: unknown;
+	onChange: (actionId: string, value: unknown) => void;
+}) {
+	const initialValue = React.useRef<PortableTextBlock[]>(
+		Array.isArray(value) ? (value as PortableTextBlock[]) : [],
+	).current;
+	return (
+		<div>
+			<label className="text-sm font-medium mb-1.5 block">{field.label}</label>
+			<PortableTextEditor
+				value={initialValue}
+				onChange={(next) => onChange(field.action_id, next)}
+				placeholder={field.placeholder}
+				className="rounded-md border border-kumo-line"
+			/>
+		</div>
+	);
+}
+
+const newBlockKey = () => `block-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+/** First human-readable string in a block's data, for the row summary. */
+function blockItemSummary(item: Record<string, unknown>): string {
+	for (const [key, value] of Object.entries(item)) {
+		if (key === "_type" || key === "_key") continue;
+		if (typeof value === "string" && value.trim()) return value;
+	}
+	return "";
+}
+
+/**
+ * Ordered list of registered plugin blocks: add from the registered catalog,
+ * edit through the chosen block's own Block Kit form, duplicate, delete,
+ * drag-and-drop reorder, and move an item to a sibling list in the same form.
+ * Items are ordinary registered block objects ({ _type, _key, ...fields }).
+ */
+function BlockKitBlockListField({
+	field,
+	value,
+	onChange,
+}: {
+	field: Extract<Element, { type: "block_list" }>;
+	value: unknown;
+	onChange: (actionId: string, value: unknown) => void;
+}) {
+	const { t } = useLingui();
+	const catalog = React.useContext(PluginBlockCatalogContext);
+	const siblingsContext = React.useContext(BlockListSiblingsContext);
+	const scope = React.useContext(BlockListScopeContext);
+	const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
+
+	const [items, setItems] = React.useState<RepeaterItem[]>(() =>
+		ensureKeys(Array.isArray(value) ? value : []),
+	);
+	const lastEmittedRef = React.useRef<unknown>(value);
+	React.useEffect(() => {
+		if (value !== lastEmittedRef.current) {
+			setItems(ensureKeys(Array.isArray(value) ? value : []));
+			lastEmittedRef.current = value;
+		}
+	}, [value]);
+
+	const emit = (next: RepeaterItem[]) => {
+		setItems(next);
+		lastEmittedRef.current = next;
+		onChange(field.action_id, next);
+	};
+	const itemsRef = React.useRef(items);
+	itemsRef.current = items;
+	const emitRef = React.useRef(emit);
+	emitRef.current = emit;
+
+	const listId = `${scope?.key ?? "root"}:${field.action_id}`;
+	const listLabel = scope?.label ?? field.label;
+	// Depend on the stable `register` callback, never the context VALUE -- the
+	// value changes on every sibling update (including this component's own
+	// registration), which would re-run the effect forever.
+	const registerSibling = siblingsContext?.register;
+	React.useEffect(() => {
+		if (!registerSibling) return;
+		return registerSibling({
+			id: listId,
+			label: listLabel,
+			receive: (incoming) =>
+				emitRef.current([...itemsRef.current, { ...incoming, _key: newBlockKey() }]),
+		});
+	}, [registerSibling, listId, listLabel]);
+	const moveTargets = (siblingsContext?.siblings ?? []).filter((s) => s.id !== listId);
+
+	const allowed = React.useMemo(() => {
+		const allowedTypes = field.allowed_types;
+		return allowedTypes && allowedTypes.length > 0
+			? catalog.filter((b) => allowedTypes.includes(b.type))
+			: catalog;
+	}, [catalog, field.allowed_types]);
+
+	const [child, setChild] = React.useState<{ def: PluginBlockDef; index: number | null } | null>(
+		null,
+	);
+	const [pickingType, setPickingType] = React.useState(false);
+
+	const minItems = field.min_items ?? 0;
+	const maxItems = field.max_items;
+	const canAdd = allowed.length > 0 && (maxItems === undefined || items.length < maxItems);
+	const canRemove = items.length > minItems;
+	const addButtonLabel = field.item_label ? t`Add ${field.item_label}` : t`Add block`;
+
+	const handleAdd = () => {
+		if (!canAdd) return;
+		const only = allowed[0];
+		if (allowed.length === 1 && only) setChild({ def: only, index: null });
+		else setPickingType(true);
+	};
+
+	const handleChildSubmit = (values: Record<string, unknown>) => {
+		if (!child) return;
+		if (child.index === null) {
+			emit([...items, { _key: newBlockKey(), ...values, _type: child.def.type }]);
+		} else {
+			const index = child.index;
+			emit(
+				items.map((it, i) =>
+					i === index ? { _key: it._key, ...values, _type: child.def.type } : it,
+				),
+			);
+		}
+		setChild(null);
+	};
+
+	const handleDragEnd = (event: DragEndEvent) => {
+		const { active, over } = event;
+		if (!over || active.id === over.id) return;
+		const oldIndex = items.findIndex((it) => it._key === active.id);
+		const newIndex = items.findIndex((it) => it._key === over.id);
+		if (oldIndex === -1 || newIndex === -1) return;
+		emit(arrayMove(items, oldIndex, newIndex));
+	};
+
+	return (
+		<div className="space-y-2">
+			<div className="flex items-center justify-between">
+				<label className="text-sm font-medium">
+					{field.label}
+					{items.length > 0 && (
+						<span className="ms-2 text-kumo-subtle font-normal">({items.length})</span>
+					)}
+				</label>
+				{canAdd && !pickingType && (
+					<Button variant="outline" size="sm" icon={<Plus />} onClick={handleAdd} type="button">
+						{addButtonLabel}
+					</Button>
+				)}
+			</div>
+
+			{pickingType && (
+				<Select
+					value=""
+					onValueChange={(v) => {
+						const def = allowed.find((b) => b.type === v);
+						setPickingType(false);
+						if (def) setChild({ def, index: null });
+					}}
+					items={{
+						"": t`Choose a block type...`,
+						...Object.fromEntries(allowed.map((b) => [b.type, b.label])),
+					}}
+				/>
+			)}
+
+			{allowed.length === 0 ? (
+				<div className="rounded-lg border-2 border-dashed p-4 text-center text-sm text-kumo-subtle">
+					{t`No registered blocks are available here`}
+				</div>
+			) : items.length === 0 ? (
+				<div className="rounded-lg border-2 border-dashed p-6 text-center text-kumo-subtle">
+					<p className="text-sm">{t`No blocks yet`}</p>
+				</div>
+			) : (
+				<DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+					<SortableContext
+						items={items.map((it) => it._key)}
+						strategy={verticalListSortingStrategy}
+					>
+						<div className="space-y-2">
+							{items.map((item, index) => (
+								<BlockListItemRow
+									key={item._key}
+									item={item}
+									index={index}
+									def={catalog.find((b) => b.type === item._type)}
+									moveTargets={moveTargets}
+									canRemove={canRemove}
+									canDuplicate={maxItems === undefined || items.length < maxItems}
+									onEdit={(def) => setChild({ def, index })}
+									onDuplicate={() => {
+										const copy = { ...item, _key: newBlockKey() };
+										emit([...items.slice(0, index + 1), copy, ...items.slice(index + 1)]);
+									}}
+									onRemove={() => emit(items.filter((it) => it._key !== item._key))}
+									onMove={(target) => {
+										target.receive(item);
+										emit(items.filter((it) => it._key !== item._key));
+									}}
+								/>
+							))}
+						</div>
+					</SortableContext>
+				</DndContext>
+			)}
+
+			<PluginBlockModal
+				block={child?.def ?? null}
+				initialValues={
+					child && child.index !== null && items[child.index]
+						? (({ _type, _key, ...rest }) => rest)(items[child.index]!)
+						: undefined
+				}
+				onClose={() => setChild(null)}
+				onInsert={handleChildSubmit}
+			/>
+		</div>
+	);
+}
+
+function BlockListItemRow({
+	item,
+	index,
+	def,
+	moveTargets,
+	canRemove,
+	canDuplicate,
+	onEdit,
+	onDuplicate,
+	onRemove,
+	onMove,
+}: {
+	item: RepeaterItem;
+	index: number;
+	def: PluginBlockDef | undefined;
+	moveTargets: BlockListSibling[];
+	canRemove: boolean;
+	canDuplicate: boolean;
+	onEdit: (def: PluginBlockDef) => void;
+	onDuplicate: () => void;
+	onRemove: () => void;
+	onMove: (target: BlockListSibling) => void;
+}) {
+	const { t } = useLingui();
+	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+		id: item._key,
+	});
+	const style = { transform: CSS.Transform.toString(transform), transition };
+	const summary = blockItemSummary(item);
+	const typeLabel = def?.label ?? String(item._type ?? "");
+
+	return (
+		<div
+			ref={setNodeRef}
+			style={style}
+			className={cn(
+				"rounded-lg border border-kumo-line bg-kumo-base",
+				isDragging && "opacity-50 ring-2 ring-kumo-brand",
+			)}
+		>
+			<div className="flex items-center gap-2 border-b-0 px-3 py-2">
+				<span
+					className="inline-flex h-4 w-4 shrink-0 cursor-grab text-kumo-subtle"
+					aria-label={t`Drag to reorder`}
+					{...attributes}
+					{...listeners}
+				>
+					<DotsSixVertical className="h-4 w-4" />
+				</span>
+				<span className="min-w-0 flex-1 truncate text-sm">
+					<span className="font-medium">{typeLabel}</span>
+					{summary && <span className="ms-2 text-kumo-subtle">{summary}</span>}
+				</span>
+				{moveTargets.length > 0 && (
+					<Select
+						value=""
+						onValueChange={(v) => {
+							const target = moveTargets.find((s) => s.id === v);
+							if (target) onMove(target);
+						}}
+						items={{
+							"": t`Move to...`,
+							...Object.fromEntries(moveTargets.map((s) => [s.id, s.label])),
+						}}
+					/>
+				)}
+				{def && (
+					<Button
+						variant="ghost"
+						shape="square"
+						type="button"
+						onClick={() => onEdit(def)}
+						aria-label={t`Edit item ${index + 1}`}
+					>
+						<Pencil className="h-3.5 w-3.5" />
+					</Button>
+				)}
+				{canDuplicate && (
+					<Button
+						variant="ghost"
+						shape="square"
+						type="button"
+						onClick={onDuplicate}
+						aria-label={t`Duplicate item ${index + 1}`}
+					>
+						<CopySimple className="h-3.5 w-3.5" />
+					</Button>
+				)}
+				{canRemove && (
+					<Button
+						variant="ghost"
+						shape="square"
+						type="button"
+						onClick={onRemove}
+						aria-label={t`Remove item ${index + 1}`}
+					>
+						<Trash className="h-3.5 w-3.5 text-kumo-danger" />
+					</Button>
+				)}
+			</div>
 		</div>
 	);
 }
@@ -2447,6 +2842,10 @@ export { portableTextToProsemirror as _portableTextToProsemirror };
 export {
 	buildPluginBlockFormValues as _buildPluginBlockFormValues,
 	hasPluginBlockFormData as _hasPluginBlockFormData,
+	BlockKitPortableTextField as _BlockKitPortableTextField,
+	BlockKitBlockListField as _BlockKitBlockListField,
+	BlockListSiblingsProvider as _BlockListSiblingsProvider,
+	PluginBlockCatalogContext as _PluginBlockCatalogContext,
 };
 
 // =============================================================================
@@ -3460,17 +3859,19 @@ export function PortableTextEditor({
 				/>
 
 				{/* Plugin block insertion/editing modal */}
-				<PluginBlockModal
-					block={pluginBlockModal}
-					initialValues={pluginBlockInitialValues}
-					onClose={() => {
-						pendingBlockInsertPosRef.current = null;
-						setPluginBlockModal(null);
-						setPluginBlockInitialValues(undefined);
-						editingBlockPosRef.current = null;
-					}}
-					onInsert={handlePluginBlockInsert}
-				/>
+				<PluginBlockCatalogContext.Provider value={pluginBlocks}>
+					<PluginBlockModal
+						block={pluginBlockModal}
+						initialValues={pluginBlockInitialValues}
+						onClose={() => {
+							pendingBlockInsertPosRef.current = null;
+							setPluginBlockModal(null);
+							setPluginBlockInitialValues(undefined);
+							editingBlockPosRef.current = null;
+						}}
+						onInsert={handlePluginBlockInsert}
+					/>
+				</PluginBlockCatalogContext.Provider>
 
 				{/* Section picker modal */}
 				<SectionPickerModal

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -139,6 +139,7 @@ import {
 	PluginBlockExtension,
 	registerPluginBlocks,
 	resolveIcon,
+	visiblePluginBlocks,
 } from "./editor/PluginBlockNode";
 import { MediaPickerModal } from "./MediaPickerModal";
 import { SectionPickerModal } from "./SectionPickerModal";
@@ -2516,9 +2517,11 @@ function BlockKitBlockListField({
 
 	const allowed = React.useMemo(() => {
 		const allowedTypes = field.allowed_types;
+		// An explicit allowed_types list is the parent block's own offer and may name
+		// hidden types; without one, only visible blocks are offered here.
 		return allowedTypes && allowedTypes.length > 0
 			? catalog.filter((b) => allowedTypes.includes(b.type))
-			: catalog;
+			: visiblePluginBlocks(catalog);
 	}, [catalog, field.allowed_types]);
 
 	const [child, setChild] = React.useState<{ def: PluginBlockDef; index: number | null } | null>(
@@ -2678,7 +2681,7 @@ function BlockListItemRow({
 	});
 	const style = { transform: CSS.Transform.toString(transform), transition };
 	const summary = blockItemSummary(item);
-	const typeLabel = def?.label ?? String(item._type ?? "");
+	const typeLabel = def?.label ?? (typeof item._type === "string" ? item._type : "");
 
 	return (
 		<div
@@ -3146,7 +3149,8 @@ export function PortableTextEditor({
 
 		// Add plugin block commands (API labels/descriptions: plain strings, not msg-wrapped).
 		// Plugins can supply a custom `category` (plain string) — falls back to "Embeds".
-		for (const block of pluginBlocks) {
+		// Hidden blocks stay registered (existing content renders and edits) but are not offered.
+		for (const block of visiblePluginBlocks(pluginBlocks)) {
 			cmds.push({
 				id: `plugin-${block.pluginId}-${block.type}`,
 				title: block.label,

--- a/packages/admin/src/components/editor/PluginBlockNode.tsx
+++ b/packages/admin/src/components/editor/PluginBlockNode.tsx
@@ -52,6 +52,19 @@ export interface PluginBlockDef {
 	 * Optional display category in the slash menu. Defaults to "Embeds" when omitted.
 	 */
 	category?: string;
+	/**
+	 * Registered but not offered: a hidden block never appears on document-level
+	 * insert surfaces (the slash menu) or in a `block_list` picker without an
+	 * `allowed_types` list. Existing blocks of the type still render and edit
+	 * normally, and a `block_list` whose `allowed_types` names the type still
+	 * offers it — hiding removes a door, never content behind it.
+	 */
+	hidden?: boolean;
+}
+
+/** The blocks document-level insert surfaces may offer (see `PluginBlockDef.hidden`). */
+export function visiblePluginBlocks(blocks: PluginBlockDef[]): PluginBlockDef[] {
+	return blocks.filter((block) => !block.hidden);
 }
 
 // =============================================================================

--- a/packages/admin/src/components/editor/PluginBlockNode.tsx
+++ b/packages/admin/src/components/editor/PluginBlockNode.tsx
@@ -62,11 +62,6 @@ export interface PluginBlockDef {
 	hidden?: boolean;
 }
 
-/** The blocks document-level insert surfaces may offer (see `PluginBlockDef.hidden`). */
-export function visiblePluginBlocks(blocks: PluginBlockDef[]): PluginBlockDef[] {
-	return blocks.filter((block) => !block.hidden);
-}
-
 // =============================================================================
 // Plugin Block Registry (stored per-editor instance via TipTap extension storage)
 // =============================================================================

--- a/packages/admin/src/components/editor/PluginBlockNode.tsx
+++ b/packages/admin/src/components/editor/PluginBlockNode.tsx
@@ -25,6 +25,7 @@ import {
 	LinkSimple,
 	Code,
 	Copy,
+	CopySimple,
 	Cube,
 	ListBullets,
 } from "@phosphor-icons/react";
@@ -368,6 +369,28 @@ function PluginBlockNodeView({
 								aria-label={hasFields ? t`Edit` : t`Edit URL`}
 							>
 								<Pencil className="h-4 w-4" />
+							</Button>
+							<Button
+								type="button"
+								variant="ghost"
+								shape="square"
+								className="h-8 w-8"
+								onClick={() => {
+									const pos = typeof getPos === "function" ? getPos() : null;
+									if (pos == null) return;
+									editor
+										.chain()
+										.focus()
+										.insertContentAt(pos + node.nodeSize, {
+											type: node.type.name,
+											attrs: { ...node.attrs },
+										})
+										.run();
+								}}
+								title={t`Duplicate`}
+								aria-label={t`Duplicate`}
+							>
+								<CopySimple className="h-4 w-4" />
 							</Button>
 							<Button
 								type="button"

--- a/packages/admin/tests/editor/block-kit-structured-fields.test.tsx
+++ b/packages/admin/tests/editor/block-kit-structured-fields.test.tsx
@@ -11,13 +11,14 @@
 import * as React from "react";
 import { describe, it, expect, vi } from "vitest";
 
-import { visiblePluginBlocks } from "../../src/components/editor/PluginBlockNode";
 import type { PluginBlockDef } from "../../src/components/PortableTextEditor";
 import {
 	_BlockKitBlockListField,
 	_BlockKitPortableTextField,
+	_BlockKitRepeater,
 	_BlockListSiblingsProvider,
 	_PluginBlockCatalogContext,
+	_visiblePluginBlocks,
 	PortableTextEditor,
 } from "../../src/components/PortableTextEditor";
 import { render } from "../utils/render";
@@ -238,7 +239,7 @@ describe("block_list field", () => {
 
 describe("hidden plugin blocks", () => {
 	it("visiblePluginBlocks keeps only defs without the hidden flag", () => {
-		expect(visiblePluginBlocks(catalog).map((b) => b.type)).toEqual(["acme.heading", "acme.note"]);
+		expect(_visiblePluginBlocks(catalog).map((b) => b.type)).toEqual(["acme.heading", "acme.note"]);
 	});
 
 	it("the default add picker offers only visible blocks", async () => {
@@ -313,5 +314,97 @@ describe("plugin block Duplicate affordance", () => {
 		const copies = blocks.filter((b) => b._type === "acme.heading");
 		expect(copies[0]!.text).toBe("Duplicate me");
 		expect(copies[1]!.text).toBe("Duplicate me");
+	});
+});
+
+describe("late seeding and sibling moves inside a repeater", () => {
+	it("a portable_text field re-seeds when its value arrives after mount, until the author types", async () => {
+		const onChange = vi.fn();
+		const Host = ({ value }: { value: unknown }) => (
+			<_BlockKitPortableTextField
+				field={{ type: "portable_text", action_id: "content", label: "Content" }}
+				value={value}
+				onChange={onChange}
+			/>
+		);
+		const { rerender } = await render(<Host value={undefined} />);
+		await vi.waitFor(() => expect(query('[contenteditable="true"]')).toBeTruthy());
+		expect(screenRoot().textContent).not.toContain("arrived late");
+		// the dialog's effect seeds the value a tick after the first render
+		await rerender(
+			<Host
+				value={[
+					{
+						_type: "block",
+						_key: "b1",
+						style: "normal",
+						markDefs: [],
+						children: [{ _type: "span", _key: "s1", text: "arrived late", marks: [] }],
+					},
+				]}
+			/>,
+		);
+		await vi.waitFor(() => expect(screenRoot().textContent).toContain("arrived late"));
+		// typing keeps the seeded document and emits the FULL array (never just the typed text)
+		const pm = query<HTMLElement>('[contenteditable="true"]')!;
+		pm.focus();
+		document.execCommand("insertText", false, "!");
+		await vi.waitFor(() => expect(onChange).toHaveBeenCalled(), { timeout: 3000 });
+		const emitted = onChange.mock.calls.at(-1)![1] as Array<{ children?: Array<{ text: string }> }>;
+		const text = emitted
+			.flatMap((b) => b.children ?? [])
+			.map((s) => s.text)
+			.join("");
+		expect(text).toContain("arrived late");
+	});
+
+	it("moving a block between two repeater rows keeps it (the second row write does not erase the first)", async () => {
+		const onChange = vi.fn();
+		await render(
+			<_PluginBlockCatalogContext.Provider value={catalog}>
+				<_BlockListSiblingsProvider>
+					<_BlockKitRepeater
+						field={{
+							type: "repeater",
+							action_id: "columns",
+							label: "Columns",
+							fields: [
+								{ type: "text_input", action_id: "width", label: "Width" },
+								{ type: "block_list", action_id: "blocks", label: "Blocks" },
+							],
+						}}
+						value={[
+							{ width: "55", blocks: [{ _type: "acme.heading", _key: "k1", text: "Movable" }] },
+							{ width: "45", blocks: [] },
+						]}
+						onChange={onChange}
+					/>
+				</_BlockListSiblingsProvider>
+			</_PluginBlockCatalogContext.Provider>,
+		);
+		// expand both rows so both block lists mount and register as move targets
+		const headers = () =>
+			queryAll<HTMLButtonElement>('button[aria-expanded="false"]:not([aria-label])');
+		await vi.waitFor(() => expect(headers().length).toBe(2));
+		click(headers()[0]);
+		await vi.waitFor(() => expect(headers().length).toBe(1));
+		click(headers()[0]);
+		await vi.waitFor(() => expect(byAria("Edit item 1").length).toBeGreaterThan(0));
+		// the first row's item offers "Move to…" naming the sibling row (labelled by its width)
+		// (it appears once the second row's list has registered — a tick after it mounts)
+		const findMove = () =>
+			queryAll<HTMLElement>("[role='combobox']").find((c) => c.textContent?.includes("Move to"));
+		await vi.waitFor(() => expect(findMove(), "a Move to… control on the block row").toBeTruthy());
+		findMove()!.click();
+		await vi.waitFor(() => expect(queryAll("[role='option']").length).toBeGreaterThan(1));
+		click(queryAll<HTMLElement>("[role='option']").find((o) => o.textContent === "45"));
+		await vi.waitFor(() => expect(onChange).toHaveBeenCalled());
+		const rows = onChange.mock.calls.at(-1)![1] as Array<{
+			width: string;
+			blocks: Array<{ text: string }>;
+		}>;
+		expect(rows[0]!.blocks).toHaveLength(0);
+		expect(rows[1]!.blocks).toHaveLength(1);
+		expect(rows[1]!.blocks[0]!.text).toBe("Movable");
 	});
 });

--- a/packages/admin/tests/editor/block-kit-structured-fields.test.tsx
+++ b/packages/admin/tests/editor/block-kit-structured-fields.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * Structured Block Kit fields: `portable_text` and `block_list`, plus the
+ * plugin-block Duplicate affordance. Focused behaviour coverage:
+ *   - portable_text mounts a real nested editor and emits Portable Text
+ *     arrays (never strings), preserving marks on the emitted spans;
+ *   - block_list adds a registered block through its own Block Kit form,
+ *     edits it, duplicates it, removes it, reorders data, and moves an item
+ *     to a sibling list registered in the same form;
+ *   - the plugin-block node card duplicates a block in the document.
+ */
+import * as React from "react";
+import { describe, it, expect, vi } from "vitest";
+
+import type { PluginBlockDef } from "../../src/components/PortableTextEditor";
+import {
+	_BlockKitBlockListField,
+	_BlockKitPortableTextField,
+	_BlockListSiblingsProvider,
+	_PluginBlockCatalogContext,
+	PortableTextEditor,
+} from "../../src/components/PortableTextEditor";
+import { render } from "../utils/render";
+
+vi.mock("../../src/components/MediaPickerModal", () => ({
+	MediaPickerModal: () => null,
+}));
+vi.mock("../../src/components/SectionPickerModal", () => ({
+	SectionPickerModal: () => null,
+}));
+vi.mock("../../src/components/editor/DragHandleWrapper", () => ({
+	DragHandleWrapper: () => null,
+}));
+
+const catalog: PluginBlockDef[] = [
+	{
+		type: "acme.heading",
+		pluginId: "acme",
+		label: "Heading",
+		fields: [{ type: "text_input", action_id: "text", label: "Text" }],
+	},
+	{
+		type: "acme.note",
+		pluginId: "acme",
+		label: "Note",
+		fields: [{ type: "text_input", action_id: "body", label: "Body" }],
+	},
+];
+
+function screenRoot(): HTMLElement {
+	return document.body;
+}
+
+function query<T extends HTMLElement>(selector: string): T | null {
+	return screenRoot().querySelector<T>(selector);
+}
+
+function queryAll<T extends HTMLElement>(selector: string): T[] {
+	return [...screenRoot().querySelectorAll<T>(selector)];
+}
+
+function byAria(label: string): HTMLElement[] {
+	return queryAll<HTMLElement>(`[aria-label="${label}"]`);
+}
+
+function click(el: HTMLElement | null | undefined) {
+	expect(el, "expected an element to click").toBeTruthy();
+	el!.click();
+}
+
+describe("portable_text field", () => {
+	it("mounts a nested editor and emits Portable Text arrays, never strings", async () => {
+		const onChange = vi.fn();
+		await render(
+			<_BlockKitPortableTextField
+				field={{ type: "portable_text", action_id: "content", label: "Content" }}
+				value={[
+					{
+						_type: "block",
+						_key: "b1",
+						style: "normal",
+						markDefs: [],
+						children: [{ _type: "span", _key: "s1", text: "seeded", marks: ["strong"] }],
+					},
+				]}
+				onChange={onChange}
+			/>,
+		);
+		await vi.waitFor(() => expect(query('[contenteditable="true"]')).toBeTruthy());
+		expect(screenRoot().textContent).toContain("seeded");
+
+		const pm = query<HTMLElement>('[contenteditable="true"]')!;
+		pm.focus();
+		document.execCommand("insertText", false, "!");
+		await vi.waitFor(() => expect(onChange).toHaveBeenCalled(), { timeout: 3000 });
+
+		const [actionId, emitted] = onChange.mock.calls.at(-1)!;
+		expect(actionId).toBe("content");
+		expect(Array.isArray(emitted)).toBe(true);
+		const blocks = emitted as Array<{ _type: string; children?: Array<{ marks?: string[] }> }>;
+		expect(blocks[0]!._type).toBe("block");
+		// the seeded strong mark survives the round trip
+		expect(blocks[0]!.children?.some((span) => (span.marks ?? []).includes("strong"))).toBe(true);
+	});
+});
+
+describe("block_list field", () => {
+	function renderList(
+		onChange: (actionId: string, value: unknown) => void,
+		value: unknown = [],
+		extra?: React.ReactNode,
+	) {
+		return render(
+			<_PluginBlockCatalogContext.Provider value={catalog}>
+				<_BlockListSiblingsProvider>
+					<_BlockKitBlockListField
+						field={{ type: "block_list", action_id: "blocks", label: "Blocks" }}
+						value={value}
+						onChange={onChange}
+					/>
+					{extra}
+				</_BlockListSiblingsProvider>
+			</_PluginBlockCatalogContext.Provider>,
+		);
+	}
+
+	it("adds a registered block through its own Block Kit form", async () => {
+		const onChange = vi.fn();
+		await renderList(onChange);
+
+		click(queryAll<HTMLButtonElement>("button").find((b) => b.textContent?.includes("Add block")));
+		// two registered types -> a type picker appears; committing a choice opens the child form.
+		await vi.waitFor(() => expect(queryAll("[role='combobox']").length).toBeGreaterThan(0));
+		const trigger = queryAll<HTMLElement>("[role='combobox']").at(-1);
+		expect(trigger).toBeTruthy();
+
+		// drive the child form directly through the modal once a type is chosen
+		// (the base-ui select needs a real pointer; choose via keyboard events instead)
+		trigger!.focus();
+		trigger!.click();
+		await vi.waitFor(() => expect(queryAll("[role='option']").length).toBeGreaterThan(0));
+		click(queryAll<HTMLElement>("[role='option']").find((o) => o.textContent === "Heading"));
+
+		await vi.waitFor(() => expect(screenRoot().textContent).toContain("Insert Heading"));
+		const textInput = queryAll<HTMLInputElement>("input[type='text']").at(-1)!;
+		textInput.focus();
+		const nativeSetter = Object.getOwnPropertyDescriptor(
+			window.HTMLInputElement.prototype,
+			"value",
+		)!.set!;
+		nativeSetter.call(textInput, "Hello world");
+		textInput.dispatchEvent(new Event("input", { bubbles: true }));
+		await vi.waitFor(() =>
+			expect(
+				queryAll<HTMLButtonElement>("button").find(
+					(b) => b.type === "submit" && !b.disabled && b.textContent === "Insert",
+				),
+			).toBeTruthy(),
+		);
+		click(
+			queryAll<HTMLButtonElement>("button").find(
+				(b) => b.type === "submit" && b.textContent === "Insert",
+			),
+		);
+
+		await vi.waitFor(() => expect(onChange).toHaveBeenCalled());
+		const [actionId, emitted] = onChange.mock.calls.at(-1)!;
+		expect(actionId).toBe("blocks");
+		const items = emitted as Array<Record<string, unknown>>;
+		expect(items).toHaveLength(1);
+		expect(items[0]!._type).toBe("acme.heading");
+		expect(typeof items[0]!._key).toBe("string");
+		expect(items[0]!.text).toBe("Hello world");
+	});
+
+	it("duplicates and removes items, keeping ordinary block objects", async () => {
+		const onChange = vi.fn();
+		await renderList(onChange, [
+			{ _type: "acme.heading", _key: "k1", text: "One" },
+			{ _type: "acme.note", _key: "k2", body: "Two" },
+		]);
+
+		click(byAria("Duplicate item 1")[0]);
+		await vi.waitFor(() => expect(onChange).toHaveBeenCalled());
+		let items = onChange.mock.calls.at(-1)![1] as Array<Record<string, unknown>>;
+		expect(items.map((i) => i._type)).toEqual(["acme.heading", "acme.heading", "acme.note"]);
+		expect(items[1]!.text).toBe("One");
+		expect(items[1]!._key).not.toBe("k1");
+
+		await vi.waitFor(() => expect(byAria("Remove item 3").length).toBeGreaterThan(0));
+		click(byAria("Remove item 3")[0]);
+		items = onChange.mock.calls.at(-1)![1] as Array<Record<string, unknown>>;
+		expect(items.map((i) => i._key)).toEqual(["k1", items[1]!._key]);
+	});
+
+	it("moves an item to a sibling list registered in the same form", async () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		await render(
+			<_PluginBlockCatalogContext.Provider value={catalog}>
+				<_BlockListSiblingsProvider>
+					<_BlockKitBlockListField
+						field={{ type: "block_list", action_id: "colA", label: "Column A" }}
+						value={[{ _type: "acme.heading", _key: "k1", text: "Movable" }]}
+						onChange={first}
+					/>
+					<_BlockKitBlockListField
+						field={{ type: "block_list", action_id: "colB", label: "Column B" }}
+						value={[]}
+						onChange={second}
+					/>
+				</_BlockListSiblingsProvider>
+			</_PluginBlockCatalogContext.Provider>,
+		);
+
+		// the first list's item offers a move target naming the sibling
+		const moveTrigger = queryAll<HTMLElement>("[role='combobox']").at(0);
+		expect(moveTrigger).toBeTruthy();
+		moveTrigger!.click();
+		await vi.waitFor(() => expect(queryAll("[role='option']").length).toBeGreaterThan(0));
+		click(queryAll<HTMLElement>("[role='option']").find((o) => o.textContent === "Column B"));
+
+		await vi.waitFor(() => expect(second).toHaveBeenCalled());
+		const received = second.mock.calls.at(-1)![1] as Array<Record<string, unknown>>;
+		expect(received).toHaveLength(1);
+		expect(received[0]!.text).toBe("Movable");
+		const remaining = first.mock.calls.at(-1)![1] as Array<Record<string, unknown>>;
+		expect(remaining).toHaveLength(0);
+	});
+});
+
+describe("plugin block Duplicate affordance", () => {
+	it("duplicates a plugin block in the document with identical data", async () => {
+		const onChange = vi.fn();
+		await render(
+			<PortableTextEditor
+				value={[{ _type: "acme.heading", _key: "pb1", text: "Duplicate me" } as never]}
+				onChange={onChange}
+				pluginBlocks={catalog}
+			/>,
+		);
+		await vi.waitFor(() => expect(byAria("Duplicate").length).toBeGreaterThan(0), {
+			timeout: 5000,
+		});
+
+		click(byAria("Duplicate")[0]);
+		await vi.waitFor(() => {
+			const blocks = (onChange.mock.calls.at(-1)?.[0] ?? []) as Array<Record<string, unknown>>;
+			expect(blocks.filter((b) => b._type === "acme.heading")).toHaveLength(2);
+		});
+		const blocks = onChange.mock.calls.at(-1)![0] as Array<Record<string, unknown>>;
+		const copies = blocks.filter((b) => b._type === "acme.heading");
+		expect(copies[0]!.text).toBe("Duplicate me");
+		expect(copies[1]!.text).toBe("Duplicate me");
+	});
+});

--- a/packages/admin/tests/editor/block-kit-structured-fields.test.tsx
+++ b/packages/admin/tests/editor/block-kit-structured-fields.test.tsx
@@ -11,6 +11,7 @@
 import * as React from "react";
 import { describe, it, expect, vi } from "vitest";
 
+import { visiblePluginBlocks } from "../../src/components/editor/PluginBlockNode";
 import type { PluginBlockDef } from "../../src/components/PortableTextEditor";
 import {
 	_BlockKitBlockListField,
@@ -43,6 +44,13 @@ const catalog: PluginBlockDef[] = [
 		pluginId: "acme",
 		label: "Note",
 		fields: [{ type: "text_input", action_id: "body", label: "Body" }],
+	},
+	{
+		type: "acme.widget",
+		pluginId: "acme",
+		label: "Widget",
+		hidden: true,
+		fields: [{ type: "text_input", action_id: "title", label: "Title" }],
 	},
 ];
 
@@ -225,6 +233,60 @@ describe("block_list field", () => {
 		expect(received[0]!.text).toBe("Movable");
 		const remaining = first.mock.calls.at(-1)![1] as Array<Record<string, unknown>>;
 		expect(remaining).toHaveLength(0);
+	});
+});
+
+describe("hidden plugin blocks", () => {
+	it("visiblePluginBlocks keeps only defs without the hidden flag", () => {
+		expect(visiblePluginBlocks(catalog).map((b) => b.type)).toEqual(["acme.heading", "acme.note"]);
+	});
+
+	it("the default add picker offers only visible blocks", async () => {
+		await render(
+			<_PluginBlockCatalogContext.Provider value={catalog}>
+				<_BlockListSiblingsProvider>
+					<_BlockKitBlockListField
+						field={{ type: "block_list", action_id: "blocks", label: "Blocks" }}
+						value={[]}
+						onChange={vi.fn()}
+					/>
+				</_BlockListSiblingsProvider>
+			</_PluginBlockCatalogContext.Provider>,
+		);
+
+		click(queryAll<HTMLButtonElement>("button").find((b) => b.textContent?.includes("Add block")));
+		await vi.waitFor(() => expect(queryAll("[role='combobox']").length).toBeGreaterThan(0));
+		const trigger = queryAll<HTMLElement>("[role='combobox']").at(-1)!;
+		trigger.focus();
+		trigger.click();
+		await vi.waitFor(() => expect(queryAll("[role='option']").length).toBeGreaterThan(0));
+		const labels = queryAll<HTMLElement>("[role='option']").map((o) => o.textContent);
+		expect(labels).toContain("Heading");
+		expect(labels).toContain("Note");
+		expect(labels).not.toContain("Widget");
+	});
+
+	it("an explicit allowed_types list still offers a hidden block", async () => {
+		await render(
+			<_PluginBlockCatalogContext.Provider value={catalog}>
+				<_BlockListSiblingsProvider>
+					<_BlockKitBlockListField
+						field={{
+							type: "block_list",
+							action_id: "blocks",
+							label: "Blocks",
+							allowed_types: ["acme.widget"],
+						}}
+						value={[]}
+						onChange={vi.fn()}
+					/>
+				</_BlockListSiblingsProvider>
+			</_PluginBlockCatalogContext.Provider>,
+		);
+
+		// a single allowed type skips the picker and opens the child form directly
+		click(queryAll<HTMLButtonElement>("button").find((b) => b.textContent?.includes("Add block")));
+		await vi.waitFor(() => expect(screenRoot().textContent).toContain("Insert Widget"));
 	});
 });
 

--- a/packages/blocks/src/builders.ts
+++ b/packages/blocks/src/builders.ts
@@ -38,6 +38,8 @@ import type {
 	ToggleElement,
 	TabBlock,
 	TabPanel,
+	PortableTextElement,
+	BlockListElement,
 } from "./types.js";
 
 // ── Block Builders ───────────────────────────────────────────────────────────
@@ -374,6 +376,46 @@ function mediaPicker(
 	};
 }
 
+function portableText(
+	actionId: string,
+	label: string,
+	opts?: {
+		placeholder?: string;
+		initialValue?: Array<Record<string, unknown>>;
+	},
+): PortableTextElement {
+	return {
+		type: "portable_text",
+		action_id: actionId,
+		label,
+		...(opts?.placeholder !== undefined && { placeholder: opts.placeholder }),
+		...(opts?.initialValue !== undefined && { initial_value: opts.initialValue }),
+	};
+}
+
+function blockList(
+	actionId: string,
+	label: string,
+	opts?: {
+		itemLabel?: string;
+		allowedTypes?: string[];
+		minItems?: number;
+		maxItems?: number;
+		initialValue?: Array<Record<string, unknown>>;
+	},
+): BlockListElement {
+	return {
+		type: "block_list",
+		action_id: actionId,
+		label,
+		...(opts?.itemLabel !== undefined && { item_label: opts.itemLabel }),
+		...(opts?.allowedTypes !== undefined && { allowed_types: opts.allowedTypes }),
+		...(opts?.minItems !== undefined && { min_items: opts.minItems }),
+		...(opts?.maxItems !== undefined && { max_items: opts.maxItems }),
+		...(opts?.initialValue !== undefined && { initial_value: opts.initialValue }),
+	};
+}
+
 function timeseriesChart(opts: {
 	blockId?: string;
 	series: ChartSeries[];
@@ -532,4 +574,6 @@ export const elements = {
 	radio,
 	repeater,
 	mediaPicker,
+	portableText,
+	blockList,
 };

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -25,6 +25,8 @@ export type {
 	RepeaterElement,
 	RepeaterSubField,
 	MediaPickerElement,
+	PortableTextElement,
+	BlockListElement,
 	Element,
 	// Form
 	FieldCondition,

--- a/packages/blocks/src/render-element.tsx
+++ b/packages/blocks/src/render-element.tsx
@@ -56,6 +56,11 @@ export function renderElement(
 			return null;
 		case "media_picker":
 			return null;
+		case "portable_text":
+		case "block_list":
+			// Admin-authoring only, like `repeater`: the value is persisted on the
+			// parent block and consumed by the plugin's own runtime component.
+			return null;
 		default: {
 			const _exhaustive: never = element;
 			return null;

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -97,14 +97,18 @@ export interface RadioElement {
 }
 
 /**
- * Sub-field types allowed inside a RepeaterElement. Limited to the scalar
- * inputs the admin widget currently renders inline.
+ * Sub-field types allowed inside a RepeaterElement: the scalar inputs the
+ * admin widget renders inline, plus the two structured fields (`portable_text`
+ * and `block_list`) so a repeater row can carry rich text or an ordered list
+ * of registered blocks (e.g. a column carrying its content).
  */
 export type RepeaterSubField =
 	| TextInputElement
 	| NumberInputElement
 	| SelectElement
-	| ToggleElement;
+	| ToggleElement
+	| PortableTextElement
+	| BlockListElement;
 
 /**
  * Array-of-objects field. Renders as a list of collapsible cards with inline
@@ -150,6 +154,46 @@ export interface MediaPickerElement {
 	placeholder?: string;
 }
 
+/**
+ * Rich-text field whose value is a Portable Text block array. The admin widget
+ * renders it as a nested instance of the standard Portable Text editor, so the
+ * value keeps its full structure -- blocks, spans, marks, markDefs and keys --
+ * and is never flattened to a string. The runtime block renderer
+ * (`renderElement`) deliberately returns `null` for `portable_text`; the value
+ * is persisted on the parent block and consumed by the plugin's own runtime
+ * component.
+ */
+export interface PortableTextElement {
+	type: "portable_text";
+	action_id: string;
+	label: string;
+	placeholder?: string;
+	initial_value?: Array<Record<string, unknown>>;
+}
+
+/**
+ * Ordered list of registered plugin blocks. The admin widget renders it as a
+ * list of cards with add (choosing from the same registered block catalog the
+ * document editor offers), edit (the chosen block's own Block Kit form),
+ * duplicate, delete, drag-and-drop reordering, and -- when several block lists
+ * are present in one form -- moving an item to a sibling list. Each stored
+ * item is an ordinary registered block object (`{ _type, _key, ...fields }`),
+ * never serialized HTML or a private document format. Like `repeater`, the
+ * runtime block renderer returns `null` for `block_list`.
+ */
+export interface BlockListElement {
+	type: "block_list";
+	action_id: string;
+	label: string;
+	/** Singular label used in the UI (e.g. "Block" → "Add Block"). */
+	item_label?: string;
+	/** Registered block types an item may use. Defaults to every registered block. */
+	allowed_types?: string[];
+	min_items?: number;
+	max_items?: number;
+	initial_value?: Array<Record<string, unknown>>;
+}
+
 export type Element =
 	| ButtonElement
 	| TextInputElement
@@ -162,7 +206,9 @@ export type Element =
 	| ComboboxElement
 	| RadioElement
 	| RepeaterElement
-	| MediaPickerElement;
+	| MediaPickerElement
+	| PortableTextElement
+	| BlockListElement;
 
 // ── Form Fields (elements + optional condition) ──────────────────────────────
 

--- a/packages/blocks/src/validation.ts
+++ b/packages/blocks/src/validation.ts
@@ -33,9 +33,18 @@ const ELEMENT_TYPES = new Set([
 	"combobox",
 	"repeater",
 	"media_picker",
+	"portable_text",
+	"block_list",
 ]);
 
-const REPEATER_SUB_FIELD_TYPES = new Set(["text_input", "number_input", "select", "toggle"]);
+const REPEATER_SUB_FIELD_TYPES = new Set([
+	"text_input",
+	"number_input",
+	"select",
+	"toggle",
+	"portable_text",
+	"block_list",
+]);
 
 const COLUMN_FORMATS = new Set(["text", "badge", "relative_time", "number", "code"]);
 
@@ -580,6 +589,113 @@ function validateElement(value: unknown, path: string, errors: ValidationError[]
 					path: `${path}.placeholder`,
 					message: "Field 'placeholder' must be a string",
 				});
+			}
+			break;
+		}
+		case "portable_text": {
+			if (value.placeholder !== undefined && typeof value.placeholder !== "string") {
+				errors.push({
+					path: `${path}.placeholder`,
+					message: "Field 'placeholder' must be a string",
+				});
+			}
+			if (value.initial_value !== undefined) {
+				if (!Array.isArray(value.initial_value)) {
+					errors.push({
+						path: `${path}.initial_value`,
+						message: "Field 'initial_value' must be an array of Portable Text blocks",
+					});
+				} else {
+					for (let i = 0; i < value.initial_value.length; i++) {
+						if (!isRecord(value.initial_value[i])) {
+							errors.push({
+								path: `${path}.initial_value[${i}]`,
+								message: "Each initial_value entry must be a Portable Text block object",
+							});
+						}
+					}
+				}
+			}
+			break;
+		}
+		case "block_list": {
+			if (value.item_label !== undefined && typeof value.item_label !== "string") {
+				errors.push({
+					path: `${path}.item_label`,
+					message: "Field 'item_label' must be a string",
+				});
+			}
+			if (value.allowed_types !== undefined) {
+				if (!Array.isArray(value.allowed_types)) {
+					errors.push({
+						path: `${path}.allowed_types`,
+						message: "Field 'allowed_types' must be an array of block type strings",
+					});
+				} else {
+					for (let i = 0; i < value.allowed_types.length; i++) {
+						const entry = value.allowed_types[i];
+						if (typeof entry !== "string" || entry.length === 0) {
+							errors.push({
+								path: `${path}.allowed_types[${i}]`,
+								message: "Each allowed_types entry must be a non-empty string",
+							});
+						}
+					}
+				}
+			}
+			const minOk =
+				value.min_items === undefined ||
+				(typeof value.min_items === "number" &&
+					Number.isInteger(value.min_items) &&
+					value.min_items >= 0);
+			if (!minOk) {
+				errors.push({
+					path: `${path}.min_items`,
+					message: "Field 'min_items' must be a non-negative integer",
+				});
+			}
+			const maxOk =
+				value.max_items === undefined ||
+				(typeof value.max_items === "number" &&
+					Number.isInteger(value.max_items) &&
+					value.max_items >= 0);
+			if (!maxOk) {
+				errors.push({
+					path: `${path}.max_items`,
+					message: "Field 'max_items' must be a non-negative integer",
+				});
+			}
+			if (
+				minOk &&
+				maxOk &&
+				value.min_items !== undefined &&
+				value.max_items !== undefined &&
+				typeof value.min_items === "number" &&
+				typeof value.max_items === "number" &&
+				value.min_items > value.max_items
+			) {
+				errors.push({
+					path: `${path}.min_items`,
+					message: "Field 'min_items' must be less than or equal to 'max_items'",
+				});
+			}
+			if (value.initial_value !== undefined) {
+				if (!Array.isArray(value.initial_value)) {
+					errors.push({
+						path: `${path}.initial_value`,
+						message: "Field 'initial_value' must be an array",
+					});
+				} else {
+					for (let i = 0; i < value.initial_value.length; i++) {
+						const entry = value.initial_value[i];
+						if (!isRecord(entry) || typeof entry._type !== "string" || entry._type.length === 0) {
+							errors.push({
+								path: `${path}.initial_value[${i}]`,
+								message: "Each initial_value entry must be a block object with a '_type' string",
+							});
+						}
+					}
+				}
 			}
 			break;
 		}

--- a/packages/blocks/tests/validation.test.ts
+++ b/packages/blocks/tests/validation.test.ts
@@ -159,6 +159,75 @@ describe("validateBlocks", () => {
 			expect(result).toEqual({ valid: true, errors: [] });
 		});
 
+		it("portable_text", () => {
+			const result = validateBlocks([
+				{
+					type: "actions",
+					elements: [
+						{
+							type: "portable_text",
+							action_id: "content",
+							label: "Content",
+							placeholder: "Write...",
+							initial_value: [
+								{
+									_type: "block",
+									_key: "b1",
+									style: "normal",
+									markDefs: [{ _key: "l1", _type: "link", href: "https://example.com" }],
+									children: [{ _type: "span", _key: "s1", text: "hello", marks: ["strong", "l1"] }],
+								},
+							],
+						},
+					],
+				},
+			]);
+			expect(result).toEqual({ valid: true, errors: [] });
+		});
+
+		it("block_list", () => {
+			const result = validateBlocks([
+				{
+					type: "actions",
+					elements: [
+						{
+							type: "block_list",
+							action_id: "blocks",
+							label: "Blocks",
+							item_label: "Block",
+							allowed_types: ["acme.heading", "acme.text"],
+							min_items: 0,
+							max_items: 12,
+							initial_value: [{ _type: "acme.heading", _key: "k1", text: "Hi" }],
+						},
+					],
+				},
+			]);
+			expect(result).toEqual({ valid: true, errors: [] });
+		});
+
+		it("repeater with portable_text and block_list sub-fields", () => {
+			const result = validateBlocks([
+				{
+					type: "actions",
+					elements: [
+						{
+							type: "repeater",
+							action_id: "columns",
+							label: "Columns",
+							item_label: "Column",
+							fields: [
+								{ type: "number_input", action_id: "width", label: "Width" },
+								{ type: "portable_text", action_id: "intro", label: "Intro" },
+								{ type: "block_list", action_id: "blocks", label: "Blocks" },
+							],
+						},
+					],
+				},
+			]);
+			expect(result).toEqual({ valid: true, errors: [] });
+		});
+
 		it("media_picker (minimal)", () => {
 			const result = validateBlocks([
 				{
@@ -268,6 +337,61 @@ describe("validateBlocks", () => {
 			const paths = result.errors.map((e) => e.path);
 			expect(paths).toContain("blocks[0].columns[0].key");
 			expect(paths).toContain("blocks[0].columns[0].label");
+		});
+
+		it("portable_text with non-array initial_value", () => {
+			const result = validateBlocks([
+				{
+					type: "actions",
+					elements: [
+						{
+							type: "portable_text",
+							action_id: "content",
+							label: "Content",
+							initial_value: "a plain string",
+						},
+					],
+				},
+			]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0].path).toContain("initial_value");
+		});
+
+		it("block_list with an initial_value entry missing _type", () => {
+			const result = validateBlocks([
+				{
+					type: "actions",
+					elements: [
+						{
+							type: "block_list",
+							action_id: "blocks",
+							label: "Blocks",
+							initial_value: [{ text: "no type here" }],
+						},
+					],
+				},
+			]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0].message).toContain("_type");
+		});
+
+		it("block_list with min_items greater than max_items", () => {
+			const result = validateBlocks([
+				{
+					type: "actions",
+					elements: [
+						{
+							type: "block_list",
+							action_id: "blocks",
+							label: "Blocks",
+							min_items: 3,
+							max_items: 1,
+						},
+					],
+				},
+			]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0].path).toContain("min_items");
 		});
 
 		it("table column with invalid format", () => {


### PR DESCRIPTION
## What does this PR do?

Adds two structured Block Kit elements — `portable_text` and `block_list` — and a Duplicate action on plugin block cards, so plugin blocks can carry rich text and nested registered-block content that stays fully editable in the admin editor.

- **`portable_text`**: the plugin block dialog mounts the existing `PortableTextEditor` for a Portable Text block array. Structure round-trips intact (blocks, spans, marks, markDefs, keys) and is never flattened to a string. The previous best option — a multiline `text_input` over stored Portable Text — showed an empty box and replaced the array with a plain string on save.
- **`block_list`**: an ordered list of registered plugin blocks (`{ _type, _key, ...fields }` items). Authors add from the same registered catalog the document editor offers, edit through the chosen block's own Block Kit form, duplicate, delete, drag to reorder, and move an item to a sibling list when one form holds several lists (including lists nested in `repeater` rows — e.g. one list per column). `allowed_types` / `min_items` / `max_items` bound the list.
- **Duplicate** on plugin block cards inserts an identical copy after the original, beside Edit and Delete.

Both elements are additive `Element` union members with validation mirroring their peers, are accepted as `repeater` sub-fields, and return `null` from the runtime `renderElement` exactly like `repeater`. No existing block or stored value changes behavior.

Discussion: https://github.com/emdash-cms/emdash/discussions/2673 (opened alongside this PR — maintainer approval pending; happy to adjust the design there).

Closes #

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (`@emdash-cms/blocks` and `@emdash-cms/admin`; `registry-verification` needs built siblings and is untouched)
- [x] `pnpm lint` passes (`lint:quick` clean)
- [x] `pnpm test` passes (blocks 120/120; full admin browser suite 124 files / 1523 tests; new focused suite `tests/editor/block-kit-structured-fields.test.tsx` covers all three behaviors)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/2673 (approval pending — opened with this PR)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

```
blocks:  Test Files  4 passed (4) · Tests  120 passed (120)
admin:   Test Files  124 passed (124) · Tests  1523 passed (1523)
new:     tests/editor/block-kit-structured-fields.test.tsx  5 passed (5)
```
