### PR TITLE
feat(plugin-cli): add delegated release commands

### DIFF
--- a/.changeset/delegated-release-client.md
+++ b/.changeset/delegated-release-client.md
@@ -1,7 +1,10 @@
 ---
 "@emdash-cms/registry-client": minor
+"@emdash-cms/plugin-cli": minor
 ---
 
 Adds typed clients for the experimental delegated release service. `ReleaseServiceClient` submits, polls, and cancels GitHub OpenID Connect release intents, and manages publisher workload policies and retained delegation through a publisher session. `ReleaseServiceOperatorClient` exposes the Cloudflare Access status, pause, suspension, revocation, cancellation, and reconciliation operations.
 
 Both clients validate response envelopes and return stable `ReleaseServiceError` codes with retry metadata. Mutation helpers require idempotency keys, and workload polling requests a fresh token from the configured provider for each call.
+
+The plugin CLI adds `emdash-plugin release submit`, `release status`, and `release cancel` for GitHub Actions jobs. The commands request audience-bound OIDC tokens from the runner, support JSON output, and use the GitHub run identity as the default idempotency key.

--- a/packages/plugin-cli/README.md
+++ b/packages/plugin-cli/README.md
@@ -25,6 +25,9 @@ emdash-plugin build                          Build dist/ artifacts (plugin.mjs, 
 emdash-plugin dev                            Watch sources and rebuild on change
 emdash-plugin bundle                         Pack dist/ + assets into a registry tarball
 emdash-plugin publish --url <url>            Publish a release that points at a hosted tarball
+emdash-plugin release submit <release.json>  Submit a delegated release with GitHub OIDC
+emdash-plugin release status <intent-id>     Read a delegated release intent
+emdash-plugin release cancel <intent-id>     Cancel an unpublished delegated release intent
 emdash-plugin validate [path]                Validate emdash-plugin.jsonc against the v1 schema
 emdash-plugin login <handle-or-did>          Interactive atproto OAuth login
 emdash-plugin logout [--did <did>]           Revoke the active session
@@ -34,7 +37,7 @@ emdash-plugin search <query>                 Free-text search
 emdash-plugin info <handle-or-did> <slug>    Show package details
 ```
 
-The non-interactive output commands (`whoami`, `validate`, `search`, `info`, `login`, `publish`) accept `--json` for machine-readable output. Discovery commands (`search`, `info`) accept `--registry-url <url>` (or `EMDASH_REGISTRY_URL`).
+The non-interactive output commands (`whoami`, `validate`, `search`, `info`, `login`, `publish`, `release submit`, `release status`, `release cancel`) accept `--json` for machine-readable output. Discovery commands (`search`, `info`) accept `--registry-url <url>` (or `EMDASH_REGISTRY_URL`).
 
 ## Development
 
@@ -83,6 +86,29 @@ emdash-plugin publish --url https://example.com/foo-1.0.0.tar.gz
 ```
 
 On first publish, pass `--license` and `--security-email` (or `--security-url`) to bootstrap the package profile — or keep them in `emdash-plugin.jsonc` (see below).
+
+## Delegated releases
+
+The `release` commands authenticate with the current GitHub Actions OpenID Connect (OIDC) identity. Grant the job `id-token: write`; the CLI requests a token whose audience is the release-service origin for every API call.
+
+The following command submits a generated package release record and waits for publication or an approval request:
+
+```sh
+emdash-plugin release submit release.json \
+  --service-url https://release.example.com \
+  --publisher-did did:web:publisher.example.com
+```
+
+Set `EMDASH_RELEASE_SERVICE_URL` and `EMDASH_PUBLISHER_DID` to omit the two target flags. The default idempotency key uses the GitHub run ID and attempt. Pass `--idempotency-key` when separate jobs must replay the same submission.
+
+Use `--no-wait` to return after the service accepts the intent. The status and cancellation commands require the same publisher and GitHub workload identity:
+
+```sh
+emdash-plugin release status 01JABCDEFGHJKMNPQRSTVWXYZ0
+emdash-plugin release cancel 01JABCDEFGHJKMNPQRSTVWXYZ0
+```
+
+These commands fail outside GitHub Actions because no OIDC request endpoint is available. Use the delegated release Action when the workflow only needs submission and outputs.
 
 ## `emdash-plugin.jsonc`
 

--- a/packages/plugin-cli/src/commands/release.ts
+++ b/packages/plugin-cli/src/commands/release.ts
@@ -1,0 +1,186 @@
+import type { ReleaseIntentResource } from "@emdash-cms/registry-client/release-service";
+import { defineCommand } from "citty";
+import { consola } from "consola";
+import pc from "picocolors";
+
+import {
+	cancelDelegatedReleaseIntent,
+	getDelegatedReleaseIntent,
+	submitDelegatedRelease,
+} from "../release-service/operations.js";
+
+const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/;
+const FAILURE_STATES = new Set([
+	"invalid",
+	"rejected",
+	"cancelled",
+	"expired",
+	"failed",
+	"conflict",
+]);
+
+function requiredTarget(args: { "publisher-did"?: string; "service-url"?: string }) {
+	const serviceUrl = args["service-url"] || process.env["EMDASH_RELEASE_SERVICE_URL"];
+	const publisherDid = args["publisher-did"] || process.env["EMDASH_PUBLISHER_DID"];
+	if (!serviceUrl) throw new Error("Release service URL is required");
+	if (!publisherDid) throw new Error("Publisher DID is required");
+	return { serviceUrl, publisherDid };
+}
+
+function positiveInteger(value: string, name: string, maximum: number): number {
+	if (!POSITIVE_INTEGER_PATTERN.test(value)) throw new Error(`${name} must be a positive integer`);
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed) || parsed > maximum) {
+		throw new Error(`${name} is outside the supported range`);
+	}
+	return parsed;
+}
+
+function printIntent(intent: ReleaseIntentResource, json: boolean): void {
+	if (json) {
+		console.log(JSON.stringify(intent, null, 2));
+		return;
+	}
+	console.log(`${pc.bold(intent.packageSlug)} ${pc.dim(intent.version)}`);
+	console.log(`  Intent: ${intent.id}`);
+	console.log(`  State:  ${intent.state}`);
+	if (intent.approvalUrl) console.log(`  Approve: ${intent.approvalUrl}`);
+	if (intent.result) {
+		console.log(`  URI:    ${intent.result.uri}`);
+		console.log(`  CID:    ${intent.result.cid}`);
+	}
+	if (intent.reasonCode) console.log(`  Reason: ${intent.reasonCode}`);
+}
+
+const commonArgs = {
+	"service-url": {
+		type: "string" as const,
+		description: "Release service origin (or EMDASH_RELEASE_SERVICE_URL)",
+	},
+	"publisher-did": {
+		type: "string" as const,
+		description: "Publisher DID (or EMDASH_PUBLISHER_DID)",
+	},
+	json: {
+		type: "boolean" as const,
+		description: "Output the intent as JSON",
+	},
+};
+
+export const releaseSubmitCommand = defineCommand({
+	meta: {
+		name: "submit",
+		description: "Submit a delegated release from GitHub Actions OIDC",
+	},
+	args: {
+		"release-file": {
+			type: "positional",
+			description: "Package release record JSON file",
+			required: true,
+		},
+		...commonArgs,
+		"idempotency-key": {
+			type: "string",
+			description: "Stable submission key (defaults to the GitHub run identity)",
+		},
+		"no-wait": {
+			type: "boolean",
+			description: "Return after the service accepts the intent",
+		},
+		"wait-for-approval": {
+			type: "boolean",
+			description: "Keep polling while the intent awaits approval",
+			default: false,
+		},
+		"poll-interval-seconds": {
+			type: "string",
+			description: "Seconds between status requests",
+			default: "5",
+		},
+		"timeout-minutes": {
+			type: "string",
+			description: "Maximum polling time",
+			default: "30",
+		},
+	},
+	async run({ args }) {
+		const target = requiredTarget(args);
+		let previousState: string | null = null;
+		const intent = await submitDelegatedRelease({
+			...target,
+			releaseFile: args["release-file"],
+			idempotencyKey: args["idempotency-key"],
+			wait: !args["no-wait"],
+			waitForApproval: args["wait-for-approval"],
+			pollIntervalMs:
+				positiveInteger(args["poll-interval-seconds"], "poll-interval-seconds", 300) * 1000,
+			maxWaitMs: positiveInteger(args["timeout-minutes"], "timeout-minutes", 360) * 60_000,
+			onUpdate: args.json
+				? undefined
+				: (current) => {
+						if (current.state !== previousState) {
+							previousState = current.state;
+							consola.info(`Release intent ${current.id} entered ${current.state}`);
+						}
+					},
+		});
+		printIntent(intent, args.json);
+		if (FAILURE_STATES.has(intent.state)) {
+			throw new Error(
+				`Release intent ended in ${intent.state}${intent.reasonCode ? ` (${intent.reasonCode})` : ""}`,
+			);
+		}
+	},
+});
+
+export const releaseStatusCommand = defineCommand({
+	meta: { name: "status", description: "Read a delegated release intent" },
+	args: {
+		"intent-id": {
+			type: "positional",
+			description: "Release intent ULID",
+			required: true,
+		},
+		...commonArgs,
+	},
+	async run({ args }) {
+		const intent = await getDelegatedReleaseIntent({
+			...requiredTarget(args),
+			intentId: args["intent-id"],
+		});
+		printIntent(intent, args.json);
+	},
+});
+
+export const releaseCancelCommand = defineCommand({
+	meta: { name: "cancel", description: "Cancel an unpublished delegated release intent" },
+	args: {
+		"intent-id": {
+			type: "positional",
+			description: "Release intent ULID",
+			required: true,
+		},
+		...commonArgs,
+		"idempotency-key": {
+			type: "string",
+			description: "Stable cancellation key (defaults to the GitHub run identity)",
+		},
+	},
+	async run({ args }) {
+		const intent = await cancelDelegatedReleaseIntent({
+			...requiredTarget(args),
+			intentId: args["intent-id"],
+			idempotencyKey: args["idempotency-key"],
+		});
+		printIntent(intent, args.json);
+	},
+});
+
+export const releaseCommand = defineCommand({
+	meta: { name: "release", description: "Manage delegated release intents" },
+	subCommands: {
+		submit: releaseSubmitCommand,
+		status: releaseStatusCommand,
+		cancel: releaseCancelCommand,
+	},
+});

--- a/packages/plugin-cli/src/index.ts
+++ b/packages/plugin-cli/src/index.ts
@@ -33,6 +33,7 @@ import { loginCommand } from "./commands/login.js";
 import { logoutCommand } from "./commands/logout.js";
 import { pdsConformanceCommand } from "./commands/pds-conformance.js";
 import { publishCommand } from "./commands/publish.js";
+import { releaseCommand } from "./commands/release.js";
 import { searchCommand } from "./commands/search.js";
 import { switchCommand } from "./commands/switch.js";
 import { updatePackageCommand } from "./commands/update-package.js";
@@ -58,6 +59,7 @@ const main = defineCommand({
 		dev: devCommand,
 		bundle: bundleCommand,
 		publish: publishCommand,
+		release: releaseCommand,
 		"update-package": updatePackageCommand,
 		validate: validateCommand,
 	},

--- a/packages/plugin-cli/src/release-service/operations.ts
+++ b/packages/plugin-cli/src/release-service/operations.ts
@@ -1,0 +1,178 @@
+import { readFile, stat } from "node:fs/promises";
+
+import { safeParse } from "@atcute/lexicons";
+import {
+	ReleaseServiceClient,
+	createReleaseIdempotencyKey,
+	type ReleaseIntentResource,
+} from "@emdash-cms/registry-client/release-service";
+import { PackageRelease } from "@emdash-cms/registry-lexicons";
+
+const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/;
+const MAX_RELEASE_FILE_BYTES = 128 * 1024;
+const MAX_OIDC_TOKEN_CHARS = 16 * 1024;
+
+export interface ReleaseServiceEnvironment {
+	readonly [key: string]: string | undefined;
+}
+
+export interface ReleaseServiceOperationDependencies {
+	fetch?: typeof fetch;
+	environment?: ReleaseServiceEnvironment;
+	readReleaseRecord?: (path: string) => Promise<unknown>;
+}
+
+export interface ReleaseServiceTarget {
+	serviceUrl: string;
+	publisherDid: string;
+}
+
+export interface SubmitDelegatedReleaseOptions extends ReleaseServiceTarget {
+	releaseFile: string;
+	idempotencyKey?: string;
+	wait?: boolean;
+	waitForApproval?: boolean;
+	pollIntervalMs?: number;
+	maxWaitMs?: number;
+	onUpdate?: (intent: ReleaseIntentResource) => void | Promise<void>;
+}
+
+export interface MutateReleaseIntentOptions extends ReleaseServiceTarget {
+	intentId: string;
+	idempotencyKey?: string;
+}
+
+async function defaultReadReleaseRecord(path: string): Promise<unknown> {
+	try {
+		const metadata = await stat(path);
+		if (!metadata.isFile() || metadata.size > MAX_RELEASE_FILE_BYTES) {
+			throw new Error("invalid release file");
+		}
+		return JSON.parse(await readFile(path, "utf8"));
+	} catch {
+		throw new Error("Release record file could not be read");
+	}
+}
+
+function defaultIdempotencyKey(environment: ReleaseServiceEnvironment): string {
+	const runId = environment["GITHUB_RUN_ID"];
+	const runAttempt = environment["GITHUB_RUN_ATTEMPT"];
+	if (
+		runId &&
+		runAttempt &&
+		POSITIVE_INTEGER_PATTERN.test(runId) &&
+		POSITIVE_INTEGER_PATTERN.test(runAttempt)
+	) {
+		return `github-run-${runId}-attempt-${runAttempt}`;
+	}
+	return createReleaseIdempotencyKey("emdash-plugin-release");
+}
+
+export async function requestGithubOidcToken(
+	audience: string,
+	dependencies: ReleaseServiceOperationDependencies = {},
+): Promise<string> {
+	const environment = dependencies.environment ?? process.env;
+	const requestUrl = environment["ACTIONS_ID_TOKEN_REQUEST_URL"];
+	const requestToken = environment["ACTIONS_ID_TOKEN_REQUEST_TOKEN"];
+	if (!requestUrl || !requestToken) {
+		throw new Error("GitHub Actions OIDC is unavailable");
+	}
+	let url: URL;
+	try {
+		url = new URL(requestUrl);
+		if (url.protocol !== "https:" || url.username !== "" || url.password !== "") {
+			throw new Error("invalid OIDC URL");
+		}
+		url.searchParams.set("audience", audience);
+	} catch {
+		throw new Error("GitHub Actions OIDC is unavailable");
+	}
+	const response = await (dependencies.fetch ?? globalThis.fetch)(url, {
+		headers: { authorization: `Bearer ${requestToken}` },
+		signal: AbortSignal.timeout(30_000),
+	});
+	if (!response.ok) throw new Error("GitHub Actions OIDC request failed");
+	let payload: unknown;
+	try {
+		payload = await response.json();
+	} catch {
+		throw new Error("GitHub Actions OIDC response is invalid");
+	}
+	if (
+		payload === null ||
+		typeof payload !== "object" ||
+		Array.isArray(payload) ||
+		!("value" in payload) ||
+		typeof payload.value !== "string" ||
+		payload.value.length === 0 ||
+		payload.value.length > MAX_OIDC_TOKEN_CHARS
+	) {
+		throw new Error("GitHub Actions OIDC response is invalid");
+	}
+	return payload.value;
+}
+
+function releaseClient(
+	target: ReleaseServiceTarget,
+	dependencies: ReleaseServiceOperationDependencies,
+): ReleaseServiceClient {
+	return new ReleaseServiceClient({
+		serviceUrl: target.serviceUrl,
+		fetch: dependencies.fetch,
+		workloadToken: () => requestGithubOidcToken(target.serviceUrl, dependencies),
+	});
+}
+
+export async function submitDelegatedRelease(
+	options: SubmitDelegatedReleaseOptions,
+	dependencies: ReleaseServiceOperationDependencies = {},
+): Promise<ReleaseIntentResource> {
+	const rawRelease = await (dependencies.readReleaseRecord ?? defaultReadReleaseRecord)(
+		options.releaseFile,
+	);
+	const release = safeParse(PackageRelease.mainSchema, rawRelease);
+	if (!release.ok) throw new Error("Release record file is invalid");
+	const environment = dependencies.environment ?? process.env;
+	const client = releaseClient(options, dependencies);
+	const submitted = await client.submitIntent(
+		{
+			publisherDid: options.publisherDid,
+			packageSlug: release.value.package,
+			version: release.value.version,
+			release: release.value,
+		},
+		{ idempotencyKey: options.idempotencyKey ?? defaultIdempotencyKey(environment) },
+	);
+	if (options.wait === false) return submitted.intent;
+	return await client.waitForIntent(options.publisherDid, submitted.intent.id, {
+		pollIntervalMs: options.pollIntervalMs,
+		maxWaitMs: options.maxWaitMs,
+		stopOnApproval: !(options.waitForApproval ?? false),
+		onUpdate: options.onUpdate,
+	});
+}
+
+export async function getDelegatedReleaseIntent(
+	options: ReleaseServiceTarget & { intentId: string },
+	dependencies: ReleaseServiceOperationDependencies = {},
+): Promise<ReleaseIntentResource> {
+	return await releaseClient(options, dependencies).getIntent(
+		options.publisherDid,
+		options.intentId,
+	);
+}
+
+export async function cancelDelegatedReleaseIntent(
+	options: MutateReleaseIntentOptions,
+	dependencies: ReleaseServiceOperationDependencies = {},
+): Promise<ReleaseIntentResource> {
+	const environment = dependencies.environment ?? process.env;
+	return await releaseClient(options, dependencies).cancelIntent(
+		options.publisherDid,
+		options.intentId,
+		{
+			idempotencyKey: options.idempotencyKey ?? defaultIdempotencyKey(environment),
+		},
+	);
+}

--- a/packages/plugin-cli/tests/release-service-operations.test.ts
+++ b/packages/plugin-cli/tests/release-service-operations.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import releaseFixture from "../../registry-verification/fixtures/records/release.json";
+import {
+	cancelDelegatedReleaseIntent,
+	getDelegatedReleaseIntent,
+	requestGithubOidcToken,
+	submitDelegatedRelease,
+} from "../src/release-service/operations.js";
+
+const SERVICE = "https://release.example.com";
+const PUBLISHER_DID = "did:web:publisher.example.com";
+const INTENT_ID = "01JABCDEFGHJKMNPQRSTVWXYZ0";
+const ENVIRONMENT = {
+	ACTIONS_ID_TOKEN_REQUEST_URL: "https://token.actions.example/id-token?api-version=1",
+	ACTIONS_ID_TOKEN_REQUEST_TOKEN: "runner-request-token",
+	GITHUB_RUN_ID: "10000000001",
+	GITHUB_RUN_ATTEMPT: "2",
+};
+
+function intent(state: string) {
+	return {
+		id: INTENT_ID,
+		publisherDid: PUBLISHER_DID,
+		packageSlug: "gallery",
+		version: "1.2.3",
+		state,
+		stateGeneration: 2,
+		reasonCode: null,
+		workflowId: INTENT_ID,
+		expiresAt: 1_800_000_000_000,
+		createdAt: 1_799_999_000_000,
+		updatedAt: 1_799_999_500_000,
+		result: null,
+		approvalUrl: null,
+	};
+}
+
+function success(data: unknown, status = 200): Response {
+	return Response.json({ data, requestId: "request-1" }, { status });
+}
+
+describe("delegated release CLI operations", () => {
+	it("requests a GitHub OIDC token for the release-service audience", async () => {
+		const calls: Array<{ headers: Headers; url: URL }> = [];
+		const token = await requestGithubOidcToken(SERVICE, {
+			environment: ENVIRONMENT,
+			fetch: async (input, init) => {
+				calls.push({
+					url: new URL(input instanceof Request ? input.url : input.toString()),
+					headers: new Headers(init?.headers),
+				});
+				return Response.json({ value: "header.payload.signature" });
+			},
+		});
+
+		expect(token).toBe("header.payload.signature");
+		expect(calls[0]?.url.searchParams.get("audience")).toBe(SERVICE);
+		expect(calls[0]?.headers.get("authorization")).toBe("Bearer runner-request-token");
+	});
+
+	it("submits with the stable GitHub run idempotency identity", async () => {
+		const serviceRequests: Request[] = [];
+		const result = await submitDelegatedRelease(
+			{
+				serviceUrl: SERVICE,
+				publisherDid: PUBLISHER_DID,
+				releaseFile: "release.json",
+				wait: false,
+			},
+			{
+				environment: ENVIRONMENT,
+				readReleaseRecord: async () => structuredClone(releaseFixture),
+				fetch: async (input, init) => {
+					const url = new URL(input instanceof Request ? input.url : input.toString());
+					if (url.hostname === "token.actions.example") {
+						return Response.json({ value: "header.payload.signature" });
+					}
+					serviceRequests.push(new Request(url, init));
+					return success({ intent: intent("received"), replayed: false }, 202);
+				},
+			},
+		);
+
+		expect(result.state).toBe("received");
+		expect(serviceRequests).toHaveLength(1);
+		expect(serviceRequests[0]?.headers.get("idempotency-key")).toBe(
+			"github-run-10000000001-attempt-2",
+		);
+		expect(serviceRequests[0]?.headers.get("authorization")).toBe(
+			"Bearer header.payload.signature",
+		);
+	});
+
+	it("uses fresh OIDC tokens for status and cancellation", async () => {
+		let tokenCount = 0;
+		const serviceRequests: Request[] = [];
+		const fetch: typeof globalThis.fetch = async (input, init) => {
+			const url = new URL(input instanceof Request ? input.url : input.toString());
+			if (url.hostname === "token.actions.example") {
+				return Response.json({ value: `header.payload.signature-${++tokenCount}` });
+			}
+			serviceRequests.push(new Request(url, init));
+			return success({ intent: intent(url.pathname.endsWith("/cancel") ? "cancelled" : "ready") });
+		};
+		const dependencies = { environment: ENVIRONMENT, fetch };
+
+		await getDelegatedReleaseIntent(
+			{ serviceUrl: SERVICE, publisherDid: PUBLISHER_DID, intentId: INTENT_ID },
+			dependencies,
+		);
+		await cancelDelegatedReleaseIntent(
+			{ serviceUrl: SERVICE, publisherDid: PUBLISHER_DID, intentId: INTENT_ID },
+			dependencies,
+		);
+
+		expect(tokenCount).toBe(2);
+		expect(serviceRequests.map((request) => request.headers.get("authorization"))).toEqual([
+			"Bearer header.payload.signature-1",
+			"Bearer header.payload.signature-2",
+		]);
+	});
+
+	it("rejects an invalid release record before requesting OIDC", async () => {
+		let fetched = false;
+		await expect(
+			submitDelegatedRelease(
+				{
+					serviceUrl: SERVICE,
+					publisherDid: PUBLISHER_DID,
+					releaseFile: "release.json",
+				},
+				{
+					environment: ENVIRONMENT,
+					readReleaseRecord: async () => ({ package: "gallery" }),
+					fetch: async () => {
+						fetched = true;
+						throw new Error("unexpected fetch");
+					},
+				},
+			),
+		).rejects.toThrow("Release record file is invalid");
+		expect(fetched).toBe(false);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds noninteractive delegated-release CLI commands for submission, status, cancellation, and approval-aware waiting. Commands use the typed release-service client and keep workload credentials out of command-line arguments.

Depends on #2709. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
