### PR TITLE
feat(release-service): resolve Secrets Store bindings

### DIFF
--- a/apps/release-service/src/config.ts
+++ b/apps/release-service/src/config.ts
@@ -8,19 +8,21 @@ import { getDelegatedReleasePermission } from "@emdash-cms/registry-lexicons";
 import type { AccessConfiguration } from "./access/auth.js";
 import { createEnvelopeEncryption, type EnvelopeEncryption } from "./crypto/encryption.js";
 
-export type ConfigurationBindings = Record<
-	keyof Pick<
-		Env,
-		| "PUBLIC_ORIGIN"
-		| "DEPLOYMENT_ID"
-		| "OAUTH_REDIRECT_URIS"
-		| "OAUTH_ASSERTION_KEYSET"
-		| "ENCRYPTION_KEYRING"
-		| "ACCESS_TEAM_DOMAIN"
-		| "ACCESS_VIEWER_AUD"
-		| "ACCESS_REVIEWER_AUD"
-		| "ACCESS_ADMIN_AUD"
-	>,
+type ConfigurationStringBinding =
+	| "PUBLIC_ORIGIN"
+	| "DEPLOYMENT_ID"
+	| "OAUTH_REDIRECT_URIS"
+	| "ACCESS_TEAM_DOMAIN"
+	| "ACCESS_VIEWER_AUD"
+	| "ACCESS_REVIEWER_AUD"
+	| "ACCESS_ADMIN_AUD";
+type ConfigurationSecretBinding = "OAUTH_ASSERTION_KEYSET" | "ENCRYPTION_KEYRING";
+type ConfigurationSecretSource = string | SecretsStoreSecret;
+
+export type ConfigurationBindings = Record<ConfigurationStringBinding, string> &
+	Record<ConfigurationSecretBinding, ConfigurationSecretSource>;
+type ResolvedConfigurationBindings = Record<
+	ConfigurationStringBinding | ConfigurationSecretBinding,
 	string
 >;
 
@@ -105,7 +107,7 @@ function parseAccessTeamDomain(value: unknown): string | null {
 }
 
 function parseAccessAudiences(
-	bindings: ConfigurationBindings,
+	bindings: ResolvedConfigurationBindings,
 ): AccessConfiguration["audiences"] | null {
 	const audiences = {
 		viewer: bindings.ACCESS_VIEWER_AUD,
@@ -244,7 +246,7 @@ async function parseAssertionKeyset(value: string): Promise<{
 }
 
 async function parseConfiguration(
-	bindings: ConfigurationBindings,
+	bindings: ResolvedConfigurationBindings,
 ): Promise<CachedServiceConfiguration> {
 	const issues: string[] = [];
 	const publicOrigin = parseOrigin(bindings.PUBLIC_ORIGIN);
@@ -312,23 +314,45 @@ function getConfigurationCache(): WeakMap<object, ConfigurationCacheEntry> {
 	return (target[CONFIGURATION_CACHE_SYMBOL] ??= new WeakMap());
 }
 
+async function resolveSecret(source: ConfigurationSecretSource): Promise<string> {
+	if (typeof source === "string") return source;
+	const value = await source.get();
+	if (typeof value !== "string") throw new TypeError("Secret value is invalid");
+	return value;
+}
+
 export async function loadConfiguration(
 	bindings: ConfigurationBindings,
 ): Promise<ServiceConfiguration> {
-	const snapshot = CONFIGURATION_BINDING_KEYS.map((key) => bindings[key]);
+	let assertionKeyset: string;
+	let encryptionKeyring: string;
+	try {
+		[assertionKeyset, encryptionKeyring] = await Promise.all([
+			resolveSecret(bindings.OAUTH_ASSERTION_KEYSET),
+			resolveSecret(bindings.ENCRYPTION_KEYRING),
+		]);
+	} catch {
+		throw new ConfigurationError(["SECRET_STORE_UNAVAILABLE"]);
+	}
+	const resolved: ResolvedConfigurationBindings = {
+		...bindings,
+		OAUTH_ASSERTION_KEYSET: assertionKeyset,
+		ENCRYPTION_KEYRING: encryptionKeyring,
+	};
+	const snapshot = CONFIGURATION_BINDING_KEYS.map((key) => resolved[key]);
 	const cache = getConfigurationCache();
 	const cached = cache.get(bindings);
 	let promise = cached?.snapshot.every((value, index) => value === snapshot[index])
 		? cached.promise
 		: null;
 	if (!promise) {
-		promise = parseConfiguration(bindings);
+		promise = parseConfiguration(resolved);
 		cache.set(bindings, { snapshot, promise });
 	}
 	const configuration = await promise;
 	let encryption: EnvelopeEncryption;
 	try {
-		encryption = createEnvelopeEncryption(bindings.ENCRYPTION_KEYRING, configuration.deploymentId);
+		encryption = createEnvelopeEncryption(encryptionKeyring, configuration.deploymentId);
 	} catch {
 		throw new ConfigurationError(["ENCRYPTION_KEYRING_INVALID"]);
 	}

--- a/apps/release-service/test/config.test.ts
+++ b/apps/release-service/test/config.test.ts
@@ -95,4 +95,46 @@ describe("release-service OAuth configuration", () => {
 			issues: ["ENCRYPTION_KEYRING_INVALID"],
 		});
 	});
+
+	it("resolves assertion and encryption values from Secrets Store bindings", async () => {
+		let reads = 0;
+		const configuration = await loadConfiguration({
+			...TEST_BINDINGS,
+			OAUTH_ASSERTION_KEYSET: {
+				async get() {
+					reads += 1;
+					return TEST_BINDINGS.OAUTH_ASSERTION_KEYSET;
+				},
+			},
+			ENCRYPTION_KEYRING: {
+				async get() {
+					reads += 1;
+					return TEST_BINDINGS.ENCRYPTION_KEYRING;
+				},
+			},
+		});
+
+		expect(configuration.oauth.activeAssertionKeyId).toBe(ASSERTION_KEY_2.kid);
+		expect(configuration.encryption.currentKeyVersion).toBe(1);
+		expect(reads).toBe(2);
+	});
+
+	it("fails closed when Secrets Store retrieval fails without exposing the cause", async () => {
+		const sensitive = "secret store returned sensitive provider detail";
+		try {
+			await loadConfiguration({
+				...TEST_BINDINGS,
+				ENCRYPTION_KEYRING: {
+					async get() {
+						throw new Error(sensitive);
+					},
+				},
+			});
+			expect.fail("expected configuration failure");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ConfigurationError);
+			expect(error).toMatchObject({ issues: ["SECRET_STORE_UNAVAILABLE"] });
+			expect(JSON.stringify(error)).not.toContain(sensitive);
+		}
+	});
 });

--- a/docs/technical-specs/delegated-release-service-operations.md
+++ b/docs/technical-specs/delegated-release-service-operations.md
@@ -16,18 +16,18 @@ This runbook covers self-host deployment, routine maintenance, and incident reco
 
 The release-service Worker expects the following resources.
 
-| Binding | Resource | Purpose |
-| --- | --- | --- |
-| `PUBLISHER_DO` | `PublisherDurableObject` | Per-publisher delegation, workload, intent, publication, audit, restore, and rate-limit state |
-| `APPROVER_DO` | `ApproverDurableObject` | Per-approver sessions, passkeys, decisions, audit, and encrypted OAuth transactions |
-| `SERVICE_CONTROL_DO` | `ServiceControlDurableObject` | Global pause mode, publisher suspension, publication permits, and operator audit |
-| `IDENTITY_DIRECTORY_DO` | `IdentityDirectoryDurableObject` | Non-authoritative publisher and approver inventory, sharded by DID hash |
-| `RELEASE_INTENT_WORKFLOW` | Workflow | Verification, approval wait, publication, and reconciliation |
-| `PUBLISHER_ARCHIVE_WORKFLOW` | Workflow | Bounded, retryable publisher snapshot and audit export |
-| `RELEASE_VERIFIER` | Service binding | Isolated artifact and provenance verification |
-| `OPERATIONS_ARCHIVE` | R2 bucket | Encrypted publisher snapshot pages and append-only sanitized audit pages |
-| `OPERATIONS_METRICS` | Analytics Engine dataset | Privacy-safe operational alert events |
-| `ASSETS` | Worker static assets | Publisher, approver, and Access operator web surfaces |
+| Binding                      | Resource                         | Purpose                                                                                       |
+| ---------------------------- | -------------------------------- | --------------------------------------------------------------------------------------------- |
+| `PUBLISHER_DO`               | `PublisherDurableObject`         | Per-publisher delegation, workload, intent, publication, audit, restore, and rate-limit state |
+| `APPROVER_DO`                | `ApproverDurableObject`          | Per-approver sessions, passkeys, decisions, audit, and encrypted OAuth transactions           |
+| `SERVICE_CONTROL_DO`         | `ServiceControlDurableObject`    | Global pause mode, publisher suspension, publication permits, and operator audit              |
+| `IDENTITY_DIRECTORY_DO`      | `IdentityDirectoryDurableObject` | Non-authoritative publisher and approver inventory, sharded by DID hash                       |
+| `RELEASE_INTENT_WORKFLOW`    | Workflow                         | Verification, approval wait, publication, and reconciliation                                  |
+| `PUBLISHER_ARCHIVE_WORKFLOW` | Workflow                         | Bounded, retryable publisher snapshot and audit export                                        |
+| `RELEASE_VERIFIER`           | Service binding                  | Isolated artifact and provenance verification                                                 |
+| `OPERATIONS_ARCHIVE`         | R2 bucket                        | Encrypted publisher snapshot pages and append-only sanitized audit pages                      |
+| `OPERATIONS_METRICS`         | Analytics Engine dataset         | Privacy-safe operational alert events                                                         |
+| `ASSETS`                     | Worker static assets             | Publisher, approver, and Access operator web surfaces                                         |
 
 The initial Durable Object migration tag is `v1`. It contains every class and table required before the first deployment.
 
@@ -49,11 +49,11 @@ Changing `DEPLOYMENT_ID` makes existing encryption envelopes unreadable because 
 
 Create Access applications whose path specificity supplies the audience required by each route family.
 
-| Audience | Paths | Capability |
-| --- | --- | --- |
-| Viewer | `/admin*`, `/admin/api/status`, `/admin/api/directory`, read-only publisher and audit routes | Load the operator console and inspect state |
-| Reviewer | `/admin/api/intents/*` | Cancel or reconcile release intents |
-| Admin | `/admin/api/pause`, `/admin/api/publishers/*`, `/admin/api/approvers/*` | Pause publication, suspend or revoke publishers, rotate keys, archive, and restore |
+| Audience | Paths                                                                                        | Capability                                                                         |
+| -------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Viewer   | `/admin*`, `/admin/api/status`, `/admin/api/directory`, read-only publisher and audit routes | Load the operator console and inspect state                                        |
+| Reviewer | `/admin/api/intents/*`                                                                       | Cancel or reconcile release intents                                                |
+| Admin    | `/admin/api/pause`, `/admin/api/publishers/*`, `/admin/api/approvers/*`                      | Pause publication, suspend or revoke publishers, rotate keys, archive, and restore |
 
 The Worker verifies the Access JWT issuer and the route-specific audience. Access group claims do not grant a role inside the Worker.
 
@@ -69,7 +69,7 @@ pnpm exec wrangler secret put ENCRYPTION_KEYRING
 
 `OAUTH_ASSERTION_KEYSET` contains the active confidential-client assertion key and any previous public keys still needed by an authorization server. `ENCRYPTION_KEYRING` contains the active encryption key and retained decryption keys.
 
-The base configuration uses Worker secret bindings. A Secrets Store deployment requires an adapter that resolves each `SecretsStoreSecret.get()` result before calling `loadConfiguration()`. The current configuration loader accepts string bindings, so do not replace them with Secrets Store bindings until that adapter and its failure tests are present. Do not commit a Secrets Store ID to the reusable base configuration.
+The base configuration uses Worker secret bindings. `loadConfiguration()` also accepts `SecretsStoreSecret` bindings and resolves each value with `get()` on every load, so key rotation is visible to the configuration cache. Define Secrets Store bindings in a deployment-specific Wrangler environment. Do not commit a Secrets Store ID to the reusable base configuration.
 
 ### R2 and verifier
 
@@ -243,30 +243,30 @@ Archive audit pages remain in R2. Restore begins a new shard audit history with 
 
 `OPERATIONS_METRICS` writes privacy-safe Analytics Engine points with this layout:
 
-| Position | Value |
-| --- | --- |
-| `index1` | Publisher/workload hash or `global` |
-| `blob1` | Event name |
-| `blob2` | Outcome or error code |
-| `blob3` | Scope |
-| `blob4` | Request ID |
-| `double1` | Event value, normally `1` |
-| `double2` | Unix time in milliseconds |
+| Position  | Value                               |
+| --------- | ----------------------------------- |
+| `index1`  | Publisher/workload hash or `global` |
+| `blob1`   | Event name                          |
+| `blob2`   | Outcome or error code               |
+| `blob3`   | Scope                               |
+| `blob4`   | Request ID                          |
+| `double1` | Event value, normally `1`           |
+| `double2` | Unix time in milliseconds           |
 
 Configure alert queries for these event names:
 
-| Event | Required response |
-| --- | --- |
-| `publication_paused` | Confirm the incident owner and reason immediately |
-| `refresh_failure` | Check authorization-server health and retained key availability |
-| `reconciliation_required` | Monitor backlog age and deterministic PDS outcomes |
-| `verifier_failure` | Check verifier availability and failure-code distribution |
-| `access_denied` | Investigate spikes by audience and request path logs |
-| `archive_gap` | Resume the failed archive page and verify the manifest |
-| `restore_failure` | Keep the publisher suspended and inspect archive/page ordering |
-| `configuration_failure` | Keep readiness failed and correct variables or secrets |
-| `directory_failure` | Repair projection registration without changing authority |
-| `intent_rate_limited` | Review workload, repository, and publisher abuse patterns |
+| Event                     | Required response                                               |
+| ------------------------- | --------------------------------------------------------------- |
+| `publication_paused`      | Confirm the incident owner and reason immediately               |
+| `refresh_failure`         | Check authorization-server health and retained key availability |
+| `reconciliation_required` | Monitor backlog age and deterministic PDS outcomes              |
+| `verifier_failure`        | Check verifier availability and failure-code distribution       |
+| `access_denied`           | Investigate spikes by audience and request path logs            |
+| `archive_gap`             | Resume the failed archive page and verify the manifest          |
+| `restore_failure`         | Keep the publisher suspended and inspect archive/page ordering  |
+| `configuration_failure`   | Keep readiness failed and correct variables or secrets          |
+| `directory_failure`       | Repair projection registration without changing authority       |
+| `intent_rate_limited`     | Review workload, repository, and publisher abuse patterns       |
 
 Alert delivery is deployment-specific. A production launch requires tested notification routing and an on-call owner for every event above.
 


### PR DESCRIPTION
## What does this PR do?

Adds runtime resolution for Cloudflare Secrets Store bindings used by the release service and documents the required binding layout. Configuration validation fails closed when a required secret cannot be resolved.

Depends on #2720. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
