### PR TITLE
fix(release-service): require directory registration before authority

### DIFF
--- a/apps/release-service/src/oauth/routes.ts
+++ b/apps/release-service/src/oauth/routes.ts
@@ -23,6 +23,10 @@ import {
 	canonicalizeRedirectTarget,
 } from "./custody.js";
 
+export interface OAuthRouteDependencies {
+	registerDirectoryIdentity?: typeof registerDirectoryIdentity;
+}
+
 export async function handleApproverIdentityAuthorize(
 	request: Request,
 	requestId: string,
@@ -269,6 +273,7 @@ export async function handleOAuthCallback(
 	request: Request,
 	requestId: string,
 	configuration: ServiceConfiguration,
+	dependencies: OAuthRouteDependencies = {},
 ): Promise<Response> {
 	try {
 		const params = new URL(request.url).searchParams;
@@ -307,26 +312,30 @@ export async function handleOAuthCallback(
 							redirectTarget: route.redirectTarget,
 						},
 					});
-		await client.callback(params);
-		try {
-			await registerDirectoryIdentity(
-				route.purpose === "approver_identity" ? "approver" : "publisher",
-				route.expectedDid,
-			);
-		} catch (error) {
-			writeOperationsMetric({
-				event: "directory_failure",
-				outcome: route.purpose === "approver_identity" ? "approver" : "publisher",
-				requestId,
-			});
-			console.error(
-				JSON.stringify({
-					event: "identity_directory_registration_failed",
+		const identityKind = route.purpose === "approver_identity" ? "approver" : "publisher";
+		const register = dependencies.registerDirectoryIdentity ?? registerDirectoryIdentity;
+		const registerIdentity = async () => {
+			try {
+				await register(identityKind, route.expectedDid);
+			} catch (error) {
+				writeOperationsMetric({
+					event: "directory_failure",
+					outcome: identityKind,
 					requestId,
-					name: error instanceof Error ? error.name : "UnknownError",
-				}),
-			);
-		}
+				});
+				console.error(
+					JSON.stringify({
+						event: "identity_directory_registration_failed",
+						requestId,
+						name: error instanceof Error ? error.name : "UnknownError",
+					}),
+				);
+				throw error;
+			}
+		};
+		if (route.purpose === "release_delegation") await registerIdentity();
+		await client.callback(params);
+		if (route.purpose !== "release_delegation") await registerIdentity();
 		const headers = new Headers({
 			"cache-control": "no-store",
 			location: new URL(route.redirectTarget, configuration.publicOrigin).toString(),

--- a/apps/release-service/test/oauth-routes.test.ts
+++ b/apps/release-service/test/oauth-routes.test.ts
@@ -181,6 +181,47 @@ describe("publisher OAuth routes", () => {
 		).resolves.toEqual([expect.objectContaining({ did: DID, kind: "publisher" })]);
 	});
 
+	it("fails the callback before issuing an app session when directory registration fails", async () => {
+		const network = oauthNetwork();
+		vi.stubGlobal("fetch", network.fetch);
+		const config = await configuration();
+		const start = await handlePublisherIdentityAuthorize(
+			new Request(`${ORIGIN}/v1/publisher/session/authorize`, {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					origin: ORIGIN,
+					"x-emdash-request": "1",
+				},
+				body: JSON.stringify({ identifier: DID, redirectTarget: "/publisher" }),
+			}),
+			"route-start-directory-failure",
+			config,
+		);
+		const routeCookie = cookiePair(start.headers.get("set-cookie") ?? "");
+		const state =
+			network.requests.find((request) => request.path === "/par")?.body.get("state") ?? "";
+
+		const callback = await handleOAuthCallback(
+			new Request(
+				`${ORIGIN}/oauth/callback?code=code-1&state=${encodeURIComponent(state)}&iss=${encodeURIComponent("https://authorization.example")}`,
+				{ headers: { cookie: routeCookie } },
+			),
+			"route-callback-directory-failure",
+			config,
+			{
+				registerDirectoryIdentity: async () => {
+					throw new Error("directory unavailable");
+				},
+			},
+		);
+
+		expect(callback.status).toBe(400);
+		const setCookie = callback.headers.get("set-cookie") ?? "";
+		expect(setCookie).not.toContain("__Host-emdash_publisher_session=");
+		expect(setCookie).not.toContain("__Host-emdash_publisher_csrf=");
+	});
+
 	it("keeps approver identity state and cookies in the approver realm", async () => {
 		const network = oauthNetwork();
 		vi.stubGlobal("fetch", network.fetch);
@@ -295,6 +336,50 @@ describe("publisher OAuth routes", () => {
 			"atproto repo:com.emdashcms.experimental.package.release?action=create",
 		);
 		expect(par?.body.get("scope")).not.toContain("transition:generic");
+	});
+
+	it("does not retain delegated authority when directory registration fails", async () => {
+		const network = oauthNetwork();
+		vi.stubGlobal("fetch", network.fetch);
+		const config = await configuration();
+		const session = await createPublisherApplicationSession(env.PUBLISHER_DO, DID);
+		const sessionCookies = session.setCookieHeaders.map(cookiePair);
+		const csrf = sessionCookies[1]?.split("=", 2)[1] ?? "";
+		const start = await handlePublisherDelegationAuthorize(
+			new Request(`${ORIGIN}/v1/publisher/delegation/authorize`, {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					cookie: sessionCookies.join("; "),
+					origin: ORIGIN,
+					"x-emdash-request": "1",
+					"x-emdash-csrf": csrf,
+				},
+				body: JSON.stringify({ redirectTarget: "/publisher" }),
+			}),
+			"delegation-directory-start",
+			config,
+		);
+		const routeCookie = cookiePair(start.headers.get("set-cookie") ?? "");
+		const state =
+			network.requests.find((request) => request.path === "/par")?.body.get("state") ?? "";
+
+		const callback = await handleOAuthCallback(
+			new Request(
+				`${ORIGIN}/oauth/callback?code=code-1&state=${encodeURIComponent(state)}&iss=${encodeURIComponent("https://authorization.example")}`,
+				{ headers: { cookie: [...sessionCookies, routeCookie].join("; ") } },
+			),
+			"delegation-directory-callback",
+			config,
+			{
+				registerDirectoryIdentity: async () => {
+					throw new Error("directory unavailable");
+				},
+			},
+		);
+
+		expect(callback.status).toBe(400);
+		await expect(env.PUBLISHER_DO.getByName(DID).getDelegation(DID)).resolves.toBeNull();
 	});
 
 	it("rejects callback state substitution and clears the routing cookie", async () => {

--- a/docs/technical-specs/delegated-release-service-operations.md
+++ b/docs/technical-specs/delegated-release-service-operations.md
@@ -97,11 +97,11 @@ After deployment, `GET /health` must return `200` without loading configuration.
 
 ## Operations directory
 
-Successful publisher and approver OAuth callbacks register the DID in one of 256 directory Durable Objects. Directory registration failure emits `directory_failure` but does not block OAuth or create authority.
+Successful publisher and approver OAuth callbacks register the DID in one of 256 directory Durable Objects before issuing an application session or retaining release delegation. Directory registration failure emits `directory_failure`, fails the callback, and leaves no new application session or delegated authority.
 
 The operator console skips empty partitions when listing publishers or approvers. API clients can resume one partition at a time with `ReleaseServiceOperatorClient.listDirectory()`. Fleet operations must retain the returned cursor until it becomes absent.
 
-Rebuild a missing directory as publishers and approvers complete OAuth again. Directory rows are not evidence of active delegation or approver eligibility; query each authoritative shard before acting.
+Rebuild a missing directory as publishers and approvers complete OAuth again. Directory rows are not evidence of active delegation or approver eligibility; query each authoritative shard before acting. Do not start fleet key verification or retire a key until every lost directory partition has been rebuilt.
 
 ## Rotate encryption keys
 
@@ -264,7 +264,7 @@ Configure alert queries for these event names:
 | `archive_gap`             | Resume the failed archive page and verify the manifest          |
 | `restore_failure`         | Keep the publisher suspended and inspect archive/page ordering  |
 | `configuration_failure`   | Keep readiness failed and correct variables or secrets          |
-| `directory_failure`       | Repair projection registration without changing authority       |
+| `directory_failure`       | Retry authorization so registration completes before authority  |
 | `intent_rate_limited`     | Review workload, repository, and publisher abuse patterns       |
 
 Alert delivery is deployment-specific. A production launch requires tested notification routing and an on-call owner for every event above.


### PR DESCRIPTION
## What does this PR do?

Requires a publisher to be registered in the sharded identity directory before the service accepts delegated authority. This prevents orphaned authority that operators cannot discover or recover.

Depends on #2736. Part of the delegated release service specified in [RFC #1870](https://github.com/emdash-cms/emdash/pull/1870).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (review as applicable to this layer)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (review as applicable to published packages)
- [ ] New features link to an approved Discussion: maintainer implementation of RFC #1870

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Cumulative top-of-stack verification:

- `pnpm lint:json`
- `pnpm typecheck`
- release service: 39 test files, 328 tests
- release-service encryption-v2: 1 test
- release-service UI: 3 test files, 9 tests
- release action: 2 test files, 7 tests
- registry client: 8 test files, 115 tests
- plugin CLI: 23 test files, 403 tests
