### PR TITLE
fix(release-service): harden state and recovery bounds

### DIFF
--- a/apps/release-service/src/approvals/digest.ts
+++ b/apps/release-service/src/approvals/digest.ts
@@ -150,7 +150,9 @@ function normalizeApproverDids(values: readonly string[]): readonly string[] {
 	if (!Array.isArray(values) || values.length === 0 || values.length > 32) {
 		throw new ApprovalDigestError();
 	}
-	const normalized = [...values].toSorted((left, right) => left.localeCompare(right));
+	const normalized = [...values].toSorted((left, right) =>
+		left < right ? -1 : left > right ? 1 : 0,
+	);
 	if (
 		normalized.some((value) => typeof value !== "string" || !DID_PATTERN.test(value)) ||
 		new Set(normalized).size !== normalized.length

--- a/apps/release-service/src/approver-do/store.ts
+++ b/apps/release-service/src/approver-do/store.ts
@@ -450,6 +450,7 @@ export class ApproverStore {
 				.toArray()[0];
 			if (existing) return { ok: false, code: "IDENTITY_TRANSACTION_EXISTS" } as const;
 			this.#deleteExpiredIdentityTransactions(now, MAX_ACTIVE_IDENTITY_TRANSACTIONS);
+			this.storage.sql.exec("DELETE FROM identity_transactions WHERE completed_at IS NOT NULL");
 			const count = this.storage.sql
 				.exec<{ count: number }>(
 					"SELECT COUNT(*) AS count FROM identity_transactions WHERE completed_at IS NULL",
@@ -859,6 +860,7 @@ export class ApproverStore {
 				.toArray()[0];
 			if (existing) return { ok: false, code: "CHALLENGE_EXISTS" } as const;
 			this.#expireChallenges(now, MAX_ACTIVE_CHALLENGES);
+			this.storage.sql.exec("DELETE FROM approval_challenges WHERE consumed_at IS NOT NULL");
 			const count = this.storage.sql
 				.exec<{ count: number }>(
 					"SELECT COUNT(*) AS count FROM approval_challenges WHERE consumed_at IS NULL",

--- a/apps/release-service/src/backup/routes.ts
+++ b/apps/release-service/src/backup/routes.ts
@@ -136,6 +136,9 @@ async function writeEncryptedObject(
 	if (created) return false;
 	const existing = await env.OPERATIONS_ARCHIVE.get(key);
 	if (!existing) throw new ApiError("ARCHIVE_OPERATION_FAILED", 503, "Archive write failed");
+	if (existing.size > MAX_ARCHIVE_OBJECT_BYTES) {
+		throw new ApiError("ARCHIVE_OPERATION_FAILED", 409, "Archive page conflicts with prior write");
+	}
 	let existingPlaintext: string;
 	try {
 		existingPlaintext = decoder.decode(
@@ -191,13 +194,20 @@ async function writeAuditObject(
 	const lastSequence = String(last.sequence).padStart(20, "0");
 	const key = `audit/${ownerHash}/${firstSequence}-${lastSequence}.json`;
 	const content = JSON.stringify({ version: SNAPSHOT_VERSION, publisherDid, events });
+	if (encoder.encode(content).byteLength > MAX_ARCHIVE_OBJECT_BYTES) {
+		throw new ApiError("ARCHIVE_OPERATION_FAILED", 500, "Audit export exceeded its size limit");
+	}
 	const created = await env.OPERATIONS_ARCHIVE.put(key, content, {
 		onlyIf: { etagDoesNotMatch: "*" },
 		httpMetadata: { contentType: "application/json" },
 	});
 	if (created) return;
 	const existing = await env.OPERATIONS_ARCHIVE.get(key);
-	if (!existing || (await existing.text()) !== content) {
+	if (
+		!existing ||
+		existing.size > MAX_ARCHIVE_OBJECT_BYTES ||
+		(await existing.text()) !== content
+	) {
 		throw new ApiError("ARCHIVE_OPERATION_FAILED", 409, "Audit export conflicts with prior write");
 	}
 }

--- a/apps/release-service/src/publisher-do/intent-state.ts
+++ b/apps/release-service/src/publisher-do/intent-state.ts
@@ -616,6 +616,32 @@ export class IntentStateStore {
 			.map(rowToIntent);
 	}
 
+	listExpirable(now: number, limit: number): readonly StoredIntent[] {
+		if (
+			!Number.isSafeInteger(now) ||
+			now < 0 ||
+			!Number.isSafeInteger(limit) ||
+			limit < 1 ||
+			limit > 100
+		) {
+			throw new IntentStateError();
+		}
+		return this.#storage.sql
+			.exec<IntentRow>(
+				`SELECT id, package_slug, version, state, state_generation,
+				        workload_policy_version, workload_identity_digest, workload_idempotency_digest,
+				        request_digest, workload_identity_json, release_input_json, state_data_json,
+				        workflow_id, expires_at, created_at, updated_at
+				 FROM intents
+				 WHERE expires_at <= ? AND state IN ('received', 'verifying', 'verified', 'ready')
+				 ORDER BY expires_at, id LIMIT ?`,
+				now,
+				limit,
+			)
+			.toArray()
+			.map(rowToIntent);
+	}
+
 	listTransitions(intentId: string): readonly IntentTransition[] {
 		if (!ULID_PATTERN.test(intentId)) throw new IntentStateError();
 		return this.#storage.sql

--- a/apps/release-service/src/publisher-do/publisher-do.ts
+++ b/apps/release-service/src/publisher-do/publisher-do.ts
@@ -91,8 +91,11 @@ const HASH_PATTERN = /^[A-Za-z0-9_-]{32,128}$/;
 const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 const ACTOR_IDENTITY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,255}$/;
 const MAX_CIPHERTEXT_CHARS = 1_500_000;
+const MAX_ACTIVE_OAUTH_STATES = 20;
 const MAX_REFRESH_LEASE_MS = 5 * 60_000;
 const MAX_PUBLISHER_SESSION_MS = 24 * 60 * 60_000;
+const MAX_ACTIVE_PUBLISHER_SESSIONS = 20;
+const MAINTENANCE_BATCH_SIZE = 100;
 const REFRESH_TOKEN_BYTES = 32;
 const BASE64_PADDING_PATTERN = /=+$/;
 const ENCRYPTION_CURSOR_PATTERN = /^(?:delegation:1|oauth-state:[A-Za-z0-9_-]{32,128})$/;
@@ -134,6 +137,7 @@ export interface PutOAuthStateInput {
 	clientKeyId: string;
 	redirectTarget: string;
 	expiresAt: number;
+	now?: number;
 }
 
 export interface StoredOAuthState {
@@ -144,7 +148,9 @@ export interface StoredOAuthState {
 	expiresAt: number;
 }
 
-export type PutOAuthStateResult = { ok: true } | { ok: false; code: "OAUTH_STATE_EXISTS" };
+export type PutOAuthStateResult =
+	| { ok: true }
+	| { ok: false; code: "OAUTH_STATE_EXISTS" | "OAUTH_STATE_LIMIT_REACHED" };
 
 export interface PutDelegationInput {
 	publisherDid: string;
@@ -292,7 +298,10 @@ export interface StoredPublisherSession {
 
 export type CreatePublisherSessionResult =
 	| { ok: true; session: StoredPublisherSession }
-	| { ok: false; code: "PUBLISHER_SESSION_EXISTS" | "PUBLISHER_SUSPENDED" };
+	| {
+			ok: false;
+			code: "PUBLISHER_SESSION_EXISTS" | "PUBLISHER_SESSION_LIMIT_REACHED" | "PUBLISHER_SUSPENDED";
+	  };
 
 export type ValidatePublisherSessionResult =
 	| { ok: true; session: StoredPublisherSession }
@@ -397,6 +406,14 @@ function encodeBase64Url(bytes: Uint8Array): string {
 
 async function hashRefreshToken(token: string): Promise<string> {
 	const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
+	return encodeBase64Url(new Uint8Array(digest));
+}
+
+async function expirationDigest(intentId: string, expiresAt: number): Promise<string> {
+	const digest = await crypto.subtle.digest(
+		"SHA-256",
+		new TextEncoder().encode(JSON.stringify(["intent-expired", intentId, expiresAt])),
+	);
 	return encodeBase64Url(new Uint8Array(digest));
 }
 
@@ -616,9 +633,11 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		return this.#workloadPolicies.list(afterPackageSlug, limit);
 	}
 
-	createIntent(input: CreateIntentInput): CreateIntentResult {
+	async createIntent(input: CreateIntentInput): Promise<CreateIntentResult> {
 		this.#assertPublisherDid(input.publisherDid);
-		return this.#intents.create(input);
+		const result = this.#intents.create(input);
+		if (result.ok) await this.#scheduleNextAlarm(input.now ?? Date.now());
+		return result;
 	}
 
 	consumeIntentRateLimit(input: ConsumeIntentRateLimitInput): ConsumeIntentRateLimitResult {
@@ -707,7 +726,9 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		return result;
 	}
 
-	createPublisherSession(input: CreatePublisherSessionInput): CreatePublisherSessionResult {
+	async createPublisherSession(
+		input: CreatePublisherSessionInput,
+	): Promise<CreatePublisherSessionResult> {
 		this.#assertPublisherDid(input.publisherDid);
 		const now = input.now ?? Date.now();
 		if (
@@ -720,7 +741,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		) {
 			throw new PublisherStateError("PUBLISHER_SESSION_INVALID");
 		}
-		return this.ctx.storage.transactionSync(() => {
+		const result = this.ctx.storage.transactionSync(() => {
 			const owner = this.#readPublisherSessionOwner();
 			if (!owner || owner.status === "suspended") {
 				return { ok: false, code: "PUBLISHER_SUSPENDED" } as const;
@@ -733,6 +754,12 @@ export class PublisherDurableObject extends DurableObject<Env> {
 				.toArray()[0];
 			if (existing) return { ok: false, code: "PUBLISHER_SESSION_EXISTS" } as const;
 			this.ctx.storage.sql.exec("DELETE FROM publisher_sessions WHERE expires_at <= ?", now);
+			const count = this.ctx.storage.sql
+				.exec<{ count: number }>("SELECT COUNT(*) AS count FROM publisher_sessions")
+				.one().count;
+			if (count >= MAX_ACTIVE_PUBLISHER_SESSIONS) {
+				return { ok: false, code: "PUBLISHER_SESSION_LIMIT_REACHED" } as const;
+			}
 			this.ctx.storage.sql.exec(
 				`INSERT INTO publisher_sessions (
 					token_hash, csrf_hash, session_epoch, expires_at, created_at, last_seen_at
@@ -760,6 +787,8 @@ export class PublisherDurableObject extends DurableObject<Env> {
 				},
 			} as const;
 		});
+		if (result.ok) await this.#scheduleNextAlarm(now);
+		return result;
 	}
 
 	validatePublisherSession(
@@ -857,8 +886,9 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		});
 	}
 
-	putOAuthState(input: PutOAuthStateInput): PutOAuthStateResult {
+	async putOAuthState(input: PutOAuthStateInput): Promise<PutOAuthStateResult> {
 		this.#assertPublisherDid(input.publisherDid);
+		const now = input.now ?? Date.now();
 		if (
 			!HASH_PATTERN.test(input.stateHash) ||
 			!validBoundedString(input.encryptedState, MAX_CIPHERTEXT_CHARS) ||
@@ -867,11 +897,13 @@ export class PublisherDurableObject extends DurableObject<Env> {
 			!validBoundedString(input.clientKeyId, 128) ||
 			!validBoundedString(input.redirectTarget, 2048) ||
 			!Number.isSafeInteger(input.expiresAt) ||
-			input.expiresAt <= Date.now()
+			input.expiresAt <= now ||
+			!Number.isSafeInteger(now) ||
+			now < 0
 		) {
 			throw new PublisherStateError("OAUTH_STATE_INVALID");
 		}
-		return this.ctx.storage.transactionSync(() => {
+		const result = this.ctx.storage.transactionSync(() => {
 			const existing = this.ctx.storage.sql
 				.exec<{ state_hash: string }>(
 					"SELECT state_hash FROM oauth_states WHERE state_hash = ?",
@@ -879,6 +911,13 @@ export class PublisherDurableObject extends DurableObject<Env> {
 				)
 				.toArray()[0];
 			if (existing) return { ok: false, code: "OAUTH_STATE_EXISTS" } as const;
+			this.ctx.storage.sql.exec("DELETE FROM oauth_states WHERE expires_at <= ?", now);
+			const count = this.ctx.storage.sql
+				.exec<{ count: number }>("SELECT COUNT(*) AS count FROM oauth_states")
+				.one().count;
+			if (count >= MAX_ACTIVE_OAUTH_STATES) {
+				return { ok: false, code: "OAUTH_STATE_LIMIT_REACHED" } as const;
+			}
 			this.ctx.storage.sql.exec(
 				`INSERT INTO oauth_states (
 						state_hash, encrypted_state, encryption_key_version, encryption_purpose, client_key_id,
@@ -891,29 +930,31 @@ export class PublisherDurableObject extends DurableObject<Env> {
 				input.clientKeyId,
 				input.redirectTarget,
 				input.expiresAt,
-				Date.now(),
+				now,
 			);
 			this.#appendAudit(
 				"oauth-state-created",
 				"publisher",
 				input.publisherDid,
 				input.stateHash,
-				Date.now(),
+				now,
 			);
 			return { ok: true } as const;
 		});
+		if (result.ok) await this.#scheduleNextAlarm(now);
+		return result;
 	}
 
-	consumeOAuthState(
+	async consumeOAuthState(
 		publisherDid: string,
 		stateHash: string,
 		now = Date.now(),
-	): StoredOAuthState | null {
+	): Promise<StoredOAuthState | null> {
 		this.#assertPublisherDid(publisherDid);
 		if (!HASH_PATTERN.test(stateHash) || !Number.isSafeInteger(now)) {
 			throw new PublisherStateError("OAUTH_STATE_INVALID");
 		}
-		return this.ctx.storage.transactionSync(() => {
+		const result = this.ctx.storage.transactionSync(() => {
 			const row = this.ctx.storage.sql
 				.exec<OAuthStateRow>(
 					`SELECT encrypted_state, encryption_key_version, client_key_id, redirect_target, expires_at
@@ -943,6 +984,8 @@ export class PublisherDurableObject extends DurableObject<Env> {
 				expiresAt: row.expires_at,
 			};
 		});
+		await this.#scheduleNextAlarm(now);
+		return result;
 	}
 
 	putDelegation(input: PutDelegationInput): PutDelegationResult {
@@ -1589,7 +1632,29 @@ export class PublisherDurableObject extends DurableObject<Env> {
 	}
 
 	async #scheduleNextAlarm(now: number): Promise<void> {
-		const deadline = this.#publicationOperations.nextDeadline();
+		const candidates = this.ctx.storage.sql
+			.exec<{
+				operation_deadline: number | null;
+				oauth_expiry: number | null;
+				session_expiry: number | null;
+				idempotency_expiry: number | null;
+				rate_expiry: number | null;
+				intent_expiry: number | null;
+			}>(
+				`SELECT
+					(SELECT MIN(scheduled_at) FROM deadlines) AS operation_deadline,
+					(SELECT MIN(expires_at) FROM oauth_states) AS oauth_expiry,
+					(SELECT MIN(expires_at) FROM publisher_sessions) AS session_expiry,
+					(SELECT MIN(expires_at) FROM intent_idempotency) AS idempotency_expiry,
+					(SELECT MIN(expires_at) FROM intent_rate_idempotency) AS rate_expiry,
+					(SELECT MIN(expires_at) FROM intents
+					 WHERE state IN ('received', 'verifying', 'verified', 'ready')) AS intent_expiry`,
+			)
+			.one();
+		const deadlines = Object.values(candidates).filter(
+			(value): value is number => typeof value === "number",
+		);
+		const deadline = deadlines.length === 0 ? null : Math.min(...deadlines);
 		if (deadline === null) {
 			await this.ctx.storage.deleteAlarm();
 			return;
@@ -1600,10 +1665,29 @@ export class PublisherDurableObject extends DurableObject<Env> {
 	override async alarm(): Promise<void> {
 		const now = Date.now();
 		this.#publicationOperations.recoverExpired(now);
+		const publisherDid = this.#objectName;
+		if (publisherDid !== undefined) {
+			for (const intent of this.#intents.listExpirable(now, MAINTENANCE_BATCH_SIZE)) {
+				this.#intents.transition({
+					publisherDid,
+					intentId: intent.id,
+					expectedState: intent.state,
+					expectedGeneration: intent.stateGeneration,
+					toState: "expired",
+					transitionDigest: await expirationDigest(intent.id, intent.expiresAt),
+					actorRealm: "system",
+					actorIdentity: "release-service",
+					reasonCode: "INTENT_EXPIRED",
+					stateDataJson: '{"reasonCode":"INTENT_EXPIRED"}',
+					now,
+				});
+			}
+		}
 		this.ctx.storage.transactionSync(() => {
 			this.ctx.storage.sql.exec("DELETE FROM oauth_states WHERE expires_at <= ?", now);
 			this.ctx.storage.sql.exec("DELETE FROM publisher_sessions WHERE expires_at <= ?", now);
 			this.ctx.storage.sql.exec("DELETE FROM intent_idempotency WHERE expires_at <= ?", now);
+			this.ctx.storage.sql.exec("DELETE FROM intent_rate_idempotency WHERE expires_at <= ?", now);
 		});
 		await this.#scheduleNextAlarm(now);
 	}

--- a/apps/release-service/src/publisher-do/workload-policy.ts
+++ b/apps/release-service/src/publisher-do/workload-policy.ts
@@ -74,7 +74,7 @@ function normalizeValues(
 	if (normalized.some((value) => typeof value !== "string" || !validate(value))) {
 		throw new WorkloadPolicyError();
 	}
-	normalized.sort((left, right) => left.localeCompare(right));
+	normalized.sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
 	if (new Set(normalized).size !== normalized.length) throw new WorkloadPolicyError();
 	return normalized;
 }

--- a/apps/release-service/src/publishing/workflow.ts
+++ b/apps/release-service/src/publishing/workflow.ts
@@ -39,7 +39,7 @@ const RECONCILIATION_STEP_CONFIG = {
 
 export interface PublicationWorkflowOutput {
 	intentId: string;
-	state: "conflict" | "failed" | "invalid" | "published" | "ready";
+	state: "conflict" | "expired" | "failed" | "invalid" | "published" | "ready";
 	reasonCode: string | null;
 }
 
@@ -55,6 +55,7 @@ type TransitionSummary =
 type AttemptResult =
 	| { state: "published"; uri: string; cid: string }
 	| { state: "reconciling" }
+	| { state: "expired" }
 	| { state: "blocked"; reasonCode: string }
 	| { state: "failed"; reasonCode: string };
 
@@ -212,6 +213,21 @@ export async function publishVerifiedIntent(
 				if (current?.state === "reconciling") return { state: "reconciling" };
 				if (!current || current.state !== "ready") {
 					return { state: "failed", reasonCode: "INTENT_NOT_READY" };
+				}
+				if (current.expiresAt <= Date.now()) {
+					const expired = await transition(publisher, {
+						publisherDid,
+						intentId: originalIntent.id,
+						expectedState: "ready",
+						expectedGeneration: current.stateGeneration,
+						toState: "expired",
+						transitionDigest: await digest(["expired", originalIntent.id, current.expiresAt]),
+						actorRealm: "system",
+						actorIdentity: "release-service",
+						reasonCode: "INTENT_EXPIRED",
+						stateDataJson: JSON.stringify({ reasonCode: "INTENT_EXPIRED" }),
+					});
+					return expired.ok ? { state: "expired" } : { state: "failed", reasonCode: expired.code };
 				}
 				const permit = await control.issuePublicationPermit(
 					publisherDid,
@@ -394,6 +410,9 @@ export async function publishVerifiedIntent(
 		);
 		if (attemptResult.state === "published") {
 			return { intentId: originalIntent.id, state: "published", reasonCode: null };
+		}
+		if (attemptResult.state === "expired") {
+			return { intentId: originalIntent.id, state: "expired", reasonCode: "INTENT_EXPIRED" };
 		}
 		if (attemptResult.state === "failed") {
 			return { intentId: originalIntent.id, state: "failed", reasonCode: attemptResult.reasonCode };

--- a/apps/release-service/src/workflows/publisher-archive.ts
+++ b/apps/release-service/src/workflows/publisher-archive.ts
@@ -81,9 +81,13 @@ export async function startPublisherArchiveWorkflow(
 		try {
 			const existing = await workflow.get(id);
 			const status = await existing.status();
-			return status.status === "unknown"
-				? { ok: false, code: "ARCHIVE_WORKFLOW_UNAVAILABLE" }
-				: { ok: true, workflowId: id, created: false };
+			if (status.status === "unknown") {
+				return { ok: false, code: "ARCHIVE_WORKFLOW_UNAVAILABLE" };
+			}
+			if (status.status === "errored" || status.status === "terminated") {
+				await existing.restart();
+			}
+			return { ok: true, workflowId: id, created: false };
 		} catch {
 			return { ok: false, code: "ARCHIVE_WORKFLOW_UNAVAILABLE" };
 		}

--- a/apps/release-service/test/approval-digest.test.ts
+++ b/apps/release-service/test/approval-digest.test.ts
@@ -109,6 +109,13 @@ describe("approval digest", () => {
 		);
 	});
 
+	it("uses ordinal ordering for canonical approver DIDs", async () => {
+		const encoded = await encodeAwaitingApprovalState(EVIDENCE, ["did:plc:a", "did:plc:B"]);
+		const parsed = JSON.parse(encoded) as { approverDids: string[] };
+
+		expect(parsed.approverDids).toEqual(["did:plc:B", "did:plc:a"]);
+	});
+
 	it("rejects a substituted evidence digest", async () => {
 		const encoded = await encodeAwaitingApprovalState(EVIDENCE, ["did:plc:approver"]);
 		const substituted = encoded.replace(await computeApprovalEvidenceDigest(EVIDENCE), DIGEST_A);

--- a/apps/release-service/test/approver-do.test.ts
+++ b/apps/release-service/test/approver-do.test.ts
@@ -104,6 +104,33 @@ describe("ApproverDurableObject", () => {
 		expect(JSON.stringify(persisted.audit)).not.toContain("encrypted-identity-state");
 	});
 
+	it("bounds retained identity transaction tombstones", async () => {
+		const stub = approver();
+		const now = 1_800_000_000_000;
+		for (let index = 0; index < 30; index += 1) {
+			const stateHash = String(index).padStart(43, "a");
+			await stub.putIdentityTransaction({
+				approverDid: APPROVER_DID,
+				stateHash,
+				encryptedState: "encrypted-identity-state",
+				encryptionKeyVersion: 1,
+				clientKeyId: "assertion-1",
+				redirectTarget: "/approver",
+				expiresAt: now + 60_000,
+				now,
+			});
+			await stub.consumeIdentityTransaction(APPROVER_DID, stateHash, now + 1);
+		}
+
+		await expect(
+			runInDurableObject(stub, (_instance, state) =>
+				state.storage.sql
+					.exec<{ count: number }>("SELECT COUNT(*) AS count FROM identity_transactions")
+					.one(),
+			),
+		).resolves.toEqual({ count: 1 });
+	});
+
 	it("rejects expired identity proof state without returning encrypted material", async () => {
 		const stub = approver();
 		const now = 1_800_000_000_000;
@@ -311,6 +338,30 @@ describe("ApproverDurableObject", () => {
 		await expect(
 			stub.consumeChallenge(APPROVER_DID, CHALLENGE_HASH, "approval", now + 3),
 		).resolves.toEqual({ ok: false, code: "CHALLENGE_CONSUMED" });
+	});
+
+	it("bounds retained challenge tombstones while issuing new challenges", async () => {
+		const stub = approver();
+		const now = 1_800_000_000_000;
+		for (let index = 0; index < 75; index += 1) {
+			const challengeHash = String(index).padStart(43, "a");
+			await stub.createChallenge(APPROVER_DID, {
+				challengeHash,
+				kind: "registration",
+				context: "registration-context",
+				expiresAt: now + 60_000,
+				now,
+			});
+			await stub.consumeChallenge(APPROVER_DID, challengeHash, "registration", now + 1);
+		}
+
+		await expect(
+			runInDurableObject(stub, (_instance, state) =>
+				state.storage.sql
+					.exec<{ count: number }>("SELECT COUNT(*) AS count FROM approval_challenges")
+					.one(),
+			),
+		).resolves.toEqual({ count: 1 });
 	});
 
 	it("invalidates outstanding intent challenges on credential revocation", async () => {

--- a/apps/release-service/test/publisher-archive-routes.test.ts
+++ b/apps/release-service/test/publisher-archive-routes.test.ts
@@ -1,6 +1,6 @@
 import { abortAllDurableObjects, reset } from "cloudflare:test";
 import { env } from "cloudflare:workers";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AccessActor } from "../src/access/auth.js";
 import {
@@ -57,10 +57,35 @@ function prepareRestoreRequest(): Request {
 }
 
 afterEach(async () => {
+	vi.restoreAllMocks();
 	await reset();
 });
 
 describe("publisher operations archive", () => {
+	it("rejects an oversized conflicting snapshot without reading its body", async () => {
+		const configuration = await loadConfiguration(TEST_BINDINGS);
+		const text = vi.fn(async () => {
+			throw new Error("oversized body must not be read");
+		});
+		// @ts-expect-error - conditional R2 writes return null when the precondition fails
+		vi.spyOn(env.OPERATIONS_ARCHIVE, "put").mockResolvedValue(null);
+		vi.spyOn(env.OPERATIONS_ARCHIVE, "get").mockResolvedValue({
+			size: 1_500_001,
+			text,
+		} as unknown as R2ObjectBody);
+
+		const response = await handleArchivePublisher(
+			request(null, 0),
+			"oversized-conflict",
+			configuration,
+			{ publisherDid: PUBLISHER_DID },
+			ADMIN,
+		);
+
+		expect(response.status).toBe(409);
+		expect(text).not.toHaveBeenCalled();
+	});
+
 	it("writes resumable encrypted snapshots and append-only sanitized audit pages", async () => {
 		const configuration = await loadConfiguration(TEST_BINDINGS);
 		const publisher = env.PUBLISHER_DO.getByName(PUBLISHER_DID);

--- a/apps/release-service/test/publisher-archive-workflow.test.ts
+++ b/apps/release-service/test/publisher-archive-workflow.test.ts
@@ -1,6 +1,6 @@
 import { reset } from "cloudflare:test";
 import { env } from "cloudflare:workers";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AccessActor } from "../src/access/auth.js";
 import { handleStartPublisherArchive } from "../src/backup/workflow-route.js";
@@ -53,6 +53,28 @@ describe("PublisherArchiveWorkflow", () => {
 				created: true,
 			},
 		});
+	});
+
+	it("restarts an errored deterministic archive instance", async () => {
+		const restart = vi.fn(async () => undefined);
+		const workflow = {
+			create: vi.fn(async () => {
+				throw new Error("instance already exists");
+			}),
+			get: vi.fn(async () => ({
+				status: async () => ({ status: "errored" }),
+				restart,
+			})),
+		} as unknown as Parameters<typeof startPublisherArchiveWorkflow>[0];
+
+		await expect(
+			startPublisherArchiveWorkflow(workflow, {
+				publisherDid: PUBLISHER_DID,
+				archiveId: ARCHIVE_ID,
+				actorIdentity: "admin@example.com",
+			}),
+		).resolves.toMatchObject({ ok: true, created: false });
+		expect(restart).toHaveBeenCalledOnce();
 	});
 
 	it("resumes bounded pages to an encrypted completion manifest", async () => {

--- a/apps/release-service/test/publisher-do.test.ts
+++ b/apps/release-service/test/publisher-do.test.ts
@@ -1,4 +1,9 @@
-import { abortAllDurableObjects, reset, runInDurableObject } from "cloudflare:test";
+import {
+	abortAllDurableObjects,
+	reset,
+	runDurableObjectAlarm,
+	runInDurableObject,
+} from "cloudflare:test";
 import { env } from "cloudflare:workers";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -75,6 +80,31 @@ describe("PublisherDurableObject", () => {
 		await expect(stub.revokePublisherSession(DID, secondHash)).resolves.toBe(false);
 	});
 
+	it("limits active publisher sessions per shard", async () => {
+		const stub = publisher();
+		const now = 1_800_000_000_000;
+		for (let index = 0; index < 20; index += 1) {
+			await expect(
+				stub.createPublisherSession({
+					publisherDid: DID,
+					tokenHash: String(index).padStart(43, "A"),
+					csrfHash: SESSION_CSRF_HASH,
+					expiresAt: now + 60_000,
+					now,
+				}),
+			).resolves.toMatchObject({ ok: true });
+		}
+		await expect(
+			stub.createPublisherSession({
+				publisherDid: DID,
+				tokenHash: "Z".repeat(43),
+				csrfHash: SESSION_CSRF_HASH,
+				expiresAt: now + 60_000,
+				now,
+			}),
+		).resolves.toEqual({ ok: false, code: "PUBLISHER_SESSION_LIMIT_REACHED" });
+	});
+
 	it("invalidates all publisher sessions by epoch and blocks suspended publishers", async () => {
 		const stub = publisher();
 		const now = 1_800_000_000_000;
@@ -102,6 +132,75 @@ describe("PublisherDurableObject", () => {
 				now,
 			}),
 		).resolves.toEqual({ ok: false, code: "PUBLISHER_SUSPENDED" });
+	});
+
+	it("schedules one alarm for publisher state expiry and expires pending intents", async () => {
+		const stub = publisher();
+		const now = Date.now();
+		await stub.putWorkloadPolicy({
+			publisherDid: DID,
+			packageSlug: "gallery",
+			repository: "example/gallery",
+			repositoryId: "123",
+			repositoryOwnerId: "456",
+			workflowRef: "example/gallery/.github/workflows/release.yml@refs/heads/main",
+			allowedRefs: [],
+			allowedEnvironments: [],
+			active: true,
+			expectedVersion: null,
+			now,
+		});
+		await stub.createPublisherSession({
+			publisherDid: DID,
+			tokenHash: SESSION_TOKEN_HASH,
+			csrfHash: SESSION_CSRF_HASH,
+			expiresAt: now + 40_000,
+			now,
+		});
+		await stub.putOAuthState({
+			publisherDid: DID,
+			stateHash: STATE_HASH,
+			encryptedState: "encrypted-oauth-state",
+			encryptionKeyVersion: 2,
+			encryptionPurpose: "oauth-console-transaction",
+			clientKeyId: "assertion-1",
+			redirectTarget: "/publisher",
+			expiresAt: now + 30_000,
+			now,
+		});
+		await stub.createIntent({
+			publisherDid: DID,
+			intentId: "01JABCDEFGHJKMNPQRSTVWXYZ0",
+			packageSlug: "gallery",
+			version: "1.2.3",
+			workloadPolicyVersion: 1,
+			workloadIdentityDigest: "A".repeat(43),
+			workloadIdempotencyDigest: "I".repeat(43),
+			idempotencyKey: "publisher-alarm-intent-0001",
+			requestDigest: "B".repeat(43),
+			workloadIdentityJson: '{"issuer":"github-actions"}',
+			releaseInputJson: '{"release":{"package":"gallery","version":"1.2.3"}}',
+			expiresAt: now + 20_000,
+			now,
+		});
+
+		await expect(
+			runInDurableObject(stub, (_instance, state) => state.storage.getAlarm()),
+		).resolves.toBe(now + 20_000);
+		await runInDurableObject(stub, (_instance, state) => {
+			state.storage.sql.exec("UPDATE intents SET expires_at = ?", now - 1);
+			state.storage.sql.exec("UPDATE oauth_states SET expires_at = ?", now - 1);
+			state.storage.sql.exec("UPDATE publisher_sessions SET expires_at = ?", now - 1);
+		});
+		await runDurableObjectAlarm(stub);
+
+		await expect(stub.getIntent(DID, "01JABCDEFGHJKMNPQRSTVWXYZ0")).resolves.toMatchObject({
+			state: "expired",
+		});
+		await expect(stub.consumeOAuthState(DID, STATE_HASH, now)).resolves.toBeNull();
+		await expect(
+			stub.validatePublisherSession(DID, SESSION_TOKEN_HASH, null, now),
+		).resolves.toEqual({ ok: false, code: "PUBLISHER_SESSION_INVALID" });
 	});
 
 	it("isolates publisher, repository, and workload admission budgets", async () => {
@@ -290,6 +389,39 @@ describe("PublisherDurableObject", () => {
 			},
 		]);
 		expect(JSON.stringify(auditRows)).not.toContain("encrypted-oauth-state");
+	});
+
+	it("limits active publisher OAuth states per shard", async () => {
+		const stub = publisher();
+		const now = 1_800_000_000_000;
+		for (let index = 0; index < 20; index += 1) {
+			await expect(
+				stub.putOAuthState({
+					publisherDid: DID,
+					stateHash: String(index).padStart(43, "a"),
+					encryptedState: "encrypted-oauth-state",
+					encryptionKeyVersion: 2,
+					encryptionPurpose: "oauth-console-transaction",
+					clientKeyId: "assertion-1",
+					redirectTarget: "/publisher",
+					expiresAt: now + 60_000,
+					now,
+				}),
+			).resolves.toEqual({ ok: true });
+		}
+		await expect(
+			stub.putOAuthState({
+				publisherDid: DID,
+				stateHash: "Z".repeat(43),
+				encryptedState: "encrypted-oauth-state",
+				encryptionKeyVersion: 2,
+				encryptionPurpose: "oauth-console-transaction",
+				clientKeyId: "assertion-1",
+				redirectTarget: "/publisher",
+				expiresAt: now + 60_000,
+				now,
+			}),
+		).resolves.toEqual({ ok: false, code: "OAUTH_STATE_LIMIT_REACHED" });
 	});
 
 	it("rejects duplicate state and deletes expired state on consume", async () => {

--- a/apps/release-service/test/publisher-intent-state.test.ts
+++ b/apps/release-service/test/publisher-intent-state.test.ts
@@ -257,9 +257,9 @@ describe("publisher release intents", () => {
 			code: "PUBLISHER_SUSPENDED",
 		});
 		await runInDurableObject(stub, async (instance) => {
-			expect(() =>
+			await expect(
 				instance.createIntent(intent({ workloadIdentityJson: '{ "runId": "100" }' })),
-			).toThrowError(expect.objectContaining({ code: "INTENT_INPUT_INVALID" }));
+			).rejects.toMatchObject({ code: "INTENT_INPUT_INVALID" });
 		});
 	});
 });

--- a/apps/release-service/test/release-intent-workflow.test.ts
+++ b/apps/release-service/test/release-intent-workflow.test.ts
@@ -547,6 +547,72 @@ describe("ReleaseIntentWorkflow", () => {
 		expect(createAttempts).toBe(1);
 	});
 
+	it("expires a ready intent instead of publishing it after a pause", async () => {
+		let paused = false;
+		let createAttempts = 0;
+		vi.stubGlobal(
+			"fetch",
+			workflowNetwork({
+				onAuthorizationMetadata: async () => {
+					if (paused) return;
+					paused = true;
+					await env.SERVICE_CONTROL_DO.getByName(SERVICE_CONTROL_OBJECT_NAME).setServiceMode({
+						actor: CONTROL_ACTOR,
+						idempotencyKey: "publication-expiry-pause",
+						requestDigest: "E".repeat(43),
+						mode: "publication-paused",
+						reasonCode: "TEST_PAUSE",
+					});
+				},
+				onCreateRecord: () => {
+					createAttempts += 1;
+					return Response.json({ uri: CREATED_URI, cid: CREATED_CID });
+				},
+			}),
+		);
+		await createVerifyingIntent();
+		await using introspector = await introspectWorkflowInstance(
+			env.RELEASE_INTENT_WORKFLOW,
+			INTENT_ID,
+		);
+		await env.RELEASE_INTENT_WORKFLOW.create({
+			id: INTENT_ID,
+			params: { publisherDid: PUBLISHER_DID, intentId: INTENT_ID },
+		});
+		await introspector.waitForStatus("complete");
+		await runInDurableObject(env.PUBLISHER_DO.getByName(PUBLISHER_DID), (_instance, state) => {
+			state.storage.sql.exec(
+				"UPDATE intents SET expires_at = ? WHERE id = ?",
+				Date.now() - 1,
+				INTENT_ID,
+			);
+		});
+		await env.SERVICE_CONTROL_DO.getByName(SERVICE_CONTROL_OBJECT_NAME).setServiceMode({
+			actor: CONTROL_ACTOR,
+			idempotencyKey: "publication-expiry-active",
+			requestDigest: "F".repeat(43),
+			mode: "active",
+			reasonCode: null,
+		});
+
+		await expect(
+			restartReleaseIntentWorkflow(
+				env.RELEASE_INTENT_WORKFLOW,
+				env.PUBLISHER_DO,
+				PUBLISHER_DID,
+				INTENT_ID,
+			),
+		).resolves.toEqual({ ok: true, workflowId: INTENT_ID, restarted: true });
+		await introspector.waitForStepResult({ name: "recovery-policy-decision" });
+		await introspector.waitForStatus("complete");
+		await expect(introspector.getOutput()).resolves.toEqual({
+			intentId: INTENT_ID,
+			state: "expired",
+			reasonCode: "INTENT_EXPIRED",
+		});
+		expect(createAttempts).toBe(0);
+	});
+
 	it("restarts an errored reconciliation and accepts the exact authoritative record", async () => {
 		let reconciliationAvailable = false;
 		let createAttempts = 0;


### PR DESCRIPTION
## What does this PR do?

Hardens release-service state parsing, pagination, archive recovery, and workflow retry bounds found during adversarial review. Malformed or oversized persisted state now fails with bounded, explicit errors.

Depends on #2726. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
