### PR TITLE
fix(release-verifier): bind provenance checksum

### DIFF
--- a/apps/release-verifier/src/verify.ts
+++ b/apps/release-verifier/src/verify.ts
@@ -204,6 +204,11 @@ export async function verifyRelease(
 			maxBytes: MAX_PROVENANCE_BYTES,
 		});
 		if (!provenanceResource.success) return provenanceResource;
+		const provenanceChecksum = await verifyMultihash(
+			provenanceResource.value.bytes,
+			input.provenance.checksum,
+		);
+		if (!provenanceChecksum.success) return provenanceChecksum;
 		const artifactDigests = await Promise.all(
 			(["SHA-256", "SHA-384", "SHA-512"] as const).map(
 				async (algorithm) =>

--- a/apps/release-verifier/test/verifier.test.ts
+++ b/apps/release-verifier/test/verifier.test.ts
@@ -176,6 +176,44 @@ describe("isolated release verifier", () => {
 		});
 	});
 
+	it("rejects provenance that does not match the signed checksum", async () => {
+		const fixture = await createDelegatedReleaseConformanceFixture();
+		const verify = vi.fn(async (input: ProvenanceVerificationInput) => ({
+			success: true as const,
+			value: {
+				predicateType: "https://slsa.dev/provenance/v1" as const,
+				artifactDigest: input.artifactDigest,
+				sourceRepository: fixture.expected.repository,
+				builderId: fixture.expected.builderId,
+			},
+		}));
+		const result = await verifyRelease(
+			{
+				...fixture.serviceInput,
+				provenance: {
+					...fixture.serviceInput.provenance,
+					checksum: await checksum(encoder.encode("different provenance")),
+				},
+			},
+			{
+				fetch: async (url) =>
+					new Response(
+						url.toString() === fixture.artifactUrl
+							? fixture.artifactBytes
+							: fixture.provenanceDocument,
+					),
+				resolveHostname: async () => ["203.0.113.5"],
+				provenanceVerifier: { verify },
+			},
+		);
+
+		expect(result).toMatchObject({
+			success: false,
+			error: { code: "CHECKSUM_MISMATCH" },
+		});
+		expect(verify).not.toHaveBeenCalled();
+	});
+
 	it("rejects checksum and bundle identity mismatches with stable reports", async () => {
 		const bytes = await validBundle();
 		const dependencies = {


### PR DESCRIPTION
## What does this PR do?

Binds provenance verification to the checksum declared by the signed release record. A provenance document for different artifact bytes can no longer satisfy verification.

Depends on #2724. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
