### PR TITLE
test(release-service): allow workflow retry backoff

### DIFF
--- a/apps/release-service/test/release-intent-workflow.test.ts
+++ b/apps/release-service/test/release-intent-workflow.test.ts
@@ -601,7 +601,7 @@ describe("ReleaseIntentWorkflow", () => {
 			reasonCode: null,
 		});
 		expect(createAttempts).toBe(1);
-	});
+	}, 15_000);
 
 	it("waits for a canonical approval transition and resumes from its event", async () => {
 		const profile: Record<string, unknown> = {


### PR DESCRIPTION
## What does this PR do?

Updates release workflow tests to model durable retry backoff instead of assuming immediate repeated execution. The assertions continue to verify terminal state and idempotent step behavior.

Depends on #2722. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
