### PR TITLE
fix(core): replace better-sqlite3 with node:sqlite

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -37,6 +37,7 @@
 		"@emdash-cms/playground",
 		"@emdash-cms/plugin-api-test",
 		"@emdash-cms/plugin-marketplace-test",
+		"@emdash-cms/plugin-mcp-smoke",
 		"@emdash-cms/plugin-sandboxed-test",
 		"@emdash-cms/template-blank",
 		"@emdash-cms/template-blog",

--- a/.changeset/node-sqlite-adapter.md
+++ b/.changeset/node-sqlite-adapter.md
@@ -1,0 +1,11 @@
+---
+"emdash": minor
+---
+
+Updates `sqlite()` and the EmDash CLI to use Node.js's built-in SQLite driver. Node.js deployments can install and run EmDash without compiling or downloading the `better-sqlite3` native add-on. Existing SQLite database files and `sqlite({ url })` configuration continue to work.
+
+This release requires Node.js 22.16 or later. Check the installed version with `node --version` and upgrade Node.js before updating EmDash if it reports an earlier release.
+
+Node.js 22 prints its standard `ExperimentalWarning: SQLite is an experimental feature` message when the SQLite adapter loads. Node.js 24 does not print this warning.
+
+If `better-sqlite3` is listed in the site's `package.json` only for EmDash, remove that dependency after updating.

--- a/.changeset/sqlite-boolean-bindings.md
+++ b/.changeset/sqlite-boolean-bindings.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes boolean query parameters on SQLite, including boolean equality filters in the plugin storage API.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 22.16.0
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       # Build emdash + its deps AND the plugin-cli + registry packages.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,7 +376,7 @@ In libraries used in a Worker but not themselves Workers, install `@cloudflare/w
 # Testing
 
 - **Framework:** vitest. Tests in `packages/core/tests/`.
-- **No mocks for the DB.** SQLite (`better-sqlite3`) by default. PostgreSQL parity tests via a real `pg` connection with per-test schema isolation (set `EMDASH_TEST_PG` to a connection string for a role with `CREATEDB` to opt in).
+- **No mocks for the DB.** Node's built-in SQLite driver by default. PostgreSQL parity tests via a real `pg` connection with per-test schema isolation (set `EMDASH_TEST_PG` to a connection string for a role with `CREATEDB` to opt in).
 - **Utilities:** `tests/utils/test-db.ts` exposes `setupTestDatabase()`, `setupTestDatabaseWithCollections()`, `teardownTestDatabase()` for SQLite and `setupTestPostgresDatabase()` etc. for Postgres. Dialect-agnostic: `setupForDialect`, `setupForDialectWithCollections`, `teardownForDialect`, plus `describeEachDialect(name, fn)`. Use the dialect wrapper for query-builder code -- regressions tend to be dialect-specific.
 - **Structure:** `tests/unit/`, `tests/integration/`, `tests/e2e/` (Playwright). Test files mirror source structure. Each test gets a fresh DB.
 

--- a/demos/plugins-demo/package.json
+++ b/demos/plugins-demo/package.json
@@ -21,7 +21,6 @@
     "@tanstack/react-query": "catalog:",
     "@tanstack/react-router": "catalog:",
     "astro": "catalog:",
-    "better-sqlite3": "catalog:",
     "emdash": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"

--- a/demos/simple/package.json
+++ b/demos/simple/package.json
@@ -23,7 +23,6 @@
     "@emdash-cms/plugin-cli": "workspace:*",
     "@emdash-cms/plugin-mcp-smoke": "workspace:*",
     "astro": "catalog:",
-    "better-sqlite3": "catalog:",
     "emdash": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"

--- a/docs/src/content/docs/deployment/database.mdx
+++ b/docs/src/content/docs/deployment/database.mdx
@@ -507,7 +507,7 @@ For a non-superuser to transfer ownership, it must own or inherit ownership of t
 
 ## SQLite
 
-SQLite with better-sqlite3 is the simplest option for Node.js deployments.
+SQLite uses Node.js's built-in database driver and is the simplest option for Node.js deployments.
 
 ```js title="astro.config.mjs"
 import { sqlite } from "emdash/db";

--- a/docs/src/content/docs/deployment/nodejs.mdx
+++ b/docs/src/content/docs/deployment/nodejs.mdx
@@ -5,12 +5,18 @@ description: Deploy EmDash to any Node.js hosting platform.
 
 import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
 
-EmDash runs on any Node.js 22+ hosting platform. This guide uses SQLite with local or S3-compatible storage; libSQL and PostgreSQL work the same way on Node.js — see [Database Options](/deployment/database/).
+EmDash runs on Node.js 22.16 or later. This guide uses SQLite with local or S3-compatible storage; libSQL and PostgreSQL work the same way on Node.js — see [Database Options](/deployment/database/).
 
 ## Prerequisites
 
-- Node.js v22.12.0 or higher
+- Node.js v22.16.0 or higher
 - A Node.js hosting provider or VPS
+
+<Aside>
+	Node.js 22 prints `ExperimentalWarning: SQLite is an experimental feature` when a site uses the
+	built-in SQLite driver. The warning comes from Node.js and does not prevent the database from
+	opening. Node.js 24 does not print this warning.
+</Aside>
 
 ## Configuration
 
@@ -122,24 +128,6 @@ The seed file is read at build time and inlined into the bundle, so it does not 
 	not interchangeable with the `Dockerfile` in the root of the EmDash repository, which builds the whole
 	pnpm monorepo and packages the blog template from source.
 </Aside>
-
-<Aside type="caution" title="Native dependencies behind restrictive networks">
-	EmDash's SQLite driver (`better-sqlite3`) installs a prebuilt binary downloaded from GitHub Releases.
-	If your build environment blocks that download (corporate proxy, offline mirror), the install falls
-	back to compiling from source and fails with a `gyp ERR! find Python` error, because slim/alpine Node
-	images ship no compiler toolchain.
-</Aside>
-
-If you hit that error, install the toolchain in the builder stage before `npm ci`:
-
-```dockerfile
-# Alpine-based images (node:22-alpine)
-RUN apk add --no-cache python3 make g++
-
-# Debian-based images (node:22-slim)
-RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ \
-    && rm -rf /var/lib/apt/lists/*
-```
 
 Build the image and run the container:
 

--- a/docs/src/content/docs/existing-project.mdx
+++ b/docs/src/content/docs/existing-project.mdx
@@ -10,7 +10,7 @@ import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
 ## Prerequisites
 
 - **Astro 6 or later** — upgrade first if you're on an older major (`npx @astrojs/upgrade`)
-- **Node.js v22.12.0 or higher** (odd-numbered versions are not supported)
+- **Node.js v22.16.0 or higher** (odd-numbered versions are not supported)
 - **Server output** — EmDash serves content at runtime, so your project needs `output: "server"` and an [adapter](https://docs.astro.build/en/guides/on-demand-rendering/) (Node, Cloudflare, ...)
 
 ## Install the Packages
@@ -34,12 +34,6 @@ yarn add emdash @astrojs/react react react-dom
 ```
 </TabItem>
 </Tabs>
-
-For a local SQLite database (the default for development), also install the driver:
-
-```bash
-npm install better-sqlite3
-```
 
 Deploying to Cloudflare? Add the Cloudflare packages as well — the [Deploy to Cloudflare](/deployment/cloudflare/) guide covers them in detail:
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -11,7 +11,7 @@ This guide walks you through creating your first EmDash site, from installation 
 
 ## Prerequisites
 
-- **Node.js** v22.12.0 or higher (odd-numbered versions are not supported)
+- **Node.js** v22.16.0 or higher (odd-numbered versions are not supported)
 - **npm**, **pnpm**, or **yarn**
 - A code editor (VS Code recommended)
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -518,7 +518,7 @@ import { sqlite, libsql, postgres } from "emdash/db";
 
 ### `sqlite(config)`
 
-SQLite database using better-sqlite3. The following example connects to a local file:
+SQLite database using Node.js's built-in database driver. The following example connects to a local file:
 
 | Option | Type     | Description                   |
 | ------ | -------- | ----------------------------- |

--- a/e2e/fixture/package.json
+++ b/e2e/fixture/package.json
@@ -8,7 +8,6 @@
 		"@emdash-cms/auth": "workspace:*",
 		"@emdash-cms/plugin-color": "workspace:*",
 		"astro": "catalog:",
-		"better-sqlite3": "catalog:",
 		"emdash": "workspace:*",
 		"react": "catalog:",
 		"react-dom": "catalog:"

--- a/fixtures/perf-site/package.json
+++ b/fixtures/perf-site/package.json
@@ -19,7 +19,6 @@
 		"@astrojs/react": "catalog:",
 		"@emdash-cms/cloudflare": "workspace:*",
 		"astro": "catalog:",
-		"better-sqlite3": "catalog:",
 		"emdash": "workspace:*",
 		"kysely": "^0.29.0",
 		"react": "catalog:",

--- a/knip.json
+++ b/knip.json
@@ -25,7 +25,7 @@
 		"packages/plugins/*": {},
 		"demos/*": {
 			"entry": ["src/**/*.{ts,astro}"],
-			"ignoreDependencies": ["better-sqlite3", "kysely-d1", "@astrojs/check"]
+			"ignoreDependencies": ["kysely-d1", "@astrojs/check"]
 		},
 		"demos/cloudflare": {
 			"ignoreDependencies": ["cloudflare", "kysely-d1"]

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
 	},
 	"packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
 	"engines": {
-		"node": ">=22"
+		"node": ">=22.16"
 	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -257,7 +257,6 @@
     "@unpic/placeholder": "^0.1.2",
     "arctic": "^3.7.0",
     "astro-portabletext": "^0.11.0",
-    "better-sqlite3": "catalog:",
     "blurhash": "^2.0.5",
     "citty": "^0.2.2",
     "consola": "^3.4.2",
@@ -299,6 +298,7 @@
     "@cloudflare/vitest-pool-workers": "catalog:",
     "@emdash-cms/blocks": "workspace:*",
     "@types/better-sqlite3": "^7.6.12",
+    "better-sqlite3": "catalog:",
     "@types/pg": "^8.16.0",
     "@types/react": "catalog:",
     "@types/sanitize-html": "^2.16.0",
@@ -325,5 +325,8 @@
     "wordpress"
   ],
   "author": "Matt Kane",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=22.16"
+  }
 }

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -363,13 +363,7 @@ export function createVirtualModulesPlugin(
 // `?url`), so both forms resolve to dist rather than the source alias.
 const ADMIN_STYLES_ALIAS = /^@emdash-cms\/admin\/styles\.css/;
 
-const NODE_NATIVE_EXTERNALS = [
-	"better-sqlite3",
-	"bindings",
-	"file-uri-to-path",
-	"@libsql/kysely-libsql",
-	"pg",
-];
+const NODE_NATIVE_EXTERNALS = ["@libsql/kysely-libsql", "pg"];
 
 /**
  * Detect whether the Cloudflare adapter is being used.

--- a/packages/core/src/database/connection.ts
+++ b/packages/core/src/database/connection.ts
@@ -1,6 +1,6 @@
-import BetterSqlite3 from "better-sqlite3";
 import { Kysely, SqliteDialect } from "kysely";
 
+import { openNodeSqliteDatabase } from "../db/node-sqlite-compat.js";
 import { EmDashDatabaseError } from "./errors.js";
 import { kyselyLogOption } from "./instrumentation.js";
 import type { Database } from "./types.js";
@@ -10,23 +10,6 @@ export { EmDashDatabaseError };
 export interface DatabaseConfig {
 	url: string;
 	authToken?: string;
-}
-
-/**
- * Returns a helpful, actionable message when better-sqlite3's native binary
- * was compiled against a different Node.js version than the one running. This
- * happens after upgrading Node without rebuilding native deps.
- *
- * Returns null if the error is not a NODE_MODULE_VERSION mismatch.
- */
-export function formatNativeModuleVersionError(error: unknown): string | null {
-	const message = error instanceof Error ? error.message : String(error);
-	if (!message.includes("NODE_MODULE_VERSION")) return null;
-	return (
-		"better-sqlite3's native binary was compiled against a different Node.js version. " +
-		"Rebuild it with `pnpm rebuild better-sqlite3` (or `npm rebuild better-sqlite3`), " +
-		"or reinstall dependencies with your current Node.js version."
-	);
 }
 
 /**
@@ -42,15 +25,7 @@ export function createDatabase(config: DatabaseConfig): Kysely<Database> {
 		if (config.url.startsWith("file:") || config.url === ":memory:") {
 			const dbPath = config.url === ":memory:" ? ":memory:" : config.url.replace("file:", "");
 
-			const sqlite = new BetterSqlite3(dbPath);
-
-			// Enable WAL mode for crash safety — writes go to a write-ahead log
-			// before being applied, preventing FTS5 shadow table corruption on
-			// process kill during content writes. No-op for :memory: databases.
-			sqlite.pragma("journal_mode = WAL");
-
-			// Enable foreign key constraints
-			sqlite.pragma("foreign_keys = ON");
+			const sqlite = openNodeSqliteDatabase(dbPath, { journalMode: "wal" });
 
 			const dialect = new SqliteDialect({
 				database: sqlite,
@@ -72,10 +47,6 @@ export function createDatabase(config: DatabaseConfig): Kysely<Database> {
 	} catch (error) {
 		if (error instanceof EmDashDatabaseError) {
 			throw error;
-		}
-		const nativeVersionHint = formatNativeModuleVersionError(error);
-		if (nativeVersionHint) {
-			throw new EmDashDatabaseError(nativeVersionHint, error);
 		}
 		throw new EmDashDatabaseError("Failed to create database", error);
 	}

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -1,5 +1,5 @@
 // `createDatabase` is intentionally not re-exported here: it lives in
-// `connection.ts`, which statically imports `better-sqlite3`. See #947.
+// `connection.ts`, which statically imports the Node-only `node:sqlite` module.
 export { EmDashDatabaseError } from "./errors.js";
 export type { DatabaseConfig } from "./connection.js";
 export {

--- a/packages/core/src/database/migrations/019_i18n.ts
+++ b/packages/core/src/database/migrations/019_i18n.ts
@@ -223,7 +223,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 		const tmp = `${t}_i18n_tmp`;
 
 		// Note: no transaction wrapper — D1 doesn't support transactions,
-		// and SQLite/better-sqlite3 is single-writer so crash-safety is
+		// and file-backed SQLite is single-writer so crash-safety is
 		// handled by the journal mode. The tmp table approach is already
 		// crash-recoverable (orphaned tmp tables are harmless).
 		{

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -264,7 +264,7 @@ function escapeRegExp(value: string): string {
  *
  * We match on the table name (not the full error text) because different
  * SQLite drivers phrase the message differently
- * (`UNIQUE constraint failed: _emdash_migrations.name` for better-sqlite3,
+ * (`UNIQUE constraint failed: _emdash_migrations.name` for file-backed SQLite,
  * `D1_ERROR: UNIQUE constraint failed: _emdash_migrations.name: SQLITE_CONSTRAINT`
  * for D1, etc.). The pattern is built from `MIGRATION_TABLE` so a rename
  * cannot silently disable race detection.
@@ -288,7 +288,7 @@ const MIGRATION_RACE_POLL_MS = 100;
  * Pattern used to detect "table does not exist" errors across the dialects
  * EmDash supports. The phrasing differs by driver:
  *
- *   - better-sqlite3: `no such table: _emdash_migrations`
+ *   - SQLite:         `no such table: _emdash_migrations`
  *   - D1:             `D1_ERROR: no such table: _emdash_migrations: SQLITE_ERROR`
  *   - PostgreSQL:     `relation "_emdash_migrations" does not exist`
  *                     (also occasionally `table "_emdash_migrations" does not exist`)

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -125,10 +125,13 @@ function matchesPublicationFence(observed: ContentItem, existing: ContentItem): 
 	);
 }
 
-function isConfirmedStatementFailure(error: unknown): boolean {
+export function isConfirmedStatementFailure(error: unknown): boolean {
 	if (typeof error !== "object" || error === null || !("code" in error)) return false;
 	const code = (error as { code?: unknown }).code;
-	return typeof code === "string" && (code.startsWith("SQLITE_") || SQLSTATE_PATTERN.test(code));
+	return (
+		typeof code === "string" &&
+		(code === "ERR_SQLITE_ERROR" || code.startsWith("SQLITE_") || SQLSTATE_PATTERN.test(code))
+	);
 }
 
 interface ResolvedOrderField {
@@ -1383,8 +1386,6 @@ export class ContentRepository {
 		if (bylineIds.length === 0) {
 			// A filter that resolved to no ids must match nothing rather than
 			// silently degrade to "no filter" and return the whole collection.
-			// `1 = 0` rather than a bound `false`: better-sqlite3 refuses to
-			// bind JS booleans.
 			return query.where(() => sql<boolean>`1 = 0`);
 		}
 

--- a/packages/core/src/db/adapters.ts
+++ b/packages/core/src/db/adapters.ts
@@ -134,9 +134,9 @@ export interface LibsqlConfig {
 }
 
 /**
- * SQLite database adapter (better-sqlite3)
+ * SQLite database adapter (node:sqlite)
  *
- * For local development and Node.js deployments.
+ * For local development and Node.js deployments. Requires Node.js 22.16 or later.
  *
  * @example
  * ```ts

--- a/packages/core/src/db/node-sqlite-compat.ts
+++ b/packages/core/src/db/node-sqlite-compat.ts
@@ -1,0 +1,78 @@
+import { DatabaseSync } from "node:sqlite";
+
+export interface NodeSqliteCompatDatabase {
+	close(): void;
+	prepare(sql: string): NodeSqliteCompatStatement;
+}
+
+export interface NodeSqliteCompatStatement {
+	readonly reader: boolean;
+	all(parameters: ReadonlyArray<unknown>): unknown[];
+	run(parameters: ReadonlyArray<unknown>): {
+		changes: number | bigint;
+		lastInsertRowid: number | bigint;
+	};
+	iterate(parameters: ReadonlyArray<unknown>): IterableIterator<unknown>;
+}
+
+export interface NodeSqliteOpenOptions {
+	journalMode?: "wal";
+}
+
+type SqliteBinding = null | number | bigint | string | Uint8Array;
+
+export function openNodeSqliteDatabase(
+	path: string,
+	options: NodeSqliteOpenOptions = {},
+): NodeSqliteCompatDatabase {
+	const database = new DatabaseSync(path);
+
+	try {
+		database.exec("PRAGMA busy_timeout = 5000");
+		database.exec("PRAGMA foreign_keys = ON");
+		// Negative cache_size values are kibibytes.
+		database.exec("PRAGMA cache_size = -16000");
+		if (options.journalMode === "wal") {
+			database.exec("PRAGMA journal_mode = WAL");
+		}
+		const journalMode = database.prepare("PRAGMA journal_mode").get()?.["journal_mode"];
+		if (journalMode === "wal") {
+			database.exec("PRAGMA synchronous = NORMAL");
+		}
+	} catch (error) {
+		try {
+			database.close();
+		} catch {
+			throw new Error("SQLite setup failed and the connection could not be closed", {
+				cause: error,
+			});
+		}
+		throw error;
+	}
+
+	return {
+		close: () => database.close(),
+		prepare(sql) {
+			const statement = database.prepare(sql);
+			return {
+				reader: statement.columns().length > 0,
+				all: (parameters) => statement.all(...toBindings(parameters)),
+				run: (parameters) => statement.run(...toBindings(parameters)),
+				iterate: (parameters) => statement.iterate(...toBindings(parameters)),
+			};
+		},
+	};
+}
+
+function toBindings(parameters: ReadonlyArray<unknown>): SqliteBinding[] {
+	return parameters.map((value) => {
+		if (value === null || typeof value === "string" || typeof value === "number") {
+			return value;
+		}
+		if (typeof value === "bigint") return value;
+		if (typeof value === "boolean") return value ? 1 : 0;
+		if (value === undefined) return null;
+		if (value instanceof Uint8Array) return value;
+		throw new TypeError(`Cannot bind ${Object.prototype.toString.call(value)} to SQLite`);
+	});
+}

--- a/packages/core/src/db/sqlite.ts
+++ b/packages/core/src/db/sqlite.ts
@@ -1,14 +1,14 @@
 /**
  * SQLite runtime adapter
  *
- * Creates a Kysely dialect for better-sqlite3.
+ * Creates a Kysely dialect for Node's built-in SQLite driver.
  * Loaded at runtime via virtual module.
  */
 
-import BetterSqlite3 from "better-sqlite3";
 import { type Dialect, SqliteDialect } from "kysely";
 
 import type { SqliteConfig } from "./adapters.js";
+import { openNodeSqliteDatabase } from "./node-sqlite-compat.js";
 
 /**
  * Create a SQLite dialect from config
@@ -18,7 +18,7 @@ export function createDialect(config: SqliteConfig): Dialect {
 	const url = config.url;
 	const filePath = url.startsWith("file:") ? url.slice(5) : url;
 
-	const database = new BetterSqlite3(filePath);
+	const database = openNodeSqliteDatabase(filePath);
 
 	return new SqliteDialect({ database });
 }

--- a/packages/core/tests/database/connection.test.ts
+++ b/packages/core/tests/database/connection.test.ts
@@ -1,13 +1,9 @@
 import { unlinkSync } from "node:fs";
 
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 import { describe, it, expect, afterEach } from "vitest";
 
-import {
-	createDatabase,
-	EmDashDatabaseError,
-	formatNativeModuleVersionError,
-} from "../../src/database/connection.js";
+import { createDatabase, EmDashDatabaseError } from "../../src/database/connection.js";
 import type { Database } from "../../src/database/types.js";
 
 describe("createDatabase", () => {
@@ -92,6 +88,18 @@ describe("createDatabase", () => {
 			expect(result).toHaveLength(1);
 			expect(result[0].id).toBe("test-1");
 		});
+
+		it("preserves the CLI connection settings", async () => {
+			db = createDatabase({ url: `file:${testDbPath}` });
+
+			const journal = await sql<{ journal_mode: string }>`PRAGMA journal_mode`.execute(db);
+			const synchronous = await sql<{ synchronous: number }>`PRAGMA synchronous`.execute(db);
+			const cache = await sql<{ cache_size: number }>`PRAGMA cache_size`.execute(db);
+
+			expect(journal.rows[0]?.journal_mode).toBe("wal");
+			expect(synchronous.rows[0]?.synchronous).toBe(1);
+			expect(cache.rows[0]?.cache_size).toBe(-16000);
+		});
 	});
 
 	describe("libSQL / Turso", () => {
@@ -139,23 +147,6 @@ describe("createDatabase", () => {
 				expect(error).toBeInstanceOf(EmDashDatabaseError);
 				expect(error).toHaveProperty("cause");
 			}
-		});
-	});
-
-	describe("formatNativeModuleVersionError", () => {
-		it("returns an actionable message for NODE_MODULE_VERSION mismatch", () => {
-			const err = new Error(
-				"The module '/path/better_sqlite3.node' was compiled against a different Node.js version using NODE_MODULE_VERSION 115. This version of Node.js requires NODE_MODULE_VERSION 127.",
-			);
-			const message = formatNativeModuleVersionError(err);
-			expect(message).not.toBeNull();
-			expect(message).toContain("better-sqlite3");
-			expect(message).toMatch(/rebuild/i);
-		});
-
-		it("returns null for unrelated errors", () => {
-			expect(formatNativeModuleVersionError(new Error("disk full"))).toBeNull();
-			expect(formatNativeModuleVersionError("some string")).toBeNull();
 		});
 	});
 

--- a/packages/core/tests/integration/fixture/package.json
+++ b/packages/core/tests/integration/fixture/package.json
@@ -8,7 +8,6 @@
 		"@emdash-cms/auth": "workspace:*",
 		"@emdash-cms/plugin-color": "workspace:*",
 		"astro": "catalog:",
-		"better-sqlite3": "^11.10.0",
 		"emdash": "workspace:*",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0"

--- a/packages/core/tests/integration/fixture/src/pages/prerender-check.astro
+++ b/packages/core/tests/integration/fixture/src/pages/prerender-check.astro
@@ -1,0 +1,13 @@
+---
+export const prerender = true;
+
+import { getEmDashCollection } from "emdash";
+
+const { entries } = await getEmDashCollection("posts");
+---
+
+<html>
+	<body>
+		<p id="entry-count">{entries.length}</p>
+	</body>
+</html>

--- a/packages/core/tests/integration/plugins/storage-dialect.test.ts
+++ b/packages/core/tests/integration/plugins/storage-dialect.test.ts
@@ -41,6 +41,7 @@ describeEachDialect("plugin storage filtered query/count (#920)", (dialect) => {
 		const db = ctx.db as unknown as Kysely<Database>;
 		return new PluginStorageRepository<ProviderDoc>(db, "emdash-smtp", "providers", [
 			"provider",
+			"active",
 			"priority",
 		]);
 	}
@@ -85,5 +86,14 @@ describeEachDialect("plugin storage filtered query/count (#920)", (dialect) => {
 		expect(await repo.count({ provider: "resend" })).toBe(2);
 		expect(await repo.count({ provider: "sendgrid" })).toBe(1);
 		expect(await repo.count({ provider: "nope" })).toBe(0);
+	});
+
+	it("supports boolean equality filters", async () => {
+		const repo = makeRepo();
+		await seed(repo);
+
+		const result = await repo.query({ where: { active: true } });
+		expect(result.items.map((item) => item.id)).toEqual(["p1"]);
+		expect(await repo.count({ active: false })).toBe(2);
 	});
 });

--- a/packages/core/tests/integration/server.ts
+++ b/packages/core/tests/integration/server.ts
@@ -75,16 +75,16 @@ export interface TestServerContext {
 // ---------------------------------------------------------------------------
 
 /**
- * Astro requires Node.js >= 22.12.0. Call from a `beforeAll` to fail the
+ * EmDash requires Node.js >= 22.16.0. Call from a `beforeAll` to fail the
  * suite immediately when the environment is misconfigured rather than
  * silently skipping.
  */
 export function assertNodeVersion(): void {
 	const [major, minor] = process.versions.node.split(".").map(Number) as [number, number];
-	const ok = major! > 22 || (major === 22 && minor! >= 12);
+	const ok = major! > 22 || (major === 22 && minor! >= 16);
 	if (!ok) {
 		throw new Error(
-			`Integration tests require Node.js >= 22.12.0 (running ${process.versions.node}). ` +
+			`Integration tests require Node.js >= 22.16.0 (running ${process.versions.node}). ` +
 				`Update your Node version instead of skipping tests.`,
 		);
 	}

--- a/packages/core/tests/integration/smoke/sqlite-prerender.test.ts
+++ b/packages/core/tests/integration/smoke/sqlite-prerender.test.ts
@@ -1,0 +1,67 @@
+import { execFile } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ensureBuilt } from "../server.js";
+
+const execAsync = promisify(execFile);
+const WORKSPACE_ROOT = resolve(import.meta.dirname, "../../../../..");
+const FIXTURE_DIR = resolve(import.meta.dirname, "../fixture");
+const SERVERS_BASE = resolve(import.meta.dirname, "../.servers");
+const DONOR_NODE_MODULES = resolve(WORKSPACE_ROOT, "demos/simple/node_modules");
+const CLI_BIN = resolve(import.meta.dirname, "../../../dist/cli/index.mjs");
+
+describe("SQLite static prerender", () => {
+	let workDir: string | undefined;
+
+	afterEach(() => {
+		if (workDir) rmSync(workDir, { recursive: true, force: true });
+	});
+
+	it("builds a page that queries a live collection", { timeout: 120_000 }, async () => {
+		await ensureBuilt();
+		mkdirSync(SERVERS_BASE, { recursive: true });
+		workDir = mkdtempSync(join(SERVERS_BASE, "prerender-"));
+		cpSync(FIXTURE_DIR, workDir, {
+			recursive: true,
+			filter: (source) => !source.split(/[\\/]/).includes("node_modules"),
+		});
+		symlinkSync(DONOR_NODE_MODULES, join(workDir, "node_modules"));
+
+		const databasePath = join(workDir, "prerender.db");
+		await execAsync(process.execPath, [
+			CLI_BIN,
+			"init",
+			"--database",
+			databasePath,
+			"--cwd",
+			workDir,
+		]);
+		await execAsync(process.execPath, [
+			CLI_BIN,
+			"seed",
+			"--database",
+			databasePath,
+			"--cwd",
+			workDir,
+		]);
+
+		const astro = join(workDir, "node_modules", ".bin", "astro");
+		await execAsync(astro, ["build"], {
+			cwd: workDir,
+			timeout: 90_000,
+			env: {
+				...process.env,
+				CI: "true",
+				EMDASH_TEST_DB: `file:${databasePath}`,
+				EMDASH_TEST_UPLOADS: join(workDir, "uploads"),
+				EMDASH_TEST_VITE_CACHE: join(workDir, ".vite-cache"),
+			},
+		});
+
+		expect(existsSync(join(workDir, "dist/client/prerender-check/index.html"))).toBe(true);
+	});
+});

--- a/packages/core/tests/unit/database/repositories/content-statement-errors.test.ts
+++ b/packages/core/tests/unit/database/repositories/content-statement-errors.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { isConfirmedStatementFailure } from "../../../../src/database/repositories/content.js";
+
+describe("isConfirmedStatementFailure", () => {
+	it("recognizes node:sqlite statement errors", () => {
+		expect(isConfirmedStatementFailure({ code: "ERR_SQLITE_ERROR" })).toBe(true);
+	});
+
+	it("does not classify non-database errors as confirmed statement failures", () => {
+		expect(isConfirmedStatementFailure(new Error("connection interrupted"))).toBe(false);
+	});
+});

--- a/packages/core/tests/unit/db/node-sqlite-compat.test.ts
+++ b/packages/core/tests/unit/db/node-sqlite-compat.test.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Kysely, SqliteDialect } from "kysely";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { openNodeSqliteDatabase } from "../../../src/db/node-sqlite-compat.js";
+
+describe("openNodeSqliteDatabase", () => {
+	const openDatabases: ReturnType<typeof openNodeSqliteDatabase>[] = [];
+	const temporaryDirectories: string[] = [];
+
+	afterEach(() => {
+		for (const database of openDatabases.splice(0)) database.close();
+		for (const directory of temporaryDirectories.splice(0)) {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	function open(path = ":memory:", options?: { journalMode?: "wal" }) {
+		const database = openNodeSqliteDatabase(path, options);
+		openDatabases.push(database);
+		return database;
+	}
+
+	function temporaryDatabasePath(): string {
+		const directory = mkdtempSync(join(tmpdir(), "emdash-node-sqlite-"));
+		temporaryDirectories.push(directory);
+		return join(directory, "data.db");
+	}
+
+	it("implements the statement contract Kysely uses", async () => {
+		const database = open();
+		const db = new Kysely<{ entries: { id: number | null; title: string } }>({
+			dialect: new SqliteDialect({ database }),
+		});
+
+		await db.schema
+			.createTable("entries")
+			.addColumn("id", "integer", (column) => column.primaryKey().autoIncrement())
+			.addColumn("title", "text", (column) => column.notNull())
+			.execute();
+
+		const inserted = await db
+			.insertInto("entries")
+			.values({ title: "First entry" })
+			.returning("id")
+			.executeTakeFirstOrThrow();
+		expect(inserted.id).toBe(1);
+		expect(await db.selectFrom("entries").selectAll().execute()).toEqual([
+			{ id: 1, title: "First entry" },
+		]);
+
+		openDatabases.pop();
+		await db.destroy();
+	});
+
+	it("normalizes supported positional values without shifting parameters", () => {
+		const database = open();
+		database.prepare("CREATE TABLE values_test (a, b, c, d, e, f)").run([]);
+		database
+			.prepare("INSERT INTO values_test VALUES (?, ?, ?, ?, ?, ?)")
+			.run([undefined, true, false, 7n, "text", new Uint8Array([1, 2])]);
+
+		const row = database.prepare("SELECT * FROM values_test").all([])[0];
+		expect(row).toEqual({
+			a: null,
+			b: 1,
+			c: 0,
+			d: 7,
+			e: "text",
+			f: new Uint8Array([1, 2]),
+		});
+	});
+
+	it.each([
+		["plain object", {}],
+		["array", []],
+		["date", new Date("2026-01-01T00:00:00.000Z")],
+		["boxed number", new Number(1)],
+	])("rejects an unsupported %s before executing the statement", (_name, value) => {
+		const database = open();
+		database.prepare("CREATE TABLE rejected_values (first, second)").run([]);
+		const insert = database.prepare("INSERT INTO rejected_values VALUES (?, ?)");
+
+		expect(() => insert.run([value, "must-not-shift"])).toThrow(/Cannot bind/);
+		expect(database.prepare("SELECT COUNT(*) AS count FROM rejected_values").all([])).toEqual([
+			{ count: 0 },
+		]);
+	});
+
+	it("matches the existing SQLite runtime connection defaults", () => {
+		const database = open(temporaryDatabasePath());
+
+		expect(database.prepare("PRAGMA journal_mode").all([])).toEqual([{ journal_mode: "delete" }]);
+		expect(database.prepare("PRAGMA synchronous").all([])).toEqual([{ synchronous: 2 }]);
+		expect(database.prepare("PRAGMA cache_size").all([])).toEqual([{ cache_size: -16000 }]);
+		expect(database.prepare("PRAGMA busy_timeout").all([])).toEqual([{ timeout: 5000 }]);
+		expect(database.prepare("PRAGMA foreign_keys").all([])).toEqual([{ foreign_keys: 1 }]);
+	});
+
+	it("matches the existing CLI WAL settings", () => {
+		const database = open(temporaryDatabasePath(), { journalMode: "wal" });
+
+		expect(database.prepare("PRAGMA journal_mode").all([])).toEqual([{ journal_mode: "wal" }]);
+		expect(database.prepare("PRAGMA synchronous").all([])).toEqual([{ synchronous: 1 }]);
+		expect(database.prepare("PRAGMA cache_size").all([])).toEqual([{ cache_size: -16000 }]);
+	});
+
+	it("keeps NORMAL synchronization when runtime reopens an existing WAL database", () => {
+		const path = temporaryDatabasePath();
+		const cliDatabase = open(path, { journalMode: "wal" });
+		cliDatabase.close();
+		openDatabases.pop();
+
+		const runtimeDatabase = open(path);
+		expect(runtimeDatabase.prepare("PRAGMA journal_mode").all([])).toEqual([
+			{ journal_mode: "wal" },
+		]);
+		expect(runtimeDatabase.prepare("PRAGMA synchronous").all([])).toEqual([{ synchronous: 1 }]);
+	});
+});

--- a/packages/core/tests/utils/test-db.ts
+++ b/packages/core/tests/utils/test-db.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 
-import Database from "better-sqlite3";
 import type { SqliteDialectConfig } from "kysely";
 import { Kysely, SqliteAdapter, SqliteDialect } from "kysely";
 import { Pool } from "pg";
@@ -17,6 +16,7 @@ import type {
 } from "../../src/database/migrations/runner.js";
 import { FailFastPostgresDialect } from "../../src/database/pg-migration-lock.js";
 import type { Database as DatabaseSchema } from "../../src/database/types.js";
+import { openNodeSqliteDatabase } from "../../src/db/node-sqlite-compat.js";
 import { waitForDeferredTasks } from "../../src/deferred-tasks.js";
 import { SchemaRegistry } from "../../src/schema/registry.js";
 import { resetTaxonomyDefsCacheForTests } from "../../src/taxonomies/index.js";
@@ -60,7 +60,7 @@ export const hasPgTestDatabase = PG_CONNECTION_STRING.length > 0;
  */
 export function createTestDatabase(): Kysely<DatabaseSchema> {
 	resetSchemaCachesForTests();
-	const sqlite = new Database(":memory:");
+	const sqlite = openNodeSqliteDatabase(":memory:");
 
 	return new Kysely<DatabaseSchema>({
 		dialect: new SqliteDialect({
@@ -167,18 +167,17 @@ export interface CompoundSelectTestDatabase {
  * Test database standing in for a backend with — or without — a
  * compound-SELECT ceiling.
  *
- * better-sqlite3 uses SQLite's upstream default of 500 and offers no way to
- * lower it, so query shapes that D1 rejects run happily in tests. Pass a
- * number and the dialect declares the ceiling the way the D1 dialect does,
- * while prepare() rejects statements past it — where SQLite itself raises the
- * error — with D1's error text, so code that inspects the message behaves the
- * same. Pass null for a backend that imposes no ceiling.
+ * SQLite's upstream default is 500, so query shapes that D1 rejects run
+ * happily in tests. Pass a number and the dialect declares the ceiling the way
+ * the D1 dialect does, while prepare() rejects statements past it — where SQLite
+ * itself raises the error — with D1's error text, so code that inspects the
+ * message behaves the same. Pass null for a backend that imposes no ceiling.
  */
 export async function setupTestDatabaseWithCompoundSelectLimit(
 	limit: number | null = D1_COMPOUND_SELECT_LIMIT,
 ): Promise<CompoundSelectTestDatabase> {
 	resetSchemaCachesForTests();
-	const sqlite = new Database(":memory:");
+	const sqlite = openNodeSqliteDatabase(":memory:");
 	const statements: string[] = [];
 	const prepare = sqlite.prepare.bind(sqlite);
 	sqlite.prepare = ((source: string) => {

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -161,10 +161,6 @@ export default defineConfig({
 	},
 	// Externalize native modules, dialect-specific packages, and internal shared modules
 	external: [
-		// Native modules that use __filename
-		"better-sqlite3",
-		"bindings",
-		"file-uri-to-path",
 		// Dialect-specific packages
 		"@libsql/kysely-libsql",
 		"pg",

--- a/packages/marketplace/package.json
+++ b/packages/marketplace/package.json
@@ -18,9 +18,7 @@
     "zod": "^3.25.67"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "catalog:",
     "@types/node": "catalog:",
-    "better-sqlite3": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
     "wrangler": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,9 +624,6 @@ importers:
       astro:
         specifier: 'catalog:'
         version: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@24.10.13)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
-      better-sqlite3:
-        specifier: 'catalog:'
-        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -747,9 +744,6 @@ importers:
       astro:
         specifier: 'catalog:'
         version: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
-      better-sqlite3:
-        specifier: 'catalog:'
-        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -817,9 +811,6 @@ importers:
       astro:
         specifier: 'catalog:'
         version: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
-      better-sqlite3:
-        specifier: 'catalog:'
-        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -884,9 +875,6 @@ importers:
       astro:
         specifier: 'catalog:'
         version: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
-      better-sqlite3:
-        specifier: 'catalog:'
-        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -1844,9 +1832,6 @@ importers:
       astro-portabletext:
         specifier: ^0.11.0
         version: 0.11.4(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))
-      better-sqlite3:
-        specifier: 'catalog:'
-        version: 12.8.0
       blurhash:
         specifier: ^2.0.5
         version: 2.0.5
@@ -1935,6 +1920,9 @@ importers:
       '@vitest/ui':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.5)
+      better-sqlite3:
+        specifier: 'catalog:'
+        version: 12.8.0
       image-size:
         specifier: 'catalog:'
         version: 2.0.2(patch_hash=77c12533e3a635c4066c55da8952f4912e8210416539dc1249550fa639271595)
@@ -2029,15 +2017,9 @@ importers:
         specifier: ^3.25.67
         version: 3.25.76
     devDependencies:
-      '@types/better-sqlite3':
-        specifier: 'catalog:'
-        version: 7.6.13
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.13
-      better-sqlite3:
-        specifier: 'catalog:'
-        version: 12.8.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -2594,9 +2576,6 @@ importers:
       astro:
         specifier: 'catalog:'
         version: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
-      better-sqlite3:
-        specifier: 'catalog:'
-        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -2625,9 +2604,6 @@ importers:
       astro:
         specifier: 'catalog:'
         version: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
-      better-sqlite3:
-        specifier: 'catalog:'
-        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -2699,9 +2675,6 @@ importers:
       astro-iconset:
         specifier: 'catalog:'
         version: 0.0.4(astro@7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      better-sqlite3:
-        specifier: 'catalog:'
-        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -2767,9 +2740,6 @@ importers:
       astro:
         specifier: 'catalog:'
         version: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
-      better-sqlite3:
-        specifier: 'catalog:'
-        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -2829,9 +2799,6 @@ importers:
       astro:
         specifier: 'catalog:'
         version: 7.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(@types/node@26.1.1)(aws4fetch@1.0.20)(jiti@2.7.0)(rollup@4.55.2)(tsx@4.21.0)(yaml@2.9.0)
-      better-sqlite3:
-        specifier: 'catalog:'
-        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core

--- a/scripts/sync-templates-repo.mjs
+++ b/scripts/sync-templates-repo.mjs
@@ -157,8 +157,8 @@ function transformPackageJson(srcPath, catalog, workspace, packageManager) {
  */
 function pnpmWorkspaceYaml(template) {
 	const allowBuilds = template.endsWith("-cloudflare")
-		? "  esbuild: true\n  workerd: true\n  better-sqlite3: false\n  sharp: false"
-		: "  esbuild: true\n  better-sqlite3: true\n  sharp: true\n  workerd: false";
+		? "  esbuild: true\n  workerd: true\n  sharp: false"
+		: "  esbuild: true\n  sharp: true\n  workerd: false";
 	return `# Build scripts: allow only what each runtime needs; rest false so
 # strictDepBuilds (pnpm >=10.26 / 11) passes.
 allowBuilds:

--- a/skills/wordpress-theme-to-emdash/references/astro-essentials.md
+++ b/skills/wordpress-theme-to-emdash/references/astro-essentials.md
@@ -1012,7 +1012,7 @@ EmDash uses Portable Text (structured JSON) instead of Markdown, enabling:
 
 ### Requirements
 
-- **Node 22.12.0+** required (Node 18 and 20 dropped)
+- **Node 22.16.0+** required (Node 18 and 20 dropped)
 - **Vite 7** under the hood
 - **Zod 4** for schemas
 

--- a/skills/wordpress-theme-to-emdash/scaffold/package.json
+++ b/skills/wordpress-theme-to-emdash/scaffold/package.json
@@ -13,7 +13,6 @@
 		"@astrojs/node": "^10.0.0-beta.0",
 		"@astrojs/react": "^5.0.0-beta.1",
 		"astro": "^6.0.0-beta.0",
-		"better-sqlite3": "^11.10.0",
 		"emdash": "workspace:*",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0"

--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -14,7 +14,6 @@
     "@astrojs/node": "catalog:",
     "@astrojs/react": "catalog:",
     "astro": "catalog:",
-    "better-sqlite3": "catalog:",
     "emdash": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"

--- a/templates/blog/package.json
+++ b/templates/blog/package.json
@@ -18,7 +18,6 @@
     "@astrojs/react": "catalog:",
     "@emdash-cms/plugin-audit-log": "workspace:*",
     "astro": "catalog:",
-    "better-sqlite3": "catalog:",
     "emdash": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"

--- a/templates/marketing/package.json
+++ b/templates/marketing/package.json
@@ -19,7 +19,6 @@
     "@iconify-json/ph": "catalog:",
     "astro": "catalog:",
     "astro-iconset": "catalog:",
-    "better-sqlite3": "catalog:",
     "emdash": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"

--- a/templates/portfolio/package.json
+++ b/templates/portfolio/package.json
@@ -17,7 +17,6 @@
     "@astrojs/node": "catalog:",
     "@astrojs/react": "catalog:",
     "astro": "catalog:",
-    "better-sqlite3": "catalog:",
     "emdash": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"

--- a/templates/starter/package.json
+++ b/templates/starter/package.json
@@ -17,7 +17,6 @@
     "@astrojs/node": "catalog:",
     "@astrojs/react": "catalog:",
     "astro": "catalog:",
-    "better-sqlite3": "catalog:",
     "emdash": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"


### PR DESCRIPTION
## What does this PR do?

Replaces `better-sqlite3` with Node.js's built-in `node:sqlite` driver for the `sqlite()` adapter and CLI database commands. This removes the compiled add-on from production installations while preserving existing SQLite files, the public adapter configuration, the runtime journal mode, the CLI's WAL mode, the 5-second busy timeout, and the 16 MiB page cache.

The compatibility layer validates positional bindings before calling `node:sqlite`, preventing unsupported objects from being treated as named-parameter maps and shifting values into the wrong columns. It also normalizes booleans and `undefined`, preserves WAL synchronization settings across runtime reopens, and recognizes Node's SQLite error code in publication failure handling.

Node.js 22.16 is the minimum because `StatementSync.columns()` first shipped in that release. Node.js 22 prints its standard SQLite experimental warning; the deployment documentation calls this out.

Adds a production-build regression for SQLite-backed static prerendering and removes obsolete runtime dependency declarations from templates, fixtures, the WordPress theme scaffold, and generated template workspace configuration.

Supersedes #2106 and retains @gruntlord5's contribution credit.

Fixes #1385
Partially addresses #1833
Discussion: https://github.com/emdash-cms/emdash/discussions/402

The production runtime still preserves its existing journal mode. The separate default-WAL decision remains tracked by #2310.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (n/a — no admin UI changes). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/402

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Non-visual change.

- Full core suite: 6,099 passed, 9 skipped.
- Node.js 22.16 adapter and migration suite: 49 passed.
- SQLite static-prerender production build: passed.
- SQLite query-count and query-text snapshots: unchanged.
- Package, demo, and template type checks: passed.
- Node SQLite, Node PostgreSQL, and Cloudflare production builds: passed.
- Documentation build: passed.
- Type-aware lint and formatting checks: passed.
