### PR TITLE
fix(admin): align byline field switches

### DIFF
--- a/.changeset/soft-lions-align.md
+++ b/.changeset/soft-lions-align.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the vertical alignment of the Required and Translatable switches in the byline field editor when helper text appears below Translatable.

--- a/e2e/tests/byline-fields.spec.ts
+++ b/e2e/tests/byline-fields.spec.ts
@@ -32,6 +32,19 @@ test.describe("Byline custom fields", () => {
 		await admin.devBypassAuth();
 	});
 
+	test("top-aligns schema switches when one has helper text", async ({ admin, page }) => {
+		await admin.goto("/byline-schema");
+		await admin.waitForLoading();
+		await page.getByRole("button", { name: "New field" }).click();
+
+		const requiredBox = await page.getByRole("switch", { name: "Required" }).boundingBox();
+		const translatableBox = await page.getByRole("switch", { name: "Translatable" }).boundingBox();
+
+		expect(requiredBox).not.toBeNull();
+		expect(translatableBox).not.toBeNull();
+		expect(Math.abs(requiredBox!.y - translatableBox!.y)).toBeLessThanOrEqual(1);
+	});
+
 	test("custom field value round-trips through the API end to end", async ({
 		admin,
 		page,

--- a/packages/admin/src/components/BylineFieldEditor.tsx
+++ b/packages/admin/src/components/BylineFieldEditor.tsx
@@ -271,7 +271,7 @@ export function BylineFieldEditor({
 					</div>
 
 					{/* Toggles */}
-					<div className="flex flex-wrap items-center gap-6">
+					<div className="flex flex-wrap items-start gap-6">
 						{/* TODO: enforce `required` on the write path — currently
 						 * descriptive only, see `BylineRepository.coerceFieldValue`. */}
 						<Switch


### PR DESCRIPTION
## What does this PR do?

Top-aligns the Required and Translatable switches in the byline field editor. The helper text below Translatable made the Required switch vertically center against the taller two-line block, producing a 16.2 px offset in the tested desktop layout.

Adds an E2E regression test that compares the rendered switch positions. The test fails before the fix with a 16.2 px difference and passes after the fix.

Related issue: none (identified during a Japanese admin UI review).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). No strings changed and no `messages.po` files are included.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: Not applicable; this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.6 Codex

## Screenshots / test output

- Before: switch top positions differed by 16.2 px.
- After: switch top positions differ by 0 px in the deployed review build.
- `pnpm exec playwright test e2e/tests/byline-fields.spec.ts --grep "top-aligns schema switches" --reporter=line` (1 passed)
- `pnpm --filter @emdash-cms/admin exec vitest run tests/routes/byline-schema.test.tsx` (18 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:quick`
- `pnpm lint:json | jq '.diagnostics | length'` (0)
- `pnpm build`
