### PR TITLE
feat(release-service): show publisher approver status

### DIFF
--- a/.changeset/delegated-release-client.md
+++ b/.changeset/delegated-release-client.md
@@ -3,7 +3,7 @@
 "@emdash-cms/plugin-cli": minor
 ---
 
-Adds typed clients for the experimental delegated release service. `ReleaseServiceClient` submits, polls, and cancels GitHub OpenID Connect release intents, and manages publisher workload policies, retained delegation, and publisher-scoped audit events through a publisher session. `ReleaseServiceOperatorClient` exposes the Cloudflare Access status and sanitized audit, sharded publisher and approver inventory, pause, suspension, revocation, cancellation, reconciliation, resumable encryption-key rotation, Workflow-backed encrypted R2 archive, and fail-safe publisher restore operations.
+Adds typed clients for the experimental delegated release service. `ReleaseServiceClient` submits, polls, and cancels GitHub OpenID Connect release intents; manages publisher workload policies and retained delegation; and lets publishers inspect approver passkey enrolment and publisher-scoped audit events through a publisher session. `ReleaseServiceOperatorClient` exposes the Cloudflare Access status and sanitized audit, sharded publisher and approver inventory, pause, suspension, revocation, cancellation, reconciliation, resumable encryption-key rotation, Workflow-backed encrypted R2 archive, and fail-safe publisher restore operations.
 
 Both clients validate response envelopes and return stable `ReleaseServiceError` codes with retry metadata. Mutation helpers require idempotency keys, and workload polling requests a fresh token from the configured provider for each call.
 

--- a/apps/release-service/src/approvals/authority.ts
+++ b/apps/release-service/src/approvals/authority.ts
@@ -15,6 +15,7 @@ import { decodeAwaitingApprovalState, type ApprovalEvidence } from "./digest.js"
 const DNS_ENDPOINT = "https://cloudflare-dns.com/dns-query";
 const MAX_DNS_RESPONSE_BYTES = 64 * 1024;
 const MAX_PROFILE_RESPONSE_BYTES = 256 * 1024;
+const PACKAGE_SLUG_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
 
 export type ApprovalAuthorityErrorCode =
 	| "APPROVAL_EVIDENCE_INVALID"
@@ -43,6 +44,11 @@ export interface LoadedApprovalIntent {
 export interface VerifyCurrentApproverOptions {
 	actorResolver?: ActorResolver;
 	fetch?: typeof globalThis.fetch;
+}
+
+export interface CurrentApprovalPolicy {
+	profileCid: string;
+	approverDids: readonly string[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -244,20 +250,41 @@ export async function verifyCurrentApprover(
 	if (!isDid(evidence.publisherDid) || !isDid(approverDid)) {
 		throw new ApprovalAuthorityError("APPROVAL_EVIDENCE_INVALID");
 	}
+	const policy = await loadCurrentApprovalPolicy(
+		evidence.publisherDid,
+		evidence.packageSlug,
+		options,
+	);
+	if (!policy.approverDids.includes(approverDid)) {
+		throw new ApprovalAuthorityError("APPROVER_NOT_AUTHORIZED");
+	}
+	if (policy.profileCid !== evidence.profileCid) {
+		throw new ApprovalAuthorityError("PROFILE_CHANGED");
+	}
+}
+
+export async function loadCurrentApprovalPolicy(
+	publisherDid: string,
+	packageSlug: string,
+	options: VerifyCurrentApproverOptions = {},
+): Promise<CurrentApprovalPolicy> {
+	if (!isDid(publisherDid) || !PACKAGE_SLUG_PATTERN.test(packageSlug)) {
+		throw new ApprovalAuthorityError("PROFILE_FETCH_FAILED");
+	}
 	const fetchImplementation = options.fetch ?? globalThis.fetch;
 	let actor;
 	try {
 		actor = await (
 			options.actorResolver ??
 			createWorkerActorResolver(createGuardedIdentityFetch(fetchImplementation))
-		).resolve(evidence.publisherDid, { signal: AbortSignal.timeout(30_000), noCache: true });
+		).resolve(publisherDid, { signal: AbortSignal.timeout(30_000), noCache: true });
 	} catch {
 		throw new ApprovalAuthorityError("PROFILE_FETCH_FAILED");
 	}
-	if (actor.did !== evidence.publisherDid) {
+	if (actor.did !== publisherDid) {
 		throw new ApprovalAuthorityError("PROFILE_FETCH_FAILED");
 	}
-	const requestedUrl = profileRecordUrl(actor.pds, evidence.publisherDid, evidence.packageSlug);
+	const requestedUrl = profileRecordUrl(actor.pds, publisherDid, packageSlug);
 	const resource = await fetchVerifiedResource(requestedUrl, {
 		fetch: (url, init) => fetchImplementation(url, init),
 		resolveHostname: (hostname) => resolvePublicHostname(hostname, fetchImplementation),
@@ -277,7 +304,7 @@ export async function verifyCurrentApprover(
 	} catch {
 		throw new ApprovalAuthorityError("PROFILE_FETCH_FAILED");
 	}
-	const expectedUri = `at://${evidence.publisherDid}/${NSID.packageProfile}/${evidence.packageSlug}`;
+	const expectedUri = `at://${publisherDid}/${NSID.packageProfile}/${packageSlug}`;
 	if (
 		!isRecord(envelope) ||
 		envelope["uri"] !== expectedUri ||
@@ -293,10 +320,15 @@ export async function verifyCurrentApprover(
 	const rawExtension = profile.value.extensions?.[NSID.packageProfileExtension];
 	const extension = safeParse(PackageProfileExtension.mainSchema, rawExtension);
 	if (!extension.ok) throw new ApprovalAuthorityError("PROFILE_FETCH_FAILED");
-	if (!extension.value.releasePolicy?.approvers?.includes(approverDid)) {
-		throw new ApprovalAuthorityError("APPROVER_NOT_AUTHORIZED");
+	const approverDids = extension.value.releasePolicy?.approvers ?? [];
+	if (
+		new Set(approverDids).size !== approverDids.length ||
+		approverDids.some((approverDid) => !isDid(approverDid))
+	) {
+		throw new ApprovalAuthorityError("PROFILE_FETCH_FAILED");
 	}
-	if (envelope["cid"] !== evidence.profileCid) {
-		throw new ApprovalAuthorityError("PROFILE_CHANGED");
-	}
+	return {
+		profileCid: envelope["cid"],
+		approverDids: [...approverDids].toSorted(),
+	};
 }

--- a/apps/release-service/src/approver-do/approver-do.ts
+++ b/apps/release-service/src/approver-do/approver-do.ts
@@ -10,6 +10,7 @@ import {
 	ApproverStoreError,
 	type ApproverAuditEvent,
 	type ApproverCredential,
+	type ApproverEnrollmentStatus,
 	type ApprovalReceipt,
 	type CleanupResult,
 	type CommitVerifiedDecisionInput,
@@ -35,6 +36,7 @@ import {
 export type {
 	ApproverAuditEvent,
 	ApproverCredential,
+	ApproverEnrollmentStatus,
 	ApprovalDecision,
 	ApprovalReceipt,
 	CleanupResult,
@@ -152,6 +154,11 @@ export class ApproverDurableObject extends DurableObject<Env> {
 	): readonly ApproverCredential[] {
 		this.#assertApproverDid(approverDid);
 		return this.#store.listCredentials(approverDid, afterCredentialId, limit);
+	}
+
+	getEnrollmentStatus(approverDid: string): ApproverEnrollmentStatus {
+		this.#assertObjectName(approverDid);
+		return this.#store.getEnrollmentStatus(approverDid);
 	}
 
 	getCredentialForVerification(

--- a/apps/release-service/src/approver-do/store.ts
+++ b/apps/release-service/src/approver-do/store.ts
@@ -108,6 +108,14 @@ export interface ApproverCredential {
 	revokedAt: number | null;
 }
 
+export interface ApproverEnrollmentStatus {
+	credentialCount: number;
+	activeCredentialCount: number;
+	firstEnrolledAt: number | null;
+	lastEnrolledAt: number | null;
+	lastRevokedAt: number | null;
+}
+
 export interface CredentialVerificationMaterial {
 	id: string;
 	publicKey: Uint8Array;
@@ -272,6 +280,15 @@ interface CredentialRow {
 	created_at: number;
 	last_used_at: number | null;
 	revoked_at: number | null;
+}
+
+interface EnrollmentStatusRow {
+	[key: string]: string | number | ArrayBuffer | null;
+	credential_count: number;
+	active_credential_count: number;
+	first_enrolled_at: number | null;
+	last_enrolled_at: number | null;
+	last_revoked_at: number | null;
 }
 
 interface ChallengeRow {
@@ -756,6 +773,43 @@ export class ApproverStore {
 						)
 						.toArray();
 		return rows.map(credentialView);
+	}
+
+	getEnrollmentStatus(approverDid: string): ApproverEnrollmentStatus {
+		if (!validDid(approverDid)) {
+			throw new ApproverStoreError("APPROVER_DID_INVALID");
+		}
+		const owner = this.#readOwner();
+		if (!owner) {
+			return {
+				credentialCount: 0,
+				activeCredentialCount: 0,
+				firstEnrolledAt: null,
+				lastEnrolledAt: null,
+				lastRevokedAt: null,
+			};
+		}
+		if (owner.did !== approverDid) {
+			throw new ApproverStoreError("APPROVER_DID_MISMATCH");
+		}
+		const row = this.storage.sql
+			.exec<EnrollmentStatusRow>(
+				`SELECT COUNT(*) AS credential_count,
+				        COALESCE(SUM(CASE WHEN revoked_at IS NULL THEN 1 ELSE 0 END), 0)
+				          AS active_credential_count,
+				        MIN(created_at) AS first_enrolled_at,
+				        MAX(created_at) AS last_enrolled_at,
+				        MAX(revoked_at) AS last_revoked_at
+				 FROM credentials`,
+			)
+			.one();
+		return {
+			credentialCount: row.credential_count,
+			activeCredentialCount: row.active_credential_count,
+			firstEnrolledAt: row.first_enrolled_at,
+			lastEnrolledAt: row.last_enrolled_at,
+			lastRevokedAt: row.last_revoked_at,
+		};
 	}
 
 	getCredentialForVerification(

--- a/apps/release-service/src/publisher/routes.ts
+++ b/apps/release-service/src/publisher/routes.ts
@@ -4,6 +4,11 @@ import { env } from "cloudflare:workers";
 import { readJsonObject } from "../api/body.js";
 import { ApiError } from "../api/errors.js";
 import { apiFailure, apiSuccess } from "../api/response.js";
+import {
+	ApprovalAuthorityError,
+	loadCurrentApprovalPolicy,
+	type CurrentApprovalPolicy,
+} from "../approvals/authority.js";
 import type { ServiceConfiguration } from "../config.js";
 import { serializeIntentResource } from "../intents/routes.js";
 import { createPublisherOAuthClient } from "../oauth/custody.js";
@@ -19,11 +24,17 @@ const ULID_PATTERN = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$/;
 const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/;
 const WORKLOAD_PATH_PATTERN = /^\/v1\/publisher\/workloads\/([A-Za-z][A-Za-z0-9_-]{0,63})$/;
+const APPROVER_STATUS_PATH_PATTERN =
+	/^\/v1\/publisher\/workloads\/([A-Za-z][A-Za-z0-9_-]{0,63})\/approvers$/;
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
 
 export interface PublisherRouteDependencies {
 	revokeDelegation?: (publisherDid: `did:${string}:${string}`) => Promise<void>;
+	loadCurrentApprovalPolicy?: (
+		publisherDid: string,
+		packageSlug: string,
+	) => Promise<CurrentApprovalPolicy>;
 }
 
 function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
@@ -82,6 +93,12 @@ function routeFailure(error: unknown, requestId: string): Response {
 	if (error instanceof WorkloadPolicyError) {
 		return apiFailure(
 			new ApiError("INVALID_REQUEST", 400, "Invalid workload policy request"),
+			requestId,
+		);
+	}
+	if (error instanceof ApprovalAuthorityError) {
+		return apiFailure(
+			new ApiError("PROFILE_FETCH_FAILED", 503, "Package profile could not be verified"),
 			requestId,
 		);
 	}
@@ -148,6 +165,13 @@ export function matchPublisherWorkloadPath(
 	pathname: string,
 ): Readonly<Record<string, string>> | null {
 	const match = WORKLOAD_PATH_PATTERN.exec(pathname);
+	return match?.[1] ? { packageSlug: match[1] } : null;
+}
+
+export function matchPublisherApproverStatusPath(
+	pathname: string,
+): Readonly<Record<string, string>> | null {
+	const match = APPROVER_STATUS_PATH_PATTERN.exec(pathname);
 	return match?.[1] ? { packageSlug: match[1] } : null;
 }
 
@@ -248,6 +272,56 @@ export async function handleListPublisherWorkloads(
 		const items = rows.slice(0, limit);
 		const nextCursor = rows.length > limit ? items.at(-1)?.packageSlug : undefined;
 		return apiSuccess({ items, ...(nextCursor ? { nextCursor } : {}) }, requestId);
+	} catch (error) {
+		return routeFailure(error, requestId);
+	}
+}
+
+export async function handleGetPublisherApproverStatus(
+	request: Request,
+	requestId: string,
+	configuration: ServiceConfiguration,
+	params: Readonly<Record<string, string>>,
+	dependencies: PublisherRouteDependencies = {},
+): Promise<Response> {
+	try {
+		const session = await publisherSession(request, configuration);
+		const url = new URL(request.url);
+		if ([...url.searchParams].length > 0) {
+			throw new ApiError(
+				"INVALID_REQUEST",
+				400,
+				"Approver status query does not accept parameters",
+			);
+		}
+		const packageSlug = params["packageSlug"];
+		if (!packageSlug || !PACKAGE_SLUG_PATTERN.test(packageSlug)) {
+			throw new ApiError("NOT_FOUND", 404, "Workload policy not found");
+		}
+		const publisher = env.PUBLISHER_DO.getByName(session.publisherDid);
+		if (!(await publisher.getWorkloadPolicy(session.publisherDid, packageSlug))) {
+			throw new ApiError("NOT_FOUND", 404, "Workload policy not found");
+		}
+		const policy = dependencies.loadCurrentApprovalPolicy
+			? await dependencies.loadCurrentApprovalPolicy(session.publisherDid, packageSlug)
+			: await loadCurrentApprovalPolicy(session.publisherDid, packageSlug);
+		const items = await Promise.all(
+			policy.approverDids.map(async (approverDid) => {
+				const enrollment =
+					await env.APPROVER_DO.getByName(approverDid).getEnrollmentStatus(approverDid);
+				return {
+					did: approverDid,
+					status:
+						enrollment.activeCredentialCount > 0
+							? ("enrolled" as const)
+							: enrollment.credentialCount > 0
+								? ("revoked" as const)
+								: ("not_enrolled" as const),
+					...enrollment,
+				};
+			}),
+		);
+		return apiSuccess({ packageSlug, profileCid: policy.profileCid, items }, requestId);
 	} catch (error) {
 		return routeFailure(error, requestId);
 	}

--- a/apps/release-service/src/routes.ts
+++ b/apps/release-service/src/routes.ts
@@ -70,12 +70,14 @@ import {
 } from "./operator/routes.js";
 import {
 	handleDisablePublisherWorkload,
+	handleGetPublisherApproverStatus,
 	handleGetPublisher,
 	handleListPublisherAudit,
 	handleListPublisherIntents,
 	handleListPublisherWorkloads,
 	handlePutPublisherWorkload,
 	handleRevokePublisherDelegation,
+	matchPublisherApproverStatusPath,
 	matchPublisherWorkloadPath,
 } from "./publisher/routes.js";
 
@@ -175,6 +177,13 @@ export const ROUTES = Object.freeze([
 		path: "/v1/publisher/workloads/{packageSlug}",
 		match: matchPublisherWorkloadPath,
 		handler: handleDisablePublisherWorkload,
+	},
+	{
+		method: "GET",
+		path: "/v1/publisher/workloads/{packageSlug}/approvers",
+		match: matchPublisherApproverStatusPath,
+		handler: (request, requestId, configuration, params) =>
+			handleGetPublisherApproverStatus(request, requestId, configuration, params),
 	},
 	{
 		method: "GET",

--- a/apps/release-service/src/ui/App.test.tsx
+++ b/apps/release-service/src/ui/App.test.tsx
@@ -1,5 +1,5 @@
 import { I18nProvider } from "@lingui/react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { getApproval, listApproverCredentials } from "./api.js";
@@ -107,6 +107,23 @@ describe("release-service web surfaces", () => {
 						],
 					});
 				}
+				if (path === "/v1/publisher/workloads/gallery/approvers") {
+					return success({
+						packageSlug: "gallery",
+						profileCid: "bafyprofile",
+						items: [
+							{
+								did: "did:plc:approver",
+								status: "enrolled",
+								credentialCount: 1,
+								activeCredentialCount: 1,
+								firstEnrolledAt: 1_799_999_000_000,
+								lastEnrolledAt: 1_799_999_000_000,
+								lastRevokedAt: null,
+							},
+						],
+					});
+				}
 				return success({
 					items: [
 						{
@@ -135,6 +152,9 @@ describe("release-service web surfaces", () => {
 		expect(screen.getByText("Awaiting approval")).toBeTruthy();
 		expect(screen.getByRole("heading", { name: "Publisher audit" })).toBeTruthy();
 		expect(screen.getByText("workload-policy-stored")).toBeTruthy();
+		fireEvent.click(screen.getByRole("button", { name: "Check approvers" }));
+		expect(await screen.findByRole("heading", { name: "Approver status" })).toBeTruthy();
+		expect(screen.getByText("did:plc:approver")).toBeTruthy();
 	});
 
 	it("shows immutable workload and provenance evidence before approval", async () => {

--- a/apps/release-service/src/ui/PublisherPage.tsx
+++ b/apps/release-service/src/ui/PublisherPage.tsx
@@ -3,6 +3,7 @@ import {
 	ReleaseServiceClient,
 	ReleaseServiceError,
 	createReleaseIdempotencyKey,
+	type PublisherApproverStatusResult,
 	type PublisherAuditEventResource,
 	type PublisherResource,
 	type ReleaseIntentResource,
@@ -83,6 +84,7 @@ export function PublisherPage() {
 		[],
 	);
 	const [data, setData] = useState<PublisherData | null>(null);
+	const [approverStatus, setApproverStatus] = useState<PublisherApproverStatusResult | null>(null);
 	const [loginRequired, setLoginRequired] = useState(false);
 	const [error, setError] = useState<unknown>(null);
 	const [busy, setBusy] = useState(false);
@@ -109,6 +111,7 @@ export function PublisherPage() {
 				audit: audit.items,
 				...(audit.nextCursor ? { auditCursor: audit.nextCursor } : {}),
 			});
+			setApproverStatus(null);
 			setLoginRequired(false);
 		} catch (cause) {
 			if (
@@ -198,6 +201,18 @@ export function PublisherPage() {
 						}
 					: current,
 			);
+		} catch (cause) {
+			setError(cause);
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	async function loadApproverStatus(workloadPackageSlug: string) {
+		setBusy(true);
+		setError(null);
+		try {
+			setApproverStatus(await client.getPublisherApproverStatus(workloadPackageSlug));
 		} catch (cause) {
 			setError(cause);
 		} finally {
@@ -306,6 +321,7 @@ export function PublisherPage() {
 							<Table.Head>{t("publisher.workloads.repository", "Repository")}</Table.Head>
 							<Table.Head>{t("publisher.workloads.workflow", "Workflow")}</Table.Head>
 							<Table.Head>{t("publisher.workloads.status", "Status")}</Table.Head>
+							<Table.Head>{t("publisher.workloads.approvers", "Approvers")}</Table.Head>
 						</Table.Row>
 					</Table.Header>
 					<Table.Body>
@@ -321,11 +337,92 @@ export function PublisherPage() {
 											: t("status.disabled", "Disabled")}
 									</Badge>
 								</Table.Cell>
+								<Table.Cell>
+									<Button
+										loading={busy}
+										onClick={() => loadApproverStatus(workload.packageSlug)}
+										variant="outline"
+									>
+										{t("publisher.workloads.checkApprovers", "Check approvers")}
+									</Button>
+								</Table.Cell>
 							</Table.Row>
 						))}
 					</Table.Body>
 				</Table>
 			</Surface>
+
+			{approverStatus ? (
+				<Surface className="rounded-xl border bg-kumo-base p-6">
+					<div>
+						<h2 className="text-xl font-semibold text-kumo-strong">
+							{t("publisher.approvers.title", "Approver status")}
+						</h2>
+						<p className="mt-1 text-sm text-kumo-subtle">
+							{t(
+								"publisher.approvers.description",
+								"Passkey enrolment for approvers in the current signed profile for {packageSlug}.",
+								{ packageSlug: approverStatus.packageSlug },
+							)}
+						</p>
+						<p className="mt-1 break-all text-sm text-kumo-subtle">
+							{t("publisher.approvers.profileCid", "Profile CID: {profileCid}", {
+								profileCid: approverStatus.profileCid,
+							})}
+						</p>
+					</div>
+					{approverStatus.items.length > 0 ? (
+						<div className="mt-5 overflow-x-auto">
+							<Table>
+								<Table.Header>
+									<Table.Row>
+										<Table.Head>{t("publisher.approvers.did", "Approver")}</Table.Head>
+										<Table.Head>{t("publisher.approvers.status", "Status")}</Table.Head>
+										<Table.Head>
+											{t("publisher.approvers.activeCredentials", "Active credentials")}
+										</Table.Head>
+										<Table.Head>
+											{t("publisher.approvers.lastEnrolled", "Last enrolled")}
+										</Table.Head>
+									</Table.Row>
+								</Table.Header>
+								<Table.Body>
+									{approverStatus.items.map((item) => (
+										<Table.Row key={item.did}>
+											<Table.Cell className="break-all">{item.did}</Table.Cell>
+											<Table.Cell>
+												<Badge variant={item.status === "enrolled" ? "success" : "warning"}>
+													{item.status === "enrolled"
+														? t("publisher.approvers.enrolled", "Enrolled")
+														: item.status === "revoked"
+															? t("publisher.approvers.revoked", "Credentials revoked")
+															: t("publisher.approvers.notEnrolled", "Not enrolled")}
+												</Badge>
+											</Table.Cell>
+											<Table.Cell>{item.activeCredentialCount}</Table.Cell>
+											<Table.Cell>
+												{item.lastEnrolledAt === null
+													? t("publisher.approvers.never", "Never")
+													: new Intl.DateTimeFormat(document.documentElement.lang, {
+															dateStyle: "medium",
+															timeStyle: "short",
+														}).format(item.lastEnrolledAt)}
+											</Table.Cell>
+										</Table.Row>
+									))}
+								</Table.Body>
+							</Table>
+						</div>
+					) : (
+						<p className="mt-5 text-sm text-kumo-subtle">
+							{t(
+								"publisher.approvers.empty",
+								"No approvers are listed in the current signed package profile.",
+							)}
+						</p>
+					)}
+				</Surface>
+			) : null}
 
 			<Surface className="overflow-x-auto rounded-xl border bg-kumo-base p-0">
 				<Table>

--- a/apps/release-service/test/approval-authority.test.ts
+++ b/apps/release-service/test/approval-authority.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
 	ApprovalAuthorityError,
+	loadCurrentApprovalPolicy,
 	loadApprovalIntent,
 	verifyCurrentApprover,
 } from "../src/approvals/authority.js";
@@ -225,6 +226,21 @@ describe("approval authority", () => {
 				fetch: authorityFetch({ cid: "bafyreib3p6qchangedprofilecid" }),
 			}),
 		).rejects.toMatchObject({ code: "PROFILE_CHANGED" });
+	});
+
+	it("loads the current signed approver policy for publisher status views", async () => {
+		await expect(
+			loadCurrentApprovalPolicy(PUBLISHER_DID, "gallery", {
+				actorResolver: actorResolver(),
+				fetch: authorityFetch(),
+			}),
+		).resolves.toEqual({ profileCid: PROFILE_CID, approverDids: [APPROVER_DID] });
+		await expect(
+			loadCurrentApprovalPolicy(PUBLISHER_DID, "gallery", {
+				actorResolver: actorResolver(),
+				fetch: authorityFetch({ approvers: [APPROVER_DID, APPROVER_DID] }),
+			}),
+		).rejects.toMatchObject({ code: "PROFILE_FETCH_FAILED" });
 	});
 
 	it("rejects private PDS resolution before fetching the record", async () => {

--- a/apps/release-service/test/approver-do.test.ts
+++ b/apps/release-service/test/approver-do.test.ts
@@ -303,6 +303,36 @@ describe("ApproverDurableObject", () => {
 		).resolves.toEqual({ ok: false, code: "CREDENTIAL_STATE_CHANGED" });
 	});
 
+	it("reports enrolment and revocation state without initializing an empty shard", async () => {
+		const empty = env.APPROVER_DO.getByName(OTHER_APPROVER_DID);
+		await expect(empty.getEnrollmentStatus(OTHER_APPROVER_DID)).resolves.toEqual({
+			credentialCount: 0,
+			activeCredentialCount: 0,
+			firstEnrolledAt: null,
+			lastEnrolledAt: null,
+			lastRevokedAt: null,
+		});
+		await expect(
+			runInDurableObject(empty, (_instance, state) =>
+				state.storage.sql.exec<{ count: number }>("SELECT COUNT(*) AS count FROM approver").one(),
+			),
+		).resolves.toEqual({ count: 0 });
+
+		const stub = approver();
+		const now = 1_800_000_000_000;
+		await stub.enrolCredential(APPROVER_DID, credentialInput(CREDENTIAL_ID, now));
+		await stub.enrolCredential(APPROVER_DID, credentialInput(SECOND_CREDENTIAL_ID, now + 1));
+		await stub.revokeCredential(APPROVER_DID, CREDENTIAL_ID, now + 2);
+
+		await expect(stub.getEnrollmentStatus(APPROVER_DID)).resolves.toEqual({
+			credentialCount: 2,
+			activeCredentialCount: 1,
+			firstEnrolledAt: now,
+			lastEnrolledAt: now + 1,
+			lastRevokedAt: now + 2,
+		});
+	});
+
 	it("binds approval challenges to intent inputs and consumes them once", async () => {
 		const stub = approver();
 		const now = 1_800_000_000_000;

--- a/apps/release-service/test/publisher-routes.test.ts
+++ b/apps/release-service/test/publisher-routes.test.ts
@@ -6,12 +6,14 @@ import { loadConfiguration } from "../src/config.js";
 import { createPublisherApplicationSession } from "../src/publisher-session/session.js";
 import {
 	handleDisablePublisherWorkload,
+	handleGetPublisherApproverStatus,
 	handleGetPublisher,
 	handleListPublisherAudit,
 	handleListPublisherIntents,
 	handleListPublisherWorkloads,
 	handlePutPublisherWorkload,
 	handleRevokePublisherDelegation,
+	matchPublisherApproverStatusPath,
 } from "../src/publisher/routes.js";
 import { TEST_BINDINGS } from "./fixtures/oauth.js";
 
@@ -145,6 +147,73 @@ describe("publisher API", () => {
 		expect(await disabled.json()).toMatchObject({
 			data: { policy: { active: false, stateVersion: 2 }, replayed: false },
 		});
+	});
+
+	it("compares signed approvers with safe enrolment summaries", async () => {
+		const configuration = await loadConfiguration(TEST_BINDINGS);
+		const enrolledDid = "did:plc:enrolled-approver";
+		const missingDid = "did:plc:missing-approver";
+		const revokedDid = "did:plc:revoked-approver";
+		await env.PUBLISHER_DO.getByName(PUBLISHER_DID).putWorkloadPolicy({
+			publisherDid: PUBLISHER_DID,
+			...policyBody(),
+			active: true,
+			now: NOW,
+		});
+		await env.APPROVER_DO.getByName(enrolledDid).enrolCredential(enrolledDid, {
+			credentialId: "publisher-visible-status",
+			publicKey: new Uint8Array([1, 2, 3]),
+			algorithm: -7,
+			counter: 0,
+			transports: ["internal"],
+			name: "Private credential name",
+			now: NOW + 1,
+		});
+		await env.APPROVER_DO.getByName(revokedDid).enrolCredential(revokedDid, {
+			credentialId: "revoked-publisher-status",
+			publicKey: new Uint8Array([4, 5, 6]),
+			algorithm: -7,
+			counter: 0,
+			transports: ["internal"],
+			name: "Revoked private credential",
+			now: NOW + 1,
+		});
+		await env.APPROVER_DO.getByName(revokedDid).revokeCredential(
+			revokedDid,
+			"revoked-publisher-status",
+			NOW + 2,
+		);
+		const params = matchPublisherApproverStatusPath("/v1/publisher/workloads/gallery/approvers");
+		expect(params).toEqual({ packageSlug: "gallery" });
+
+		const response = await handleGetPublisherApproverStatus(
+			request("/v1/publisher/workloads/gallery/approvers", await sessionHeaders()),
+			"request-approvers",
+			configuration,
+			params!,
+			{
+				loadCurrentApprovalPolicy: async () => ({
+					profileCid: "bafyprofile",
+					approverDids: [enrolledDid, missingDid, revokedDid],
+				}),
+			},
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toMatchObject({
+			data: {
+				packageSlug: "gallery",
+				profileCid: "bafyprofile",
+				items: [
+					{ did: enrolledDid, status: "enrolled", activeCredentialCount: 1 },
+					{ did: missingDid, status: "not_enrolled", activeCredentialCount: 0 },
+					{ did: revokedDid, status: "revoked", activeCredentialCount: 0 },
+				],
+			},
+		});
+		expect(JSON.stringify(body)).not.toContain("Private credential name");
+		expect(JSON.stringify(body)).not.toContain("publisher-visible-status");
 	});
 
 	it("lists only intents from the authenticated publisher shard", async () => {

--- a/packages/registry-client/src/release-service/index.ts
+++ b/packages/registry-client/src/release-service/index.ts
@@ -16,6 +16,8 @@ import {
 	type OperatorPublisherResource,
 	type PreparePublisherRestoreResult,
 	type PublisherArchiveKind,
+	type PublisherApproverStatusResource,
+	type PublisherApproverStatusResult,
 	type PublisherAuditEventResource,
 	type PublisherArchivePageInput,
 	type PublisherArchivePageResult,
@@ -51,6 +53,9 @@ export type {
 	OperatorPublisherResource,
 	PreparePublisherRestoreResult,
 	PublisherArchiveKind,
+	PublisherApproverEnrollmentState,
+	PublisherApproverStatusResource,
+	PublisherApproverStatusResult,
 	PublisherAuditEventResource,
 	PublisherArchivePageInput,
 	PublisherArchivePageResult,
@@ -272,6 +277,14 @@ function nullableString(value: Record<string, unknown>, key: string): string | n
 function safeInteger(value: Record<string, unknown>, key: string): number | null {
 	const item = value[key];
 	return Number.isSafeInteger(item) ? Number(item) : null;
+}
+
+function nullableSafeInteger(
+	value: Record<string, unknown>,
+	key: string,
+): number | null | undefined {
+	const item = value[key];
+	return item === null ? null : Number.isSafeInteger(item) ? Number(item) : undefined;
 }
 
 function parseIntentResult(value: unknown): ReleaseIntentResult | null | undefined {
@@ -604,6 +617,57 @@ function parsePublisherAuditEvent(value: unknown): PublisherAuditEventResource {
 		subject,
 		reasonCode,
 		createdAt,
+	};
+}
+
+function parsePublisherApproverStatus(value: unknown): PublisherApproverStatusResource {
+	if (!isRecord(value)) throw invalidResponse();
+	const did = stringValue(value, "did");
+	const status = value["status"];
+	const credentialCount = safeInteger(value, "credentialCount");
+	const activeCredentialCount = safeInteger(value, "activeCredentialCount");
+	const firstEnrolledAt = nullableSafeInteger(value, "firstEnrolledAt");
+	const lastEnrolledAt = nullableSafeInteger(value, "lastEnrolledAt");
+	const lastRevokedAt = nullableSafeInteger(value, "lastRevokedAt");
+	const expectedStatus =
+		activeCredentialCount !== null && activeCredentialCount > 0
+			? "enrolled"
+			: credentialCount !== null && credentialCount > 0
+				? "revoked"
+				: "not_enrolled";
+	if (
+		!did ||
+		!DID_PATTERN.test(did) ||
+		(status !== "enrolled" && status !== "not_enrolled" && status !== "revoked") ||
+		status !== expectedStatus ||
+		credentialCount === null ||
+		credentialCount < 0 ||
+		activeCredentialCount === null ||
+		activeCredentialCount < 0 ||
+		activeCredentialCount > credentialCount ||
+		firstEnrolledAt === undefined ||
+		lastEnrolledAt === undefined ||
+		lastRevokedAt === undefined ||
+		(credentialCount === 0 &&
+			(firstEnrolledAt !== null || lastEnrolledAt !== null || lastRevokedAt !== null)) ||
+		(credentialCount > 0 &&
+			(firstEnrolledAt === null ||
+				lastEnrolledAt === null ||
+				firstEnrolledAt < 0 ||
+				lastEnrolledAt < firstEnrolledAt)) ||
+		(lastRevokedAt !== null && (firstEnrolledAt === null || lastRevokedAt < firstEnrolledAt)) ||
+		(status === "revoked" && lastRevokedAt === null)
+	) {
+		throw invalidResponse();
+	}
+	return {
+		did,
+		status,
+		credentialCount,
+		activeCredentialCount,
+		firstEnrolledAt,
+		lastEnrolledAt,
+		lastRevokedAt,
 	};
 }
 
@@ -992,6 +1056,32 @@ export class ReleaseServiceClient extends BaseReleaseServiceClient {
 			`${url.pathname}${url.search}`,
 			{ method: "GET", credentials: "include" },
 			(value) => parsePage(value, parsePublisherAuditEvent),
+		);
+	}
+
+	async getPublisherApproverStatus(packageSlug: string): Promise<PublisherApproverStatusResult> {
+		if (!PACKAGE_SLUG_PATTERN.test(packageSlug)) {
+			throw new ReleaseServiceError({
+				code: "CLIENT_RESPONSE_INVALID",
+				message: "Package slug is invalid",
+			});
+		}
+		return await this.call(
+			`/v1/publisher/workloads/${encodeURIComponent(packageSlug)}/approvers`,
+			{ method: "GET", credentials: "include" },
+			(value) => {
+				if (!isRecord(value) || !Array.isArray(value["items"])) throw invalidResponse();
+				const returnedPackageSlug = stringValue(value, "packageSlug");
+				const profileCid = stringValue(value, "profileCid");
+				if (returnedPackageSlug !== packageSlug || !profileCid || !CID_PATTERN.test(profileCid)) {
+					throw invalidResponse();
+				}
+				return {
+					packageSlug: returnedPackageSlug,
+					profileCid,
+					items: value["items"].map(parsePublisherApproverStatus),
+				};
+			},
 		);
 	}
 }

--- a/packages/registry-client/src/release-service/types.ts
+++ b/packages/registry-client/src/release-service/types.ts
@@ -208,6 +208,24 @@ export interface PublisherAuditEventResource {
 	createdAt: number;
 }
 
+export type PublisherApproverEnrollmentState = "enrolled" | "not_enrolled" | "revoked";
+
+export interface PublisherApproverStatusResource {
+	did: string;
+	status: PublisherApproverEnrollmentState;
+	credentialCount: number;
+	activeCredentialCount: number;
+	firstEnrolledAt: number | null;
+	lastEnrolledAt: number | null;
+	lastRevokedAt: number | null;
+}
+
+export interface PublisherApproverStatusResult {
+	packageSlug: string;
+	profileCid: string;
+	items: PublisherApproverStatusResource[];
+}
+
 export interface EncryptionRotationPageInput {
 	afterCursor: string | null;
 	limit: number;

--- a/packages/registry-client/tests/release-service.test.ts
+++ b/packages/registry-client/tests/release-service.test.ts
@@ -322,6 +322,37 @@ describe("ReleaseServiceClient", () => {
 		expect(captured).toBe(`${SERVICE}/v1/publisher/audit?cursor=2&limit=1`);
 	});
 
+	it("reads publisher-visible approver enrolment status", async () => {
+		let captured = "";
+		const client = new ReleaseServiceClient({
+			serviceUrl: SERVICE,
+			fetch: async (input) => {
+				captured = input instanceof Request ? input.url : input.toString();
+				return success({
+					packageSlug: "gallery",
+					profileCid: "bafyprofile",
+					items: [
+						{
+							did: "did:plc:approver",
+							status: "enrolled",
+							credentialCount: 2,
+							activeCredentialCount: 1,
+							firstEnrolledAt: 1_799_999_000_000,
+							lastEnrolledAt: 1_799_999_500_000,
+							lastRevokedAt: 1_799_999_750_000,
+						},
+					],
+				});
+			},
+		});
+
+		await expect(client.getPublisherApproverStatus("gallery")).resolves.toMatchObject({
+			packageSlug: "gallery",
+			items: [{ did: "did:plc:approver", status: "enrolled", activeCredentialCount: 1 }],
+		});
+		expect(captured).toBe(`${SERVICE}/v1/publisher/workloads/gallery/approvers`);
+	});
+
 	it("creates valid collision-resistant idempotency keys", () => {
 		const first = createReleaseIdempotencyKey("github action");
 		const second = createReleaseIdempotencyKey("github action");


### PR DESCRIPTION
## What does this PR do?

Adds the publisher-facing approver readiness view backed by the authoritative approver shard. Publishers can see whether required approval credentials are available before submitting a release.

Depends on #2732. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
