### PR TITLE
fix(admin): keep translated sentences complete

### DIFF
--- a/.changeset/bright-lions-translate.md
+++ b/.changeset/bright-lions-translate.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Makes passkey guidance, plugin setup instructions, signup messages, domain removal warnings, and WordPress import guidance translate as complete sentences so locales can reorder links, emphasized text, and dynamic values naturally.

--- a/.changeset/bright-lions-translate.md
+++ b/.changeset/bright-lions-translate.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Makes passkey guidance, plugin setup instructions, signup messages, domain removal warnings, and WordPress import guidance translate as complete sentences so locales can reorder links, emphasized text, and dynamic values naturally.
+Makes passkey guidance, plugin setup instructions, signup messages, domain removal warnings, and WordPress import guidance translate as complete sentences so locales can reorder links, emphasized text, and dynamic values naturally. Content type empty states also use a context-specific message instead of sharing a label with content entries.

--- a/packages/admin/src/components/ContentTypeList.tsx
+++ b/packages/admin/src/components/ContentTypeList.tsx
@@ -203,7 +203,7 @@ export function ContentTypeList({
 									<td colSpan={columnCount} className="px-4 py-8 text-center text-kumo-subtle">
 										{t`No content types yet.`}{" "}
 										<Link to="/content-types/new" className="text-kumo-link underline">
-											{t`Create your first one`}
+											{t`Create your first content type`}
 										</Link>
 									</td>
 								</tr>

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -8,7 +8,7 @@
 
 import { Badge, Button, Checkbox, Switch, Toast } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
-import { useLingui } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import {
 	Gear,
 	FileText,
@@ -55,6 +55,18 @@ import { CaretNext } from "./ArrowIcons.js";
 import { CapabilityConsentDialog } from "./CapabilityConsentDialog.js";
 import { DialogError, getMutationError } from "./DialogError.js";
 import { RouterLinkButton } from "./RouterLinkButton.js";
+
+export function _MarketplaceInstallMessage() {
+	return (
+		<Trans>
+			Browse the{" "}
+			<Link to="/plugins/marketplace" className="text-kumo-link hover:underline">
+				marketplace
+			</Link>{" "}
+			to install plugins, or add them to your astro.config.mjs.
+		</Trans>
+	);
+}
 
 export interface PluginManagerProps {
 	/** Admin manifest — used to check if marketplace is configured */
@@ -200,13 +212,7 @@ export function PluginManager({ manifest }: PluginManagerProps) {
 					<h3 className="mt-4 text-lg font-medium">{t`No plugins configured`}</h3>
 					<p className="mt-2 text-sm text-kumo-subtle">
 						{hasMarketplace ? (
-							<>
-								{t`Browse the`}{" "}
-								<Link to="/plugins/marketplace" className="text-kumo-link hover:underline">
-									{t`marketplace`}
-								</Link>{" "}
-								{t`to install plugins, or add them to your astro.config.mjs.`}
-							</>
+							<_MarketplaceInstallMessage />
 						) : (
 							t`Add plugins to your astro.config.mjs to extend EmDash functionality.`
 						)}
@@ -502,9 +508,7 @@ function PluginCard({
 							aria-expanded={expanded}
 						>
 							{expanded ? <CaretDown className="h-4 w-4" /> : <CaretNext className="h-4 w-4" />}
-							<span className="sr-only">
-								{expanded ? t`Collapse` : t`Expand`} {t`details`}
-							</span>
+							<span className="sr-only">{expanded ? t`Collapse details` : t`Expand details`}</span>
 						</Button>
 					</div>
 				</div>

--- a/packages/admin/src/components/SignupPage.tsx
+++ b/packages/admin/src/components/SignupPage.tsx
@@ -11,7 +11,7 @@
  */
 
 import { Button, Input, Loader } from "@cloudflare/kumo";
-import { useLingui } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
@@ -20,6 +20,23 @@ import { requestSignup, verifySignupToken, type SignupVerifyResult } from "../li
 import { PasskeyRegistration } from "./auth/PasskeyRegistration";
 import { BrandLogo } from "./Logo.js";
 import { RouterLinkButton } from "./RouterLinkButton.js";
+
+export function _VerificationSentMessage({ email }: { email: string }) {
+	return (
+		<Trans>
+			We've sent a verification link to{" "}
+			<span className="font-medium text-kumo-default">{email}</span>
+		</Trans>
+	);
+}
+
+export function _SignupRoleMessage({ roleName }: { roleName: string }) {
+	return (
+		<Trans>
+			You'll be signing up as <span className="font-medium text-kumo-default">{roleName}</span>
+		</Trans>
+	);
+}
 
 // ============================================================================
 // Types
@@ -130,8 +147,7 @@ function CheckEmailStep({ email, onResend, isResending, resendCooldown }: CheckE
 			<div>
 				<h2 className="text-xl font-semibold">{t`Check your email`}</h2>
 				<p className="text-kumo-subtle mt-2">
-					{t`We've sent a verification link to`}{" "}
-					<span className="font-medium text-kumo-default">{email}</span>
+					<_VerificationSentMessage email={email} />
 				</p>
 			</div>
 
@@ -189,8 +205,7 @@ function VerifyStep({ verifyResult, token, onBack: _onBack }: VerifyStepProps) {
 				</div>
 				<h2 className="text-xl font-semibold">{t`Email verified!`}</h2>
 				<p className="text-kumo-subtle mt-2">
-					{t`You'll be signing up as`}{" "}
-					<span className="font-medium text-kumo-default">{verifyResult.roleName}</span>
+					<_SignupRoleMessage roleName={verifyResult.roleName} />
 				</p>
 			</div>
 

--- a/packages/admin/src/components/TaxonomyManager.tsx
+++ b/packages/admin/src/components/TaxonomyManager.tsx
@@ -30,6 +30,11 @@ import { DialogError, getMutationError } from "./DialogError.js";
 import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js";
 import { TranslationsPanel } from "./TranslationsPanel.js";
 
+export function _TaxonomyNotFoundMessage({ taxonomyName }: { taxonomyName: string }) {
+	const { t } = useLingui();
+	return <>{t`Taxonomy not found: ${taxonomyName}`}</>;
+}
+
 interface TaxonomyManagerProps {
 	taxonomyName: string;
 }
@@ -1011,7 +1016,7 @@ export function TaxonomyManager({ taxonomyName }: TaxonomyManagerProps) {
 	if (!taxonomyDef) {
 		return (
 			<div>
-				{t`Taxonomy not found:`} {taxonomyName}
+				<_TaxonomyNotFoundMessage taxonomyName={taxonomyName} />
 			</div>
 		);
 	}

--- a/packages/admin/src/components/WordPressImport.tsx
+++ b/packages/admin/src/components/WordPressImport.tsx
@@ -10,7 +10,7 @@ import {
 } from "@cloudflare/kumo";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg, plural } from "@lingui/core/macro";
-import { useLingui } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import {
 	Upload,
 	Check,
@@ -60,6 +60,23 @@ import {
 } from "../lib/api";
 import { cn } from "../lib/utils";
 import { CaretNext } from "./ArrowIcons.js";
+
+export function _WordPressExporterMessage() {
+	return (
+		<Trans>
+			For the best import experience, install the{" "}
+			<span className="font-medium">EmDash Exporter</span> plugin on your WordPress site.
+		</Trans>
+	);
+}
+
+export function _WordPressExportStep() {
+	return (
+		<Trans>
+			2. Go to <strong>Tools → Export</strong>
+		</Trans>
+	);
+}
 
 // ============================================================================
 // Constants
@@ -1204,9 +1221,7 @@ function FeatureComparison() {
 				<div className="flex items-start gap-2 text-sm">
 					<Sparkle className="h-4 w-4 text-kumo-link flex-shrink-0 mt-0.5" />
 					<p className="text-kumo-default">
-						{t`For the best import experience, install the`}{" "}
-						<span className="font-medium">{t`EmDash Exporter`}</span>{" "}
-						{t`plugin on your WordPress site.`}
+						<_WordPressExporterMessage />
 					</p>
 				</div>
 			</div>
@@ -1274,7 +1289,7 @@ function ProbeResultStep({
 					<ol className="mt-3 space-y-2 text-sm text-kumo-subtle">
 						<li>{t`1. Log into your WordPress admin dashboard`}</li>
 						<li>
-							{t`2. Go to`} <strong>{t`Tools → Export`}</strong>
+							<_WordPressExportStep />
 						</li>
 						<li>{t`3. Select "All content"`}</li>
 						<li>{t`4. Click "Download Export File"`}</li>

--- a/packages/admin/src/components/auth/PasskeyContextMessage.tsx
+++ b/packages/admin/src/components/auth/PasskeyContextMessage.tsx
@@ -1,0 +1,13 @@
+import { Trans } from "@lingui/react/macro";
+
+export function _InsecurePasskeyContextMessage() {
+	return (
+		<Trans>
+			Passkeys require a <strong className="text-kumo-default">secure context</strong>: use{" "}
+			<strong className="text-kumo-default">HTTPS</strong>, or open the admin at{" "}
+			<strong className="text-kumo-default">http://localhost</strong> (with your dev port). Plain{" "}
+			<code className="text-xs">http://</code> on a custom hostname is not treated as secure, even
+			on loopback.
+		</Trans>
+	);
+}

--- a/packages/admin/src/components/auth/PasskeyLogin.tsx
+++ b/packages/admin/src/components/auth/PasskeyLogin.tsx
@@ -20,6 +20,7 @@ import {
 	isPasskeyEnvironmentUsable,
 	isWebAuthnSecureContext,
 } from "../../lib/webauthn-environment";
+import { _InsecurePasskeyContextMessage } from "./PasskeyContextMessage.js";
 
 // ============================================================================
 // Constants
@@ -301,16 +302,7 @@ export function PasskeyLogin({
 				<h3 className="font-medium text-kumo-danger">{t`Passkeys Not Available Here`}</h3>
 				<p className="mt-1 text-sm text-kumo-subtle">
 					{insecureContext ? (
-						<>
-							{t`Passkeys require a`}{" "}
-							<strong className="text-kumo-default">{t`secure context`}</strong>
-							{t`: use`} <strong className="text-kumo-default">HTTPS</strong>
-							{t`, or open the admin at`}{" "}
-							<strong className="text-kumo-default">http://localhost</strong>{" "}
-							{t`(with your dev port).`}
-							{t`Plain`} <code className="text-xs">http://</code>{" "}
-							{t`on a custom hostname is not treated as secure, even on loopback.`}
-						</>
+						<_InsecurePasskeyContextMessage />
 					) : (
 						<>
 							{t`Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge.`}

--- a/packages/admin/src/components/auth/PasskeyRegistration.tsx
+++ b/packages/admin/src/components/auth/PasskeyRegistration.tsx
@@ -20,6 +20,7 @@ import {
 	isPasskeyEnvironmentUsable,
 	isWebAuthnSecureContext,
 } from "../../lib/webauthn-environment";
+import { _InsecurePasskeyContextMessage } from "./PasskeyContextMessage.js";
 
 // ============================================================================
 // Constants
@@ -300,16 +301,7 @@ export function PasskeyRegistration({
 				<h3 className="font-medium text-kumo-danger">{t`Passkeys Not Available Here`}</h3>
 				<p className="mt-1 text-sm text-kumo-subtle">
 					{insecureContext ? (
-						<>
-							{t`Passkeys require a`}{" "}
-							<strong className="text-kumo-default">{t`secure context`}</strong>
-							{t`: use`} <strong className="text-kumo-default">HTTPS</strong>
-							{t`, or open the admin at`}{" "}
-							<strong className="text-kumo-default">http://localhost</strong>{" "}
-							{t`(with your dev port).`}
-							{t`Plain`} <code className="text-xs">http://</code>{" "}
-							{t`on a custom hostname is not treated as secure, even on loopback.`}
-						</>
+						<_InsecurePasskeyContextMessage />
 					) : (
 						<>
 							{t`Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge.`}

--- a/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
+++ b/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
@@ -15,7 +15,7 @@ import {
 	Switch,
 	useKumoToastManager,
 } from "@cloudflare/kumo";
-import { useLingui } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { Pencil, Plus, Trash, X } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
@@ -32,6 +32,15 @@ import { ConfirmDialog } from "../ConfirmDialog.js";
 import { DialogError, getMutationError } from "../DialogError.js";
 import { SettingRow, SettingsFrame, SettingsSection } from "./SettingsLayout.js";
 import { useAllowedDomainsRolesConfig } from "./useAllowedDomainsRolesConfig.js";
+
+export function _DomainRemovalMessage({ domain }: { domain: string }) {
+	return (
+		<Trans>
+			Users from <strong>{domain}</strong> will no longer be able to sign up without an invite.
+			Existing users are not affected.
+		</Trans>
+	);
+}
 
 export function AllowedDomainsSettings() {
 	const { t } = useLingui();
@@ -370,12 +379,7 @@ export function AllowedDomainsSettings() {
 					deleteMutation.reset();
 				}}
 				title={t`Remove Domain?`}
-				description={
-					<>
-						{t`Users from`} <strong>{deletingDomain}</strong>{" "}
-						{t`will no longer be able to sign up without an invite. Existing users are not affected.`}
-					</>
-				}
+				description={<_DomainRemovalMessage domain={deletingDomain ?? ""} />}
 				confirmLabel={t`Remove Domain`}
 				pendingLabel={t`Removing...`}
 				isPending={deleteMutation.isPending}

--- a/packages/admin/tests/components/ContentTypeList.test.tsx
+++ b/packages/admin/tests/components/ContentTypeList.test.tsx
@@ -213,6 +213,9 @@ describe("ContentTypeList", () => {
 		it("shows 'No content types yet' when no collections", async () => {
 			const screen = await render(<ContentTypeList collections={[]} />);
 			await expect.element(screen.getByText(NO_CONTENT_TYPES_REGEX)).toBeInTheDocument();
+			await expect
+				.element(screen.getByRole("link", { name: "Create your first content type" }))
+				.toBeInTheDocument();
 		});
 	});
 

--- a/packages/admin/tests/components/translation-units.test.tsx
+++ b/packages/admin/tests/components/translation-units.test.tsx
@@ -1,0 +1,136 @@
+import { i18n } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
+import { screen } from "@testing-library/react";
+import type * as React from "react";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tanstack/react-router", async () => {
+	const actual = await vi.importActual("@tanstack/react-router");
+	return {
+		...actual,
+		Link: ({ children, to, ...props }: React.ComponentProps<"a"> & { to: string }) => (
+			<a href={to} {...props}>
+				{children}
+			</a>
+		),
+	};
+});
+
+import { _InsecurePasskeyContextMessage } from "../../src/components/auth/PasskeyContextMessage.js";
+import { _MarketplaceInstallMessage } from "../../src/components/PluginManager.js";
+import { _DomainRemovalMessage } from "../../src/components/settings/AllowedDomainsSettings.js";
+import { _SignupRoleMessage, _VerificationSentMessage } from "../../src/components/SignupPage.js";
+import { _TaxonomyNotFoundMessage } from "../../src/components/TaxonomyManager.js";
+import {
+	_WordPressExporterMessage,
+	_WordPressExportStep,
+} from "../../src/components/WordPressImport.js";
+import { render } from "../utils/render.js";
+
+const jaMessages = {
+	[msg`Passkeys require a <0>secure context</0>: use <1>HTTPS</1>, or open the admin at <2>http://localhost</2> (with your dev port). Plain <3>http://</3> on a custom hostname is not treated as secure, even on loopback.`
+		.id!]:
+		"パスキーには<0>セキュアコンテキスト</0>が必要です。<1>HTTPS</1>を使用するか、<2>http://localhost</2>（開発用ポートを含む）で管理画面を開いてください。カスタムホスト名の<3>http://</3>は、ループバックでも安全な接続として扱われません。",
+	[msg`Browse the <0>marketplace</0> to install plugins, or add them to your astro.config.mjs.`
+		.id!]:
+		"<0>マーケットプレイス</0>からプラグインをインストールするか、astro.config.mjsに追加してください。",
+	[msg`Users from <0>{domain}</0> will no longer be able to sign up without an invite. Existing users are not affected.`
+		.id!]:
+		"<0>{domain}</0>のユーザーは招待なしで登録できなくなります。既存のユーザーには影響しません。",
+	[msg`For the best import experience, install the <0>EmDash Exporter</0> plugin on your WordPress site.`
+		.id!]:
+		"より完全にインポートするには、WordPressサイトに<0>EmDash Exporter</0>プラグインをインストールしてください。",
+	[msg`2. Go to <0>Tools → Export</0>`.id!]: "2. <0>ツール → エクスポート</0>を開きます。",
+	[msg`We've sent a verification link to <0>{email}</0>`.id!]:
+		"<0>{email}</0>に確認リンクを送信しました。",
+	[msg`You'll be signing up as <0>{roleName}</0>`.id!]: "<0>{roleName}</0>として登録します。",
+	[msg`Taxonomy not found: {taxonomyName}`.id!]: "{taxonomyName}が見つかりません。",
+};
+
+beforeAll(() => {
+	i18n.loadAndActivate({ locale: "ja", messages: jaMessages });
+});
+
+afterAll(() => {
+	i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+
+describe("complete translation units", () => {
+	it("allows passkey guidance to reorder emphasized values", async () => {
+		await render(
+			<p data-testid="passkey-guidance">
+				<_InsecurePasskeyContextMessage />
+			</p>,
+		);
+
+		expect(screen.getByTestId("passkey-guidance").textContent).toBe(
+			"パスキーにはセキュアコンテキストが必要です。HTTPSを使用するか、http://localhost（開発用ポートを含む）で管理画面を開いてください。カスタムホスト名のhttp://は、ループバックでも安全な接続として扱われません。",
+		);
+	});
+
+	it("allows links and dynamic values to move before their surrounding text", async () => {
+		await render(
+			<p data-testid="marketplace-guidance">
+				<_MarketplaceInstallMessage />
+			</p>,
+		);
+		expect(screen.getByRole("link", { name: "マーケットプレイス" })).toBeTruthy();
+		expect(screen.getByTestId("marketplace-guidance").textContent).toBe(
+			"マーケットプレイスからプラグインをインストールするか、astro.config.mjsに追加してください。",
+		);
+
+		await render(
+			<p data-testid="domain-removal">
+				<_DomainRemovalMessage domain="example.com" />
+			</p>,
+		);
+		expect(screen.getByTestId("domain-removal").textContent).toBe(
+			"example.comのユーザーは招待なしで登録できなくなります。既存のユーザーには影響しません。",
+		);
+	});
+
+	it("keeps WordPress instructions in complete reorderable sentences", async () => {
+		await render(
+			<p data-testid="exporter-guidance">
+				<_WordPressExporterMessage />
+			</p>,
+		);
+		expect(screen.getByTestId("exporter-guidance").textContent).toBe(
+			"より完全にインポートするには、WordPressサイトにEmDash Exporterプラグインをインストールしてください。",
+		);
+
+		await render(
+			<p data-testid="export-step">
+				<_WordPressExportStep />
+			</p>,
+		);
+		expect(screen.getByTestId("export-step").textContent).toBe(
+			"2. ツール → エクスポートを開きます。",
+		);
+	});
+
+	it("allows signup values and taxonomy names to precede their translated text", async () => {
+		await render(
+			<p data-testid="verification-sent">
+				<_VerificationSentMessage email="user@example.com" />
+			</p>,
+		);
+		expect(screen.getByTestId("verification-sent").textContent).toBe(
+			"user@example.comに確認リンクを送信しました。",
+		);
+
+		await render(
+			<p data-testid="signup-role">
+				<_SignupRoleMessage roleName="編集者" />
+			</p>,
+		);
+		expect(screen.getByTestId("signup-role").textContent).toBe("編集者として登録します。");
+
+		await render(
+			<p data-testid="taxonomy-not-found">
+				<_TaxonomyNotFoundMessage taxonomyName="タグ" />
+			</p>,
+		);
+		expect(screen.getByTestId("taxonomy-not-found").textContent).toBe("タグが見つかりません。");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes admin messages that were assembled from separately translated fragments around links, emphasis, and dynamic values. Each affected sentence is now a complete Lingui translation unit, allowing languages such as Japanese to reorder those elements without changing the meaning of individual source messages.

This covers passkey secure-context guidance, empty plugin marketplace guidance, plugin detail screen-reader labels, allowed-domain removal, WordPress exporter instructions, signup confirmation messages, and taxonomy not-found errors. It also gives the content type empty-state action its own context-specific source message instead of sharing a label with content entries.

Related to #2675.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: not applicable — this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex (GPT-5)

## Screenshots / test output

- `pnpm typecheck`
- `pnpm lint`
- `pnpm dlx vitest@4.1.10 --run tests/components/translation-units.test.tsx tests/components/PluginManager.test.tsx tests/components/SignupPage.test.tsx tests/components/TaxonomyManager.test.tsx tests/components/settings/AllowedDomainsSettings.test.tsx` (68 tests passed)
- `pnpm dlx vitest@4.1.10 --run tests/components/ContentTypeList.test.tsx` (21 tests passed)
