### PR TITLE
fix(labeler): preserve admin path when serving SPA

### DIFF
--- a/apps/labeler/wrangler.jsonc
+++ b/apps/labeler/wrangler.jsonc
@@ -7,6 +7,7 @@
 	"routes": [{ "pattern": "labels.emdashcms.com", "custom_domain": true }],
 	"assets": {
 		"binding": "ASSETS",
+		"html_handling": "none",
 		"run_worker_first": [
 			"/",
 			"/_admin",


### PR DESCRIPTION
## What does this PR do?

Prevents the labeler administration shell from redirecting authenticated users from `/_admin` to `/`.

The Worker serves the SPA by fetching `/index.html` through the static-assets binding. Static assets default to `html_handling: "auto-trailing-slash"`, which canonicalizes that internal request to `/` and returns a redirect. Setting `html_handling` to `none` makes the binding return the HTML asset directly while the browser remains on the Access-protected `/_admin` route.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable) — existing routing tests pass; the regression is Cloudflare static-assets canonicalization verified in the generated deployment config.
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — not applicable; no UI strings changed.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package) — not applicable; the labeler app is private.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... — not applicable; this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex (GPT-5)

## Screenshots / test output

- Type-aware lint: 0 diagnostics.
- Labeler typecheck passed.
- Labeler production build passed and emitted `assets.html_handling: "none"`.
- Labeler routing tests: 8 passed.

~ 🤖 Codex
