### PR TITLE
feat(release-service): enforce sharded abuse budgets

### DIFF
--- a/apps/release-service/src/api/errors.ts
+++ b/apps/release-service/src/api/errors.ts
@@ -34,7 +34,8 @@ export type ApiErrorCode =
 	| "SERVICE_UNAVAILABLE"
 	| "VERSION_RESERVED"
 	| "WORKFLOW_UNAVAILABLE"
-	| "WORKLOAD_NOT_ALLOWED";
+	| "WORKLOAD_NOT_ALLOWED"
+	| "WORKLOAD_RATE_LIMITED";
 
 export interface SerializedApiError {
 	code: ApiErrorCode;

--- a/apps/release-service/src/intents/routes.ts
+++ b/apps/release-service/src/intents/routes.ts
@@ -328,6 +328,39 @@ export async function handleSubmitReleaseIntent(
 		if (!policy || !evaluateWorkloadPolicy(identity, policy).ok) {
 			throw new ApiError("WORKLOAD_NOT_ALLOWED", 403, "Workload is not authorized");
 		}
+		const workloadRateKey = await digest([
+			"intent-rate-limit",
+			1,
+			identity.repository.id,
+			identity.workflow.ref,
+			release.value.package,
+		]);
+		const rateLimit = await publisher.consumeIntentRateLimit({
+			publisherDid,
+			repositoryId: identity.repository.id,
+			workloadKey: workloadRateKey,
+			idempotencyKey,
+			expiresAt: now + INTENT_LIFETIME_MS,
+			now,
+		});
+		if (!rateLimit.ok) {
+			console.warn(
+				JSON.stringify({
+					event: "release_intent_rate_limited",
+					requestId,
+					scope: rateLimit.scope,
+					workloadKey: workloadRateKey,
+					retryAt: rateLimit.retryAt,
+				}),
+			);
+			const response = apiFailure(
+				new ApiError("WORKLOAD_RATE_LIMITED", 429, "Release intent rate limit exceeded"),
+				requestId,
+			);
+			const headers = new Headers(response.headers);
+			headers.set("retry-after", String(Math.max(1, Math.ceil((rateLimit.retryAt - now) / 1000))));
+			return new Response(response.body, { status: response.status, headers });
+		}
 		const workloadIdentityDigest = await digestWorkloadIdentity(identity);
 		const created = await publisher.createIntent({
 			publisherDid,

--- a/apps/release-service/src/publisher-do/publisher-do.ts
+++ b/apps/release-service/src/publisher-do/publisher-do.ts
@@ -30,6 +30,12 @@ import {
 	type CompletePublicationOperationResult,
 } from "./publication-operation.js";
 import {
+	initializeIntentRateLimitSchema,
+	IntentRateLimitStore,
+	type ConsumeIntentRateLimitInput,
+	type ConsumeIntentRateLimitResult,
+} from "./rate-limit.js";
+import {
 	initializeVerificationStepSchema,
 	VerificationStepStore,
 	type PutVerificationStepInput,
@@ -78,6 +84,7 @@ export type {
 	ApplyPublisherRestorePageResult,
 	PublisherRestoreKind,
 } from "./operations-restore.js";
+export type { ConsumeIntentRateLimitInput, ConsumeIntentRateLimitResult } from "./rate-limit.js";
 
 const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
 const HASH_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
@@ -395,6 +402,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 	readonly #publicationOperations: PublicationOperationStore;
 	readonly #verificationSteps: VerificationStepStore;
 	readonly #operationsRestore: OperationsRestoreStore;
+	readonly #intentRateLimits: IntentRateLimitStore;
 
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env);
@@ -404,6 +412,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		this.#publicationOperations = new PublicationOperationStore(ctx.storage);
 		this.#verificationSteps = new VerificationStepStore(ctx.storage);
 		this.#operationsRestore = new OperationsRestoreStore(ctx.storage);
+		this.#intentRateLimits = new IntentRateLimitStore(ctx.storage);
 		void ctx.blockConcurrencyWhile(async () => {
 			this.#initializeSchema();
 		});
@@ -487,6 +496,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		initializePublicationOperationSchema(this.ctx.storage);
 		initializeVerificationStepSchema(this.ctx.storage);
 		initializeOperationsRestoreSchema(this.ctx.storage);
+		initializeIntentRateLimitSchema(this.ctx.storage);
 	}
 
 	#assertPublisherObjectName(publisherDid: string): void {
@@ -604,6 +614,11 @@ export class PublisherDurableObject extends DurableObject<Env> {
 	createIntent(input: CreateIntentInput): CreateIntentResult {
 		this.#assertPublisherDid(input.publisherDid);
 		return this.#intents.create(input);
+	}
+
+	consumeIntentRateLimit(input: ConsumeIntentRateLimitInput): ConsumeIntentRateLimitResult {
+		this.#assertPublisherDid(input.publisherDid);
+		return this.#intentRateLimits.consume(input);
 	}
 
 	findIdempotentIntent(

--- a/apps/release-service/src/publisher-do/rate-limit.ts
+++ b/apps/release-service/src/publisher-do/rate-limit.ts
@@ -1,0 +1,157 @@
+const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
+const DECIMAL_ID_PATTERN = /^[1-9][0-9]*$/;
+const DIGEST_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$/;
+const WINDOW_MS = 60_000;
+const MAX_IDEMPOTENCY_MS = 24 * 60 * 60_000;
+const LIMITS = {
+	publisher: 120,
+	repository: 60,
+	workload: 30,
+} as const;
+
+type RateLimitScope = keyof typeof LIMITS;
+
+export interface ConsumeIntentRateLimitInput {
+	publisherDid: string;
+	repositoryId: string;
+	workloadKey: string;
+	idempotencyKey: string;
+	expiresAt: number;
+	now?: number;
+}
+
+export type ConsumeIntentRateLimitResult =
+	| { ok: true; replayed: boolean; retryAt: number }
+	| { ok: false; code: "RATE_LIMITED"; scope: RateLimitScope; retryAt: number };
+
+export class IntentRateLimitError extends Error {
+	constructor() {
+		super("INTENT_RATE_LIMIT_INVALID");
+		this.name = "IntentRateLimitError";
+	}
+}
+
+interface RateWindowRow {
+	[key: string]: string | number | ArrayBuffer | null;
+	window_start: number;
+	count: number;
+}
+
+interface IdempotencyRow {
+	[key: string]: string | number | ArrayBuffer | null;
+	expires_at: number;
+}
+
+export function initializeIntentRateLimitSchema(storage: DurableObjectStorage): void {
+	storage.sql.exec(`
+		CREATE TABLE IF NOT EXISTS intent_rate_windows (
+			scope TEXT NOT NULL CHECK (scope IN ('publisher', 'repository', 'workload')),
+			subject_key TEXT NOT NULL,
+			window_start INTEGER NOT NULL,
+			count INTEGER NOT NULL CHECK (count >= 1),
+			updated_at INTEGER NOT NULL,
+			PRIMARY KEY (scope, subject_key)
+		);
+		CREATE TABLE IF NOT EXISTS intent_rate_idempotency (
+			workload_key TEXT NOT NULL,
+			mutation_key TEXT NOT NULL,
+			expires_at INTEGER NOT NULL,
+			created_at INTEGER NOT NULL,
+			PRIMARY KEY (workload_key, mutation_key)
+		);
+		CREATE INDEX IF NOT EXISTS idx_intent_rate_idempotency_expiry
+			ON intent_rate_idempotency(expires_at);
+	`);
+}
+
+export class IntentRateLimitStore {
+	constructor(private readonly storage: DurableObjectStorage) {}
+
+	consume(input: ConsumeIntentRateLimitInput): ConsumeIntentRateLimitResult {
+		const now = input.now ?? Date.now();
+		if (
+			!DID_PATTERN.test(input.publisherDid) ||
+			!DECIMAL_ID_PATTERN.test(input.repositoryId) ||
+			!DIGEST_PATTERN.test(input.workloadKey) ||
+			!IDEMPOTENCY_KEY_PATTERN.test(input.idempotencyKey) ||
+			!Number.isSafeInteger(now) ||
+			now < 0 ||
+			!Number.isSafeInteger(input.expiresAt) ||
+			input.expiresAt <= now ||
+			input.expiresAt - now > MAX_IDEMPOTENCY_MS
+		) {
+			throw new IntentRateLimitError();
+		}
+		return this.storage.transactionSync(() => {
+			const idempotency = this.storage.sql
+				.exec<IdempotencyRow>(
+					`SELECT expires_at FROM intent_rate_idempotency
+					 WHERE workload_key = ? AND mutation_key = ?`,
+					input.workloadKey,
+					input.idempotencyKey,
+				)
+				.toArray()[0];
+			const windowStart = Math.floor(now / WINDOW_MS) * WINDOW_MS;
+			const retryAt = windowStart + WINDOW_MS;
+			if (idempotency && idempotency.expires_at > now) {
+				return { ok: true, replayed: true, retryAt } as const;
+			}
+			if (idempotency) {
+				this.storage.sql.exec(
+					`DELETE FROM intent_rate_idempotency
+					 WHERE workload_key = ? AND mutation_key = ?`,
+					input.workloadKey,
+					input.idempotencyKey,
+				);
+			}
+			const subjects: ReadonlyArray<readonly [RateLimitScope, string]> = [
+				["workload", input.workloadKey],
+				["repository", input.repositoryId],
+				["publisher", input.publisherDid],
+			];
+			for (const [scope, subject] of subjects) {
+				const current = this.storage.sql
+					.exec<RateWindowRow>(
+						`SELECT window_start, count FROM intent_rate_windows
+						 WHERE scope = ? AND subject_key = ?`,
+						scope,
+						subject,
+					)
+					.toArray()[0];
+				const count = current?.window_start === windowStart ? current.count : 0;
+				if (count >= LIMITS[scope]) {
+					return { ok: false, code: "RATE_LIMITED", scope, retryAt } as const;
+				}
+			}
+			for (const [scope, subject] of subjects) {
+				this.storage.sql.exec(
+					`INSERT INTO intent_rate_windows (
+						scope, subject_key, window_start, count, updated_at
+					) VALUES (?, ?, ?, 1, ?)
+					ON CONFLICT(scope, subject_key) DO UPDATE SET
+						window_start = excluded.window_start,
+						count = CASE
+							WHEN intent_rate_windows.window_start = excluded.window_start
+							THEN intent_rate_windows.count + 1 ELSE 1 END,
+						updated_at = excluded.updated_at`,
+					scope,
+					subject,
+					windowStart,
+					now,
+				);
+			}
+			this.storage.sql.exec(
+				`INSERT INTO intent_rate_idempotency (
+					workload_key, mutation_key, expires_at, created_at
+				) VALUES (?, ?, ?, ?)`,
+				input.workloadKey,
+				input.idempotencyKey,
+				input.expiresAt,
+				now,
+			);
+			this.storage.sql.exec("DELETE FROM intent_rate_idempotency WHERE expires_at <= ?", now);
+			return { ok: true, replayed: false, retryAt } as const;
+		});
+	}
+}

--- a/apps/release-service/test/intent-routes.test.ts
+++ b/apps/release-service/test/intent-routes.test.ts
@@ -2,6 +2,7 @@ import type { PackageRelease } from "@emdash-cms/registry-lexicons";
 import { reset } from "cloudflare:test";
 import { env } from "cloudflare:workers";
 import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT, type JWTVerifyGetKey } from "jose";
+import { ulid } from "ulidx";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import releaseFixture from "../../../packages/registry-verification/fixtures/records/release.json";
@@ -316,5 +317,65 @@ describe("release intent API", () => {
 		);
 		expect(response.status).toBe(503);
 		expect(await response.json()).toMatchObject({ error: { code: "SERVICE_PAUSED" } });
+	});
+
+	it("rate limits one workload without consuming another publisher shard", async () => {
+		await putPolicy();
+		const configuration = await loadConfiguration(TEST_BINDINGS);
+		const workloadToken = await token();
+		for (let index = 0; index < 30; index += 1) {
+			const version = `1.2.${index}`;
+			const value = release();
+			value.version = version;
+			const response = await handleSubmitReleaseIntent(
+				request("/v1/release-intents", workloadToken, {
+					method: "POST",
+					body: {
+						publisherDid: PUBLISHER_DID,
+						packageSlug: "gallery",
+						version,
+						release: value,
+					},
+					idempotencyKey: `github-rate-limit-${String(index).padStart(4, "0")}`,
+				}),
+				`request-${index}`,
+				configuration,
+				{ ...submitDependencies, intentId: () => ulid(NOW + index) },
+			);
+			expect(response.status).toBe(202);
+		}
+		const blockedRelease = release();
+		blockedRelease.version = "1.2.30";
+		const blocked = await handleSubmitReleaseIntent(
+			request("/v1/release-intents", workloadToken, {
+				method: "POST",
+				body: {
+					publisherDid: PUBLISHER_DID,
+					packageSlug: "gallery",
+					version: "1.2.30",
+					release: blockedRelease,
+				},
+				idempotencyKey: "github-rate-limit-over-limit",
+			}),
+			"request-blocked",
+			configuration,
+			{ ...submitDependencies, intentId: () => ulid(NOW + 31) },
+		);
+		expect(blocked.status).toBe(429);
+		expect(blocked.headers.get("retry-after")).toBe("60");
+		await expect(blocked.json()).resolves.toMatchObject({
+			error: { code: "WORKLOAD_RATE_LIMITED" },
+		});
+
+		await expect(
+			env.PUBLISHER_DO.getByName("did:plc:other").consumeIntentRateLimit({
+				publisherDid: "did:plc:other",
+				repositoryId: "123456789",
+				workloadKey: "Z".repeat(43),
+				idempotencyKey: "other-publisher-rate-limit",
+				expiresAt: NOW + 24 * 60 * 60_000,
+				now: NOW,
+			}),
+		).resolves.toMatchObject({ ok: true });
 	});
 });

--- a/apps/release-service/test/publisher-do.test.ts
+++ b/apps/release-service/test/publisher-do.test.ts
@@ -104,6 +104,114 @@ describe("PublisherDurableObject", () => {
 		).resolves.toEqual({ ok: false, code: "PUBLISHER_SUSPENDED" });
 	});
 
+	it("isolates publisher, repository, and workload admission budgets", async () => {
+		const stub = publisher();
+		const now = 1_800_000_000_000;
+		const workloadKey = "W".repeat(43);
+		for (let index = 0; index < 30; index += 1) {
+			await expect(
+				stub.consumeIntentRateLimit({
+					publisherDid: DID,
+					repositoryId: "123",
+					workloadKey,
+					idempotencyKey: `rate-workload-a-${String(index).padStart(4, "0")}`,
+					expiresAt: now + 24 * 60 * 60_000,
+					now,
+				}),
+			).resolves.toMatchObject({ ok: true, replayed: false });
+		}
+		await expect(
+			stub.consumeIntentRateLimit({
+				publisherDid: DID,
+				repositoryId: "123",
+				workloadKey,
+				idempotencyKey: "rate-workload-a-over-limit",
+				expiresAt: now + 24 * 60 * 60_000,
+				now,
+			}),
+		).resolves.toMatchObject({ ok: false, code: "RATE_LIMITED", scope: "workload" });
+		await expect(
+			stub.consumeIntentRateLimit({
+				publisherDid: DID,
+				repositoryId: "123",
+				workloadKey,
+				idempotencyKey: "rate-workload-a-0000",
+				expiresAt: now + 24 * 60 * 60_000,
+				now,
+			}),
+		).resolves.toMatchObject({ ok: true, replayed: true });
+		await expect(
+			stub.consumeIntentRateLimit({
+				publisherDid: DID,
+				repositoryId: "123",
+				workloadKey: "X".repeat(43),
+				idempotencyKey: "rate-workload-b-0000",
+				expiresAt: now + 24 * 60 * 60_000,
+				now,
+			}),
+		).resolves.toMatchObject({ ok: true });
+		for (let index = 1; index <= 29; index += 1) {
+			await stub.consumeIntentRateLimit({
+				publisherDid: DID,
+				repositoryId: "123",
+				workloadKey: `Y${String(index).padStart(42, "0")}`,
+				idempotencyKey: `rate-repository-${String(index).padStart(4, "0")}`,
+				expiresAt: now + 24 * 60 * 60_000,
+				now,
+			});
+		}
+		await expect(
+			stub.consumeIntentRateLimit({
+				publisherDid: DID,
+				repositoryId: "123",
+				workloadKey: "Q".repeat(43),
+				idempotencyKey: "rate-repository-over-limit",
+				expiresAt: now + 24 * 60 * 60_000,
+				now,
+			}),
+		).resolves.toMatchObject({ ok: false, code: "RATE_LIMITED", scope: "repository" });
+		for (let index = 0; index < 60; index += 1) {
+			await stub.consumeIntentRateLimit({
+				publisherDid: DID,
+				repositoryId: "456",
+				workloadKey: `P${String(index).padStart(42, "0")}`,
+				idempotencyKey: `rate-publisher-${String(index).padStart(4, "0")}`,
+				expiresAt: now + 24 * 60 * 60_000,
+				now,
+			});
+		}
+		await expect(
+			stub.consumeIntentRateLimit({
+				publisherDid: DID,
+				repositoryId: "789",
+				workloadKey: "V".repeat(43),
+				idempotencyKey: "rate-publisher-over-limit",
+				expiresAt: now + 24 * 60 * 60_000,
+				now,
+			}),
+		).resolves.toMatchObject({ ok: false, code: "RATE_LIMITED", scope: "publisher" });
+		await expect(
+			env.PUBLISHER_DO.getByName(OTHER_DID).consumeIntentRateLimit({
+				publisherDid: OTHER_DID,
+				repositoryId: "123",
+				workloadKey,
+				idempotencyKey: "rate-other-publisher-0000",
+				expiresAt: now + 24 * 60 * 60_000,
+				now,
+			}),
+		).resolves.toMatchObject({ ok: true });
+		await expect(
+			stub.consumeIntentRateLimit({
+				publisherDid: DID,
+				repositoryId: "123",
+				workloadKey,
+				idempotencyKey: "rate-next-window-0000",
+				expiresAt: now + 24 * 60 * 60_000,
+				now: now + 60_000,
+			}),
+		).resolves.toMatchObject({ ok: true, replayed: false });
+	});
+
 	it("routes and binds one object to one publisher DID", async () => {
 		const stub = publisher();
 		await stub.initializePublisher(DID);

--- a/packages/registry-client/src/release-service/index.ts
+++ b/packages/registry-client/src/release-service/index.ts
@@ -101,6 +101,7 @@ const API_ERROR_CODES: Readonly<Record<ReleaseServiceApiErrorCode, true>> = {
 	VERSION_RESERVED: true,
 	WORKFLOW_UNAVAILABLE: true,
 	WORKLOAD_NOT_ALLOWED: true,
+	WORKLOAD_RATE_LIMITED: true,
 };
 const RETRYABLE_ERROR_CODES: ReadonlySet<ReleaseServiceClientErrorCode> = new Set([
 	"CONFIGURATION_ERROR",
@@ -111,6 +112,7 @@ const RETRYABLE_ERROR_CODES: ReadonlySet<ReleaseServiceClientErrorCode> = new Se
 	"SERVICE_PAUSED",
 	"SERVICE_UNAVAILABLE",
 	"WORKFLOW_UNAVAILABLE",
+	"WORKLOAD_RATE_LIMITED",
 ]);
 const INTENT_STATES: Readonly<Record<ReleaseIntentState, true>> = {
 	received: true,

--- a/packages/registry-client/src/release-service/types.ts
+++ b/packages/registry-client/src/release-service/types.ts
@@ -52,7 +52,8 @@ export type ReleaseServiceApiErrorCode =
 	| "SERVICE_UNAVAILABLE"
 	| "VERSION_RESERVED"
 	| "WORKFLOW_UNAVAILABLE"
-	| "WORKLOAD_NOT_ALLOWED";
+	| "WORKLOAD_NOT_ALLOWED"
+	| "WORKLOAD_RATE_LIMITED";
 
 export type ReleaseServiceClientErrorCode =
 	| ReleaseServiceApiErrorCode


### PR DESCRIPTION
## What does this PR do?

Adds per-publisher admission and mutation budgets inside the publisher Durable Object. The limits are sharded with publisher state, avoiding a global database or coordination bottleneck.

Depends on #2713. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
