### PR TITLE
fix(registry): add Worker-safe records entrypoint

### DIFF
--- a/.changeset/swift-verifiers-match.md
+++ b/.changeset/swift-verifiers-match.md
@@ -5,3 +5,5 @@
 Adds optional artifact digest candidates to `GitHubProvenanceVerifier`, allowing callers that compute several supported digest algorithms in one isolated artifact fetch to verify the digest selected by a signed SLSA provenance subject.
 
 Existing callers can continue passing only `artifactDigest`. Successful results return the candidate that matched the signed subject.
+
+Adds `@emdash-cms/registry-verification/records` for Worker callers that supply an explicit `ProvenanceVerifier`. The runtime-neutral entry does not load the Node-oriented default Sigstore verifier, while the package root keeps the existing default-verifier behavior.

--- a/apps/release-service/src/approvals/authority.ts
+++ b/apps/release-service/src/approvals/authority.ts
@@ -2,7 +2,7 @@ import type { ActorResolver } from "@atcute/identity-resolver";
 import { safeParse } from "@atcute/lexicons";
 import { isDid } from "@atcute/lexicons/syntax";
 import { NSID, PackageProfile, PackageProfileExtension } from "@emdash-cms/registry-lexicons";
-import { fetchVerifiedResource } from "@emdash-cms/registry-verification";
+import { fetchVerifiedResource } from "@emdash-cms/registry-verification/fetch";
 
 import { createWorkerActorResolver } from "../oauth/custody.js";
 import type {

--- a/apps/release-service/src/verification/evaluate.ts
+++ b/apps/release-service/src/verification/evaluate.ts
@@ -6,12 +6,12 @@ import {
 	PackageRelease,
 	PackageReleaseExtension,
 } from "@emdash-cms/registry-lexicons";
+import { decodeMultihash } from "@emdash-cms/registry-verification/checksum";
 import {
-	decodeMultihash,
 	verifyPackageReleaseRecords,
 	type ProvenanceVerifier,
 	type VerifiedRecordContext,
-} from "@emdash-cms/registry-verification";
+} from "@emdash-cms/registry-verification/records";
 import { base64url } from "jose";
 
 import type {

--- a/apps/release-service/src/verification/pds.ts
+++ b/apps/release-service/src/verification/pds.ts
@@ -1,7 +1,7 @@
 import type { ActorResolver } from "@atcute/identity-resolver";
 import { isDid } from "@atcute/lexicons/syntax";
 import { NSID } from "@emdash-cms/registry-lexicons";
-import { fetchVerifiedResource } from "@emdash-cms/registry-verification";
+import { fetchVerifiedResource } from "@emdash-cms/registry-verification/fetch";
 import compareVersions from "semver/functions/compare.js";
 import validVersion from "semver/functions/valid.js";
 

--- a/apps/release-verifier/vite.config.ts
+++ b/apps/release-verifier/vite.config.ts
@@ -1,6 +1,15 @@
+import { fileURLToPath } from "node:url";
+
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
 
 export default defineConfig({
 	plugins: [cloudflare()],
+	resolve: {
+		alias: {
+			"@emdash-cms/registry-verification": fileURLToPath(
+				new URL("../../packages/registry-verification/src/index.ts", import.meta.url),
+			),
+		},
+	},
 });

--- a/packages/registry-verification/package.json
+++ b/packages/registry-verification/package.json
@@ -20,6 +20,10 @@
 		"./fetch": {
 			"types": "./dist/fetch-entry.d.ts",
 			"default": "./dist/fetch-entry.js"
+		},
+		"./records": {
+			"types": "./dist/records-entry.d.ts",
+			"default": "./dist/records-entry.js"
 		}
 	},
 	"files": [

--- a/packages/registry-verification/src/index.ts
+++ b/packages/registry-verification/src/index.ts
@@ -17,7 +17,8 @@ export {
 export { validatePluginBundle } from "./bundle.js";
 export { GitHubProvenanceVerifier } from "./provenance.js";
 export { canonicalizeRepositoryUrl } from "./repository.js";
-export { inspectPackageReleaseRecords, verifyPackageReleaseRecords } from "./records.js";
+export { inspectPackageReleaseRecords } from "./records.js";
+export { verifyPackageReleaseRecords } from "./records-default.js";
 export type { DecodedMultihash, MultihashAlgorithm } from "./checksum.js";
 export type {
 	FetchImplementation,

--- a/packages/registry-verification/src/records-default.ts
+++ b/packages/registry-verification/src/records-default.ts
@@ -1,0 +1,13 @@
+import { GitHubProvenanceVerifier } from "./provenance.js";
+import {
+	verifyPackageReleaseRecordsWithDefaultVerifier,
+	type RecordVerificationInput,
+	type RecordVerificationReport,
+} from "./records.js";
+
+/** Validate signed profile/release records and apply the complete provenance policy. */
+export function verifyPackageReleaseRecords(
+	input: RecordVerificationInput,
+): Promise<RecordVerificationReport> {
+	return verifyPackageReleaseRecordsWithDefaultVerifier(input, new GitHubProvenanceVerifier());
+}

--- a/packages/registry-verification/src/records-entry.ts
+++ b/packages/registry-verification/src/records-entry.ts
@@ -1,0 +1,32 @@
+import type { ProvenanceVerifier, VerifiedProvenance } from "./provenance.js";
+import { verifyPackageReleaseRecordsWithVerifier } from "./records.js";
+import type {
+	NormalizedReleasePolicy,
+	ProvenanceEvidence,
+	ProvenanceStatus,
+	RecordVerificationCode,
+	RecordVerificationInputWithVerifier,
+	RecordVerificationReason,
+	RecordVerificationReport,
+	VerifiedRecordContext,
+} from "./records.js";
+
+export type RecordVerificationInput = RecordVerificationInputWithVerifier;
+
+export function verifyPackageReleaseRecords(
+	input: RecordVerificationInput,
+): Promise<RecordVerificationReport> {
+	return verifyPackageReleaseRecordsWithVerifier(input);
+}
+
+export type {
+	NormalizedReleasePolicy,
+	ProvenanceEvidence,
+	ProvenanceStatus,
+	ProvenanceVerifier,
+	RecordVerificationCode,
+	RecordVerificationReason,
+	RecordVerificationReport,
+	VerifiedProvenance,
+	VerifiedRecordContext,
+};

--- a/packages/registry-verification/src/records.ts
+++ b/packages/registry-verification/src/records.ts
@@ -14,7 +14,6 @@ import {
 
 import { compareDigestBytes, decodeMultihash } from "./checksum.js";
 import type { VerificationErrorCode } from "./errors.js";
-import { GitHubProvenanceVerifier } from "./provenance.js";
 import type { ProvenanceVerifier, VerifiedProvenance } from "./provenance.js";
 import { canonicalizeRepositoryUrl } from "./repository.js";
 
@@ -41,6 +40,9 @@ export interface RecordVerificationInput {
 }
 
 export type RecordInspectionInput = Omit<RecordVerificationInput, "provenance">;
+export type RecordVerificationInputWithVerifier = Omit<RecordVerificationInput, "provenance"> & {
+	provenance?: ProvenanceEvidence & { verifier: ProvenanceVerifier };
+};
 
 export type RecordVerificationCode =
 	| VerificationErrorCode
@@ -217,9 +219,9 @@ export async function inspectPackageReleaseRecords(
 	};
 }
 
-/** Validate signed records and apply the complete provenance policy. */
-export async function verifyPackageReleaseRecords(
+async function verifyPackageReleaseRecordsInternal(
 	input: RecordVerificationInput,
+	defaultVerifier: ProvenanceVerifier | null,
 ): Promise<RecordVerificationReport> {
 	const inspection = await inspectPackageReleaseRecords(input);
 	if (!inspection.success) return inspection;
@@ -267,7 +269,14 @@ export async function verifyPackageReleaseRecords(
 			"failed",
 		);
 	}
-	const verifier = input.provenance.verifier ?? new GitHubProvenanceVerifier();
+	const verifier = input.provenance.verifier ?? defaultVerifier;
+	if (!verifier) {
+		return failed(
+			"PROVENANCE_UNVERIFIABLE",
+			"The supplied provenance verifier is unavailable.",
+			"failed",
+		);
+	}
 	let provenanceResult: Awaited<ReturnType<ProvenanceVerifier["verify"]>>;
 	try {
 		provenanceResult = await verifier.verify({
@@ -298,6 +307,19 @@ export async function verifyPackageReleaseRecords(
 			verifiedProvenance: provenanceResult.value,
 		},
 	};
+}
+
+export function verifyPackageReleaseRecordsWithVerifier(
+	input: RecordVerificationInputWithVerifier,
+): Promise<RecordVerificationReport> {
+	return verifyPackageReleaseRecordsInternal(input, null);
+}
+
+export function verifyPackageReleaseRecordsWithDefaultVerifier(
+	input: RecordVerificationInput,
+	defaultVerifier: ProvenanceVerifier,
+): Promise<RecordVerificationReport> {
+	return verifyPackageReleaseRecordsInternal(input, defaultVerifier);
 }
 
 function normalizePolicy(

--- a/packages/registry-verification/tests/records.test.ts
+++ b/packages/registry-verification/tests/records.test.ts
@@ -10,6 +10,7 @@ import type {
 	VerifiedProvenance,
 } from "../src/index.js";
 import { inspectPackageReleaseRecords, verifyPackageReleaseRecords } from "../src/index.js";
+import { verifyPackageReleaseRecords as verifyPackageReleaseRecordsWithExplicitVerifier } from "../src/records-entry.js";
 
 const publisherDid = "did:plc:publisher";
 const packageSlug = "gallery";
@@ -77,6 +78,23 @@ describe("verifyPackageReleaseRecords", () => {
 					approvers: [],
 				},
 			},
+		});
+	});
+
+	it("keeps unattested releases available through the runtime-neutral entrypoint", async () => {
+		const report = await verifyPackageReleaseRecordsWithExplicitVerifier({
+			publisherDid,
+			package: packageSlug,
+			version,
+			rkey,
+			profile: cloneProfile(),
+			release: cloneRelease(),
+		});
+
+		expect(report).toMatchObject({
+			success: true,
+			status: "unattested",
+			code: "PROVENANCE_ABSENT_OPTIONAL",
 		});
 	});
 

--- a/packages/registry-verification/tsdown.config.ts
+++ b/packages/registry-verification/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig([
 	{
-		entry: ["src/bundle.ts", "src/checksum.ts", "src/fetch-entry.ts"],
+		entry: ["src/bundle.ts", "src/checksum.ts", "src/fetch-entry.ts", "src/records-entry.ts"],
 		format: ["esm"],
 		outExtensions: () => ({ js: ".js" }),
 		dts: true,
@@ -19,8 +19,7 @@ export default defineConfig([
 		clean: false,
 		platform: "node",
 		target: "es2024",
-		// Sigstore is bundled so the published workerd path carries our pinned
-		// @sigstore/core algorithm-selection fix instead of resolving a pristine copy.
+		outputOptions: { codeSplitting: false },
 		inlineOnly: false,
 		external: ["@emdash-cms/plugin-types", "modern-tar"],
 	},


### PR DESCRIPTION
## What does this PR do?

Adds a Worker-safe registry-record verification entrypoint and moves Node-specific defaults behind separate exports. Release-service and verifier Workers can validate signed records without bundling unsupported Node modules.

Depends on #2721. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
