### PR TITLE
test(release-service): add browser conformance

### DIFF
--- a/apps/release-service/e2e/web-surfaces.spec.ts
+++ b/apps/release-service/e2e/web-surfaces.spec.ts
@@ -1,0 +1,218 @@
+import { Buffer } from "node:buffer";
+
+import { expect, test } from "@playwright/test";
+
+import { addVirtualWebAuthnAuthenticator } from "../../../e2e/fixtures/virtual-authenticator.js";
+
+const PUBLISHER_DID = "did:web:publisher.example.com";
+const INTENT_ID = "01JABCDEFGHJKMNPQRSTVWXYZ0";
+const BASE_URL = "http://localhost:5185";
+const WEB_IDEMPOTENCY_KEY = /^web-/;
+
+function success(data: unknown) {
+	return {
+		status: 200,
+		contentType: "application/json",
+		body: JSON.stringify({ data, requestId: "pw" }),
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+test("Access denies an unauthenticated operator API request", async ({ request }) => {
+	const response = await request.get("/admin/api/status");
+	expect(response.status()).toBe(401);
+	expect(response.headers()["content-type"]).toContain("application/json");
+	expect(await response.json()).toMatchObject({ error: { code: "ACCESS_AUTH_REQUIRED" } });
+});
+
+test("publisher login sends mutation fencing and remains RTL-safe on mobile", async ({ page }) => {
+	await page.setViewportSize({ width: 390, height: 844 });
+	let authorizationRequest: { body: unknown; headers: Record<string, string> } | null = null;
+	await page.route("**/v1/publisher**", async (route) => {
+		const request = route.request();
+		const path = new URL(request.url()).pathname;
+		if (path === "/v1/publisher/session/authorize" && request.method() === "POST") {
+			authorizationRequest = {
+				body: request.postDataJSON(),
+				headers: await request.allHeaders(),
+			};
+			await route.fulfill(success({ authorizationUrl: `${BASE_URL}/oauth/mock` }));
+			return;
+		}
+		await route.fulfill({
+			status: 401,
+			contentType: "application/json",
+			body: JSON.stringify({
+				error: { code: "PUBLISHER_SESSION_INVALID", message: "Publisher session is not valid" },
+				requestId: "pw",
+			}),
+		});
+	});
+
+	await page.goto("/publisher?locale=ar");
+	await expect(page.getByRole("heading", { name: "Sign in as a publisher" })).toBeVisible();
+	expect(await page.locator("html").getAttribute("dir")).toBe("rtl");
+	expect(
+		await page.evaluate(
+			() => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+		),
+	).toBe(true);
+	await page.getByLabel("Handle or DID").fill("publisher.example.com");
+	await page.getByRole("button", { name: "Continue with Atmosphere" }).click();
+	await page.waitForURL("**/oauth/mock");
+
+	expect(authorizationRequest).not.toBeNull();
+	expect(authorizationRequest!.headers["x-emdash-request"]).toBe("1");
+	expect(authorizationRequest!.headers["origin"]).toBe(BASE_URL);
+	expect(authorizationRequest!.body).toEqual({
+		identifier: "publisher.example.com",
+		redirectTarget: "/publisher?locale=ar",
+	});
+});
+
+test("approver enrols and uses a user-verified virtual passkey", async ({ page }) => {
+	const removeAuthenticator = await addVirtualWebAuthnAuthenticator(page);
+	let credentialId: string | null = null;
+	let decisionAssertion: unknown = null;
+	let decisionHeaders: Record<string, string> | null = null;
+	try {
+		await page.route("**/v1/**", async (route) => {
+			const request = route.request();
+			const url = new URL(request.url());
+			if (url.pathname === "/v1/approver/credentials" && request.method() === "GET") {
+				await route.fulfill(
+					success({
+						items: credentialId
+							? [
+									{
+										id: credentialId,
+										name: "Virtual key",
+										transports: ["internal"],
+										createdAt: Date.now(),
+										lastUsedAt: null,
+										revokedAt: null,
+									},
+								]
+							: [],
+					}),
+				);
+				return;
+			}
+			if (url.pathname === "/v1/approver/credentials/options") {
+				await route.fulfill(
+					success({
+						challenge: "AQID",
+						rp: { id: "localhost", name: "EmDash" },
+						user: { id: "BAUG", name: "did:plc:approver", displayName: "Approver" },
+						pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+						authenticatorSelection: {
+							residentKey: "preferred",
+							userVerification: "required",
+						},
+						attestation: "none",
+					}),
+				);
+				return;
+			}
+			if (url.pathname === "/v1/approver/credentials" && request.method() === "POST") {
+				const body: unknown = request.postDataJSON();
+				if (
+					body === null ||
+					typeof body !== "object" ||
+					Array.isArray(body) ||
+					!("rawId" in body) ||
+					typeof body.rawId !== "string"
+				) {
+					throw new Error("Passkey registration response is invalid");
+				}
+				credentialId = body.rawId;
+				expect((await request.allHeaders())["x-emdash-request"]).toBe("1");
+				await route.fulfill(success(null));
+				return;
+			}
+			if (url.pathname.endsWith("/options")) {
+				expect((await request.allHeaders())["x-emdash-request"]).toBe("1");
+				await route.fulfill(
+					success({
+						challenge: "BwgJ",
+						rpId: "localhost",
+						userVerification: "required",
+						allowCredentials: [{ type: "public-key", id: credentialId }],
+					}),
+				);
+				return;
+			}
+			if (url.pathname === `/v1/approvals/${INTENT_ID}` && request.method() === "POST") {
+				decisionAssertion = request.postDataJSON();
+				decisionHeaders = await request.allHeaders();
+				await route.fulfill(success(null));
+				return;
+			}
+			if (url.pathname === `/v1/approvals/${INTENT_ID}`) {
+				await route.fulfill(
+					success({
+						intent: {
+							id: INTENT_ID,
+							packageSlug: "gallery",
+							version: "1.2.3",
+							state: "awaiting_approval",
+							expiresAt: Date.now() + 60_000,
+						},
+						evidence: { profileCid: "bafyprofile" },
+						evidenceDigest: "D".repeat(43),
+						review: {
+							source: {
+								repository: "example/gallery",
+								workflowRef: "example/gallery/.github/workflows/release.yml@refs/heads/main",
+								commitSha: "a".repeat(40),
+								runId: "100",
+								actor: "release-bot",
+							},
+							artifact: { url: "https://example.com/gallery.tgz", checksum: "sha256:artifact" },
+							provenance: {
+								url: "https://example.com/provenance.json",
+								checksum: "sha256:provenance",
+								predicateType: "https://slsa.dev/provenance/v1",
+								sourceRepository: "https://github.com/example/gallery",
+								builderId:
+									"https://github.com/example/gallery/.github/workflows/release.yml@refs/heads/main",
+							},
+							accessDiff: { escalation: false, changes: [] },
+						},
+					}),
+				);
+				return;
+			}
+			await route.abort();
+		});
+
+		await page.goto(`/approvals/${INTENT_ID}?publisher=${encodeURIComponent(PUBLISHER_DID)}`);
+		await expect(page.getByRole("heading", { name: "Review delegated release" })).toBeVisible();
+		await page.getByLabel("Passkey name").fill("Virtual key");
+		await page.getByRole("button", { name: "Enrol passkey" }).click();
+		await expect(page.getByText("Virtual key", { exact: true })).toBeVisible();
+		await page.getByRole("button", { name: "Approve release" }).click();
+		await expect(
+			page.getByText("Approval recorded. The release workflow can continue."),
+		).toBeVisible();
+		expect(decisionAssertion).toMatchObject({
+			decision: "approve",
+			response: { type: "public-key" },
+		});
+		expect(decisionHeaders?.["x-emdash-request"]).toBe("1");
+		expect(decisionHeaders?.["idempotency-key"]).toMatch(WEB_IDEMPOTENCY_KEY);
+		const credential = isRecord(decisionAssertion) ? decisionAssertion["response"] : null;
+		const assertion = isRecord(credential) ? credential["response"] : null;
+		if (!isRecord(assertion) || typeof assertion["authenticatorData"] !== "string") {
+			throw new Error("Passkey assertion response is invalid");
+		}
+		const authenticatorData = Buffer.from(assertion["authenticatorData"], "base64url");
+		expect(authenticatorData.byteLength).toBeGreaterThan(32);
+		expect(authenticatorData[32]! & 0x04).toBe(0x04);
+	} finally {
+		await removeAuthenticator();
+	}
+});

--- a/apps/release-service/package.json
+++ b/apps/release-service/package.json
@@ -12,6 +12,7 @@
 		"typecheck": "tsgo --noEmit && tsgo --noEmit -p tsconfig.ui.json",
 		"test": "vitest run && pnpm run test:ui",
 		"test:ui": "vitest run --config vitest.ui.config.ts",
+		"test:browser": "playwright test --config playwright.config.ts",
 		"types": "wrangler types"
 	},
 	"dependencies": {
@@ -37,6 +38,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "catalog:",
 		"@cloudflare/vitest-pool-workers": "catalog:",
+		"@playwright/test": "^1.61.1",
 		"@tailwindcss/vite": "^4.3.3",
 		"@testing-library/react": "^16.3.0",
 		"@types/react": "catalog:",

--- a/apps/release-service/playwright.config.ts
+++ b/apps/release-service/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+import { TEST_BINDINGS } from "./test/fixtures/oauth.js";
+
+export default defineConfig({
+	testDir: "./e2e",
+	fullyParallel: false,
+	workers: 1,
+	retries: 0,
+	reporter: "list",
+	timeout: 30_000,
+	use: {
+		baseURL: "http://localhost:5185",
+		trace: "on-first-retry",
+		screenshot: "only-on-failure",
+		...devices["Desktop Chrome"],
+	},
+	webServer: {
+		command: "pnpm dev --host 127.0.0.1 --port 5185",
+		url: "http://localhost:5185/health",
+		reuseExistingServer: false,
+		timeout: 60_000,
+		env: { ...process.env, ...TEST_BINDINGS },
+	},
+});

--- a/apps/release-service/vitest.config.ts
+++ b/apps/release-service/vitest.config.ts
@@ -8,7 +8,9 @@ process.env["ENCRYPTION_KEYRING"] ??=
 	'{"current":1,"keys":[{"version":1,"key":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"}]}';
 
 export default defineConfig({
-	test: { exclude: [...configDefaults.exclude, "src/ui/**/*.test.{ts,tsx}"] },
+	test: {
+		exclude: [...configDefaults.exclude, "src/ui/**/*.test.{ts,tsx}", "e2e/**/*.spec.ts"],
+	},
 	plugins: [
 		cloudflareTest({
 			wrangler: { configPath: "./wrangler.jsonc" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,6 +591,9 @@ importers:
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
         version: 0.16.3(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.0.11(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))


### PR DESCRIPTION
## What does this PR do?

Adds browser conformance coverage for the publisher, approver, and Access-protected operator surfaces. The tests exercise navigation, browser-held OAuth state, passkey handoffs, and protected admin routes.

Depends on #2723. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
