### PR TITLE
fix(registry): accept loopback approval URLs

### DIFF
--- a/packages/registry-client/src/release-service/index.ts
+++ b/packages/registry-client/src/release-service/index.ts
@@ -324,7 +324,7 @@ function parseIntent(value: unknown, serviceUrl?: string): ReleaseIntentResource
 		} catch {
 			throw invalidResponse();
 		}
-		if (parsedApproval.origin !== serviceUrl || parsedApproval.protocol !== "https:") {
+		if (parsedApproval.origin !== serviceUrl) {
 			throw invalidResponse();
 		}
 	}

--- a/packages/registry-client/tests/release-service.test.ts
+++ b/packages/registry-client/tests/release-service.test.ts
@@ -12,7 +12,7 @@ const PUBLISHER_DID = "did:web:publisher.example.com";
 const INTENT_ID = "01JABCDEFGHJKMNPQRSTVWXYZ0";
 const CSRF = "C".repeat(43);
 
-function intent(state = "received") {
+function intent(state = "received", service = SERVICE) {
 	return {
 		id: INTENT_ID,
 		publisherDid: PUBLISHER_DID,
@@ -28,7 +28,7 @@ function intent(state = "received") {
 		result: null,
 		approvalUrl:
 			state === "awaiting_approval"
-				? `${SERVICE}/approvals/${INTENT_ID}?publisher=${encodeURIComponent(PUBLISHER_DID)}`
+				? `${service}/approvals/${INTENT_ID}?publisher=${encodeURIComponent(PUBLISHER_DID)}`
 				: null,
 	};
 }
@@ -72,6 +72,19 @@ describe("ReleaseServiceClient", () => {
 					workloadToken: "header.payload.signature",
 				}),
 		).toThrow("HTTPS origin or a loopback");
+	});
+
+	it("accepts an approval URL on the configured loopback origin", async () => {
+		const service = "http://127.0.0.1:5175";
+		const client = new ReleaseServiceClient({
+			serviceUrl: service,
+			fetch: async () => success({ intent: intent("awaiting_approval", service) }),
+			workloadToken: "header.payload.signature",
+		});
+
+		await expect(client.getIntent(PUBLISHER_DID, INTENT_ID)).resolves.toMatchObject({
+			approvalUrl: `${service}/approvals/${INTENT_ID}?publisher=${encodeURIComponent(PUBLISHER_DID)}`,
+		});
 	});
 
 	it("submits a typed intent without retaining or exposing the workload token", async () => {


### PR DESCRIPTION
## What does this PR do?

Allows validated loopback approval URLs returned by a locally running release service while retaining the existing external URL restrictions. This keeps local conformance and development flows usable without weakening production URL checks.

Depends on #2725. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
