### PR TITLE
fix(admin): refresh sidebar after taxonomy creation

### DIFF
--- a/.changeset/gentle-falcons-refresh.md
+++ b/.changeset/gentle-falcons-refresh.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes newly created taxonomies not appearing in the admin sidebar until the page is reloaded.

--- a/packages/admin/src/components/TaxonomyManager.tsx
+++ b/packages/admin/src/components/TaxonomyManager.tsx
@@ -719,6 +719,7 @@ function CreateTaxonomyDialog({
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["taxonomy-defs"] });
 			void queryClient.invalidateQueries({ queryKey: ["taxonomy-def"] });
+			void queryClient.invalidateQueries({ queryKey: ["manifest"] });
 			onCreated();
 			resetForm();
 		},

--- a/packages/admin/tests/taxonomy-sidebar-refresh.test.tsx
+++ b/packages/admin/tests/taxonomy-sidebar-refresh.test.tsx
@@ -102,7 +102,7 @@ describe("taxonomy sidebar refresh", () => {
 				return json({ data: { pending: 0, approved: 0, spam: 0, trash: 0 } });
 			}
 			if (method === "GET" && url === "/_emdash/api/taxonomies") {
-				return json({ data: { taxonomies: manifestFetches > 1 ? [category, genre] : [category] } });
+				return json({ data: { taxonomies: [category, genre] } });
 			}
 			if (method === "GET" && url.startsWith("/_emdash/api/taxonomies/category/terms")) {
 				return json({ data: { terms: [] } });

--- a/packages/admin/tests/taxonomy-sidebar-refresh.test.tsx
+++ b/packages/admin/tests/taxonomy-sidebar-refresh.test.tsx
@@ -1,0 +1,162 @@
+import { LinkProvider, Toasty, type LinkComponentProps } from "@cloudflare/kumo";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { RouterProvider } from "@tanstack/react-router";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { userEvent } from "vitest/browser";
+
+import { ThemeProvider } from "../src/components/ThemeProvider";
+import type { AdminManifest } from "../src/lib/api";
+import { createAdminRouter } from "../src/router";
+import { render } from "./utils/render.tsx";
+
+const category = {
+	id: "category",
+	name: "category",
+	label: "Categories",
+	labelSingular: "Category",
+	hierarchical: true,
+	collections: ["posts"],
+	locale: "en",
+	translationGroup: "category",
+};
+
+const genre = {
+	id: "genre",
+	name: "genre",
+	label: "Genres",
+	labelSingular: "Genre",
+	hierarchical: false,
+	collections: ["posts"],
+	locale: "en",
+	translationGroup: "genre",
+};
+
+const initialManifest: AdminManifest = {
+	version: "1.0.0",
+	hash: "initial",
+	authMode: "passkey",
+	collections: {
+		posts: {
+			label: "Posts",
+			labelSingular: "Post",
+			supports: [],
+			hasSeo: false,
+			fields: {},
+		},
+	},
+	plugins: {},
+	taxonomies: [category],
+};
+
+const refreshedManifest: AdminManifest = {
+	...initialManifest,
+	hash: "refreshed",
+	taxonomies: [category, genre],
+};
+
+const TestLink = React.forwardRef<HTMLAnchorElement, LinkComponentProps>(
+	({ href, to, children, ...props }, ref) => (
+		<a ref={ref} href={href ?? to} {...props}>
+			{children}
+		</a>
+	),
+);
+TestLink.displayName = "TestLink";
+
+function json(data: unknown, status = 200) {
+	return Promise.resolve(
+		new Response(JSON.stringify(data), {
+			status,
+			headers: { "Content-Type": "application/json" },
+		}),
+	);
+}
+
+describe("taxonomy sidebar refresh", () => {
+	let originalFetch: typeof fetch;
+	let manifestFetches: number;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+		manifestFetches = 0;
+		i18n.loadAndActivate({ locale: "en", messages: {} });
+
+		globalThis.fetch = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+			const url =
+				typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			const method = init?.method ?? "GET";
+
+			if (method === "GET" && url === "/_emdash/api/manifest") {
+				manifestFetches += 1;
+				return json({ data: manifestFetches === 1 ? initialManifest : refreshedManifest });
+			}
+			if (method === "GET" && url === "/_emdash/api/auth/me") {
+				return json({
+					data: { id: "admin", email: "admin@example.com", name: "Admin", role: 50 },
+				});
+			}
+			if (method === "GET" && url === "/_emdash/api/admin/comments/counts") {
+				return json({ data: { pending: 0, approved: 0, spam: 0, trash: 0 } });
+			}
+			if (method === "GET" && url === "/_emdash/api/taxonomies") {
+				return json({ data: { taxonomies: manifestFetches > 1 ? [category, genre] : [category] } });
+			}
+			if (method === "GET" && url.startsWith("/_emdash/api/taxonomies/category/terms")) {
+				return json({ data: { terms: [] } });
+			}
+			if (method === "POST" && url === "/_emdash/api/taxonomies") {
+				return json({ data: { taxonomy: genre } }, 201);
+			}
+
+			throw new Error(`Unexpected request: ${method} ${url}`);
+		}) as typeof fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("shows a newly created taxonomy in the sidebar without reloading", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: { retry: false, gcTime: 0, staleTime: 60_000 },
+				mutations: { retry: false },
+			},
+		});
+		const router = createAdminRouter(queryClient);
+		await router.navigate({
+			to: "/taxonomies/$taxonomy",
+			params: { taxonomy: "category" },
+		});
+
+		function TestApp() {
+			return (
+				<ThemeProvider defaultTheme="light">
+					<I18nProvider i18n={i18n}>
+						<Toasty>
+							<QueryClientProvider client={queryClient}>
+								<LinkProvider component={TestLink}>
+									<RouterProvider router={router} />
+								</LinkProvider>
+							</QueryClientProvider>
+						</Toasty>
+					</I18nProvider>
+				</ThemeProvider>
+			);
+		}
+
+		const screen = await render(<TestApp />);
+		await expect.element(screen.getByRole("link", { name: "Categories" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Genres" }).query()).toBeNull();
+
+		await screen.getByRole("button", { name: "New Taxonomy" }).click();
+		await screen.getByRole("textbox", { name: "Label" }).fill("Genres");
+		await userEvent.keyboard("{Enter}");
+
+		await expect.element(screen.getByRole("link", { name: "Genres" })).toBeInTheDocument();
+		expect(manifestFetches).toBe(2);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes newly created taxonomies not appearing in the admin sidebar until the page is reloaded.

The taxonomy creation mutation already refreshed taxonomy-definition queries, but the sidebar reads taxonomy definitions from the cached admin manifest. This change invalidates that manifest after a successful creation so the active shell refetches it and renders the new navigation entry immediately.

No linked issue.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @emdash-cms/admin test --run` — 125 files and 1,530 tests passed
- `pnpm --filter @emdash-cms/admin build`
- Manual browser verification: created `Live Refresh Check` from the Categories screen and confirmed its sidebar link appeared without a page reload or route change.
