### PR TITLE
feat(plugin-cli): add secure release browser handoffs

### DIFF
--- a/.changeset/delegated-release-client.md
+++ b/.changeset/delegated-release-client.md
@@ -8,3 +8,5 @@ Adds typed clients for the experimental delegated release service. `ReleaseServi
 Both clients validate response envelopes and return stable `ReleaseServiceError` codes with retry metadata. Mutation helpers require idempotency keys, and workload polling requests a fresh token from the configured provider for each call.
 
 The plugin CLI adds `emdash-plugin release dry-run`, `release submit`, `release status`, and `release cancel` for GitHub Actions jobs. Dry-run verifies workload admission without creating an intent, consuming rate budget, or reserving a version. The commands request audience-bound OIDC tokens from the runner, support JSON output, and use the GitHub run identity as the default idempotency key where a mutation occurs.
+
+Interactive `release delegate`, `revoke`, `workload`, `enrol`, `approve`, and `reject` commands print validated browser handoffs. Publisher application sessions, OAuth credentials, and passkey assertions remain at the release-service origin instead of entering the terminal process.

--- a/apps/release-service/src/ui/App.test.tsx
+++ b/apps/release-service/src/ui/App.test.tsx
@@ -236,6 +236,31 @@ describe("release-service web surfaces", () => {
 		expect(approve.hasAttribute("disabled")).toBe(false);
 	});
 
+	it("manages approver passkeys without requiring an active release", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				success({
+					items: [
+						{
+							id: "credential",
+							name: "Work laptop",
+							transports: ["internal"],
+							createdAt: 1_799_999_000_000,
+							lastUsedAt: null,
+							revokedAt: null,
+						},
+					],
+				}),
+			),
+		);
+		renderApp("/approver");
+
+		expect(await screen.findByRole("heading", { name: "Approver passkeys" })).toBeTruthy();
+		expect(screen.getByText("Work laptop")).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Enrol passkey" })).toBeTruthy();
+	});
+
 	it("renders the Access operator control surface", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/apps/release-service/src/ui/App.tsx
+++ b/apps/release-service/src/ui/App.tsx
@@ -7,7 +7,7 @@ export function App() {
 	const path = location.pathname;
 	const content = path.startsWith("/admin") ? (
 		<OperatorPage />
-	) : path.startsWith("/approvals/") ? (
+	) : path === "/approver" || path.startsWith("/approvals/") ? (
 		<ApproverPage />
 	) : (
 		<PublisherPage />

--- a/apps/release-service/src/ui/ApproverPage.tsx
+++ b/apps/release-service/src/ui/ApproverPage.tsx
@@ -27,12 +27,19 @@ function detail(value: string | null, fallback: string): string {
 
 export function ApproverPage() {
 	const t = useT();
+	const standalone = location.pathname === "/approver";
 	const intentId = location.pathname.startsWith("/approvals/")
 		? location.pathname.slice("/approvals/".length)
 		: "";
 	const publisherDid = new URLSearchParams(location.search).get("publisher") ?? "";
+	const requestedDecisionValue = new URLSearchParams(location.search).get("decision");
+	const requestedDecision =
+		requestedDecisionValue === "approve" || requestedDecisionValue === "reject"
+			? requestedDecisionValue
+			: null;
 	const [approval, setApproval] = useState<ApprovalResource | null>(null);
 	const [credentials, setCredentials] = useState<ApproverCredential[]>([]);
+	const [loaded, setLoaded] = useState(false);
 	const [loginRequired, setLoginRequired] = useState(false);
 	const [credentialName, setCredentialName] = useState("");
 	const [error, setError] = useState<unknown>(null);
@@ -41,8 +48,24 @@ export function ApproverPage() {
 
 	const refresh = useCallback(async () => {
 		setError(null);
+		if (standalone) {
+			try {
+				setCredentials(await listApproverCredentials());
+				setLoginRequired(false);
+			} catch (cause) {
+				if (cause instanceof UiApiError && cause.code === "APPROVER_SESSION_INVALID") {
+					setLoginRequired(true);
+					return;
+				}
+				setError(cause);
+			} finally {
+				setLoaded(true);
+			}
+			return;
+		}
 		if (!intentId || !publisherDid) {
 			setError(new UiApiError("INVALID_REQUEST", 400, "Approval link is incomplete"));
+			setLoaded(true);
 			return;
 		}
 		try {
@@ -59,8 +82,10 @@ export function ApproverPage() {
 				return;
 			}
 			setError(cause);
+		} finally {
+			setLoaded(true);
 		}
-	}, [intentId, publisherDid]);
+	}, [intentId, publisherDid, standalone]);
 
 	useEffect(() => {
 		void refresh();
@@ -110,8 +135,44 @@ export function ApproverPage() {
 		}
 	}
 
+	const credentialsPanel = (
+		<Surface className="rounded-xl border bg-kumo-base p-6">
+			<h2 className="text-xl font-semibold text-kumo-strong">
+				{t("approval.credentials.title", "Approver passkeys")}
+			</h2>
+			<div className="mt-4 flex flex-wrap gap-2">
+				{credentials.map((credential) => (
+					<Badge key={credential.id} variant={credential.revokedAt ? "error" : "success"}>
+						{credential.name}
+					</Badge>
+				))}
+			</div>
+			<form className="mt-5 flex flex-col gap-4 sm:flex-row sm:items-end" onSubmit={enrol}>
+				<Input
+					className="flex-1"
+					label={t("approval.credentials.name", "Passkey name")}
+					placeholder={t("approval.credentials.placeholder", "Work laptop")}
+					required
+					value={credentialName}
+					onChange={(event) => setCredentialName(event.currentTarget.value)}
+				/>
+				<Button loading={busy} type="submit" variant="secondary">
+					{t("approval.credentials.enrol", "Enrol passkey")}
+				</Button>
+			</form>
+		</Surface>
+	);
+
 	if (loginRequired) return <LoginPanel realm="approver" />;
-	if (!approval && !error) return <LoadingPanel />;
+	if (!loaded && !error) return <LoadingPanel />;
+	if (standalone) {
+		return (
+			<div className="flex flex-col gap-6">
+				{error ? <ErrorBanner error={error} /> : null}
+				{credentialsPanel}
+			</div>
+		);
+	}
 	if (!approval) return <ErrorBanner error={error} />;
 	const review = approval.review;
 	const none = t("approval.none", "Not available");
@@ -229,32 +290,21 @@ export function ApproverPage() {
 				)}
 			</Surface>
 
-			<Surface className="rounded-xl border bg-kumo-base p-6">
-				<h2 className="text-xl font-semibold text-kumo-strong">
-					{t("approval.credentials.title", "Approver passkeys")}
-				</h2>
-				<div className="mt-4 flex flex-wrap gap-2">
-					{credentials.map((credential) => (
-						<Badge key={credential.id} variant={credential.revokedAt ? "error" : "success"}>
-							{credential.name}
-						</Badge>
-					))}
-				</div>
-				<form className="mt-5 flex flex-col gap-4 sm:flex-row sm:items-end" onSubmit={enrol}>
-					<Input
-						className="flex-1"
-						label={t("approval.credentials.name", "Passkey name")}
-						placeholder={t("approval.credentials.placeholder", "Work laptop")}
-						required
-						value={credentialName}
-						onChange={(event) => setCredentialName(event.currentTarget.value)}
-					/>
-					<Button loading={busy} type="submit" variant="secondary">
-						{t("approval.credentials.enrol", "Enrol passkey")}
-					</Button>
-				</form>
-			</Surface>
+			{credentialsPanel}
 
+			{requestedDecision ? (
+				<p className="text-sm text-kumo-subtle">
+					{requestedDecision === "approve"
+						? t(
+								"approval.requested.approve",
+								"The CLI requested approval. Review the evidence before using your passkey.",
+							)
+						: t(
+								"approval.requested.reject",
+								"The CLI requested rejection. Review the evidence before using your passkey.",
+							)}
+				</p>
+			) : null}
 			<div className="flex flex-wrap justify-end gap-3">
 				<Button
 					disabled={credentials.every((credential) => credential.revokedAt !== null)}

--- a/apps/release-service/src/ui/components.tsx
+++ b/apps/release-service/src/ui/components.tsx
@@ -17,6 +17,7 @@ export function Page({ children }: { children: ReactNode }) {
 				</div>
 				<nav aria-label={t("nav.label", "Release service sections")} className="flex gap-2">
 					<Link href="/publisher">{t("nav.publisher", "Publisher")}</Link>
+					<Link href="/approver">{t("nav.approver", "Approver")}</Link>
 					<Link href="/admin">{t("nav.operator", "Operator")}</Link>
 				</nav>
 			</header>

--- a/packages/plugin-cli/README.md
+++ b/packages/plugin-cli/README.md
@@ -25,6 +25,13 @@ emdash-plugin build                          Build dist/ artifacts (plugin.mjs, 
 emdash-plugin dev                            Watch sources and rebuild on change
 emdash-plugin bundle                         Pack dist/ + assets into a registry tarball
 emdash-plugin publish --url <url>            Publish a release that points at a hosted tarball
+emdash-plugin release delegate               Print a publisher delegation browser handoff
+emdash-plugin release revoke                 Print an authority revocation browser handoff
+emdash-plugin release workload               Print a workload policy browser handoff
+emdash-plugin release enrol                  Print a passkey enrolment browser handoff
+emdash-plugin release approve <intent-id>    Print a passkey approval browser handoff
+emdash-plugin release reject <intent-id>     Print a passkey rejection browser handoff
+emdash-plugin release dry-run <release.json> Validate delegated release admission with GitHub OIDC
 emdash-plugin release submit <release.json>  Submit a delegated release with GitHub OIDC
 emdash-plugin release status <intent-id>     Read a delegated release intent
 emdash-plugin release cancel <intent-id>     Cancel an unpublished delegated release intent
@@ -37,7 +44,7 @@ emdash-plugin search <query>                 Free-text search
 emdash-plugin info <handle-or-did> <slug>    Show package details
 ```
 
-The non-interactive output commands (`whoami`, `validate`, `search`, `info`, `login`, `publish`, `release submit`, `release status`, `release cancel`) accept `--json` for machine-readable output. Discovery commands (`search`, `info`) accept `--registry-url <url>` (or `EMDASH_REGISTRY_URL`).
+The non-interactive output commands accept `--json` for machine-readable output. Discovery commands (`search`, `info`) accept `--registry-url <url>` (or `EMDASH_REGISTRY_URL`).
 
 ## Development
 
@@ -89,7 +96,7 @@ On first publish, pass `--license` and `--security-email` (or `--security-url`) 
 
 ## Delegated releases
 
-The `release` commands authenticate with the current GitHub Actions OpenID Connect (OIDC) identity. Grant the job `id-token: write`; the CLI requests a token whose audience is the release-service origin for every API call.
+The automation commands (`dry-run`, `submit`, `status`, and `cancel`) authenticate with the current GitHub Actions OpenID Connect (OIDC) identity. Grant the job `id-token: write`; the CLI requests a token whose audience is the release-service origin for every API call.
 
 The following command submits a generated package release record and waits for publication or an approval request:
 
@@ -109,6 +116,19 @@ emdash-plugin release cancel 01JABCDEFGHJKMNPQRSTVWXYZ0
 ```
 
 These commands fail outside GitHub Actions because no OIDC request endpoint is available. Use the delegated release Action when the workflow only needs submission and outputs.
+
+Publisher authorization and passkeys remain browser operations. The following commands print a validated browser handoff instead of copying OAuth sessions or WebAuthn assertions into the terminal:
+
+```sh
+emdash-plugin release delegate --service-url https://release.example.com
+emdash-plugin release workload --service-url https://release.example.com
+emdash-plugin release enrol --service-url https://release.example.com
+emdash-plugin release approve 01JABCDEFGHJKMNPQRSTVWXYZ0 \
+  --service-url https://release.example.com \
+  --publisher-did did:web:publisher.example.com
+```
+
+Use `release revoke` to open publisher authority revocation and `release reject` to open the rejection ceremony. The service keeps its application-session cookies and passkey ceremony at its own origin.
 
 ## `emdash-plugin.jsonc`
 

--- a/packages/plugin-cli/src/commands/release.ts
+++ b/packages/plugin-cli/src/commands/release.ts
@@ -10,7 +10,9 @@ import {
 	cancelDelegatedReleaseIntent,
 	dryRunDelegatedRelease,
 	getDelegatedReleaseIntent,
+	interactiveReleaseUrl,
 	submitDelegatedRelease,
+	type InteractiveReleaseAction,
 } from "../release-service/operations.js";
 
 const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/;
@@ -29,6 +31,12 @@ function requiredTarget(args: { "publisher-did"?: string; "service-url"?: string
 	if (!serviceUrl) throw new Error("Release service URL is required");
 	if (!publisherDid) throw new Error("Publisher DID is required");
 	return { serviceUrl, publisherDid };
+}
+
+function requiredService(args: { "service-url"?: string }): string {
+	const serviceUrl = args["service-url"] || process.env["EMDASH_RELEASE_SERVICE_URL"];
+	if (!serviceUrl) throw new Error("Release service URL is required");
+	return serviceUrl;
 }
 
 function positiveInteger(value: string, name: string, maximum: number): number {
@@ -66,6 +74,16 @@ function printDryRun(result: DryRunReleaseIntentResult, json: boolean): void {
 	console.log(`  Policy:    ${result.workloadPolicyVersion}`);
 }
 
+function printBrowserHandoff(action: InteractiveReleaseAction, url: URL, json: boolean): void {
+	if (json) {
+		console.log(JSON.stringify({ action, url: url.toString() }));
+		return;
+	}
+	consola.info("Open your browser to:");
+	console.log(`  ${pc.cyan(pc.bold(url.toString()))}`);
+	consola.info("OAuth sessions and passkey assertions remain in the browser.");
+}
+
 const commonArgs = {
 	"service-url": {
 		type: "string" as const,
@@ -80,6 +98,86 @@ const commonArgs = {
 		description: "Output the intent as JSON",
 	},
 };
+
+const browserArgs = {
+	"service-url": commonArgs["service-url"],
+	json: {
+		type: "boolean" as const,
+		description: "Output the browser handoff as JSON",
+	},
+};
+
+export const releaseDelegateCommand = defineCommand({
+	meta: { name: "delegate", description: "Print a browser handoff for publisher delegation" },
+	args: browserArgs,
+	async run({ args }) {
+		const url = interactiveReleaseUrl("delegate", { serviceUrl: requiredService(args) });
+		printBrowserHandoff("delegate", url, args.json);
+	},
+});
+
+export const releaseRevokeCommand = defineCommand({
+	meta: { name: "revoke", description: "Print a browser handoff for authority revocation" },
+	args: browserArgs,
+	async run({ args }) {
+		const url = interactiveReleaseUrl("revoke", { serviceUrl: requiredService(args) });
+		printBrowserHandoff("revoke", url, args.json);
+	},
+});
+
+export const releaseWorkloadCommand = defineCommand({
+	meta: { name: "workload", description: "Print a browser handoff for workload policies" },
+	args: browserArgs,
+	async run({ args }) {
+		const url = interactiveReleaseUrl("workload", { serviceUrl: requiredService(args) });
+		printBrowserHandoff("workload", url, args.json);
+	},
+});
+
+export const releaseEnrolCommand = defineCommand({
+	meta: { name: "enrol", description: "Print a browser handoff for passkey enrolment" },
+	args: browserArgs,
+	async run({ args }) {
+		const url = interactiveReleaseUrl("enrol", { serviceUrl: requiredService(args) });
+		printBrowserHandoff("enrol", url, args.json);
+	},
+});
+
+const approvalBrowserArgs = {
+	"intent-id": {
+		type: "positional" as const,
+		description: "Release intent ULID",
+		required: true,
+	},
+	...browserArgs,
+	"publisher-did": commonArgs["publisher-did"],
+};
+
+export const releaseApproveCommand = defineCommand({
+	meta: { name: "approve", description: "Print a browser handoff for passkey approval" },
+	args: approvalBrowserArgs,
+	async run({ args }) {
+		const target = requiredTarget(args);
+		const url = interactiveReleaseUrl("approve", {
+			...target,
+			intentId: args["intent-id"],
+		});
+		printBrowserHandoff("approve", url, args.json);
+	},
+});
+
+export const releaseRejectCommand = defineCommand({
+	meta: { name: "reject", description: "Print a browser handoff for passkey rejection" },
+	args: approvalBrowserArgs,
+	async run({ args }) {
+		const target = requiredTarget(args);
+		const url = interactiveReleaseUrl("reject", {
+			...target,
+			intentId: args["intent-id"],
+		});
+		printBrowserHandoff("reject", url, args.json);
+	},
+});
 
 export const releaseSubmitCommand = defineCommand({
 	meta: {
@@ -215,9 +313,15 @@ export const releaseCancelCommand = defineCommand({
 export const releaseCommand = defineCommand({
 	meta: { name: "release", description: "Manage delegated release intents" },
 	subCommands: {
+		approve: releaseApproveCommand,
+		delegate: releaseDelegateCommand,
 		"dry-run": releaseDryRunCommand,
+		enrol: releaseEnrolCommand,
+		reject: releaseRejectCommand,
+		revoke: releaseRevokeCommand,
 		submit: releaseSubmitCommand,
 		status: releaseStatusCommand,
 		cancel: releaseCancelCommand,
+		workload: releaseWorkloadCommand,
 	},
 });

--- a/packages/plugin-cli/src/release-service/operations.ts
+++ b/packages/plugin-cli/src/release-service/operations.ts
@@ -10,6 +10,8 @@ import {
 import { PackageRelease } from "@emdash-cms/registry-lexicons";
 
 const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/;
+const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
+const ULID_PATTERN = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 const MAX_RELEASE_FILE_BYTES = 128 * 1024;
 const MAX_OIDC_TOKEN_CHARS = 16 * 1024;
 
@@ -45,6 +47,68 @@ export interface DryRunDelegatedReleaseOptions extends ReleaseServiceTarget {
 export interface MutateReleaseIntentOptions extends ReleaseServiceTarget {
 	intentId: string;
 	idempotencyKey?: string;
+}
+
+export type InteractiveReleaseAction =
+	| "approve"
+	| "delegate"
+	| "enrol"
+	| "reject"
+	| "revoke"
+	| "workload";
+
+export interface InteractiveReleaseOptions {
+	serviceUrl: string;
+	publisherDid?: string;
+	intentId?: string;
+}
+
+export function interactiveReleaseUrl(
+	action: InteractiveReleaseAction,
+	options: InteractiveReleaseOptions,
+): URL {
+	let service: URL;
+	try {
+		service = new URL(options.serviceUrl);
+	} catch {
+		throw new Error("Release service URL must be a secure origin");
+	}
+	const loopback =
+		service.hostname === "localhost" ||
+		service.hostname === "127.0.0.1" ||
+		service.hostname === "[::1]";
+	if (
+		(service.protocol !== "https:" && !(service.protocol === "http:" && loopback)) ||
+		service.username !== "" ||
+		service.password !== "" ||
+		service.pathname !== "/" ||
+		service.search !== "" ||
+		service.hash !== ""
+	) {
+		throw new Error("Release service URL must be a secure origin");
+	}
+	if (action === "delegate" || action === "revoke" || action === "workload") {
+		service.pathname = "/publisher";
+		service.searchParams.set("view", action === "workload" ? "workloads" : "delegation");
+		if (action === "revoke") service.searchParams.set("action", "revoke");
+		return service;
+	}
+	if (action === "enrol") {
+		service.pathname = "/approver";
+		return service;
+	}
+	if (
+		!options.intentId ||
+		!ULID_PATTERN.test(options.intentId) ||
+		!options.publisherDid ||
+		!DID_PATTERN.test(options.publisherDid)
+	) {
+		throw new Error("Approval browser handoff requires a publisher DID and intent ULID");
+	}
+	service.pathname = `/approvals/${options.intentId}`;
+	service.searchParams.set("publisher", options.publisherDid);
+	service.searchParams.set("decision", action);
+	return service;
 }
 
 async function defaultReadReleaseRecord(path: string): Promise<unknown> {

--- a/packages/plugin-cli/tests/release-service-operations.test.ts
+++ b/packages/plugin-cli/tests/release-service-operations.test.ts
@@ -5,6 +5,7 @@ import {
 	cancelDelegatedReleaseIntent,
 	dryRunDelegatedRelease,
 	getDelegatedReleaseIntent,
+	interactiveReleaseUrl,
 	requestGithubOidcToken,
 	submitDelegatedRelease,
 } from "../src/release-service/operations.js";
@@ -42,6 +43,37 @@ function success(data: unknown, status = 200): Response {
 }
 
 describe("delegated release CLI operations", () => {
+	it("creates browser handoffs without carrying service credentials", () => {
+		expect(interactiveReleaseUrl("delegate", { serviceUrl: SERVICE }).toString()).toBe(
+			`${SERVICE}/publisher?view=delegation`,
+		);
+		expect(interactiveReleaseUrl("revoke", { serviceUrl: SERVICE }).toString()).toBe(
+			`${SERVICE}/publisher?view=delegation&action=revoke`,
+		);
+		expect(interactiveReleaseUrl("workload", { serviceUrl: SERVICE }).toString()).toBe(
+			`${SERVICE}/publisher?view=workloads`,
+		);
+		expect(interactiveReleaseUrl("enrol", { serviceUrl: SERVICE }).toString()).toBe(
+			`${SERVICE}/approver`,
+		);
+		expect(
+			interactiveReleaseUrl("approve", {
+				serviceUrl: SERVICE,
+				publisherDid: PUBLISHER_DID,
+				intentId: INTENT_ID,
+			}).toString(),
+		).toBe(
+			`${SERVICE}/approvals/${INTENT_ID}?publisher=${encodeURIComponent(PUBLISHER_DID)}&decision=approve`,
+		);
+		expect(() =>
+			interactiveReleaseUrl("reject", {
+				serviceUrl: "http://release.example.com",
+				publisherDid: PUBLISHER_DID,
+				intentId: INTENT_ID,
+			}),
+		).toThrow("Release service URL must be a secure origin");
+	});
+
 	it("requests a GitHub OIDC token for the release-service audience", async () => {
 		const calls: Array<{ headers: Headers; url: URL }> = [];
 		const token = await requestGithubOidcToken(SERVICE, {


### PR DESCRIPTION
## What does this PR do?

Adds CLI handoffs for delegation, revocation, workload policy, passkey enrolment, approval, and rejection. The CLI prints browser URLs while OAuth sessions and passkey assertions remain in the browser.

Depends on #2734. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
