### PR TITLE
fix(admin): keep localized guidance in complete units

### DIFF
--- a/.changeset/bright-lions-translate.md
+++ b/.changeset/bright-lions-translate.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes translated admin guidance and WordPress import summaries so links, emphasized text, dynamic values, and plural counts can follow each locale's word order. Clarifies the content type empty-state action.

--- a/packages/admin/src/components/ContentTypeList.tsx
+++ b/packages/admin/src/components/ContentTypeList.tsx
@@ -203,7 +203,7 @@ export function ContentTypeList({
 									<td colSpan={columnCount} className="px-4 py-8 text-center text-kumo-subtle">
 										{t`No content types yet.`}{" "}
 										<Link to="/content-types/new" className="text-kumo-link underline">
-											{t`Create your first one`}
+											{t`Create your first content type`}
 										</Link>
 									</td>
 								</tr>

--- a/packages/admin/src/components/MediaImportSummary.tsx
+++ b/packages/admin/src/components/MediaImportSummary.tsx
@@ -4,15 +4,9 @@ import * as React from "react";
 
 const DescriptorMessage = Trans;
 
-const importedFilesMessage = msg({
-	message:
-		"{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}",
-});
+const importedFilesMessage = msg`{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}`;
 
-const updatedUrlsMessage = msg({
-	message:
-		"{rewrittenUrls, plural, one {<rewrittenCount>#</rewrittenCount> image URL updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}} other {<rewrittenCount>#</rewrittenCount> image URLs updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}}}",
-});
+const updatedUrlsMessage = msg`{rewrittenUrls, plural, one {<rewrittenCount>#</rewrittenCount> image URL updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}} other {<rewrittenCount>#</rewrittenCount> image URLs updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}}}`;
 
 interface MediaImportSummaryProps {
 	importedFiles: number;

--- a/packages/admin/src/components/MediaImportSummary.tsx
+++ b/packages/admin/src/components/MediaImportSummary.tsx
@@ -1,5 +1,18 @@
+import { msg } from "@lingui/core/macro";
 import { Trans } from "@lingui/react";
 import * as React from "react";
+
+const DescriptorMessage = Trans;
+
+const importedFilesMessage = msg({
+	message:
+		"{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}",
+});
+
+const updatedUrlsMessage = msg({
+	message:
+		"{rewrittenUrls, plural, one {<rewrittenCount>#</rewrittenCount> image URL updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}} other {<rewrittenCount>#</rewrittenCount> image URLs updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}}}",
+});
 
 interface MediaImportSummaryProps {
 	importedFiles: number;
@@ -15,16 +28,16 @@ export function MediaImportSummary({
 	return (
 		<>
 			<p>
-				<Trans
-					id="{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}"
+				<DescriptorMessage
+					{...importedFilesMessage}
 					values={{ importedFiles }}
 					components={{ count: <strong /> }}
 				/>
 			</p>
 			{rewrittenUrls !== undefined && updatedContentItems !== undefined && (
 				<p>
-					<Trans
-						id="{rewrittenUrls, plural, one {<rewrittenCount>#</rewrittenCount> image URL updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}} other {<rewrittenCount>#</rewrittenCount> image URLs updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}}}"
+					<DescriptorMessage
+						{...updatedUrlsMessage}
 						values={{ rewrittenUrls, updatedContentItems }}
 						components={{ rewrittenCount: <strong />, contentCount: <strong /> }}
 					/>

--- a/packages/admin/src/components/MediaImportSummary.tsx
+++ b/packages/admin/src/components/MediaImportSummary.tsx
@@ -1,5 +1,4 @@
-import { plural } from "@lingui/core/macro";
-import { Trans } from "@lingui/react/macro";
+import { Trans } from "@lingui/react";
 import * as React from "react";
 
 interface MediaImportSummaryProps {
@@ -16,25 +15,19 @@ export function MediaImportSummary({
 	return (
 		<>
 			<p>
-				<Trans>
-					<strong>{importedFiles}</strong>{" "}
-					{plural(importedFiles, { one: "file imported", other: "files imported" })}
-				</Trans>
+				<Trans
+					id="{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}"
+					values={{ importedFiles }}
+					components={{ count: <strong /> }}
+				/>
 			</p>
 			{rewrittenUrls !== undefined && updatedContentItems !== undefined && (
 				<p>
-					<Trans>
-						<strong>{rewrittenUrls}</strong>{" "}
-						{plural(rewrittenUrls, {
-							one: "image URL updated",
-							other: "image URLs updated",
-						})}{" "}
-						in <strong>{updatedContentItems}</strong>{" "}
-						{plural(updatedContentItems, {
-							one: "content item",
-							other: "content items",
-						})}
-					</Trans>
+					<Trans
+						id="{rewrittenUrls, plural, one {<rewrittenCount>#</rewrittenCount> image URL updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}} other {<rewrittenCount>#</rewrittenCount> image URLs updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}}}"
+						values={{ rewrittenUrls, updatedContentItems }}
+						components={{ rewrittenCount: <strong />, contentCount: <strong /> }}
+					/>
 				</p>
 			)}
 		</>

--- a/packages/admin/src/components/MediaImportSummary.tsx
+++ b/packages/admin/src/components/MediaImportSummary.tsx
@@ -1,0 +1,42 @@
+import { plural } from "@lingui/core/macro";
+import { Trans } from "@lingui/react/macro";
+import * as React from "react";
+
+interface MediaImportSummaryProps {
+	importedFiles: number;
+	rewrittenUrls?: number;
+	updatedContentItems?: number;
+}
+
+export function MediaImportSummary({
+	importedFiles,
+	rewrittenUrls,
+	updatedContentItems,
+}: MediaImportSummaryProps) {
+	return (
+		<>
+			<p>
+				<Trans>
+					<strong>{importedFiles}</strong>{" "}
+					{plural(importedFiles, { one: "file imported", other: "files imported" })}
+				</Trans>
+			</p>
+			{rewrittenUrls !== undefined && updatedContentItems !== undefined && (
+				<p>
+					<Trans>
+						<strong>{rewrittenUrls}</strong>{" "}
+						{plural(rewrittenUrls, {
+							one: "image URL updated",
+							other: "image URLs updated",
+						})}{" "}
+						in <strong>{updatedContentItems}</strong>{" "}
+						{plural(updatedContentItems, {
+							one: "content item",
+							other: "content items",
+						})}
+					</Trans>
+				</p>
+			)}
+		</>
+	);
+}

--- a/packages/admin/src/components/MediaImportSummary.tsx
+++ b/packages/admin/src/components/MediaImportSummary.tsx
@@ -2,6 +2,8 @@ import { msg } from "@lingui/core/macro";
 import { Trans } from "@lingui/react";
 import * as React from "react";
 
+// The alias prevents Lingui from treating the runtime renderer as a macro
+// <Trans> and reporting "Missing message ID"; msg descriptors handle extraction.
 const DescriptorMessage = Trans;
 
 const importedFilesMessage = msg`{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}`;

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -8,7 +8,7 @@
 
 import { Badge, Button, Checkbox, Switch, Toast } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
-import { useLingui } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import {
 	Gear,
 	FileText,
@@ -55,6 +55,18 @@ import { CaretNext } from "./ArrowIcons.js";
 import { CapabilityConsentDialog } from "./CapabilityConsentDialog.js";
 import { DialogError, getMutationError } from "./DialogError.js";
 import { RouterLinkButton } from "./RouterLinkButton.js";
+
+export function MarketplaceInstallMessage() {
+	return (
+		<Trans>
+			Browse the{" "}
+			<Link to="/plugins/marketplace" className="text-kumo-link hover:underline">
+				marketplace
+			</Link>{" "}
+			to install plugins, or add them to your astro.config.mjs.
+		</Trans>
+	);
+}
 
 export interface PluginManagerProps {
 	/** Admin manifest — used to check if marketplace is configured */
@@ -200,13 +212,7 @@ export function PluginManager({ manifest }: PluginManagerProps) {
 					<h3 className="mt-4 text-lg font-medium">{t`No plugins configured`}</h3>
 					<p className="mt-2 text-sm text-kumo-subtle">
 						{hasMarketplace ? (
-							<>
-								{t`Browse the`}{" "}
-								<Link to="/plugins/marketplace" className="text-kumo-link hover:underline">
-									{t`marketplace`}
-								</Link>{" "}
-								{t`to install plugins, or add them to your astro.config.mjs.`}
-							</>
+							<MarketplaceInstallMessage />
 						) : (
 							t`Add plugins to your astro.config.mjs to extend EmDash functionality.`
 						)}
@@ -502,9 +508,7 @@ function PluginCard({
 							aria-expanded={expanded}
 						>
 							{expanded ? <CaretDown className="h-4 w-4" /> : <CaretNext className="h-4 w-4" />}
-							<span className="sr-only">
-								{expanded ? t`Collapse` : t`Expand`} {t`details`}
-							</span>
+							<span className="sr-only">{expanded ? t`Collapse details` : t`Expand details`}</span>
 						</Button>
 					</div>
 				</div>

--- a/packages/admin/src/components/SignupPage.tsx
+++ b/packages/admin/src/components/SignupPage.tsx
@@ -11,7 +11,7 @@
  */
 
 import { Button, Input, Loader } from "@cloudflare/kumo";
-import { useLingui } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
@@ -20,6 +20,23 @@ import { requestSignup, verifySignupToken, type SignupVerifyResult } from "../li
 import { PasskeyRegistration } from "./auth/PasskeyRegistration";
 import { BrandLogo } from "./Logo.js";
 import { RouterLinkButton } from "./RouterLinkButton.js";
+
+export function VerificationSentMessage({ email }: { email: string }) {
+	return (
+		<Trans>
+			We've sent a verification link to{" "}
+			<span className="font-medium text-kumo-default">{email}</span>
+		</Trans>
+	);
+}
+
+export function SignupRoleMessage({ roleName }: { roleName: string }) {
+	return (
+		<Trans>
+			You'll be signing up as <span className="font-medium text-kumo-default">{roleName}</span>
+		</Trans>
+	);
+}
 
 // ============================================================================
 // Types
@@ -130,8 +147,7 @@ function CheckEmailStep({ email, onResend, isResending, resendCooldown }: CheckE
 			<div>
 				<h2 className="text-xl font-semibold">{t`Check your email`}</h2>
 				<p className="text-kumo-subtle mt-2">
-					{t`We've sent a verification link to`}{" "}
-					<span className="font-medium text-kumo-default">{email}</span>
+					<VerificationSentMessage email={email} />
 				</p>
 			</div>
 
@@ -189,8 +205,7 @@ function VerifyStep({ verifyResult, token, onBack: _onBack }: VerifyStepProps) {
 				</div>
 				<h2 className="text-xl font-semibold">{t`Email verified!`}</h2>
 				<p className="text-kumo-subtle mt-2">
-					{t`You'll be signing up as`}{" "}
-					<span className="font-medium text-kumo-default">{verifyResult.roleName}</span>
+					<SignupRoleMessage roleName={verifyResult.roleName} />
 				</p>
 			</div>
 

--- a/packages/admin/src/components/TaxonomyManager.tsx
+++ b/packages/admin/src/components/TaxonomyManager.tsx
@@ -30,6 +30,11 @@ import { DialogError, getMutationError } from "./DialogError.js";
 import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js";
 import { TranslationsPanel } from "./TranslationsPanel.js";
 
+export function TaxonomyNotFoundMessage({ taxonomyName }: { taxonomyName: string }) {
+	const { t } = useLingui();
+	return <>{t`Taxonomy not found: ${taxonomyName}`}</>;
+}
+
 interface TaxonomyManagerProps {
 	taxonomyName: string;
 }
@@ -1011,7 +1016,7 @@ export function TaxonomyManager({ taxonomyName }: TaxonomyManagerProps) {
 	if (!taxonomyDef) {
 		return (
 			<div>
-				{t`Taxonomy not found:`} {taxonomyName}
+				<TaxonomyNotFoundMessage taxonomyName={taxonomyName} />
 			</div>
 		);
 	}

--- a/packages/admin/src/components/WordPressImport.tsx
+++ b/packages/admin/src/components/WordPressImport.tsx
@@ -10,7 +10,7 @@ import {
 } from "@cloudflare/kumo";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg, plural } from "@lingui/core/macro";
-import { useLingui } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import {
 	Upload,
 	Check,
@@ -60,6 +60,24 @@ import {
 } from "../lib/api";
 import { cn } from "../lib/utils";
 import { CaretNext } from "./ArrowIcons.js";
+import { MediaImportSummary } from "./MediaImportSummary.js";
+
+export function WordPressExporterMessage() {
+	return (
+		<Trans>
+			For the best import experience, install the{" "}
+			<span className="font-medium">EmDash Exporter</span> plugin on your WordPress site.
+		</Trans>
+	);
+}
+
+export function WordPressExportStep() {
+	return (
+		<Trans>
+			2. Go to <strong>Tools → Export</strong>
+		</Trans>
+	);
+}
 
 // ============================================================================
 // Constants
@@ -1204,9 +1222,7 @@ function FeatureComparison() {
 				<div className="flex items-start gap-2 text-sm">
 					<Sparkle className="h-4 w-4 text-kumo-link flex-shrink-0 mt-0.5" />
 					<p className="text-kumo-default">
-						{t`For the best import experience, install the`}{" "}
-						<span className="font-medium">{t`EmDash Exporter`}</span>{" "}
-						{t`plugin on your WordPress site.`}
+						<WordPressExporterMessage />
 					</p>
 				</div>
 			</div>
@@ -1274,7 +1290,7 @@ function ProbeResultStep({
 					<ol className="mt-3 space-y-2 text-sm text-kumo-subtle">
 						<li>{t`1. Log into your WordPress admin dashboard`}</li>
 						<li>
-							{t`2. Go to`} <strong>{t`Tools → Export`}</strong>
+							<WordPressExportStep />
 						</li>
 						<li>{t`3. Select "All content"`}</li>
 						<li>{t`4. Click "Download Export File"`}</li>
@@ -2362,15 +2378,15 @@ function CompleteStep({
 						<h3 className="font-medium">{t`Media Import`}</h3>
 					</div>
 					<div className="p-4 space-y-2 text-sm">
-						<p>
-							<strong>{mediaResult.imported.length}</strong> {t`files imported`}
-						</p>
-						{rewriteResult && rewriteResult.updated > 0 && (
-							<p>
-								<strong>{rewriteResult.urlsRewritten}</strong> {t`image URLs updated in`}{" "}
-								<strong>{rewriteResult.updated}</strong> {t`content items`}
-							</p>
-						)}
+						<MediaImportSummary
+							importedFiles={mediaResult.imported.length}
+							rewrittenUrls={
+								rewriteResult && rewriteResult.updated > 0 ? rewriteResult.urlsRewritten : undefined
+							}
+							updatedContentItems={
+								rewriteResult && rewriteResult.updated > 0 ? rewriteResult.updated : undefined
+							}
+						/>
 					</div>
 				</div>
 			)}

--- a/packages/admin/src/components/auth/PasskeyContextMessage.tsx
+++ b/packages/admin/src/components/auth/PasskeyContextMessage.tsx
@@ -1,0 +1,13 @@
+import { Trans } from "@lingui/react/macro";
+
+export function InsecurePasskeyContextMessage() {
+	return (
+		<Trans>
+			Passkeys require a <strong className="text-kumo-default">secure context</strong>: use{" "}
+			<strong className="text-kumo-default">HTTPS</strong>, or open the admin at{" "}
+			<strong className="text-kumo-default">http://localhost</strong> (with your dev port). Plain{" "}
+			<code className="text-xs">http://</code> on a custom hostname is not treated as secure, even
+			on loopback.
+		</Trans>
+	);
+}

--- a/packages/admin/src/components/auth/PasskeyLogin.tsx
+++ b/packages/admin/src/components/auth/PasskeyLogin.tsx
@@ -20,6 +20,7 @@ import {
 	isPasskeyEnvironmentUsable,
 	isWebAuthnSecureContext,
 } from "../../lib/webauthn-environment";
+import { InsecurePasskeyContextMessage } from "./PasskeyContextMessage.js";
 
 // ============================================================================
 // Constants
@@ -301,16 +302,7 @@ export function PasskeyLogin({
 				<h3 className="font-medium text-kumo-danger">{t`Passkeys Not Available Here`}</h3>
 				<p className="mt-1 text-sm text-kumo-subtle">
 					{insecureContext ? (
-						<>
-							{t`Passkeys require a`}{" "}
-							<strong className="text-kumo-default">{t`secure context`}</strong>
-							{t`: use`} <strong className="text-kumo-default">HTTPS</strong>
-							{t`, or open the admin at`}{" "}
-							<strong className="text-kumo-default">http://localhost</strong>{" "}
-							{t`(with your dev port).`}
-							{t`Plain`} <code className="text-xs">http://</code>{" "}
-							{t`on a custom hostname is not treated as secure, even on loopback.`}
-						</>
+						<InsecurePasskeyContextMessage />
 					) : (
 						<>
 							{t`Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge.`}

--- a/packages/admin/src/components/auth/PasskeyRegistration.tsx
+++ b/packages/admin/src/components/auth/PasskeyRegistration.tsx
@@ -20,6 +20,7 @@ import {
 	isPasskeyEnvironmentUsable,
 	isWebAuthnSecureContext,
 } from "../../lib/webauthn-environment";
+import { InsecurePasskeyContextMessage } from "./PasskeyContextMessage.js";
 
 // ============================================================================
 // Constants
@@ -300,16 +301,7 @@ export function PasskeyRegistration({
 				<h3 className="font-medium text-kumo-danger">{t`Passkeys Not Available Here`}</h3>
 				<p className="mt-1 text-sm text-kumo-subtle">
 					{insecureContext ? (
-						<>
-							{t`Passkeys require a`}{" "}
-							<strong className="text-kumo-default">{t`secure context`}</strong>
-							{t`: use`} <strong className="text-kumo-default">HTTPS</strong>
-							{t`, or open the admin at`}{" "}
-							<strong className="text-kumo-default">http://localhost</strong>{" "}
-							{t`(with your dev port).`}
-							{t`Plain`} <code className="text-xs">http://</code>{" "}
-							{t`on a custom hostname is not treated as secure, even on loopback.`}
-						</>
+						<InsecurePasskeyContextMessage />
 					) : (
 						<>
 							{t`Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge.`}

--- a/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
+++ b/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
@@ -15,7 +15,7 @@ import {
 	Switch,
 	useKumoToastManager,
 } from "@cloudflare/kumo";
-import { useLingui } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { Pencil, Plus, Trash, X } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
@@ -32,6 +32,15 @@ import { ConfirmDialog } from "../ConfirmDialog.js";
 import { DialogError, getMutationError } from "../DialogError.js";
 import { SettingRow, SettingsFrame, SettingsSection } from "./SettingsLayout.js";
 import { useAllowedDomainsRolesConfig } from "./useAllowedDomainsRolesConfig.js";
+
+export function DomainRemovalMessage({ domain }: { domain: string }) {
+	return (
+		<Trans>
+			Users from <strong>{domain}</strong> will no longer be able to sign up without an invite.
+			Existing users are not affected.
+		</Trans>
+	);
+}
 
 export function AllowedDomainsSettings() {
 	const { t } = useLingui();
@@ -370,12 +379,7 @@ export function AllowedDomainsSettings() {
 					deleteMutation.reset();
 				}}
 				title={t`Remove Domain?`}
-				description={
-					<>
-						{t`Users from`} <strong>{deletingDomain}</strong>{" "}
-						{t`will no longer be able to sign up without an invite. Existing users are not affected.`}
-					</>
-				}
+				description={<DomainRemovalMessage domain={deletingDomain ?? ""} />}
 				confirmLabel={t`Remove Domain`}
 				pendingLabel={t`Removing...`}
 				isPending={deleteMutation.isPending}

--- a/packages/admin/tests/components/ContentTypeList.test.tsx
+++ b/packages/admin/tests/components/ContentTypeList.test.tsx
@@ -213,6 +213,9 @@ describe("ContentTypeList", () => {
 		it("shows 'No content types yet' when no collections", async () => {
 			const screen = await render(<ContentTypeList collections={[]} />);
 			await expect.element(screen.getByText(NO_CONTENT_TYPES_REGEX)).toBeInTheDocument();
+			await expect
+				.element(screen.getByRole("link", { name: "Create your first content type" }))
+				.toBeInTheDocument();
 		});
 	});
 

--- a/packages/admin/tests/components/MediaImportSummary.test.tsx
+++ b/packages/admin/tests/components/MediaImportSummary.test.tsx
@@ -1,0 +1,54 @@
+import { setupI18n, type I18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { MediaImportSummary } from "../../src/components/MediaImportSummary.js";
+
+function renderSummary(
+	props: React.ComponentProps<typeof MediaImportSummary>,
+	i18n: I18n = setupI18n({ locale: "en" }),
+) {
+	return renderToStaticMarkup(
+		<I18nProvider i18n={i18n}>
+			<MediaImportSummary {...props} />
+		</I18nProvider>,
+	);
+}
+
+describe("MediaImportSummary", () => {
+	it("renders each result as a complete pluralized message", () => {
+		expect(renderSummary({ importedFiles: 1, rewrittenUrls: 1, updatedContentItems: 2 })).toBe(
+			"<p><strong>1</strong> file imported</p><p><strong>1</strong> image URL updated in <strong>2</strong> content items</p>",
+		);
+
+		expect(renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 })).toBe(
+			"<p><strong>2</strong> files imported</p><p><strong>3</strong> image URLs updated in <strong>1</strong> content item</p>",
+		);
+	});
+
+	it("lets translations reorder counts together with their emphasis", () => {
+		const i18n = setupI18n();
+		const messageIds: string[] = [];
+		i18n.load("ja", {});
+		i18n.activate("ja");
+		const removeMissingListener = i18n.on("missing", ({ id }) => messageIds.push(id));
+
+		renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 }, i18n);
+		removeMissingListener();
+
+		expect(messageIds).toHaveLength(2);
+		i18n.load("ja", {
+			[messageIds[0]!]: "<0>{importedFiles}</0>件のファイルをインポートしました",
+			[messageIds[1]!]:
+				"<1>{updatedContentItems}</1>件のコンテンツで<0>{rewrittenUrls}</0>件の画像URLを更新しました",
+		});
+
+		expect(
+			renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 }, i18n),
+		).toBe(
+			"<p><strong>2</strong>件のファイルをインポートしました</p><p><strong>1</strong>件のコンテンツで<strong>3</strong>件の画像URLを更新しました</p>",
+		);
+	});
+});

--- a/packages/admin/tests/components/MediaImportSummary.test.tsx
+++ b/packages/admin/tests/components/MediaImportSummary.test.tsx
@@ -18,6 +18,11 @@ function renderSummary(
 }
 
 describe("MediaImportSummary", () => {
+	const importedFilesMessage =
+		"{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}";
+	const updatedUrlsMessage =
+		"{rewrittenUrls, plural, one {<rewrittenCount>#</rewrittenCount> image URL updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}} other {<rewrittenCount>#</rewrittenCount> image URLs updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}}}";
+
 	it("renders each result as a complete pluralized message", () => {
 		expect(renderSummary({ importedFiles: 1, rewrittenUrls: 1, updatedContentItems: 2 })).toBe(
 			"<p><strong>1</strong> file imported</p><p><strong>1</strong> image URL updated in <strong>2</strong> content items</p>",
@@ -38,11 +43,11 @@ describe("MediaImportSummary", () => {
 		renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 }, i18n);
 		removeMissingListener();
 
-		expect(messageIds).toHaveLength(2);
+		expect(messageIds).toEqual([importedFilesMessage, updatedUrlsMessage]);
 		i18n.load("ja", {
-			[messageIds[0]!]: "<0>{importedFiles}</0>件のファイルをインポートしました",
-			[messageIds[1]!]:
-				"<1>{updatedContentItems}</1>件のコンテンツで<0>{rewrittenUrls}</0>件の画像URLを更新しました",
+			[importedFilesMessage]: "<count>{importedFiles}</count>件のファイルをインポートしました",
+			[updatedUrlsMessage]:
+				"<contentCount>{updatedContentItems}</contentCount>件のコンテンツで<rewrittenCount>{rewrittenUrls}</rewrittenCount>件の画像URLを更新しました",
 		});
 
 		expect(

--- a/packages/admin/tests/components/MediaImportSummary.test.tsx
+++ b/packages/admin/tests/components/MediaImportSummary.test.tsx
@@ -18,11 +18,6 @@ function renderSummary(
 }
 
 describe("MediaImportSummary", () => {
-	const importedFilesMessage =
-		"{importedFiles, plural, one {<count>#</count> file imported} other {<count>#</count> files imported}}";
-	const updatedUrlsMessage =
-		"{rewrittenUrls, plural, one {<rewrittenCount>#</rewrittenCount> image URL updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}} other {<rewrittenCount>#</rewrittenCount> image URLs updated in {updatedContentItems, plural, one {<contentCount>#</contentCount> content item} other {<contentCount>#</contentCount> content items}}}}";
-
 	it("renders each result as a complete pluralized message", () => {
 		expect(renderSummary({ importedFiles: 1, rewrittenUrls: 1, updatedContentItems: 2 })).toBe(
 			"<p><strong>1</strong> file imported</p><p><strong>1</strong> image URL updated in <strong>2</strong> content items</p>",
@@ -43,10 +38,11 @@ describe("MediaImportSummary", () => {
 		renderSummary({ importedFiles: 2, rewrittenUrls: 3, updatedContentItems: 1 }, i18n);
 		removeMissingListener();
 
-		expect(messageIds).toEqual([importedFilesMessage, updatedUrlsMessage]);
+		expect(messageIds).toHaveLength(2);
+		const [importedFilesMessageId, updatedUrlsMessageId] = messageIds;
 		i18n.load("ja", {
-			[importedFilesMessage]: "<count>{importedFiles}</count>件のファイルをインポートしました",
-			[updatedUrlsMessage]:
+			[importedFilesMessageId!]: "<count>{importedFiles}</count>件のファイルをインポートしました",
+			[updatedUrlsMessageId!]:
 				"<contentCount>{updatedContentItems}</contentCount>件のコンテンツで<rewrittenCount>{rewrittenUrls}</rewrittenCount>件の画像URLを更新しました",
 		});
 

--- a/packages/admin/tests/components/TaxonomySidebar.test.tsx
+++ b/packages/admin/tests/components/TaxonomySidebar.test.tsx
@@ -194,6 +194,7 @@ describe("TaxonomySidebar", () => {
 		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
 		const input = screen.getByLabelText("Add Tags");
 
+		await expect.element(input).toBeInTheDocument();
 		await userEvent.tab();
 
 		expect(document.activeElement).toBe(input.element());

--- a/packages/admin/tests/components/translation-units.test.tsx
+++ b/packages/admin/tests/components/translation-units.test.tsx
@@ -1,0 +1,136 @@
+import { i18n } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
+import { screen } from "@testing-library/react";
+import type * as React from "react";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tanstack/react-router", async () => {
+	const actual = await vi.importActual("@tanstack/react-router");
+	return {
+		...actual,
+		Link: ({ children, to, ...props }: React.ComponentProps<"a"> & { to: string }) => (
+			<a href={to} {...props}>
+				{children}
+			</a>
+		),
+	};
+});
+
+import { InsecurePasskeyContextMessage } from "../../src/components/auth/PasskeyContextMessage.js";
+import { MarketplaceInstallMessage } from "../../src/components/PluginManager.js";
+import { DomainRemovalMessage } from "../../src/components/settings/AllowedDomainsSettings.js";
+import { SignupRoleMessage, VerificationSentMessage } from "../../src/components/SignupPage.js";
+import { TaxonomyNotFoundMessage } from "../../src/components/TaxonomyManager.js";
+import {
+	WordPressExporterMessage,
+	WordPressExportStep,
+} from "../../src/components/WordPressImport.js";
+import { render } from "../utils/render.js";
+
+const jaMessages = {
+	[msg`Passkeys require a <0>secure context</0>: use <1>HTTPS</1>, or open the admin at <2>http://localhost</2> (with your dev port). Plain <3>http://</3> on a custom hostname is not treated as secure, even on loopback.`
+		.id!]:
+		"パスキーには<0>セキュアコンテキスト</0>が必要です。<1>HTTPS</1>を使用するか、<2>http://localhost</2>（開発用ポートを含む）で管理画面を開いてください。カスタムホスト名の<3>http://</3>は、ループバックでも安全な接続として扱われません。",
+	[msg`Browse the <0>marketplace</0> to install plugins, or add them to your astro.config.mjs.`
+		.id!]:
+		"<0>マーケットプレイス</0>からプラグインをインストールするか、astro.config.mjsに追加してください。",
+	[msg`Users from <0>{domain}</0> will no longer be able to sign up without an invite. Existing users are not affected.`
+		.id!]:
+		"<0>{domain}</0>のユーザーは招待なしで登録できなくなります。既存のユーザーには影響しません。",
+	[msg`For the best import experience, install the <0>EmDash Exporter</0> plugin on your WordPress site.`
+		.id!]:
+		"より完全にインポートするには、WordPressサイトに<0>EmDash Exporter</0>プラグインをインストールしてください。",
+	[msg`2. Go to <0>Tools → Export</0>`.id!]: "2. <0>ツール → エクスポート</0>を開きます。",
+	[msg`We've sent a verification link to <0>{email}</0>`.id!]:
+		"<0>{email}</0>に確認リンクを送信しました。",
+	[msg`You'll be signing up as <0>{roleName}</0>`.id!]: "<0>{roleName}</0>として登録します。",
+	[msg`Taxonomy not found: {taxonomyName}`.id!]: "{taxonomyName}が見つかりません。",
+};
+
+beforeAll(() => {
+	i18n.loadAndActivate({ locale: "ja", messages: jaMessages });
+});
+
+afterAll(() => {
+	i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+
+describe("complete translation units", () => {
+	it("allows passkey guidance to reorder emphasized values", async () => {
+		await render(
+			<p data-testid="passkey-guidance">
+				<InsecurePasskeyContextMessage />
+			</p>,
+		);
+
+		expect(screen.getByTestId("passkey-guidance").textContent).toBe(
+			"パスキーにはセキュアコンテキストが必要です。HTTPSを使用するか、http://localhost（開発用ポートを含む）で管理画面を開いてください。カスタムホスト名のhttp://は、ループバックでも安全な接続として扱われません。",
+		);
+	});
+
+	it("allows links and dynamic values to move before their surrounding text", async () => {
+		await render(
+			<p data-testid="marketplace-guidance">
+				<MarketplaceInstallMessage />
+			</p>,
+		);
+		expect(screen.getByRole("link", { name: "マーケットプレイス" })).toBeTruthy();
+		expect(screen.getByTestId("marketplace-guidance").textContent).toBe(
+			"マーケットプレイスからプラグインをインストールするか、astro.config.mjsに追加してください。",
+		);
+
+		await render(
+			<p data-testid="domain-removal">
+				<DomainRemovalMessage domain="example.com" />
+			</p>,
+		);
+		expect(screen.getByTestId("domain-removal").textContent).toBe(
+			"example.comのユーザーは招待なしで登録できなくなります。既存のユーザーには影響しません。",
+		);
+	});
+
+	it("keeps WordPress instructions in complete reorderable sentences", async () => {
+		await render(
+			<p data-testid="exporter-guidance">
+				<WordPressExporterMessage />
+			</p>,
+		);
+		expect(screen.getByTestId("exporter-guidance").textContent).toBe(
+			"より完全にインポートするには、WordPressサイトにEmDash Exporterプラグインをインストールしてください。",
+		);
+
+		await render(
+			<p data-testid="export-step">
+				<WordPressExportStep />
+			</p>,
+		);
+		expect(screen.getByTestId("export-step").textContent).toBe(
+			"2. ツール → エクスポートを開きます。",
+		);
+	});
+
+	it("allows signup values and taxonomy names to precede their translated text", async () => {
+		await render(
+			<p data-testid="verification-sent">
+				<VerificationSentMessage email="user@example.com" />
+			</p>,
+		);
+		expect(screen.getByTestId("verification-sent").textContent).toBe(
+			"user@example.comに確認リンクを送信しました。",
+		);
+
+		await render(
+			<p data-testid="signup-role">
+				<SignupRoleMessage roleName="編集者" />
+			</p>,
+		);
+		expect(screen.getByTestId("signup-role").textContent).toBe("編集者として登録します。");
+
+		await render(
+			<p data-testid="taxonomy-not-found">
+				<TaxonomyNotFoundMessage taxonomyName="タグ" />
+			</p>,
+		);
+		expect(screen.getByTestId("taxonomy-not-found").textContent).toBe("タグが見つかりません。");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

- keeps dynamic values, links, emphasis, and passkey guidance inside complete Lingui translation units so locales can reorder whole sentences;
- replaces fragmented WordPress media-import counts with two complete ICU plural messages whose emphasized values can be reordered safely;
- adds Japanese reordering coverage and clarifies the content-type empty-state action;
- intentionally excludes `messages.po` updates so the post-merge extraction workflow can regenerate catalogs without feature-PR churn.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

The Discussion item is not applicable because this is a bug fix and does not add a feature.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5.6-sol)

## Screenshots / test output

No screenshots: the visible layout is unchanged; the behavior is covered by translation rendering tests.

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm --dir packages/admin test --run` — 126 files and 1,535 tests passed
- Lingui extraction produces two complete media-summary messages, and catalog compilation succeeds
- Codex Security branch-diff scan completed with full changed-source coverage and no findings
