### PR TITLE
fix(release): refresh delegated action bundle

### DIFF
--- a/apps/release-action/dist/index.js
+++ b/apps/release-action/dist/index.js
@@ -889,6 +889,7 @@ const API_ERROR_CODES = {
 	APPROVAL_INVALID: true,
 	APPROVER_SESSION_INVALID: true,
 	APPROVER_SUSPENDED: true,
+	ARCHIVE_OPERATION_FAILED: true,
 	AUTH_INVALID: true,
 	CONFIGURATION_ERROR: true,
 	CREDENTIAL_LIMIT_REACHED: true,
@@ -896,6 +897,7 @@ const API_ERROR_CODES = {
 	CREDENTIAL_REVOKED: true,
 	CSRF_INVALID: true,
 	DELEGATION_REQUIRED: true,
+	ENCRYPTION_OPERATION_FAILED: true,
 	IDEMPOTENCY_KEY_INVALID: true,
 	IDEMPOTENCY_CONFLICT: true,
 	INTERNAL_ERROR: true,
@@ -911,11 +913,13 @@ const API_ERROR_CODES = {
 	PUBLISHER_SESSION_INVALID: true,
 	PUBLISHER_SUSPENDED: true,
 	RELEASE_EXISTS: true,
+	RESTORE_OPERATION_FAILED: true,
 	SERVICE_PAUSED: true,
 	SERVICE_UNAVAILABLE: true,
 	VERSION_RESERVED: true,
 	WORKFLOW_UNAVAILABLE: true,
-	WORKLOAD_NOT_ALLOWED: true
+	WORKLOAD_NOT_ALLOWED: true,
+	WORKLOAD_RATE_LIMITED: true
 };
 const RETRYABLE_ERROR_CODES = new Set([
 	"CONFIGURATION_ERROR",
@@ -925,7 +929,8 @@ const RETRYABLE_ERROR_CODES = new Set([
 	"PUBLISHER_SUSPENDED",
 	"SERVICE_PAUSED",
 	"SERVICE_UNAVAILABLE",
-	"WORKFLOW_UNAVAILABLE"
+	"WORKFLOW_UNAVAILABLE",
+	"WORKLOAD_RATE_LIMITED"
 ]);
 const INTENT_STATES = {
 	received: true,
@@ -971,12 +976,13 @@ function isApiErrorCode(value) {
 function serviceOrigin(value) {
 	try {
 		const url = new URL(value);
-		if (url.protocol !== "https:" || url.username !== "" || url.password !== "" || url.pathname !== "/" || url.search !== "" || url.hash !== "" || url.origin !== value) throw new Error("invalid origin");
+		const loopback = url.protocol === "http:" && (url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]");
+		if (url.protocol !== "https:" && !loopback || url.username !== "" || url.password !== "" || url.pathname !== "/" || url.search !== "" || url.hash !== "" || url.origin !== value) throw new Error("invalid origin");
 		return url.origin;
 	} catch {
 		throw new ReleaseServiceError({
 			code: "CLIENT_RESPONSE_INVALID",
-			message: "Release service URL must be an HTTPS origin"
+			message: "Release service URL must be an HTTPS origin or a loopback development origin"
 		});
 	}
 }
@@ -1032,7 +1038,7 @@ function parseIntent(value, serviceUrl) {
 		} catch {
 			throw invalidResponse();
 		}
-		if (parsedApproval.origin !== serviceUrl || parsedApproval.protocol !== "https:") throw invalidResponse();
+		if (parsedApproval.origin !== serviceUrl) throw invalidResponse();
 	}
 	return {
 		id,
@@ -1172,7 +1178,7 @@ var BaseReleaseServiceClient = class {
 	fetch;
 	constructor(options) {
 		this.serviceUrl = serviceOrigin(options.serviceUrl);
-		this.fetch = options.fetch ?? globalThis.fetch;
+		this.fetch = options.fetch ?? globalThis.fetch.bind(globalThis);
 	}
 	async call(path, init, parse) {
 		let response;


### PR DESCRIPTION
## What does this PR do?

Regenerates the checked-in delegated release Action bundle from the hardened source so GitHub runners execute the reviewed implementation.

Depends on #2728. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
