### PR TITLE
feat(release-service): prepare corrupt shards for restore

### DIFF
--- a/apps/release-service/src/backup/routes.ts
+++ b/apps/release-service/src/backup/routes.ts
@@ -13,6 +13,7 @@ import { writeOperationsMetric } from "../observability/metrics.js";
 
 const ARCHIVE_PATH_PATTERN = /^\/admin\/api\/publishers\/([^/]+)\/archive$/;
 const RESTORE_PATH_PATTERN = /^\/admin\/api\/publishers\/([^/]+)\/restore$/;
+const RESTORE_PREPARE_PATH_PATTERN = /^\/admin\/api\/publishers\/([^/]+)\/restore\/prepare$/;
 const ARCHIVE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{15,63}$/;
 const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$/;
 const CURSOR_PATTERN =
@@ -257,6 +258,20 @@ export function matchPublisherRestorePath(
 	pathname: string,
 ): Readonly<Record<string, string>> | null {
 	const match = RESTORE_PATH_PATTERN.exec(pathname);
+	if (!match?.[1]) return null;
+	let publisherDid: string;
+	try {
+		publisherDid = decodeURIComponent(match[1]);
+	} catch {
+		return null;
+	}
+	return isDid(publisherDid) ? { publisherDid } : null;
+}
+
+export function matchPublisherRestorePreparePath(
+	pathname: string,
+): Readonly<Record<string, string>> | null {
+	const match = RESTORE_PREPARE_PATH_PATTERN.exec(pathname);
 	if (!match?.[1]) return null;
 	let publisherDid: string;
 	try {
@@ -548,6 +563,80 @@ export async function handleRestorePublisher(
 		);
 		return apiFailure(
 			new ApiError("RESTORE_OPERATION_FAILED", 503, "Publisher restore failed"),
+			requestId,
+		);
+	}
+}
+
+export async function handlePreparePublisherRestore(
+	request: Request,
+	requestId: string,
+	configuration: ServiceConfiguration,
+	params: Readonly<Record<string, string>>,
+	accessActor: AccessActor | null,
+): Promise<Response> {
+	try {
+		const actor = requireActor(accessActor);
+		requireIdempotencyKey(request);
+		const publisherDid = params["publisherDid"];
+		if (!publisherDid || !isDid(publisherDid)) {
+			throw new ApiError("NOT_FOUND", 404, "Publisher not found");
+		}
+		const body = await readJsonObject(request);
+		if (
+			!hasExactKeys(body, ["archiveId", "confirmPublisherDid"]) ||
+			typeof body["archiveId"] !== "string" ||
+			!ARCHIVE_ID_PATTERN.test(body["archiveId"]) ||
+			body["confirmPublisherDid"] !== publisherDid
+		) {
+			throw new ApiError("INVALID_REQUEST", 400, "Publisher restore confirmation is invalid");
+		}
+		const control = await env.SERVICE_CONTROL_DO.getByName(
+			SERVICE_CONTROL_OBJECT_NAME,
+		).readPublisherControl(actor, publisherDid);
+		if (control.status !== "suspended") {
+			throw new ApiError(
+				"RESTORE_OPERATION_FAILED",
+				409,
+				"Suspend the publisher before preparing a restore",
+			);
+		}
+		const ownerHash = await hashOwner(publisherDid);
+		const manifestPlaintext = await readEncryptedObject(
+			`snapshots/${ownerHash}/${body["archiveId"]}/manifest.json.jwe`,
+			snapshotContext(publisherDid, body["archiveId"], "manifest"),
+			configuration,
+		);
+		parseManifest(manifestPlaintext, publisherDid, body["archiveId"]);
+		const publisher = env.PUBLISHER_DO.getByName(publisherDid);
+		await publisher.setPublisherSuspended(publisherDid, true, actor.identity);
+		const result = await publisher.prepareOperationsRestore(
+			publisherDid,
+			body["archiveId"],
+			actor.identity,
+		);
+		if (!result.ok) {
+			throw new ApiError("RESTORE_OPERATION_FAILED", 409, "Publisher is not suspended");
+		}
+		return apiSuccess(
+			{
+				archiveId: body["archiveId"],
+				publisherDid,
+				prepared: true,
+				deletedIntents: result.deletedIntents,
+				deletedWorkloads: result.deletedWorkloads,
+			},
+			requestId,
+		);
+	} catch (error) {
+		writeOperationsMetric({
+			event: "restore_failure",
+			outcome: error instanceof ApiError ? error.code : "internal",
+			requestId,
+		});
+		if (error instanceof ApiError) return apiFailure(error, requestId);
+		return apiFailure(
+			new ApiError("RESTORE_OPERATION_FAILED", 503, "Publisher restore preparation failed"),
 			requestId,
 		);
 	}

--- a/apps/release-service/src/publisher-do/publisher-do.ts
+++ b/apps/release-service/src/publisher-do/publisher-do.ts
@@ -96,6 +96,7 @@ const MAX_PUBLISHER_SESSION_MS = 24 * 60 * 60_000;
 const REFRESH_TOKEN_BYTES = 32;
 const BASE64_PADDING_PATTERN = /=+$/;
 const ENCRYPTION_CURSOR_PATTERN = /^(?:delegation:1|oauth-state:[A-Za-z0-9_-]{32,128})$/;
+const ARCHIVE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{15,63}$/;
 
 export type PublisherOAuthEncryptionPurpose =
 	| "oauth-console-transaction"
@@ -195,6 +196,10 @@ export interface PublisherAuditEvent {
 	publicPayloadJson: string;
 	createdAt: number;
 }
+
+export type PreparePublisherRestoreResult =
+	| { ok: true; deletedIntents: number; deletedWorkloads: number }
+	| { ok: false; code: "PUBLISHER_NOT_SUSPENDED" };
 
 export type PutDelegationResult =
 	| { ok: true; delegation: StoredDelegation }
@@ -1049,6 +1054,71 @@ export class PublisherDurableObject extends DurableObject<Env> {
 	): ApplyPublisherRestorePageResult {
 		this.#assertPublisherDid(input.publisherDid);
 		return this.#operationsRestore.apply(input);
+	}
+
+	prepareOperationsRestore(
+		publisherDid: string,
+		archiveId: string,
+		actorIdentity: string,
+		now = Date.now(),
+	): PreparePublisherRestoreResult {
+		this.#assertPublisherDid(publisherDid);
+		if (
+			!ARCHIVE_ID_PATTERN.test(archiveId) ||
+			!ACTOR_IDENTITY_PATTERN.test(actorIdentity) ||
+			!Number.isSafeInteger(now) ||
+			now < 0
+		) {
+			throw new PublisherStateError("OPERATIONS_EXPORT_INVALID");
+		}
+		return this.ctx.storage.transactionSync(() => {
+			const publisher = this.ctx.storage.sql
+				.exec<{ status: string }>("SELECT status FROM publisher WHERE id = 1")
+				.one();
+			if (publisher.status !== "suspended") {
+				return { ok: false, code: "PUBLISHER_NOT_SUSPENDED" } as const;
+			}
+			const deletedIntents = this.ctx.storage.sql
+				.exec<{ count: number }>("SELECT COUNT(*) AS count FROM intents")
+				.one().count;
+			const deletedWorkloads = this.ctx.storage.sql
+				.exec<{ count: number }>("SELECT COUNT(*) AS count FROM workload_policies")
+				.one().count;
+			this.ctx.storage.sql.exec("DELETE FROM intent_verification_steps");
+			this.ctx.storage.sql.exec("DELETE FROM intent_transitions");
+			this.ctx.storage.sql.exec("DELETE FROM release_reservations");
+			this.ctx.storage.sql.exec("DELETE FROM intent_idempotency");
+			this.ctx.storage.sql.exec("DELETE FROM publication_operations");
+			this.ctx.storage.sql.exec("DELETE FROM deadlines");
+			this.ctx.storage.sql.exec("DELETE FROM intents");
+			this.ctx.storage.sql.exec("DELETE FROM workload_policies");
+			this.ctx.storage.sql.exec("DELETE FROM publisher_sessions");
+			this.ctx.storage.sql.exec("DELETE FROM oauth_states");
+			this.ctx.storage.sql.exec("DELETE FROM delegation");
+			this.ctx.storage.sql.exec("DELETE FROM intent_rate_windows");
+			this.ctx.storage.sql.exec("DELETE FROM intent_rate_idempotency");
+			this.ctx.storage.sql.exec("DELETE FROM operations_restore_pages");
+			this.ctx.storage.sql.exec("DELETE FROM operations_restore");
+			this.ctx.storage.sql.exec("DELETE FROM audit_events");
+			this.ctx.storage.sql.exec(
+				`UPDATE delegation_operations SET generation = generation + 1,
+				 token_hash = NULL, delegation_version = NULL, expires_at = NULL, updated_at = ?
+				 WHERE kind = 'refresh'`,
+				now,
+			);
+			this.ctx.storage.sql.exec(
+				"UPDATE publisher SET session_epoch = session_epoch + 1 WHERE id = 1",
+			);
+			this.#appendAudit(
+				"publisher-restore-prepared",
+				"access",
+				actorIdentity,
+				archiveId,
+				now,
+				"PUBLISHER_SUSPENDED",
+			);
+			return { ok: true, deletedIntents, deletedWorkloads } as const;
+		});
 	}
 
 	listAuditEvents(

--- a/apps/release-service/src/routes.ts
+++ b/apps/release-service/src/routes.ts
@@ -15,8 +15,10 @@ import {
 } from "./approvals/routes.js";
 import {
 	handleArchivePublisher,
+	handlePreparePublisherRestore,
 	handleRestorePublisher,
 	matchPublisherArchivePath,
+	matchPublisherRestorePreparePath,
 	matchPublisherRestorePath,
 } from "./backup/routes.js";
 import {
@@ -296,6 +298,13 @@ export const ROUTES = Object.freeze([
 		match: matchPublisherRestorePath,
 		accessRole: "admin",
 		handler: handleRestorePublisher,
+	},
+	{
+		method: "POST",
+		path: "/admin/api/publishers/{publisherDid}/restore/prepare",
+		match: matchPublisherRestorePreparePath,
+		accessRole: "admin",
+		handler: handlePreparePublisherRestore,
 	},
 	{
 		method: "POST",

--- a/apps/release-service/test/publisher-archive-routes.test.ts
+++ b/apps/release-service/test/publisher-archive-routes.test.ts
@@ -1,9 +1,13 @@
-import { abortAllDurableObjects, reset, runInDurableObject } from "cloudflare:test";
+import { abortAllDurableObjects, reset } from "cloudflare:test";
 import { env } from "cloudflare:workers";
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { AccessActor } from "../src/access/auth.js";
-import { handleArchivePublisher, handleRestorePublisher } from "../src/backup/routes.js";
+import {
+	handleArchivePublisher,
+	handlePreparePublisherRestore,
+	handleRestorePublisher,
+} from "../src/backup/routes.js";
 import { loadConfiguration } from "../src/config.js";
 import { SERVICE_CONTROL_OBJECT_NAME } from "../src/control-do/service-control-do.js";
 import { TEST_BINDINGS } from "./fixtures/oauth.js";
@@ -38,6 +42,17 @@ function restoreRequest(page: number): Request {
 			"idempotency-key": `publisher-restore-page-${page}`,
 		},
 		body: JSON.stringify({ archiveId: ARCHIVE_ID, page }),
+	});
+}
+
+function prepareRestoreRequest(): Request {
+	return new Request(`${TEST_BINDINGS.PUBLIC_ORIGIN}/admin/api/publishers/restore/prepare`, {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			"idempotency-key": "publisher-restore-prepare-0001",
+		},
+		body: JSON.stringify({ archiveId: ARCHIVE_ID, confirmPublisherDid: PUBLISHER_DID }),
 	});
 }
 
@@ -182,8 +197,16 @@ describe("publisher operations archive", () => {
 			reasonCode: "SHARD_RESTORE",
 			now: NOW + 2,
 		});
-		await runInDurableObject(publisher, async (_instance, state) => {
-			await state.storage.deleteAll();
+		const prepared = await handlePreparePublisherRestore(
+			prepareRestoreRequest(),
+			"restore-prepare",
+			configuration,
+			{ publisherDid: PUBLISHER_DID },
+			ADMIN,
+		);
+		expect(prepared.status).toBe(200);
+		await expect(prepared.json()).resolves.toMatchObject({
+			data: { archiveId: ARCHIVE_ID, publisherDid: PUBLISHER_DID, prepared: true },
 		});
 		await abortAllDurableObjects();
 

--- a/packages/registry-client/src/release-service/index.ts
+++ b/packages/registry-client/src/release-service/index.ts
@@ -11,6 +11,7 @@ import {
 	type EncryptionRotationResult,
 	type MutationResult,
 	type OperatorPublisherResource,
+	type PreparePublisherRestoreResult,
 	type PublisherArchiveKind,
 	type PublisherArchivePageInput,
 	type PublisherArchivePageResult,
@@ -41,6 +42,7 @@ export type {
 	EncryptionRotationResult,
 	MutationResult,
 	OperatorPublisherResource,
+	PreparePublisherRestoreResult,
 	PublisherArchiveKind,
 	PublisherArchivePageInput,
 	PublisherArchivePageResult,
@@ -1047,6 +1049,28 @@ function parsePublisherRestorePage(value: unknown): PublisherRestorePageResult {
 	};
 }
 
+function parsePreparedPublisherRestore(value: unknown): PreparePublisherRestoreResult {
+	if (!isRecord(value)) throw invalidResponse();
+	const archiveId = stringValue(value, "archiveId");
+	const publisherDid = stringValue(value, "publisherDid");
+	const deletedIntents = safeInteger(value, "deletedIntents");
+	const deletedWorkloads = safeInteger(value, "deletedWorkloads");
+	if (
+		!archiveId ||
+		!ARCHIVE_ID_PATTERN.test(archiveId) ||
+		!publisherDid ||
+		!DID_PATTERN.test(publisherDid) ||
+		value["prepared"] !== true ||
+		deletedIntents === null ||
+		deletedIntents < 0 ||
+		deletedWorkloads === null ||
+		deletedWorkloads < 0
+	) {
+		throw invalidResponse();
+	}
+	return { archiveId, publisherDid, prepared: true, deletedIntents, deletedWorkloads };
+}
+
 export class ReleaseServiceOperatorClient extends BaseReleaseServiceClient {
 	#mutationHeaders(idempotencyKey: string): Headers {
 		return new Headers({
@@ -1230,6 +1254,30 @@ export class ReleaseServiceOperatorClient extends BaseReleaseServiceClient {
 				signal: options.signal,
 			},
 			parsePublisherRestorePage,
+		);
+	}
+
+	async preparePublisherRestore(
+		publisherDid: string,
+		archiveId: string,
+		options: MutationOptions,
+	): Promise<PreparePublisherRestoreResult> {
+		if (!ARCHIVE_ID_PATTERN.test(archiveId)) {
+			throw new ReleaseServiceError({
+				code: "CLIENT_RESPONSE_INVALID",
+				message: "Publisher archive ID is invalid",
+			});
+		}
+		return await this.call(
+			`/admin/api/publishers/${encodeURIComponent(publisherDid)}/restore/prepare`,
+			{
+				method: "POST",
+				credentials: "include",
+				headers: this.#mutationHeaders(options.idempotencyKey),
+				body: JSON.stringify({ archiveId, confirmPublisherDid: publisherDid }),
+				signal: options.signal,
+			},
+			parsePreparedPublisherRestore,
 		);
 	}
 

--- a/packages/registry-client/src/release-service/types.ts
+++ b/packages/registry-client/src/release-service/types.ts
@@ -230,6 +230,14 @@ export interface PublisherRestorePageResult {
 	authorityStatus: "reauthorization_required";
 }
 
+export interface PreparePublisherRestoreResult {
+	archiveId: string;
+	publisherDid: string;
+	prepared: true;
+	deletedIntents: number;
+	deletedWorkloads: number;
+}
+
 export interface CursorPage<T> {
 	items: T[];
 	nextCursor?: string;

--- a/packages/registry-client/tests/release-service.test.ts
+++ b/packages/registry-client/tests/release-service.test.ts
@@ -458,4 +458,30 @@ describe("ReleaseServiceOperatorClient", () => {
 		);
 		expect(captured!.init?.body).toBe('{"archiveId":"publisher-archive-0001","page":3}');
 	});
+
+	it("prepares a suspended shard for restore with exact DID confirmation", async () => {
+		let captured: { init: RequestInit | undefined; url: string } | null = null;
+		const fetch: typeof globalThis.fetch = async (input, init) => {
+			captured = { url: input instanceof Request ? input.url : input.toString(), init };
+			return success({
+				archiveId: "publisher-archive-0001",
+				publisherDid: PUBLISHER_DID,
+				prepared: true,
+				deletedIntents: 3,
+				deletedWorkloads: 1,
+			});
+		};
+		const client = new ReleaseServiceOperatorClient({ serviceUrl: SERVICE, fetch });
+		await expect(
+			client.preparePublisherRestore(PUBLISHER_DID, "publisher-archive-0001", {
+				idempotencyKey: "operator-publisher-restore-prepare-0001",
+			}),
+		).resolves.toMatchObject({ prepared: true, deletedIntents: 3 });
+		expect(new URL(captured!.url).pathname).toBe(
+			`/admin/api/publishers/${encodeURIComponent(PUBLISHER_DID)}/restore/prepare`,
+		);
+		expect(captured!.init?.body).toBe(
+			`{"archiveId":"publisher-archive-0001","confirmPublisherDid":"${PUBLISHER_DID}"}`,
+		);
+	});
 });


### PR DESCRIPTION
## What does this PR do?

Adds a recovery preparation path for publisher shards that cannot initialize normally. Operators can obtain a bounded restore challenge without first loading corrupt application state.

Depends on #2718. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
