### PR TITLE
fix(media): restore AVIF to the default upload allowlist

### DIFF
--- a/.changeset/avif-media-uploads.md
+++ b/.changeset/avif-media-uploads.md
@@ -1,0 +1,10 @@
+---
+"emdash": patch
+"@emdash-cms/admin": patch
+---
+
+Fixes AVIF images being rejected with "File type not allowed" on upload. `image/avif` is back in the default media allowlist alongside PNG, JPEG, GIF, and WebP, so editors can upload `.avif` files again from the media library and from image fields that use the default allowlist.
+
+The admin file picker now offers `.avif` files and renders their thumbnails, the built-in "Images" preset in a field's allowed-types editor includes AVIF, and `.avif` works as extension shorthand in a field's `allowedMimeTypes`.
+
+SVG stays excluded from the default allowlist.

--- a/docs/src/content/docs/guides/media-library.mdx
+++ b/docs/src/content/docs/guides/media-library.mdx
@@ -40,7 +40,7 @@ EmDash accepts these file types by default:
 
 | Category  | Extensions                                      |
 | --------- | ----------------------------------------------- |
-| Images    | `.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`        |
+| Images    | `.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.avif` |
 | Documents | `.pdf`                                         |
 | Video     | `.mp4`, `.webm`, `.mov`                         |
 | Audio     | `.mp3`, `.wav`, `.ogg`                          |

--- a/packages/admin/src/components/AllowedTypesEditor.tsx
+++ b/packages/admin/src/components/AllowedTypesEditor.tsx
@@ -12,7 +12,10 @@ interface Preset {
 }
 
 const PRESETS: ReadonlyArray<Preset> = [
-	{ key: "images", mimeTypes: ["image/png", "image/jpeg", "image/gif", "image/webp"] },
+	{
+		key: "images",
+		mimeTypes: ["image/png", "image/jpeg", "image/gif", "image/webp", "image/avif"],
+	},
 	{ key: "pdf", mimeTypes: ["application/pdf"] },
 	{
 		key: "documents",

--- a/packages/admin/src/components/MediaUploadDialog.tsx
+++ b/packages/admin/src/components/MediaUploadDialog.tsx
@@ -19,13 +19,19 @@ import * as React from "react";
 import { formatFileSize } from "../lib/media-utils.js";
 
 export const LOCAL_MEDIA_UPLOAD_ACCEPT =
-	"image/png,image/jpeg,image/gif,image/webp,video/*,audio/*,application/pdf";
+	"image/png,image/jpeg,image/gif,image/webp,image/avif,video/*,audio/*,application/pdf";
 
 const DEFAULT_CONCURRENCY = 3;
 const MAX_CONCURRENCY = 6;
 const MAX_VISIBLE_ROWS = 100;
 const MAX_PREVIEW_BYTES = 8 * 1024 * 1024;
-const PREVIEW_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
+const PREVIEW_MIME_TYPES = new Set([
+	"image/jpeg",
+	"image/png",
+	"image/gif",
+	"image/webp",
+	"image/avif",
+]);
 
 type UploadStatus = "queued" | "uploading" | "complete" | "failed";
 

--- a/packages/admin/src/lib/mime-utils.ts
+++ b/packages/admin/src/lib/mime-utils.ts
@@ -5,6 +5,7 @@ export const EXTENSION_TO_MIME: Readonly<Record<string, string>> = {
 	".jpeg": "image/jpeg",
 	".gif": "image/gif",
 	".webp": "image/webp",
+	".avif": "image/avif",
 	".svg": "image/svg+xml",
 	".mp3": "audio/mpeg",
 	".wav": "audio/wav",

--- a/packages/core/src/api/handlers/media-allowlist.ts
+++ b/packages/core/src/api/handlers/media-allowlist.ts
@@ -21,6 +21,7 @@ export const GLOBAL_UPLOAD_ALLOWLIST: readonly string[] = [
 	"image/jpeg",
 	"image/gif",
 	"image/webp",
+	"image/avif",
 	"video/",
 	"audio/",
 	"application/pdf",

--- a/packages/core/src/media/mime.ts
+++ b/packages/core/src/media/mime.ts
@@ -23,6 +23,7 @@ export const EXTENSION_TO_MIME: Readonly<Record<string, string>> = {
 	".jpeg": "image/jpeg",
 	".gif": "image/gif",
 	".webp": "image/webp",
+	".avif": "image/avif",
 	".svg": "image/svg+xml",
 	".mp3": "audio/mpeg",
 	".wav": "audio/wav",

--- a/packages/core/tests/unit/media/media-allowlist.test.ts
+++ b/packages/core/tests/unit/media/media-allowlist.test.ts
@@ -15,6 +15,10 @@ describe("GLOBAL_UPLOAD_ALLOWLIST", () => {
 		expect(matchesMimeAllowlist("image/webp", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);
 	});
 
+	it("allows image/avif, which the media routes already serve inline", () => {
+		expect(matchesMimeAllowlist("image/avif", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);
+	});
+
 	it("still allows video, audio, and pdf", () => {
 		expect(matchesMimeAllowlist("video/mp4", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);
 		expect(matchesMimeAllowlist("audio/mpeg", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);

--- a/packages/core/tests/unit/media/mime.test.ts
+++ b/packages/core/tests/unit/media/mime.test.ts
@@ -76,6 +76,7 @@ describe("expandExtensionShorthand", () => {
 	it("expands known dot-extensions", () => {
 		expect(expandExtensionShorthand(".pdf")).toBe("application/pdf");
 		expect(expandExtensionShorthand(".PDF")).toBe("application/pdf");
+		expect(expandExtensionShorthand(".avif")).toBe("image/avif");
 		expect(expandExtensionShorthand(".docx")).toBe(
 			"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 		);


### PR DESCRIPTION
## What does this PR do?

AVIF uploads fail with `File type not allowed`. `image/avif` is missing from the default media allowlist, so a `.avif` file is rejected before it ever reaches storage.

**Root cause.** The regression came from #2250, not from the commit named in the issue. #2250 replaced the bare `"image/"` prefix match in `GLOBAL_UPLOAD_ALLOWLIST` with an explicit enumeration of safe raster types so that `image/svg+xml` would stop being accepted by default — a deliberate and correct security fix, since there is no upload-time content validation for SVG. `image/avif` was covered by the old prefix match but was not carried into the new enumeration. `ffaadc4` (#2553) later aligned the admin `accept` attribute and the docs table with that shortened list, which is why the issue points there.

The rest of the codebase already treats AVIF as a supported inline raster type — `SAFE_INLINE_TYPES` in `routes/api/media/file/[...key].ts` and `SAFE_INLINE_IMAGE_TYPES` in `media/image-endpoint.ts` both list `image/avif`. EmDash would serve an AVIF inline but refuse to accept one; the upload gate was the only place that disagreed.

**The change.** `image/avif` is restored in the three places a `.avif` file is turned away:

- `GLOBAL_UPLOAD_ALLOWLIST` — the server-side gate that produces the error
- `EXTENSION_TO_MIME` in core and admin — so `.avif` works as extension shorthand in a field's `allowedMimeTypes`
- The admin upload dialog's `accept` filter and thumbnail preview set, plus the built-in "Images" preset in the allowed-types editor

SVG stays excluded from the default allowlist — #2250's protection is untouched.

Closes #2602

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — n/a, no new user-visible strings; the admin changes are MIME constants. No `messages.po` changes are included.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (`patch` for `emdash` and `@emdash-cms/admin`)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Screenshots / test output

Both new assertions were written first and observed failing against the unfixed allowlist:

```
FAIL  tests/unit/media/media-allowlist.test.ts > GLOBAL_UPLOAD_ALLOWLIST > allows image/avif, which the media routes already serve inline
AssertionError: expected false to be true // Object.is equality

FAIL  tests/unit/media/mime.test.ts > expandExtensionShorthand > expands known dot-extensions
AssertionError: expected null to be 'image/avif' // Object.is equality
```

After the fix, the full core media suite passes:

```
Test Files  15 passed (15)
     Tests  150 passed (150)
```

`pnpm lint` (`oxlint --type-aware --deny-warnings`) exits clean, and `pnpm typecheck` passes.

One note on the full `pnpm --filter emdash test` run: 18 tests across 10 files fail in my local Windows environment (path-separator assertions, `pnpm`-symlink resolution, system `tar`, file-based SQLite). I verified these fail identically on an unmodified `main` checkout — same 18 failures, same 10 files — so they are pre-existing and unrelated to this change. Every media test passes.
