### PR TITLE
fix(admin): translate WordPress import summaries

### DIFF
--- a/.changeset/quiet-zebras-import.md
+++ b/.changeset/quiet-zebras-import.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes WordPress import completion summaries so translated media counts use the correct word order and singular or plural forms.

--- a/packages/admin/src/components/MediaImportSummary.tsx
+++ b/packages/admin/src/components/MediaImportSummary.tsx
@@ -1,4 +1,5 @@
-import { Trans } from "@lingui/react";
+import { plural } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react/macro";
 import * as React from "react";
 
 interface MediaImportSummaryProps {
@@ -12,24 +13,33 @@ export function MediaImportSummary({
 	rewrittenUrls,
 	updatedContentItems,
 }: MediaImportSummaryProps) {
+	const { t } = useLingui();
+	const importedFilesSummary = t({
+		message: plural(importedFiles, {
+			one: "# file imported",
+			other: "# files imported",
+		}),
+	});
+	const rewrittenUrlsSummary =
+		rewrittenUrls !== undefined && updatedContentItems !== undefined
+			? t({
+					message: plural(rewrittenUrls, {
+						one: `# image URL updated in ${plural(updatedContentItems, {
+							one: "# content item",
+							other: "# content items",
+						})}`,
+						other: `# image URLs updated in ${plural(updatedContentItems, {
+							one: "# content item",
+							other: "# content items",
+						})}`,
+					}),
+				})
+			: null;
+
 	return (
 		<>
-			<p>
-				<Trans
-					id="{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}"
-					values={{ importedFiles }}
-					components={{ count: <strong /> }}
-				/>
-			</p>
-			{rewrittenUrls !== undefined && updatedContentItems !== undefined && (
-				<p>
-					<Trans
-						id="{rewrittenUrls, plural, one {<urlCount>#</urlCount> image URL updated in {updatedContentItems, plural, one {<itemCount>#</itemCount> content item} other {<itemCount>#</itemCount> content items}}} other {<urlCount>#</urlCount> image URLs updated in {updatedContentItems, plural, one {<itemCount>#</itemCount> content item} other {<itemCount>#</itemCount> content items}}}}"
-						values={{ rewrittenUrls, updatedContentItems }}
-						components={{ urlCount: <strong />, itemCount: <strong /> }}
-					/>
-				</p>
-			)}
+			<p>{importedFilesSummary}</p>
+			{rewrittenUrlsSummary !== null && <p>{rewrittenUrlsSummary}</p>}
 		</>
 	);
 }

--- a/packages/admin/src/components/MediaImportSummary.tsx
+++ b/packages/admin/src/components/MediaImportSummary.tsx
@@ -1,0 +1,35 @@
+import { Trans } from "@lingui/react";
+import * as React from "react";
+
+interface MediaImportSummaryProps {
+	importedFiles: number;
+	rewrittenUrls?: number;
+	updatedContentItems?: number;
+}
+
+export function MediaImportSummary({
+	importedFiles,
+	rewrittenUrls,
+	updatedContentItems,
+}: MediaImportSummaryProps) {
+	return (
+		<>
+			<p>
+				<Trans
+					id="{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}"
+					values={{ importedFiles }}
+					components={{ count: <strong /> }}
+				/>
+			</p>
+			{rewrittenUrls !== undefined && updatedContentItems !== undefined && (
+				<p>
+					<Trans
+						id="{rewrittenUrls, plural, one {<urlCount>#</urlCount> image URL updated in {updatedContentItems, plural, one {<itemCount>#</itemCount> content item} other {<itemCount>#</itemCount> content items}}} other {<urlCount>#</urlCount> image URLs updated in {updatedContentItems, plural, one {<itemCount>#</itemCount> content item} other {<itemCount>#</itemCount> content items}}}}"
+						values={{ rewrittenUrls, updatedContentItems }}
+						components={{ urlCount: <strong />, itemCount: <strong /> }}
+					/>
+				</p>
+			)}
+		</>
+	);
+}

--- a/packages/admin/src/components/MediaImportSummary.tsx
+++ b/packages/admin/src/components/MediaImportSummary.tsx
@@ -1,5 +1,5 @@
 import { plural } from "@lingui/core/macro";
-import { useLingui } from "@lingui/react/macro";
+import { Trans } from "@lingui/react/macro";
 import * as React from "react";
 
 interface MediaImportSummaryProps {
@@ -13,33 +13,30 @@ export function MediaImportSummary({
 	rewrittenUrls,
 	updatedContentItems,
 }: MediaImportSummaryProps) {
-	const { t } = useLingui();
-	const importedFilesSummary = t({
-		message: plural(importedFiles, {
-			one: "# file imported",
-			other: "# files imported",
-		}),
-	});
-	const rewrittenUrlsSummary =
-		rewrittenUrls !== undefined && updatedContentItems !== undefined
-			? t({
-					message: plural(rewrittenUrls, {
-						one: `# image URL updated in ${plural(updatedContentItems, {
-							one: "# content item",
-							other: "# content items",
-						})}`,
-						other: `# image URLs updated in ${plural(updatedContentItems, {
-							one: "# content item",
-							other: "# content items",
-						})}`,
-					}),
-				})
-			: null;
-
 	return (
 		<>
-			<p>{importedFilesSummary}</p>
-			{rewrittenUrlsSummary !== null && <p>{rewrittenUrlsSummary}</p>}
+			<p>
+				<Trans>
+					<strong>{importedFiles}</strong>{" "}
+					{plural(importedFiles, { one: "file imported", other: "files imported" })}
+				</Trans>
+			</p>
+			{rewrittenUrls !== undefined && updatedContentItems !== undefined && (
+				<p>
+					<Trans>
+						<strong>{rewrittenUrls}</strong>{" "}
+						{plural(rewrittenUrls, {
+							one: "image URL updated",
+							other: "image URLs updated",
+						})}{" "}
+						in <strong>{updatedContentItems}</strong>{" "}
+						{plural(updatedContentItems, {
+							one: "content item",
+							other: "content items",
+						})}
+					</Trans>
+				</p>
+			)}
 		</>
 	);
 }

--- a/packages/admin/src/components/WordPressImport.tsx
+++ b/packages/admin/src/components/WordPressImport.tsx
@@ -60,6 +60,7 @@ import {
 } from "../lib/api";
 import { cn } from "../lib/utils";
 import { CaretNext } from "./ArrowIcons.js";
+import { MediaImportSummary } from "./MediaImportSummary.js";
 
 // ============================================================================
 // Constants
@@ -2362,15 +2363,15 @@ function CompleteStep({
 						<h3 className="font-medium">{t`Media Import`}</h3>
 					</div>
 					<div className="p-4 space-y-2 text-sm">
-						<p>
-							<strong>{mediaResult.imported.length}</strong> {t`files imported`}
-						</p>
-						{rewriteResult && rewriteResult.updated > 0 && (
-							<p>
-								<strong>{rewriteResult.urlsRewritten}</strong> {t`image URLs updated in`}{" "}
-								<strong>{rewriteResult.updated}</strong> {t`content items`}
-							</p>
-						)}
+						<MediaImportSummary
+							importedFiles={mediaResult.imported.length}
+							rewrittenUrls={
+								rewriteResult && rewriteResult.updated > 0 ? rewriteResult.urlsRewritten : undefined
+							}
+							updatedContentItems={
+								rewriteResult && rewriteResult.updated > 0 ? rewriteResult.updated : undefined
+							}
+						/>
 					</div>
 				</div>
 			)}

--- a/packages/admin/src/locales/ja/messages.po
+++ b/packages/admin/src/locales/ja/messages.po
@@ -203,6 +203,16 @@ msgstr "{0, plural, one {メディアファイル} other {メディアファイ�
 msgid "{0, plural, one {User} other {Users}}"
 msgstr "{0, plural, one {ユーザー} other {ユーザー}}"
 
+#. js-lingui-explicit-id
+#: packages/admin/src/components/MediaImportSummary.tsx:18
+msgid "{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}"
+msgstr "<count>{importedFiles}</count>件のファイルをインポートしました"
+
+#. js-lingui-explicit-id
+#: packages/admin/src/components/MediaImportSummary.tsx:26
+msgid "{rewrittenUrls, plural, one {<urlCount>#</urlCount> image URL updated in {updatedContentItems, plural, one {<itemCount>#</itemCount> content item} other {<itemCount>#</itemCount> content items}}} other {<urlCount>#</urlCount> image URLs updated in {updatedContentItems, plural, one {<itemCount>#</itemCount> content item} other {<itemCount>#</itemCount> content items}}}}"
+msgstr "<itemCount>{updatedContentItems}</itemCount>件のコンテンツで<urlCount>{rewrittenUrls}</urlCount>件の画像URLを更新しました"
+
 #. placeholder {0}: envLabel(m.key)
 #. placeholder {1}: m.required
 #. placeholder {2}: m.host

--- a/packages/admin/src/locales/ja/messages.po
+++ b/packages/admin/src/locales/ja/messages.po
@@ -203,16 +203,6 @@ msgstr "{0, plural, one {メディアファイル} other {メディアファイ�
 msgid "{0, plural, one {User} other {Users}}"
 msgstr "{0, plural, one {ユーザー} other {ユーザー}}"
 
-#. js-lingui-explicit-id
-#: packages/admin/src/components/MediaImportSummary.tsx:18
-msgid "{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}"
-msgstr "<count>{importedFiles}</count>件のファイルをインポートしました"
-
-#. js-lingui-explicit-id
-#: packages/admin/src/components/MediaImportSummary.tsx:26
-msgid "{rewrittenUrls, plural, one {<urlCount>#</urlCount> image URL updated in {updatedContentItems, plural, one {<itemCount>#</itemCount> content item} other {<itemCount>#</itemCount> content items}}} other {<urlCount>#</urlCount> image URLs updated in {updatedContentItems, plural, one {<itemCount>#</itemCount> content item} other {<itemCount>#</itemCount> content items}}}}"
-msgstr "<itemCount>{updatedContentItems}</itemCount>件のコンテンツで<urlCount>{rewrittenUrls}</urlCount>件の画像URLを更新しました"
-
 #. placeholder {0}: envLabel(m.key)
 #. placeholder {1}: m.required
 #. placeholder {2}: m.host

--- a/packages/admin/tests/components/MediaImportSummary.test.tsx
+++ b/packages/admin/tests/components/MediaImportSummary.test.tsx
@@ -6,11 +6,6 @@ import { describe, expect, it } from "vitest";
 
 import { MediaImportSummary } from "../../src/components/MediaImportSummary.js";
 
-const IMPORTED_FILES_MESSAGE =
-	"{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}";
-const REWRITTEN_URLS_MESSAGE =
-	"{rewrittenUrls, plural, one {<urlCount>#</urlCount> image URL updated in {updatedContentItems, plural, one {<itemCount>#</itemCount> content item} other {<itemCount>#</itemCount> content items}}} other {<urlCount>#</urlCount> image URLs updated in {updatedContentItems, plural, one {<itemCount>#</itemCount> content item} other {<itemCount>#</itemCount> content items}}}}";
-
 function renderSummary(
 	props: React.ComponentProps<typeof MediaImportSummary>,
 	i18n: I18n = setupI18n({ locale: "en" }),
@@ -25,27 +20,35 @@ function renderSummary(
 describe("MediaImportSummary", () => {
 	it("renders each result as a complete pluralized message", () => {
 		expect(renderSummary({ importedFiles: 1, rewrittenUrls: 1, updatedContentItems: 2 })).toBe(
-			"<p><strong>1</strong> file imported</p><p><strong>1</strong> image URL updated in <strong>2</strong> content items</p>",
+			"<p>1 file imported</p><p>1 image URL updated in 2 content items</p>",
 		);
 
 		expect(renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 })).toBe(
-			"<p><strong>2</strong> files imported</p><p><strong>3</strong> image URLs updated in <strong>1</strong> content item</p>",
+			"<p>2 files imported</p><p>3 image URLs updated in 1 content item</p>",
 		);
 	});
 
 	it("lets translations reorder both counts without joining message fragments", () => {
 		const i18n = setupI18n();
-		i18n.load("ja", {
-			[IMPORTED_FILES_MESSAGE]: "<count>{importedFiles}</count>件のファイルをインポートしました",
-			[REWRITTEN_URLS_MESSAGE]:
-				"<itemCount>{updatedContentItems}</itemCount>件のコンテンツで<urlCount>{rewrittenUrls}</urlCount>件の画像URLを更新しました",
-		});
+		const messageIds: string[] = [];
+		i18n.load("ja", {});
 		i18n.activate("ja");
+		const removeMissingListener = i18n.on("missing", ({ id }) => messageIds.push(id));
+
+		renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 }, i18n);
+		removeMissingListener();
+
+		expect(messageIds).toHaveLength(2);
+		i18n.load("ja", {
+			[messageIds[0]!]: "{importedFiles}件のファイルをインポートしました",
+			[messageIds[1]!]:
+				"{updatedContentItems}件のコンテンツで{rewrittenUrls}件の画像URLを更新しました",
+		});
 
 		expect(
 			renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 }, i18n),
 		).toBe(
-			"<p><strong>2</strong>件のファイルをインポートしました</p><p><strong>1</strong>件のコンテンツで<strong>3</strong>件の画像URLを更新しました</p>",
+			"<p>2件のファイルをインポートしました</p><p>1件のコンテンツで3件の画像URLを更新しました</p>",
 		);
 	});
 });

--- a/packages/admin/tests/components/MediaImportSummary.test.tsx
+++ b/packages/admin/tests/components/MediaImportSummary.test.tsx
@@ -20,11 +20,11 @@ function renderSummary(
 describe("MediaImportSummary", () => {
 	it("renders each result as a complete pluralized message", () => {
 		expect(renderSummary({ importedFiles: 1, rewrittenUrls: 1, updatedContentItems: 2 })).toBe(
-			"<p>1 file imported</p><p>1 image URL updated in 2 content items</p>",
+			"<p><strong>1</strong> file imported</p><p><strong>1</strong> image URL updated in <strong>2</strong> content items</p>",
 		);
 
 		expect(renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 })).toBe(
-			"<p>2 files imported</p><p>3 image URLs updated in 1 content item</p>",
+			"<p><strong>2</strong> files imported</p><p><strong>3</strong> image URLs updated in <strong>1</strong> content item</p>",
 		);
 	});
 
@@ -40,15 +40,15 @@ describe("MediaImportSummary", () => {
 
 		expect(messageIds).toHaveLength(2);
 		i18n.load("ja", {
-			[messageIds[0]!]: "{importedFiles}件のファイルをインポートしました",
+			[messageIds[0]!]: "<0>{importedFiles}</0>件のファイルをインポートしました",
 			[messageIds[1]!]:
-				"{updatedContentItems}件のコンテンツで{rewrittenUrls}件の画像URLを更新しました",
+				"<1>{updatedContentItems}</1>件のコンテンツで<0>{rewrittenUrls}</0>件の画像URLを更新しました",
 		});
 
 		expect(
 			renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 }, i18n),
 		).toBe(
-			"<p>2件のファイルをインポートしました</p><p>1件のコンテンツで3件の画像URLを更新しました</p>",
+			"<p><strong>2</strong>件のファイルをインポートしました</p><p><strong>1</strong>件のコンテンツで<strong>3</strong>件の画像URLを更新しました</p>",
 		);
 	});
 });

--- a/packages/admin/tests/components/MediaImportSummary.test.tsx
+++ b/packages/admin/tests/components/MediaImportSummary.test.tsx
@@ -15,30 +15,22 @@ function renderSummary(
 	props: React.ComponentProps<typeof MediaImportSummary>,
 	i18n: I18n = setupI18n({ locale: "en" }),
 ) {
-	const html = renderToStaticMarkup(
+	return renderToStaticMarkup(
 		<I18nProvider i18n={i18n}>
 			<MediaImportSummary {...props} />
 		</I18nProvider>,
 	);
-
-	return html
-		.replaceAll("</p>", "\n")
-		.replaceAll(/<[^>]+>/g, "")
-		.trim()
-		.split("\n");
 }
 
 describe("MediaImportSummary", () => {
 	it("renders each result as a complete pluralized message", () => {
-		expect(renderSummary({ importedFiles: 1, rewrittenUrls: 1, updatedContentItems: 2 })).toEqual([
-			"1 file imported",
-			"1 image URL updated in 2 content items",
-		]);
+		expect(renderSummary({ importedFiles: 1, rewrittenUrls: 1, updatedContentItems: 2 })).toBe(
+			"<p><strong>1</strong> file imported</p><p><strong>1</strong> image URL updated in <strong>2</strong> content items</p>",
+		);
 
-		expect(renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 })).toEqual([
-			"2 files imported",
-			"3 image URLs updated in 1 content item",
-		]);
+		expect(renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 })).toBe(
+			"<p><strong>2</strong> files imported</p><p><strong>3</strong> image URLs updated in <strong>1</strong> content item</p>",
+		);
 	});
 
 	it("lets translations reorder both counts without joining message fragments", () => {
@@ -52,6 +44,8 @@ describe("MediaImportSummary", () => {
 
 		expect(
 			renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 }, i18n),
-		).toEqual(["2件のファイルをインポートしました", "1件のコンテンツで3件の画像URLを更新しました"]);
+		).toBe(
+			"<p><strong>2</strong>件のファイルをインポートしました</p><p><strong>1</strong>件のコンテンツで<strong>3</strong>件の画像URLを更新しました</p>",
+		);
 	});
 });

--- a/packages/admin/tests/components/MediaImportSummary.test.tsx
+++ b/packages/admin/tests/components/MediaImportSummary.test.tsx
@@ -1,0 +1,57 @@
+import { setupI18n, type I18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { MediaImportSummary } from "../../src/components/MediaImportSummary.js";
+
+const IMPORTED_FILES_MESSAGE =
+	"{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}";
+const REWRITTEN_URLS_MESSAGE =
+	"{rewrittenUrls, plural, one {<urlCount>#</urlCount> image URL updated in {updatedContentItems, plural, one {<itemCount>#</itemCount> content item} other {<itemCount>#</itemCount> content items}}} other {<urlCount>#</urlCount> image URLs updated in {updatedContentItems, plural, one {<itemCount>#</itemCount> content item} other {<itemCount>#</itemCount> content items}}}}";
+
+function renderSummary(
+	props: React.ComponentProps<typeof MediaImportSummary>,
+	i18n: I18n = setupI18n({ locale: "en" }),
+) {
+	const html = renderToStaticMarkup(
+		<I18nProvider i18n={i18n}>
+			<MediaImportSummary {...props} />
+		</I18nProvider>,
+	);
+
+	return html
+		.replaceAll("</p>", "\n")
+		.replaceAll(/<[^>]+>/g, "")
+		.trim()
+		.split("\n");
+}
+
+describe("MediaImportSummary", () => {
+	it("renders each result as a complete pluralized message", () => {
+		expect(renderSummary({ importedFiles: 1, rewrittenUrls: 1, updatedContentItems: 2 })).toEqual([
+			"1 file imported",
+			"1 image URL updated in 2 content items",
+		]);
+
+		expect(renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 })).toEqual([
+			"2 files imported",
+			"3 image URLs updated in 1 content item",
+		]);
+	});
+
+	it("lets translations reorder both counts without joining message fragments", () => {
+		const i18n = setupI18n();
+		i18n.load("ja", {
+			[IMPORTED_FILES_MESSAGE]: "<count>{importedFiles}</count>件のファイルをインポートしました",
+			[REWRITTEN_URLS_MESSAGE]:
+				"<itemCount>{updatedContentItems}</itemCount>件のコンテンツで<urlCount>{rewrittenUrls}</urlCount>件の画像URLを更新しました",
+		});
+		i18n.activate("ja");
+
+		expect(
+			renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 }, i18n),
+		).toEqual(["2件のファイルをインポートしました", "1件のコンテンツで3件の画像URLを更新しました"]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the WordPress import completion summary so media results are translated as complete messages instead of concatenated fragments. Imported-file counts use singular and plural forms, and the URL-rewrite summary keeps both counts in one nested ICU message so translations can reorder them.

The Japanese summary now reads naturally as "2件のファイルをインポートしました" and "1件のコンテンツで3件の画像URLを更新しました" while preserving the emphasized counts.

Related review: #2675

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

No screenshot is included because the completion summary requires a completed WordPress media import.

Verified locally:

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint:json` (0 diagnostics)
- `pnpm locale:compile`
- `MediaImportSummary.test.tsx` (2 tests passed)
- Targeted oxfmt check
- `git diff --check`
