### PR TITLE
feat(release-service): expose publisher audit

### DIFF
--- a/.changeset/delegated-release-client.md
+++ b/.changeset/delegated-release-client.md
@@ -3,7 +3,7 @@
 "@emdash-cms/plugin-cli": minor
 ---
 
-Adds typed clients for the experimental delegated release service. `ReleaseServiceClient` submits, polls, and cancels GitHub OpenID Connect release intents, and manages publisher workload policies and retained delegation through a publisher session. `ReleaseServiceOperatorClient` exposes the Cloudflare Access status and sanitized audit, sharded publisher and approver inventory, pause, suspension, revocation, cancellation, reconciliation, resumable encryption-key rotation, Workflow-backed encrypted R2 archive, and fail-safe publisher restore operations.
+Adds typed clients for the experimental delegated release service. `ReleaseServiceClient` submits, polls, and cancels GitHub OpenID Connect release intents, and manages publisher workload policies, retained delegation, and publisher-scoped audit events through a publisher session. `ReleaseServiceOperatorClient` exposes the Cloudflare Access status and sanitized audit, sharded publisher and approver inventory, pause, suspension, revocation, cancellation, reconciliation, resumable encryption-key rotation, Workflow-backed encrypted R2 archive, and fail-safe publisher restore operations.
 
 Both clients validate response envelopes and return stable `ReleaseServiceError` codes with retry metadata. Mutation helpers require idempotency keys, and workload polling requests a fresh token from the configured provider for each call.
 

--- a/apps/release-service/src/publisher-do/publisher-do.ts
+++ b/apps/release-service/src/publisher-do/publisher-do.ts
@@ -1190,7 +1190,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 			afterSequence < 0 ||
 			!Number.isSafeInteger(limit) ||
 			limit < 1 ||
-			limit > 100
+			limit > 101
 		) {
 			throw new PublisherStateError("OPERATIONS_EXPORT_INVALID");
 		}

--- a/apps/release-service/src/publisher/routes.ts
+++ b/apps/release-service/src/publisher/routes.ts
@@ -386,3 +386,40 @@ export async function handleListPublisherIntents(
 		return routeFailure(error, requestId);
 	}
 }
+
+export async function handleListPublisherAudit(
+	request: Request,
+	requestId: string,
+	configuration: ServiceConfiguration,
+): Promise<Response> {
+	try {
+		const session = await publisherSession(request, configuration);
+		const url = new URL(request.url);
+		if ([...url.searchParams.keys()].some((key) => key !== "cursor" && key !== "limit")) {
+			throw new ApiError("INVALID_REQUEST", 400, "Invalid pagination parameters");
+		}
+		const cursorValue = url.searchParams.get("cursor");
+		if (
+			url.searchParams.getAll("cursor").length > 1 ||
+			url.searchParams.getAll("limit").length > 1 ||
+			(cursorValue !== null && !POSITIVE_INTEGER_PATTERN.test(cursorValue))
+		) {
+			throw new ApiError("INVALID_REQUEST", 400, "Invalid pagination parameters");
+		}
+		const cursor = cursorValue === null ? 0 : Number(cursorValue);
+		if (!Number.isSafeInteger(cursor)) {
+			throw new ApiError("INVALID_REQUEST", 400, "Invalid pagination parameters");
+		}
+		const limit = parseLimit(url);
+		const rows = await env.PUBLISHER_DO.getByName(session.publisherDid).listAuditEvents(
+			session.publisherDid,
+			cursor,
+			limit + 1,
+		);
+		const items = rows.slice(0, limit);
+		const nextCursor = rows.length > limit ? String(items.at(-1)?.sequence) : undefined;
+		return apiSuccess({ items, ...(nextCursor ? { nextCursor } : {}) }, requestId);
+	} catch (error) {
+		return routeFailure(error, requestId);
+	}
+}

--- a/apps/release-service/src/routes.ts
+++ b/apps/release-service/src/routes.ts
@@ -71,6 +71,7 @@ import {
 import {
 	handleDisablePublisherWorkload,
 	handleGetPublisher,
+	handleListPublisherAudit,
 	handleListPublisherIntents,
 	handleListPublisherWorkloads,
 	handlePutPublisherWorkload,
@@ -179,6 +180,11 @@ export const ROUTES = Object.freeze([
 		method: "GET",
 		path: "/v1/publisher/intents",
 		handler: handleListPublisherIntents,
+	},
+	{
+		method: "GET",
+		path: "/v1/publisher/audit",
+		handler: handleListPublisherAudit,
 	},
 	{
 		method: "POST",

--- a/apps/release-service/src/ui/App.test.tsx
+++ b/apps/release-service/src/ui/App.test.tsx
@@ -92,6 +92,21 @@ describe("release-service web surfaces", () => {
 						],
 					});
 				}
+				if (path === "/v1/publisher/audit") {
+					return success({
+						items: [
+							{
+								sequence: 3,
+								eventType: "workload-policy-stored",
+								actorRealm: "publisher",
+								actorIdentity: PUBLISHER_DID,
+								subject: "gallery",
+								reasonCode: null,
+								createdAt: 1_799_999_250_000,
+							},
+						],
+					});
+				}
 				return success({
 					items: [
 						{
@@ -115,9 +130,11 @@ describe("release-service web surfaces", () => {
 		);
 		renderApp("/publisher");
 
-		expect(await screen.findByText(PUBLISHER_DID)).toBeTruthy();
+		expect((await screen.findAllByText(PUBLISHER_DID)).length).toBeGreaterThan(0);
 		expect(screen.getAllByText("gallery").length).toBeGreaterThan(0);
 		expect(screen.getByText("Awaiting approval")).toBeTruthy();
+		expect(screen.getByRole("heading", { name: "Publisher audit" })).toBeTruthy();
+		expect(screen.getByText("workload-policy-stored")).toBeTruthy();
 	});
 
 	it("shows immutable workload and provenance evidence before approval", async () => {

--- a/apps/release-service/src/ui/PublisherPage.tsx
+++ b/apps/release-service/src/ui/PublisherPage.tsx
@@ -3,6 +3,7 @@ import {
 	ReleaseServiceClient,
 	ReleaseServiceError,
 	createReleaseIdempotencyKey,
+	type PublisherAuditEventResource,
 	type PublisherResource,
 	type ReleaseIntentResource,
 	type WorkloadPolicyResource,
@@ -17,6 +18,8 @@ interface PublisherData {
 	publisher: PublisherResource;
 	workloads: WorkloadPolicyResource[];
 	intents: ReleaseIntentResource[];
+	audit: PublisherAuditEventResource[];
+	auditCursor?: string;
 }
 
 function stateVariant(state: string): "error" | "neutral" | "success" | "warning" {
@@ -93,12 +96,19 @@ export function PublisherPage() {
 	const refresh = useCallback(async () => {
 		setError(null);
 		try {
-			const [publisher, workloads, intents] = await Promise.all([
+			const [publisher, workloads, intents, audit] = await Promise.all([
 				client.getPublisher(),
 				client.listWorkloads({ limit: 100 }),
 				client.listPublisherIntents({ limit: 100 }),
+				client.listPublisherAudit({ limit: 50 }),
 			]);
-			setData({ publisher, workloads: workloads.items, intents: intents.items });
+			setData({
+				publisher,
+				workloads: workloads.items,
+				intents: intents.items,
+				audit: audit.items,
+				...(audit.nextCursor ? { auditCursor: audit.nextCursor } : {}),
+			});
 			setLoginRequired(false);
 		} catch (cause) {
 			if (
@@ -164,6 +174,30 @@ export function PublisherPage() {
 			setRepositoryOwnerId("");
 			setWorkflowRef("");
 			await refresh();
+		} catch (cause) {
+			setError(cause);
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	async function loadNextAuditPage() {
+		if (!data?.auditCursor) return;
+		setBusy(true);
+		setError(null);
+		try {
+			const audit = await client.listPublisherAudit({ cursor: data.auditCursor, limit: 50 });
+			setData((current) =>
+				current
+					? {
+							...current,
+							audit: audit.items,
+							...(audit.nextCursor
+								? { auditCursor: audit.nextCursor }
+								: { auditCursor: undefined }),
+						}
+					: current,
+			);
 		} catch (cause) {
 			setError(cause);
 		} finally {
@@ -321,6 +355,64 @@ export function PublisherPage() {
 						))}
 					</Table.Body>
 				</Table>
+			</Surface>
+
+			<Surface className="rounded-xl border bg-kumo-base p-6">
+				<div className="flex flex-wrap items-start justify-between gap-4">
+					<div>
+						<h2 className="text-xl font-semibold text-kumo-strong">
+							{t("publisher.audit.title", "Publisher audit")}
+						</h2>
+						<p className="mt-1 text-sm text-kumo-subtle">
+							{t(
+								"publisher.audit.description",
+								"Review sanitized events for this publisher. Private OAuth and session data is never returned.",
+							)}
+						</p>
+					</div>
+				</div>
+				{data.audit.length > 0 ? (
+					<div className="mt-5 overflow-x-auto">
+						<Table>
+							<Table.Header>
+								<Table.Row>
+									<Table.Head>{t("publisher.audit.sequence", "Sequence")}</Table.Head>
+									<Table.Head>{t("publisher.audit.event", "Event")}</Table.Head>
+									<Table.Head>{t("publisher.audit.actor", "Actor")}</Table.Head>
+									<Table.Head>{t("publisher.audit.subject", "Subject")}</Table.Head>
+									<Table.Head>{t("publisher.audit.time", "Time")}</Table.Head>
+								</Table.Row>
+							</Table.Header>
+							<Table.Body>
+								{data.audit.map((item) => (
+									<Table.Row key={item.sequence}>
+										<Table.Cell>{item.sequence}</Table.Cell>
+										<Table.Cell>{item.eventType}</Table.Cell>
+										<Table.Cell className="break-all">{item.actorIdentity}</Table.Cell>
+										<Table.Cell className="break-all">{item.subject}</Table.Cell>
+										<Table.Cell>
+											{new Intl.DateTimeFormat(document.documentElement.lang, {
+												dateStyle: "medium",
+												timeStyle: "short",
+											}).format(item.createdAt)}
+										</Table.Cell>
+									</Table.Row>
+								))}
+							</Table.Body>
+						</Table>
+					</div>
+				) : (
+					<p className="mt-5 text-sm text-kumo-subtle">
+						{t("publisher.audit.empty", "No audit events")}
+					</p>
+				)}
+				{data.auditCursor ? (
+					<div className="mt-4 flex justify-end">
+						<Button loading={busy} onClick={loadNextAuditPage} variant="outline">
+							{t("publisher.audit.next", "Next audit page")}
+						</Button>
+					</div>
+				) : null}
 			</Surface>
 		</div>
 	);

--- a/apps/release-service/test/publisher-routes.test.ts
+++ b/apps/release-service/test/publisher-routes.test.ts
@@ -7,6 +7,7 @@ import { createPublisherApplicationSession } from "../src/publisher-session/sess
 import {
 	handleDisablePublisherWorkload,
 	handleGetPublisher,
+	handleListPublisherAudit,
 	handleListPublisherIntents,
 	handleListPublisherWorkloads,
 	handlePutPublisherWorkload,
@@ -180,6 +181,26 @@ describe("publisher API", () => {
 		expect(await response.json()).toMatchObject({
 			data: { items: [{ id: INTENT_ID, publisherDid: PUBLISHER_DID }] },
 		});
+	});
+
+	it("paginates the authenticated publisher audit without private payloads", async () => {
+		const configuration = await loadConfiguration(TEST_BINDINGS);
+		await sessionHeaders();
+		const response = await handleListPublisherAudit(
+			request("/v1/publisher/audit?limit=1", await sessionHeaders()),
+			"request-audit",
+			configuration,
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toMatchObject({
+			data: {
+				items: [{ sequence: 1, eventType: "publisher-session-created" }],
+				nextCursor: "1",
+			},
+		});
+		expect(JSON.stringify(body)).not.toContain("csrf");
 	});
 
 	it("revokes retained authority idempotently without exposing OAuth errors", async () => {

--- a/packages/registry-client/src/release-service/index.ts
+++ b/packages/registry-client/src/release-service/index.ts
@@ -16,6 +16,7 @@ import {
 	type OperatorPublisherResource,
 	type PreparePublisherRestoreResult,
 	type PublisherArchiveKind,
+	type PublisherAuditEventResource,
 	type PublisherArchivePageInput,
 	type PublisherArchivePageResult,
 	type PublisherControlResource,
@@ -50,6 +51,7 @@ export type {
 	OperatorPublisherResource,
 	PreparePublisherRestoreResult,
 	PublisherArchiveKind,
+	PublisherAuditEventResource,
 	PublisherArchivePageInput,
 	PublisherArchivePageResult,
 	PublisherControlResource,
@@ -569,6 +571,42 @@ function parseControlAuditEvent(value: unknown): ControlAuditEventResource {
 	};
 }
 
+function parsePublisherAuditEvent(value: unknown): PublisherAuditEventResource {
+	if (!isRecord(value)) throw invalidResponse();
+	const sequence = safeInteger(value, "sequence");
+	const eventType = stringValue(value, "eventType");
+	const actorRealm = value["actorRealm"];
+	const actorIdentity = stringValue(value, "actorIdentity");
+	const subject = stringValue(value, "subject");
+	const reasonCode = nullableString(value, "reasonCode");
+	const createdAt = safeInteger(value, "createdAt");
+	if (
+		sequence === null ||
+		sequence < 1 ||
+		!eventType ||
+		(actorRealm !== "access" &&
+			actorRealm !== "approver" &&
+			actorRealm !== "oidc" &&
+			actorRealm !== "publisher" &&
+			actorRealm !== "system") ||
+		!actorIdentity ||
+		!subject ||
+		reasonCode === undefined ||
+		createdAt === null
+	) {
+		throw invalidResponse();
+	}
+	return {
+		sequence,
+		eventType,
+		actorRealm,
+		actorIdentity,
+		subject,
+		reasonCode,
+		createdAt,
+	};
+}
+
 function invalidResponse(requestId: string | null = null): ReleaseServiceError {
 	return new ReleaseServiceError({
 		code: "CLIENT_RESPONSE_INVALID",
@@ -925,6 +963,35 @@ export class ReleaseServiceClient extends BaseReleaseServiceClient {
 			`${url.pathname}${url.search}`,
 			{ method: "GET", credentials: "include", signal: options.signal },
 			(value) => parsePage(value, (item) => parseIntent(item, this.serviceUrl)),
+		);
+	}
+
+	async listPublisherAudit(
+		options: AuditListOptions = {},
+	): Promise<CursorPage<PublisherAuditEventResource>> {
+		const url = new URL("/v1/publisher/audit", this.serviceUrl);
+		if (options.cursor) {
+			if (!DIGITS_PATTERN.test(options.cursor)) {
+				throw new ReleaseServiceError({
+					code: "CLIENT_RESPONSE_INVALID",
+					message: "Audit cursor is invalid",
+				});
+			}
+			url.searchParams.set("cursor", options.cursor);
+		}
+		if (options.limit !== undefined) {
+			if (!Number.isSafeInteger(options.limit) || options.limit < 1 || options.limit > 100) {
+				throw new ReleaseServiceError({
+					code: "CLIENT_RESPONSE_INVALID",
+					message: "Audit limit is invalid",
+				});
+			}
+			url.searchParams.set("limit", String(options.limit));
+		}
+		return await this.call(
+			`${url.pathname}${url.search}`,
+			{ method: "GET", credentials: "include" },
+			(value) => parsePage(value, parsePublisherAuditEvent),
 		);
 	}
 }

--- a/packages/registry-client/src/release-service/types.ts
+++ b/packages/registry-client/src/release-service/types.ts
@@ -198,6 +198,16 @@ export interface ControlAuditEventResource {
 	createdAt: number;
 }
 
+export interface PublisherAuditEventResource {
+	sequence: number;
+	eventType: string;
+	actorRealm: "access" | "approver" | "oidc" | "publisher" | "system";
+	actorIdentity: string;
+	subject: string;
+	reasonCode: string | null;
+	createdAt: number;
+}
+
 export interface EncryptionRotationPageInput {
 	afterCursor: string | null;
 	limit: number;

--- a/packages/registry-client/tests/release-service.test.ts
+++ b/packages/registry-client/tests/release-service.test.ts
@@ -292,6 +292,36 @@ describe("ReleaseServiceClient", () => {
 		expect(mutationHeaders.has("authorization")).toBe(false);
 	});
 
+	it("lists only the authenticated publisher audit", async () => {
+		let captured = "";
+		const client = new ReleaseServiceClient({
+			serviceUrl: SERVICE,
+			fetch: async (input) => {
+				captured = input instanceof Request ? input.url : input.toString();
+				return success({
+					items: [
+						{
+							sequence: 3,
+							eventType: "workload-policy-stored",
+							actorRealm: "publisher",
+							actorIdentity: PUBLISHER_DID,
+							subject: "gallery",
+							reasonCode: null,
+							createdAt: 1_800_000_000_000,
+						},
+					],
+					nextCursor: "3",
+				});
+			},
+		});
+
+		await expect(client.listPublisherAudit({ cursor: "2", limit: 1 })).resolves.toMatchObject({
+			items: [{ sequence: 3, actorRealm: "publisher" }],
+			nextCursor: "3",
+		});
+		expect(captured).toBe(`${SERVICE}/v1/publisher/audit?cursor=2&limit=1`);
+	});
+
 	it("creates valid collision-resistant idempotency keys", () => {
 		const first = createReleaseIdempotencyKey("github action");
 		const second = createReleaseIdempotencyKey("github action");


### PR DESCRIPTION
## What does this PR do?

Adds publisher audit retrieval to the service API, typed client, and publisher UI. Audit responses are cursor-paginated and exclude secret material.

Depends on #2731. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
