### PR TITLE
feat(release-service): complete operator recovery surfaces

### DIFF
--- a/.changeset/delegated-release-client.md
+++ b/.changeset/delegated-release-client.md
@@ -3,7 +3,7 @@
 "@emdash-cms/plugin-cli": minor
 ---
 
-Adds typed clients for the experimental delegated release service. `ReleaseServiceClient` submits, polls, and cancels GitHub OpenID Connect release intents, and manages publisher workload policies and retained delegation through a publisher session. `ReleaseServiceOperatorClient` exposes the Cloudflare Access status, sharded publisher and approver inventory, pause, suspension, revocation, cancellation, reconciliation, resumable encryption-key rotation, Workflow-backed encrypted R2 archive, and fail-safe publisher restore operations.
+Adds typed clients for the experimental delegated release service. `ReleaseServiceClient` submits, polls, and cancels GitHub OpenID Connect release intents, and manages publisher workload policies and retained delegation through a publisher session. `ReleaseServiceOperatorClient` exposes the Cloudflare Access status and sanitized audit, sharded publisher and approver inventory, pause, suspension, revocation, cancellation, reconciliation, resumable encryption-key rotation, Workflow-backed encrypted R2 archive, and fail-safe publisher restore operations.
 
 Both clients validate response envelopes and return stable `ReleaseServiceError` codes with retry metadata. Mutation helpers require idempotency keys, and workload polling requests a fresh token from the configured provider for each call.
 

--- a/apps/release-service/src/ui/App.test.tsx
+++ b/apps/release-service/src/ui/App.test.tsx
@@ -220,8 +220,12 @@ describe("release-service web surfaces", () => {
 		expect(screen.getByRole("button", { name: "Pause admission" })).toBeTruthy();
 		expect(screen.getByRole("heading", { name: "Operations directory" })).toBeTruthy();
 		expect(screen.getByRole("button", { name: "List publishers" })).toBeTruthy();
+		expect(screen.getByRole("heading", { name: "Service audit" })).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Load audit" })).toBeTruthy();
 		expect(screen.getByRole("heading", { name: "Publisher archive" })).toBeTruthy();
 		expect(screen.getByRole("button", { name: "Start archive workflow" })).toBeTruthy();
+		expect(screen.getByRole("heading", { name: "Restore publisher shard" })).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Prepare restore" })).toBeTruthy();
 		expect(screen.getByRole("heading", { name: "Encryption maintenance" })).toBeTruthy();
 		expect(screen.getByRole("heading", { name: "Publisher lookup" })).toBeTruthy();
 	});

--- a/apps/release-service/src/ui/OperatorPage.tsx
+++ b/apps/release-service/src/ui/OperatorPage.tsx
@@ -1,12 +1,14 @@
-import { Badge, Button, Input, Surface, Table } from "@cloudflare/kumo";
+import { Badge, Button, Dialog, Input, Surface, Table } from "@cloudflare/kumo";
 import {
 	ReleaseServiceOperatorClient,
 	createReleaseIdempotencyKey,
+	type ControlAuditEventResource,
 	type DirectoryIdentityKind,
 	type DirectoryIdentityResource,
 	type EncryptionRotationResult,
 	type OperatorPublisherResource,
 	type PublisherArchivePageResult,
+	type PublisherRestorePageResult,
 	type ServiceControlState,
 	type StartPublisherArchiveResult,
 } from "@emdash-cms/registry-client/release-service";
@@ -62,6 +64,11 @@ export function OperatorPage() {
 	const [directoryKind, setDirectoryKind] = useState<DirectoryIdentityKind>("publisher");
 	const [directoryCursor, setDirectoryCursor] = useState("");
 	const [directoryItems, setDirectoryItems] = useState<DirectoryIdentityResource[]>([]);
+	const [auditItems, setAuditItems] = useState<ControlAuditEventResource[]>([]);
+	const [auditCursor, setAuditCursor] = useState("");
+	const [restorePage, setRestorePage] = useState("0");
+	const [restoreResult, setRestoreResult] = useState<PublisherRestorePageResult | null>(null);
+	const [restoreConfirmOpen, setRestoreConfirmOpen] = useState(false);
 	const [error, setError] = useState<unknown>(null);
 	const [busy, setBusy] = useState(false);
 
@@ -222,6 +229,58 @@ export function OperatorPage() {
 		}
 	}
 
+	async function listAudit(reset: boolean) {
+		setBusy(true);
+		setError(null);
+		try {
+			const result = await client.listAudit({
+				...(reset || !auditCursor ? {} : { cursor: auditCursor }),
+				limit: 50,
+			});
+			setAuditItems(result.items);
+			setAuditCursor(result.nextCursor ?? "");
+		} catch (cause) {
+			setError(cause);
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	async function preparePublisherRestore() {
+		setBusy(true);
+		setError(null);
+		try {
+			await client.preparePublisherRestore(publisherDid, archiveId, {
+				idempotencyKey: createReleaseIdempotencyKey("web-publisher-restore-prepare"),
+			});
+			setRestorePage("0");
+			setRestoreResult(null);
+			setRestoreConfirmOpen(false);
+		} catch (cause) {
+			setError(cause);
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	async function restorePublisherPage() {
+		setBusy(true);
+		setError(null);
+		try {
+			const result = await client.restorePublisher(
+				publisherDid,
+				{ archiveId, page: Number(restorePage) },
+				{ idempotencyKey: createReleaseIdempotencyKey("web-publisher-restore") },
+			);
+			setRestoreResult(result);
+			setRestorePage(String(result.nextPage));
+		} catch (cause) {
+			setError(cause);
+		} finally {
+			setBusy(false);
+		}
+	}
+
 	async function operateIntent(action: "cancel" | "reconcile") {
 		setBusy(true);
 		setError(null);
@@ -275,6 +334,63 @@ export function OperatorPage() {
 						{t("operator.service.pausePublication", "Pause publication")}
 					</Button>
 				</div>
+			</Surface>
+
+			<Surface className="rounded-xl border bg-kumo-base p-6">
+				<div className="flex flex-wrap items-start justify-between gap-4">
+					<div>
+						<h2 className="text-xl font-semibold text-kumo-strong">
+							{t("operator.audit.title", "Service audit")}
+						</h2>
+						<p className="mt-1 text-sm text-kumo-subtle">
+							{t(
+								"operator.audit.description",
+								"Review sanitized Access and service-control events in sequence.",
+							)}
+						</p>
+					</div>
+					<Button loading={busy} onClick={() => listAudit(true)} variant="outline">
+						{t("operator.audit.load", "Load audit")}
+					</Button>
+				</div>
+				{auditItems.length > 0 ? (
+					<div className="mt-5 overflow-x-auto">
+						<Table>
+							<Table.Header>
+								<Table.Row>
+									<Table.Head>{t("operator.audit.sequence", "Sequence")}</Table.Head>
+									<Table.Head>{t("operator.audit.event", "Event")}</Table.Head>
+									<Table.Head>{t("operator.audit.actor", "Actor")}</Table.Head>
+									<Table.Head>{t("operator.audit.subject", "Subject")}</Table.Head>
+									<Table.Head>{t("operator.audit.time", "Time")}</Table.Head>
+								</Table.Row>
+							</Table.Header>
+							<Table.Body>
+								{auditItems.map((item) => (
+									<Table.Row key={item.sequence}>
+										<Table.Cell>{item.sequence}</Table.Cell>
+										<Table.Cell>{item.eventType}</Table.Cell>
+										<Table.Cell className="break-all">{item.actorIdentity}</Table.Cell>
+										<Table.Cell className="break-all">{item.subject}</Table.Cell>
+										<Table.Cell>
+											{new Intl.DateTimeFormat(document.documentElement.lang, {
+												dateStyle: "medium",
+												timeStyle: "short",
+											}).format(item.createdAt)}
+										</Table.Cell>
+									</Table.Row>
+								))}
+							</Table.Body>
+						</Table>
+						{auditCursor ? (
+							<div className="mt-4 flex justify-end">
+								<Button loading={busy} onClick={() => listAudit(false)} variant="outline">
+									{t("operator.audit.next", "Next audit page")}
+								</Button>
+							</div>
+						) : null}
+					</div>
+				) : null}
 			</Surface>
 
 			<Surface className="rounded-xl border bg-kumo-base p-6">
@@ -410,7 +526,79 @@ export function OperatorPage() {
 						</p>
 					) : null}
 				</div>
+				<div className="mt-6 border-t pt-5">
+					<h3 className="font-semibold text-kumo-strong">
+						{t("operator.restore.title", "Restore publisher shard")}
+					</h3>
+					<p className="mt-1 text-sm text-kumo-subtle">
+						{t(
+							"operator.restore.description",
+							"Preparation deletes the suspended publisher shard before encrypted pages are applied in order.",
+						)}
+					</p>
+					<div className="mt-4 flex flex-wrap items-end gap-3">
+						<Input
+							label={t("operator.restore.page", "Restore page")}
+							type="number"
+							value={restorePage}
+							onChange={(event) => setRestorePage(event.currentTarget.value)}
+						/>
+						<Button
+							disabled={!publisherDid || !archiveId}
+							loading={busy}
+							onClick={() => setRestoreConfirmOpen(true)}
+							variant="secondary-destructive"
+						>
+							{t("operator.restore.prepare", "Prepare restore")}
+						</Button>
+						<Button
+							disabled={!publisherDid || !archiveId || !Number.isSafeInteger(Number(restorePage))}
+							loading={busy}
+							onClick={restorePublisherPage}
+							variant="outline"
+						>
+							{t("operator.restore.apply", "Apply restore page")}
+						</Button>
+					</div>
+					{restoreResult ? (
+						<p className="mt-4 text-sm text-kumo-subtle">
+							{restoreResult.complete
+								? t("operator.restore.complete", "Restore complete. Reauthorization is required.")
+								: t("operator.restore.next", "Restore page stored. Apply the next page.")}
+						</p>
+					) : null}
+				</div>
 			</Surface>
+
+			<Dialog.Root
+				disablePointerDismissal
+				onOpenChange={setRestoreConfirmOpen}
+				open={restoreConfirmOpen}
+			>
+				<Dialog className="p-6" size="sm">
+					<Dialog.Title className="text-lg font-semibold">
+						{t("operator.restore.confirmTitle", "Delete publisher state for restore?")}
+					</Dialog.Title>
+					<Dialog.Description className="mt-2 text-sm text-kumo-subtle">
+						{t(
+							"operator.restore.confirmDescription",
+							"The publisher must be suspended. This deletes current workload and intent state before archive pages can be restored.",
+						)}
+					</Dialog.Description>
+					<div className="mt-6 flex justify-end gap-3">
+						<Button onClick={() => setRestoreConfirmOpen(false)} variant="secondary">
+							{t("common.cancel", "Cancel")}
+						</Button>
+						<Button
+							loading={busy}
+							onClick={preparePublisherRestore}
+							variant="secondary-destructive"
+						>
+							{t("operator.restore.confirm", "Delete and prepare")}
+						</Button>
+					</div>
+				</Dialog>
+			</Dialog.Root>
 
 			<Surface className="rounded-xl border bg-kumo-base p-6">
 				<div className="flex flex-wrap items-start justify-between gap-4">

--- a/packages/registry-client/src/release-service/index.ts
+++ b/packages/registry-client/src/release-service/index.ts
@@ -3,6 +3,8 @@ import type { PackageRelease } from "@emdash-cms/registry-lexicons";
 import {
 	TERMINAL_RELEASE_INTENT_STATES,
 	type CursorPage,
+	type AuditListOptions,
+	type ControlAuditEventResource,
 	type DelegationResource,
 	type DryRunReleaseIntentResult,
 	type DirectoryIdentityKind,
@@ -35,6 +37,8 @@ import {
 
 export type {
 	CursorPage,
+	AuditListOptions,
+	ControlAuditEventResource,
 	DelegationResource,
 	DryRunReleaseIntentResult,
 	DirectoryIdentityKind,
@@ -525,6 +529,44 @@ function parsePublisherControl(value: unknown): PublisherControlResource {
 		throw invalidResponse();
 	}
 	return { publisherDid, status, reasonCode, changedBy, changedAt };
+}
+
+function parseControlAuditEvent(value: unknown): ControlAuditEventResource {
+	if (!isRecord(value)) throw invalidResponse();
+	const sequence = safeInteger(value, "sequence");
+	const eventType = stringValue(value, "eventType");
+	const actorRealm = value["actorRealm"];
+	const actorIdentity = stringValue(value, "actorIdentity");
+	const actorRole = value["actorRole"];
+	const subject = stringValue(value, "subject");
+	const reasonCode = nullableString(value, "reasonCode");
+	const createdAt = safeInteger(value, "createdAt");
+	if (
+		sequence === null ||
+		sequence < 1 ||
+		!eventType ||
+		(actorRealm !== "access" && actorRealm !== "system") ||
+		!actorIdentity ||
+		(actorRole !== null &&
+			actorRole !== "viewer" &&
+			actorRole !== "reviewer" &&
+			actorRole !== "admin") ||
+		!subject ||
+		reasonCode === undefined ||
+		createdAt === null
+	) {
+		throw invalidResponse();
+	}
+	return {
+		sequence,
+		eventType,
+		actorRealm,
+		actorIdentity,
+		actorRole,
+		subject,
+		reasonCode,
+		createdAt,
+	};
 }
 
 function invalidResponse(requestId: string | null = null): ReleaseServiceError {
@@ -1171,6 +1213,41 @@ export class ReleaseServiceOperatorClient extends BaseReleaseServiceClient {
 			`${url.pathname}${url.search}`,
 			{ method: "GET", credentials: "include", signal: options.signal },
 			(value) => parsePage(value, parseDirectoryIdentity),
+		);
+	}
+
+	async listAudit(options: AuditListOptions = {}): Promise<CursorPage<ControlAuditEventResource>> {
+		const url = new URL("/admin/api/audit", this.serviceUrl);
+		if (options.cursor) {
+			if (!DIGITS_PATTERN.test(options.cursor)) {
+				throw new ReleaseServiceError({
+					code: "CLIENT_RESPONSE_INVALID",
+					message: "Audit cursor is invalid",
+				});
+			}
+			url.searchParams.set("after", options.cursor);
+		}
+		if (options.limit !== undefined) {
+			if (!Number.isSafeInteger(options.limit) || options.limit < 1 || options.limit > 100) {
+				throw new ReleaseServiceError({
+					code: "CLIENT_RESPONSE_INVALID",
+					message: "Audit limit is invalid",
+				});
+			}
+			url.searchParams.set("limit", String(options.limit));
+		}
+		return await this.call(
+			`${url.pathname}${url.search}`,
+			{ method: "GET", credentials: "include" },
+			(value) => {
+				if (!isRecord(value) || !Array.isArray(value["items"])) throw invalidResponse();
+				const nextCursor = nullableString(value, "nextCursor");
+				if (nextCursor === undefined) throw invalidResponse();
+				return {
+					items: value["items"].map(parseControlAuditEvent),
+					...(nextCursor ? { nextCursor } : {}),
+				};
+			},
 		);
 	}
 

--- a/packages/registry-client/src/release-service/types.ts
+++ b/packages/registry-client/src/release-service/types.ts
@@ -182,6 +182,22 @@ export interface DirectoryListOptions {
 	limit?: number;
 }
 
+export interface AuditListOptions {
+	cursor?: string;
+	limit?: number;
+}
+
+export interface ControlAuditEventResource {
+	sequence: number;
+	eventType: string;
+	actorRealm: "access" | "system";
+	actorIdentity: string;
+	actorRole: "admin" | "reviewer" | "viewer" | null;
+	subject: string;
+	reasonCode: string | null;
+	createdAt: number;
+}
+
 export interface EncryptionRotationPageInput {
 	afterCursor: string | null;
 	limit: number;

--- a/packages/registry-client/tests/release-service.test.ts
+++ b/packages/registry-client/tests/release-service.test.ts
@@ -301,6 +301,37 @@ describe("ReleaseServiceClient", () => {
 });
 
 describe("ReleaseServiceOperatorClient", () => {
+	it("paginates sanitized service-control audit events", async () => {
+		let captured = "";
+		const client = new ReleaseServiceOperatorClient({
+			serviceUrl: SERVICE,
+			fetch: async (input) => {
+				captured = input instanceof Request ? input.url : input.toString();
+				return success({
+					items: [
+						{
+							sequence: 7,
+							eventType: "service-mode-changed",
+							actorRealm: "access",
+							actorIdentity: "operator-subject",
+							actorRole: "admin",
+							subject: "publication-paused",
+							reasonCode: "MAINTENANCE",
+							createdAt: 1_800_000_000_000,
+						},
+					],
+					nextCursor: "7",
+				});
+			},
+		});
+
+		await expect(client.listAudit({ cursor: "6", limit: 1 })).resolves.toMatchObject({
+			items: [{ sequence: 7, actorRole: "admin" }],
+			nextCursor: "7",
+		});
+		expect(captured).toBe(`${SERVICE}/admin/api/audit?after=6&limit=1`);
+	});
+
 	it("lists one bounded operations-directory shard", async () => {
 		let captured = "";
 		const fetch: typeof globalThis.fetch = async (input) => {


### PR DESCRIPTION
## What does this PR do?

Completes the Access-protected operator UI and client operations for publisher suspension, revocation, archive, restore, and intent reconciliation.

Depends on #2730. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
