### PR TITLE
feat(release-service): add dry-run admission

### DIFF
--- a/.changeset/delegated-release-client.md
+++ b/.changeset/delegated-release-client.md
@@ -7,4 +7,4 @@ Adds typed clients for the experimental delegated release service. `ReleaseServi
 
 Both clients validate response envelopes and return stable `ReleaseServiceError` codes with retry metadata. Mutation helpers require idempotency keys, and workload polling requests a fresh token from the configured provider for each call.
 
-The plugin CLI adds `emdash-plugin release submit`, `release status`, and `release cancel` for GitHub Actions jobs. The commands request audience-bound OIDC tokens from the runner, support JSON output, and use the GitHub run identity as the default idempotency key.
+The plugin CLI adds `emdash-plugin release dry-run`, `release submit`, `release status`, and `release cancel` for GitHub Actions jobs. Dry-run verifies workload admission without creating an intent, consuming rate budget, or reserving a version. The commands request audience-bound OIDC tokens from the runner, support JSON output, and use the GitHub run identity as the default idempotency key where a mutation occurs.

--- a/apps/release-service/src/intents/routes.ts
+++ b/apps/release-service/src/intents/routes.ts
@@ -58,6 +58,10 @@ export interface SubmitIntentDependencies {
 	startWorkflow?: typeof startReleaseIntentWorkflow;
 }
 
+export interface DryRunIntentDependencies {
+	keyResolver?: JWTVerifyGetKey;
+}
+
 function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
 	const keys = Object.keys(value);
 	return keys.length === expected.length && keys.every((key) => expected.includes(key));
@@ -414,6 +418,71 @@ export async function handleSubmitReleaseIntent(
 			},
 			requestId,
 			created.replayed ? 200 : 202,
+		);
+	} catch (error) {
+		return routeFailure(error, requestId);
+	}
+}
+
+export async function handleDryRunReleaseIntent(
+	request: Request,
+	requestId: string,
+	configuration: ServiceConfiguration,
+	dependencies: DryRunIntentDependencies = {},
+): Promise<Response> {
+	try {
+		const identity = await authenticateWorkload(request, configuration, dependencies.keyResolver);
+		const body = await readJsonObject(request, MAX_INTENT_BODY_BYTES);
+		if (
+			!hasExactKeys(body, ["publisherDid", "packageSlug", "version", "release"]) ||
+			typeof body["publisherDid"] !== "string" ||
+			!isDid(body["publisherDid"]) ||
+			typeof body["packageSlug"] !== "string" ||
+			!PACKAGE_SLUG_PATTERN.test(body["packageSlug"]) ||
+			typeof body["version"] !== "string" ||
+			!VERSION_PATTERN.test(body["version"])
+		) {
+			throw new ApiError("INVALID_REQUEST", 400, "Invalid release intent request");
+		}
+		const release = safeParse(PackageRelease.mainSchema, body["release"]);
+		if (
+			!release.ok ||
+			release.value.package !== body["packageSlug"] ||
+			release.value.version !== body["version"]
+		) {
+			throw new ApiError("INVALID_REQUEST", 400, "Invalid release intent request");
+		}
+		const publisherDid = body["publisherDid"];
+		const admission = await env.SERVICE_CONTROL_DO.getByName(
+			SERVICE_CONTROL_OBJECT_NAME,
+		).getAdmissionDecision(publisherDid);
+		if (!admission.allowed) {
+			throw new ApiError(
+				admission.code === "PUBLISHER_SUSPENDED" ? "PUBLISHER_SUSPENDED" : "SERVICE_PAUSED",
+				503,
+				admission.code === "PUBLISHER_SUSPENDED"
+					? "Publisher is suspended"
+					: "Release admission is paused",
+			);
+		}
+		const policy = await env.PUBLISHER_DO.getByName(publisherDid).getWorkloadPolicyIfInitialized(
+			publisherDid,
+			release.value.package,
+		);
+		if (!policy || !evaluateWorkloadPolicy(identity, policy).ok) {
+			throw new ApiError("WORKLOAD_NOT_ALLOWED", 403, "Workload is not authorized");
+		}
+		return apiSuccess(
+			{
+				allowed: true,
+				publisherDid,
+				packageSlug: release.value.package,
+				version: release.value.version,
+				workloadPolicyVersion: policy.stateVersion,
+				workloadIdentityDigest: await digestWorkloadIdentity(identity),
+				requestDigest: await digest(["release-intent", 1, publisherDid, release.value]),
+			},
+			requestId,
 		);
 	} catch (error) {
 		return routeFailure(error, requestId);

--- a/apps/release-service/src/publisher-do/publisher-do.ts
+++ b/apps/release-service/src/publisher-do/publisher-do.ts
@@ -624,6 +624,21 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		return this.#workloadPolicies.get(packageSlug);
 	}
 
+	getWorkloadPolicyIfInitialized(
+		publisherDid: string,
+		packageSlug: string,
+	): StoredWorkloadPolicy | null {
+		this.#assertPublisherObjectName(publisherDid);
+		const owner = this.ctx.storage.sql
+			.exec<PublisherRow>("SELECT did FROM publisher WHERE id = 1")
+			.toArray()[0];
+		if (!owner) return null;
+		if (owner.did !== publisherDid) {
+			throw new PublisherStateError("PUBLISHER_DID_MISMATCH");
+		}
+		return this.#workloadPolicies.get(packageSlug);
+	}
+
 	listWorkloadPolicies(
 		publisherDid: string,
 		afterPackageSlug: string | null,

--- a/apps/release-service/src/routes.ts
+++ b/apps/release-service/src/routes.ts
@@ -37,6 +37,7 @@ import {
 import { handleListDirectory } from "./directory/routes.js";
 import {
 	handleCancelReleaseIntent,
+	handleDryRunReleaseIntent,
 	handleGetReleaseIntent,
 	handleSubmitReleaseIntent,
 	matchIntentCancelPath,
@@ -121,6 +122,12 @@ export const ROUTES = Object.freeze([
 		path: "/v1/release-intents",
 		handler: (request, requestId, configuration) =>
 			handleSubmitReleaseIntent(request, requestId, configuration),
+	},
+	{
+		method: "POST",
+		path: "/v1/release-intents/dry-run",
+		handler: (request, requestId, configuration) =>
+			handleDryRunReleaseIntent(request, requestId, configuration),
 	},
 	{
 		method: "GET",

--- a/apps/release-service/test/intent-routes.test.ts
+++ b/apps/release-service/test/intent-routes.test.ts
@@ -1,5 +1,5 @@
 import type { PackageRelease } from "@emdash-cms/registry-lexicons";
-import { reset } from "cloudflare:test";
+import { reset, runInDurableObject } from "cloudflare:test";
 import { env } from "cloudflare:workers";
 import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT, type JWTVerifyGetKey } from "jose";
 import { ulid } from "ulidx";
@@ -10,6 +10,7 @@ import { loadConfiguration } from "../src/config.js";
 import { SERVICE_CONTROL_OBJECT_NAME } from "../src/control-do/service-control-do.js";
 import {
 	handleCancelReleaseIntent,
+	handleDryRunReleaseIntent,
 	handleGetReleaseIntent,
 	handleSubmitReleaseIntent,
 } from "../src/intents/routes.js";
@@ -121,6 +122,75 @@ afterEach(async () => {
 });
 
 describe("release intent API", () => {
+	it("dry-runs admission without reserving, rate limiting, or starting a Workflow", async () => {
+		await putPolicy();
+		const configuration = await loadConfiguration(TEST_BINDINGS);
+		const response = await handleDryRunReleaseIntent(
+			request("/v1/release-intents/dry-run", await token(), {
+				method: "POST",
+				body: {
+					publisherDid: PUBLISHER_DID,
+					packageSlug: "gallery",
+					version: "1.2.3",
+					release: release(),
+				},
+			}),
+			"request-dry-run",
+			configuration,
+			{ keyResolver },
+		);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			data: {
+				allowed: true,
+				publisherDid: PUBLISHER_DID,
+				packageSlug: "gallery",
+				version: "1.2.3",
+				workloadPolicyVersion: 1,
+				workloadIdentityDigest: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+				requestDigest: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+			},
+		});
+		await expect(
+			runInDurableObject(env.PUBLISHER_DO.getByName(PUBLISHER_DID), (_instance, state) =>
+				state.storage.sql
+					.exec<{ intents: number; reservations: number; rate_windows: number }>(
+						`SELECT
+							(SELECT COUNT(*) FROM intents) AS intents,
+							(SELECT COUNT(*) FROM release_reservations) AS reservations,
+							(SELECT COUNT(*) FROM intent_rate_windows) AS rate_windows`,
+					)
+					.one(),
+			),
+		).resolves.toEqual({ intents: 0, reservations: 0, rate_windows: 0 });
+	});
+
+	it("does not initialize an unknown publisher shard during dry-run", async () => {
+		const publisherDid = "did:plc:unknownpublisher";
+		const response = await handleDryRunReleaseIntent(
+			request("/v1/release-intents/dry-run", await token(), {
+				method: "POST",
+				body: {
+					publisherDid,
+					packageSlug: "gallery",
+					version: "1.2.3",
+					release: release(),
+				},
+			}),
+			"request-unknown-dry-run",
+			await loadConfiguration(TEST_BINDINGS),
+			{ keyResolver },
+		);
+
+		expect(response.status).toBe(403);
+		await expect(
+			runInDurableObject(env.PUBLISHER_DO.getByName(publisherDid), (_instance, state) =>
+				state.storage.sql.exec<{ count: number }>("SELECT COUNT(*) AS count FROM publisher").one(),
+			),
+		).resolves.toEqual({ count: 0 });
+	});
+
 	it("submits asynchronously, replays with a fresh matching token, and never stores the token", async () => {
 		await putPolicy();
 		const configuration = await loadConfiguration(TEST_BINDINGS);

--- a/packages/plugin-cli/src/commands/release.ts
+++ b/packages/plugin-cli/src/commands/release.ts
@@ -1,10 +1,14 @@
-import type { ReleaseIntentResource } from "@emdash-cms/registry-client/release-service";
+import type {
+	DryRunReleaseIntentResult,
+	ReleaseIntentResource,
+} from "@emdash-cms/registry-client/release-service";
 import { defineCommand } from "citty";
 import { consola } from "consola";
 import pc from "picocolors";
 
 import {
 	cancelDelegatedReleaseIntent,
+	dryRunDelegatedRelease,
 	getDelegatedReleaseIntent,
 	submitDelegatedRelease,
 } from "../release-service/operations.js";
@@ -50,6 +54,16 @@ function printIntent(intent: ReleaseIntentResource, json: boolean): void {
 		console.log(`  CID:    ${intent.result.cid}`);
 	}
 	if (intent.reasonCode) console.log(`  Reason: ${intent.reasonCode}`);
+}
+
+function printDryRun(result: DryRunReleaseIntentResult, json: boolean): void {
+	if (json) {
+		console.log(JSON.stringify(result, null, 2));
+		return;
+	}
+	console.log(`${pc.bold(result.packageSlug)} ${pc.dim(result.version)}`);
+	console.log("  Admission: allowed");
+	console.log(`  Policy:    ${result.workloadPolicyVersion}`);
 }
 
 const commonArgs = {
@@ -133,6 +147,28 @@ export const releaseSubmitCommand = defineCommand({
 	},
 });
 
+export const releaseDryRunCommand = defineCommand({
+	meta: {
+		name: "dry-run",
+		description: "Validate delegated release admission without creating an intent",
+	},
+	args: {
+		"release-file": {
+			type: "positional",
+			description: "Package release record JSON file",
+			required: true,
+		},
+		...commonArgs,
+	},
+	async run({ args }) {
+		const result = await dryRunDelegatedRelease({
+			...requiredTarget(args),
+			releaseFile: args["release-file"],
+		});
+		printDryRun(result, args.json);
+	},
+});
+
 export const releaseStatusCommand = defineCommand({
 	meta: { name: "status", description: "Read a delegated release intent" },
 	args: {
@@ -179,6 +215,7 @@ export const releaseCancelCommand = defineCommand({
 export const releaseCommand = defineCommand({
 	meta: { name: "release", description: "Manage delegated release intents" },
 	subCommands: {
+		"dry-run": releaseDryRunCommand,
 		submit: releaseSubmitCommand,
 		status: releaseStatusCommand,
 		cancel: releaseCancelCommand,

--- a/packages/plugin-cli/src/release-service/operations.ts
+++ b/packages/plugin-cli/src/release-service/operations.ts
@@ -4,6 +4,7 @@ import { safeParse } from "@atcute/lexicons";
 import {
 	ReleaseServiceClient,
 	createReleaseIdempotencyKey,
+	type DryRunReleaseIntentResult,
 	type ReleaseIntentResource,
 } from "@emdash-cms/registry-client/release-service";
 import { PackageRelease } from "@emdash-cms/registry-lexicons";
@@ -35,6 +36,10 @@ export interface SubmitDelegatedReleaseOptions extends ReleaseServiceTarget {
 	pollIntervalMs?: number;
 	maxWaitMs?: number;
 	onUpdate?: (intent: ReleaseIntentResource) => void | Promise<void>;
+}
+
+export interface DryRunDelegatedReleaseOptions extends ReleaseServiceTarget {
+	releaseFile: string;
 }
 
 export interface MutateReleaseIntentOptions extends ReleaseServiceTarget {
@@ -150,6 +155,23 @@ export async function submitDelegatedRelease(
 		maxWaitMs: options.maxWaitMs,
 		stopOnApproval: !(options.waitForApproval ?? false),
 		onUpdate: options.onUpdate,
+	});
+}
+
+export async function dryRunDelegatedRelease(
+	options: DryRunDelegatedReleaseOptions,
+	dependencies: ReleaseServiceOperationDependencies = {},
+): Promise<DryRunReleaseIntentResult> {
+	const rawRelease = await (dependencies.readReleaseRecord ?? defaultReadReleaseRecord)(
+		options.releaseFile,
+	);
+	const release = safeParse(PackageRelease.mainSchema, rawRelease);
+	if (!release.ok) throw new Error("Release record file is invalid");
+	return await releaseClient(options, dependencies).dryRunIntent({
+		publisherDid: options.publisherDid,
+		packageSlug: release.value.package,
+		version: release.value.version,
+		release: release.value,
 	});
 }
 

--- a/packages/plugin-cli/tests/release-service-operations.test.ts
+++ b/packages/plugin-cli/tests/release-service-operations.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import releaseFixture from "../../registry-verification/fixtures/records/release.json";
 import {
 	cancelDelegatedReleaseIntent,
+	dryRunDelegatedRelease,
 	getDelegatedReleaseIntent,
 	requestGithubOidcToken,
 	submitDelegatedRelease,
@@ -90,6 +91,41 @@ describe("delegated release CLI operations", () => {
 		expect(serviceRequests[0]?.headers.get("authorization")).toBe(
 			"Bearer header.payload.signature",
 		);
+	});
+
+	it("dry-runs admission without sending an idempotency key", async () => {
+		let serviceRequest: Request | null = null;
+		const result = await dryRunDelegatedRelease(
+			{
+				serviceUrl: SERVICE,
+				publisherDid: PUBLISHER_DID,
+				releaseFile: "release.json",
+			},
+			{
+				environment: ENVIRONMENT,
+				readReleaseRecord: async () => structuredClone(releaseFixture),
+				fetch: async (input, init) => {
+					const url = new URL(input instanceof Request ? input.url : input.toString());
+					if (url.hostname === "token.actions.example") {
+						return Response.json({ value: "header.payload.signature" });
+					}
+					serviceRequest = new Request(url, init);
+					return success({
+						allowed: true,
+						publisherDid: PUBLISHER_DID,
+						packageSlug: "gallery",
+						version: "1.2.3",
+						workloadPolicyVersion: 1,
+						workloadIdentityDigest: "W".repeat(43),
+						requestDigest: "R".repeat(43),
+					});
+				},
+			},
+		);
+
+		expect(result).toMatchObject({ allowed: true, workloadPolicyVersion: 1 });
+		expect(serviceRequest?.url).toBe(`${SERVICE}/v1/release-intents/dry-run`);
+		expect(serviceRequest?.headers.has("idempotency-key")).toBe(false);
 	});
 
 	it("uses fresh OIDC tokens for status and cancellation", async () => {

--- a/packages/registry-client/src/release-service/index.ts
+++ b/packages/registry-client/src/release-service/index.ts
@@ -4,6 +4,7 @@ import {
 	TERMINAL_RELEASE_INTENT_STATES,
 	type CursorPage,
 	type DelegationResource,
+	type DryRunReleaseIntentResult,
 	type DirectoryIdentityKind,
 	type DirectoryIdentityResource,
 	type DirectoryListOptions,
@@ -35,6 +36,7 @@ import {
 export type {
 	CursorPage,
 	DelegationResource,
+	DryRunReleaseIntentResult,
 	DirectoryIdentityKind,
 	DirectoryIdentityResource,
 	DirectoryListOptions,
@@ -75,6 +77,7 @@ const DIGITS_PATTERN = /^[0-9]+$/;
 const CSRF_TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 const ARCHIVE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{15,63}$/;
 const DIRECTORY_SHARD_PATTERN = /^[0-9a-f]{2}$/;
+const DIGEST_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 const API_ERROR_CODES: Readonly<Record<ReleaseServiceApiErrorCode, true>> = {
 	ACCESS_DENIED: true,
 	ACCESS_AUTH_INVALID: true,
@@ -342,6 +345,42 @@ function parseIntent(value: unknown, serviceUrl?: string): ReleaseIntentResource
 		updatedAt,
 		result,
 		approvalUrl,
+	};
+}
+
+function parseDryRunIntent(value: unknown): DryRunReleaseIntentResult {
+	if (!isRecord(value)) throw invalidResponse();
+	const publisherDid = stringValue(value, "publisherDid");
+	const packageSlug = stringValue(value, "packageSlug");
+	const version = stringValue(value, "version");
+	const workloadPolicyVersion = safeInteger(value, "workloadPolicyVersion");
+	const workloadIdentityDigest = stringValue(value, "workloadIdentityDigest");
+	const requestDigest = stringValue(value, "requestDigest");
+	if (
+		value["allowed"] !== true ||
+		!publisherDid ||
+		!DID_PATTERN.test(publisherDid) ||
+		!packageSlug ||
+		!PACKAGE_SLUG_PATTERN.test(packageSlug) ||
+		!version ||
+		!VERSION_PATTERN.test(version) ||
+		workloadPolicyVersion === null ||
+		workloadPolicyVersion < 1 ||
+		!workloadIdentityDigest ||
+		!DIGEST_PATTERN.test(workloadIdentityDigest) ||
+		!requestDigest ||
+		!DIGEST_PATTERN.test(requestDigest)
+	) {
+		throw invalidResponse();
+	}
+	return {
+		allowed: true,
+		publisherDid,
+		packageSlug,
+		version,
+		workloadPolicyVersion,
+		workloadIdentityDigest,
+		requestDigest,
 	};
 }
 
@@ -656,6 +695,24 @@ export class ReleaseServiceClient extends BaseReleaseServiceClient {
 					replayed: value["replayed"],
 				};
 			},
+		);
+	}
+
+	async dryRunIntent(
+		input: SubmitReleaseIntentInput,
+		options: RequestOptions = {},
+	): Promise<DryRunReleaseIntentResult> {
+		const headers = await this.#workloadHeaders();
+		headers.set("content-type", "application/json");
+		return await this.call(
+			"/v1/release-intents/dry-run",
+			{
+				method: "POST",
+				headers,
+				body: JSON.stringify(input),
+				signal: options.signal,
+			},
+			parseDryRunIntent,
 		);
 	}
 

--- a/packages/registry-client/src/release-service/types.ts
+++ b/packages/registry-client/src/release-service/types.ts
@@ -94,6 +94,16 @@ export interface SubmitReleaseIntentResult {
 	replayed: boolean;
 }
 
+export interface DryRunReleaseIntentResult {
+	allowed: true;
+	publisherDid: string;
+	packageSlug: string;
+	version: string;
+	workloadPolicyVersion: number;
+	workloadIdentityDigest: string;
+	requestDigest: string;
+}
+
 export interface WorkloadPolicyResource {
 	packageSlug: string;
 	repository: string;

--- a/packages/registry-client/tests/release-service.test.ts
+++ b/packages/registry-client/tests/release-service.test.ts
@@ -117,6 +117,46 @@ describe("ReleaseServiceClient", () => {
 		expect(JSON.stringify(result)).not.toContain(workloadToken);
 	});
 
+	it("dry-runs workload admission without an idempotency key", async () => {
+		let request: Request | null = null;
+		const client = new ReleaseServiceClient({
+			serviceUrl: SERVICE,
+			workloadToken: "header.payload.signature",
+			fetch: async (input, init) => {
+				request = new Request(input, init);
+				return success({
+					allowed: true,
+					publisherDid: PUBLISHER_DID,
+					packageSlug: "gallery",
+					version: "1.2.3",
+					workloadPolicyVersion: 2,
+					workloadIdentityDigest: "W".repeat(43),
+					requestDigest: "R".repeat(43),
+				});
+			},
+		});
+		const release = {
+			$type: "com.emdashcms.experimental.package.release" as const,
+			package: "gallery",
+			version: "1.2.3",
+			artifacts: {
+				package: { url: "https://example.com/gallery.tgz", checksum: "bciqexample" },
+			},
+		};
+
+		await expect(
+			client.dryRunIntent({
+				publisherDid: PUBLISHER_DID,
+				packageSlug: "gallery",
+				version: "1.2.3",
+				release,
+			}),
+		).resolves.toMatchObject({ allowed: true, workloadPolicyVersion: 2 });
+		expect(request?.url).toBe(`${SERVICE}/v1/release-intents/dry-run`);
+		expect(request?.headers.get("authorization")).toBe("Bearer header.payload.signature");
+		expect(request?.headers.has("idempotency-key")).toBe(false);
+	});
+
 	it("maps stable server errors, retry hints, and network failures", async () => {
 		const workloadToken = "header.payload.signature";
 		const pausedFetch: typeof globalThis.fetch = async () =>


### PR DESCRIPTION
## What does this PR do?

Adds a dry-run admission endpoint plus client and CLI support. Publishers can validate workload policy, release shape, service mode, and admission limits without creating a release intent.

Depends on #2729. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
