### PR TITLE
fix(core): keep Cloudflare dev maintenance running

### DIFF
--- a/.changeset/quick-bees-schedule.md
+++ b/.changeset/quick-bees-schedule.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes scheduled maintenance stopping after the initialization request in Cloudflare `astro dev`. EmDash now invokes the project's Cloudflare `scheduled()` handler from the long-lived dev server, keeping plugin cron jobs, scheduled publishing, cleanup, and declared plugin storage index creation running between requests.

--- a/.changeset/quick-bees-schedule.md
+++ b/.changeset/quick-bees-schedule.md
@@ -2,4 +2,4 @@
 "emdash": patch
 ---
 
-Fixes scheduled maintenance stopping after the initialization request in Cloudflare `astro dev`. EmDash now invokes the project's Cloudflare `scheduled()` handler from the long-lived dev server, keeping plugin cron jobs, scheduled publishing, cleanup, and declared plugin storage index creation running between requests.
+Fixes scheduled maintenance stopping after the initialization request in Cloudflare `astro dev`. EmDash now drives its own maintenance through a dev-only workerd route from the long-lived dev server, keeping plugin cron jobs, scheduled publishing, cleanup, and declared plugin storage index creation running between requests without invoking application-wide scheduled jobs.

--- a/packages/core/src/astro/integration/cloudflare-dev-scheduler.ts
+++ b/packages/core/src/astro/integration/cloudflare-dev-scheduler.ts
@@ -1,0 +1,68 @@
+import type { Server } from "node:http";
+
+import type { AstroIntegrationLogger } from "astro";
+
+const DEFAULT_INTERVAL_MS = 60_000;
+const GENERAL_CRON = "* * * * *";
+
+interface DevServer {
+	httpServer: Pick<Server, "address" | "once"> | null;
+}
+
+interface SchedulerOptions {
+	intervalMs?: number;
+	fetch?: typeof fetch;
+}
+
+export function startCloudflareDevScheduler(
+	server: DevServer,
+	logger: Pick<AstroIntegrationLogger, "warn">,
+	options: SchedulerOptions = {},
+): void {
+	const httpServer = server.httpServer;
+	if (!httpServer) return;
+
+	const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+	const fetchScheduled = options.fetch ?? fetch;
+	let stopped = false;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	const schedule = () => {
+		if (stopped) return;
+		timer = setTimeout(() => void run(), intervalMs);
+		if (typeof timer === "object" && "unref" in timer) timer.unref();
+	};
+
+	const run = async () => {
+		try {
+			const address = httpServer.address();
+			if (!address || typeof address === "string") {
+				logger.warn("Cloudflare dev scheduler could not resolve the local server port.");
+				return;
+			}
+
+			const url = new URL("/cdn-cgi/handler/scheduled", `http://localhost:${address.port}`);
+			url.searchParams.set("cron", GENERAL_CRON);
+			url.searchParams.set("format", "json");
+			const response = await fetchScheduled(url);
+			if (!response.ok) {
+				logger.warn(
+					`Cloudflare dev scheduler request failed with status ${response.status}. ` +
+						"Verify that the Worker entrypoint exports its scheduled handler.",
+				);
+			}
+		} catch (error) {
+			logger.warn(
+				`Cloudflare dev scheduler request failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		} finally {
+			schedule();
+		}
+	};
+
+	httpServer.once("listening", schedule);
+	httpServer.once("close", () => {
+		stopped = true;
+		if (timer !== undefined) clearTimeout(timer);
+	});
+}

--- a/packages/core/src/astro/integration/cloudflare-dev-scheduler.ts
+++ b/packages/core/src/astro/integration/cloudflare-dev-scheduler.ts
@@ -3,10 +3,10 @@ import type { Server } from "node:http";
 import type { AstroIntegrationLogger } from "astro";
 
 const DEFAULT_INTERVAL_MS = 60_000;
-const GENERAL_CRON = "* * * * *";
 
 interface DevServer {
-	httpServer: Pick<Server, "address" | "once"> | null;
+	httpServer: Pick<Server, "once"> | null;
+	resolvedUrls: { local: string[]; network: string[] } | null;
 }
 
 interface SchedulerOptions {
@@ -35,20 +35,18 @@ export function startCloudflareDevScheduler(
 
 	const run = async () => {
 		try {
-			const address = httpServer.address();
-			if (!address || typeof address === "string") {
-				logger.warn("Cloudflare dev scheduler could not resolve the local server port.");
+			const origin = server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0];
+			if (!origin) {
+				logger.warn("Cloudflare dev scheduler could not resolve the dev server origin.");
 				return;
 			}
 
-			const url = new URL("/cdn-cgi/handler/scheduled", `http://localhost:${address.port}`);
-			url.searchParams.set("cron", GENERAL_CRON);
-			url.searchParams.set("format", "json");
-			const response = await fetchScheduled(url);
+			const url = new URL("/_emdash/api/dev/scheduled-tasks", origin);
+			const response = await fetchScheduled(url, { method: "POST" });
 			if (!response.ok) {
 				logger.warn(
 					`Cloudflare dev scheduler request failed with status ${response.status}. ` +
-						"Verify that the Worker entrypoint exports its scheduled handler.",
+						"Verify that EmDash's dev maintenance route is available.",
 				);
 			}
 		} catch (error) {

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -585,7 +585,10 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 				});
 
 				// Inject all core routes
-				injectCoreRoutes(injectRoute, { srcDir: astroConfig.srcDir });
+				injectCoreRoutes(injectRoute, {
+					srcDir: astroConfig.srcDir,
+					cloudflareDevScheduler: command === "dev" && usesCloudflareAdapter,
+				});
 
 				// Inject routes from pluggable auth providers (authProviders config)
 				if (resolvedConfig.authProviders?.length) {

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -29,6 +29,7 @@ import { writeMigrationManifest } from "../../migrations/manifest-writer.js";
 import type { ResolvedPlugin } from "../../plugins/types.js";
 import { VERSION } from "../../version.js";
 import { local } from "../storage/adapters.js";
+import { startCloudflareDevScheduler } from "./cloudflare-dev-scheduler.js";
 import { notoSans } from "./font-provider.js";
 import {
 	injectCoreRoutes,
@@ -452,6 +453,7 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 	// Captured in astro:config:setup so the astro:server:setup hook can tell
 	// whether we're running `astro dev` (where the dev-bypass shortcut applies).
 	let astroCommand: "dev" | "build" | "preview" | "sync" | undefined;
+	let usesCloudflareAdapter = false;
 	let normalizedI18n: ReturnType<typeof normalizeAstroI18n> = null;
 	const migrationMetadata = createMigrationIntegrationMetadata(resolvedConfig.database);
 
@@ -467,6 +469,7 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 				command,
 			}) => {
 				astroCommand = command;
+				usesCloudflareAdapter = astroConfig.adapter?.name === "@astrojs/cloudflare";
 				printBanner(logger);
 				// Capture the host's Astro version so the runtime can expose it
 				// to the admin and the registry install gate for `env:astro`
@@ -634,6 +637,10 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 				await writeMigrationManifest(fileURLToPath(finalConfig.root), manifest);
 			},
 			"astro:server:setup": ({ server, logger }) => {
+				if (astroCommand === "dev" && usesCloudflareAdapter) {
+					startCloudflareDevScheduler(server, logger);
+				}
+
 				// Print route info with absolute, clickable URLs once the server
 				// is listening. Only in `astro dev` -- the dev-bypass shortcut is
 				// dev-only and the port is unknown until now.

--- a/packages/core/src/astro/integration/routes.ts
+++ b/packages/core/src/astro/integration/routes.ts
@@ -44,6 +44,7 @@ type InjectRoute = (route: { pattern: string; entrypoint: string }) => void;
 
 interface InjectCoreRoutesOptions {
 	srcDir?: URL;
+	cloudflareDevScheduler?: boolean;
 }
 
 const ROUTE_OVERRIDE_EXTENSIONS = [
@@ -952,6 +953,13 @@ export function injectCoreRoutes(
 		pattern: "/_emdash/api/dev/emails",
 		entrypoint: resolveRoute("api/dev/emails.ts"),
 	});
+
+	if (options.cloudflareDevScheduler) {
+		injectRoute({
+			pattern: "/_emdash/api/dev/scheduled-tasks",
+			entrypoint: resolveRoute("api/dev/scheduled-tasks.ts"),
+		});
+	}
 
 	// Current user endpoint (always available)
 	injectRoute({

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -525,30 +525,22 @@ export function generateBuildModule(buildTime: number): string {
  * Generates the scheduler virtual module.
  *
  * Decides — at build time, from the Astro adapter — whether the runtime gets a
- * long-lived timer heartbeat. A *production* Cloudflare build has no persistent
- * timers, so the Worker's `scheduled()` handler (a Cron Trigger) drives
- * `runScheduledTasks()` instead and this exports `null`. Every other case — any
- * other adapter (Node, Bun), and crucially local `astro dev` even under the
- * Cloudflare adapter (no Cron Trigger fires in dev) — gets a `NodeCronScheduler`
- * factory so plugin cron, scheduled publishing, and cleanup still run.
+ * long-lived timer heartbeat. Cloudflare Workers have no persistent timers, so
+ * the Worker's `scheduled()` handler drives `runScheduledTasks()` instead. In
+ * local dev the Astro integration invokes that handler from the long-lived Vite
+ * host. Other adapters (Node, Bun) get a `NodeCronScheduler` factory.
  *
  * Keeping the adapter check here — rather than in core's runtime — means the
  * runtime has no Cloudflare-specific code path; it just calls `createScheduler`
  * if one was injected. Mirrors the wait-until module's approach.
  */
-export function generateSchedulerModule(
-	adapterName: string | undefined,
-	command: "build" | "serve" | undefined,
-): string {
-	// Only suppress the timer for an actual Cloudflare *build* — that artifact
-	// runs in workerd where a Cron Trigger drives scheduled work. In `serve`
-	// (local dev) nothing fires the Cron Trigger, so fall through to the timer.
-	if (adapterName === "@astrojs/cloudflare" && command !== "serve") {
-		return `// Serverless build: an external Cron Trigger drives scheduled work.
+export function generateSchedulerModule(adapterName: string | undefined): string {
+	if (adapterName === "@astrojs/cloudflare") {
+		return `// Cloudflare: an external platform event drives scheduled work.
 export const createScheduler = null;
 `;
 	}
-	return `// Long-lived runtime (or local dev): drive scheduled work from an in-process timer.
+	return `// Long-lived runtime: drive scheduled work from an in-process timer.
 import { NodeCronScheduler } from "emdash";
 
 export function createScheduler(executor) {

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -527,8 +527,9 @@ export function generateBuildModule(buildTime: number): string {
  * Decides — at build time, from the Astro adapter — whether the runtime gets a
  * long-lived timer heartbeat. Cloudflare Workers have no persistent timers, so
  * the Worker's `scheduled()` handler drives `runScheduledTasks()` instead. In
- * local dev the Astro integration invokes that handler from the long-lived Vite
- * host. Other adapters (Node, Bun) get a `NodeCronScheduler` factory.
+ * local dev the long-lived Vite host invokes an EmDash-owned route that runs
+ * the same maintenance inside workerd. Other adapters (Node, Bun) get a
+ * `NodeCronScheduler` factory.
  *
  * Keeping the adapter check here — rather than in core's runtime — means the
  * runtime has no Cloudflare-specific code path; it just calls `createScheduler`

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -174,10 +174,7 @@ export interface VitePluginOptions {
 /**
  * Creates the EmDash virtual modules Vite plugin.
  */
-export function createVirtualModulesPlugin(
-	options: VitePluginOptions,
-	astroCommand: "dev" | "build" | "preview" | "sync",
-): Plugin {
+export function createVirtualModulesPlugin(options: VitePluginOptions): Plugin {
 	const { serializableConfig, resolvedConfig, pluginDescriptors, astroConfig } = options;
 
 	let viteCommand: "build" | "serve" | undefined;
@@ -329,17 +326,9 @@ export function createVirtualModulesPlugin(
 			}
 			// Generate scheduler module — a NodeCronScheduler factory on
 			// long-lived runtimes, or null under the Cloudflare adapter where
-			// a Cron Trigger drives scheduled work instead.
-			//
-			// Decide from Astro's command, not Vite's config.command: the
-			// Cloudflare adapter builds the worker bundle via a nested Vite
-			// *build* pass even during `astro dev`, so viteCommand reports
-			// "build" and would wrongly suppress the in-process timer (#1635).
-			// Astro's command stays "dev", which is the only case that should
-			// fall through to a NodeCronScheduler.
+			// platform events drive scheduled work.
 			if (id === RESOLVED_VIRTUAL_SCHEDULER_ID) {
-				const schedulerCommand = astroCommand === "dev" ? "serve" : "build";
-				return generateSchedulerModule(astroConfig.adapter?.name, schedulerCommand);
+				return generateSchedulerModule(astroConfig.adapter?.name);
 			}
 			// Generate env module — re-exports cloudflare:workers' env under
 			// the Cloudflare adapter, undefined otherwise (#1736).
@@ -447,7 +436,7 @@ export function createViteConfig(
 		},
 		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- Monorepo has both vite 6 (docs) and vite 7 (core). tsgo resolves correctly.
 		plugins: [
-			createVirtualModulesPlugin(options, command),
+			createVirtualModulesPlugin(options),
 			// In dev mode with source alias, compile Lingui macros on the fly
 			// and redirect locale .mjs imports to dist/.
 			// In production, macros are pre-compiled by tsdown in the admin package.

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -115,6 +115,8 @@ const PUBLIC_API_EXACT = new Set([
 	"/_emdash/api/search/suggest",
 ]);
 
+const DEV_PUBLIC_API_EXACT = new Set(["/_emdash/api/typegen", "/_emdash/api/dev/scheduled-tasks"]);
+
 // Build merged public routes at module load from auth provider descriptors.
 // Routes ending with "/" are treated as prefixes; all others are exact matches.
 const { exact: _providerExactRoutes, prefixes: _providerPrefixRoutes } = (() => {
@@ -160,7 +162,7 @@ function isPublicEmDashRoute(pathname: string): boolean {
 	if (PUBLIC_API_PREFIXES.some((p) => pathname.startsWith(p))) return true;
 	if (_providerExactRoutes.has(pathname)) return true;
 	if (_providerPrefixRoutes.some((p) => pathname.startsWith(p))) return true;
-	if (import.meta.env.DEV && pathname === "/_emdash/api/typegen") return true;
+	if (import.meta.env.DEV && DEV_PUBLIC_API_EXACT.has(pathname)) return true;
 	return false;
 }
 

--- a/packages/core/src/astro/routes/api/dev/scheduled-tasks.ts
+++ b/packages/core/src/astro/routes/api/dev/scheduled-tasks.ts
@@ -1,0 +1,14 @@
+import type { APIRoute } from "astro";
+
+import { runScheduledTasks } from "../../../middleware.js";
+
+export const prerender = false;
+
+/**
+ * Cloudflare development bridge for EmDash-owned scheduled maintenance.
+ * The integration injects this route only during Cloudflare `astro dev`.
+ */
+export const POST: APIRoute = async () => {
+	await runScheduledTasks();
+	return new Response(null, { status: 204 });
+};

--- a/packages/core/tests/unit/astro/integration/cloudflare-dev-scheduled-route.test.ts
+++ b/packages/core/tests/unit/astro/integration/cloudflare-dev-scheduled-route.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, expect, it, vi } from "vitest";
+
+const maintenance = vi.hoisted(() => ({
+	runScheduledTasks: vi.fn(async () => ({ published: [] })),
+}));
+
+vi.mock("../../../../src/astro/middleware.js", () => maintenance);
+
+import { POST } from "../../../../src/astro/routes/api/dev/scheduled-tasks.js";
+
+beforeEach(() => {
+	maintenance.runScheduledTasks.mockClear();
+});
+
+it("runs EmDash maintenance directly inside the workerd request", async () => {
+	const response = await POST({} as never);
+
+	expect(maintenance.runScheduledTasks).toHaveBeenCalledExactlyOnceWith();
+	expect(response.status).toBe(204);
+});

--- a/packages/core/tests/unit/astro/integration/cloudflare-dev-scheduler.test.ts
+++ b/packages/core/tests/unit/astro/integration/cloudflare-dev-scheduler.test.ts
@@ -1,0 +1,70 @@
+import { EventEmitter } from "node:events";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startCloudflareDevScheduler } from "../../../../src/astro/integration/cloudflare-dev-scheduler.js";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("Cloudflare dev scheduler", () => {
+	function createServer() {
+		return Object.assign(new EventEmitter(), {
+			address: () => ({ address: "127.0.0.1", family: "IPv4", port: 4323 }),
+		});
+	}
+
+	it("drives the Worker scheduled handler from the long-lived dev server", async () => {
+		vi.useFakeTimers();
+		const httpServer = createServer();
+		const fetchScheduled = vi.fn(async () => new Response(null, { status: 200 }));
+		const warn = vi.fn();
+
+		startCloudflareDevScheduler(
+			{ httpServer: httpServer as never },
+			{ warn },
+			{ intervalMs: 1_000, fetch: fetchScheduled },
+		);
+		httpServer.emit("listening");
+
+		await vi.advanceTimersByTimeAsync(999);
+		expect(fetchScheduled).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(fetchScheduled).toHaveBeenCalledOnce();
+		const url = new URL(String(fetchScheduled.mock.calls[0]?.[0]));
+		expect(url.origin).toBe("http://localhost:4323");
+		expect(url.pathname).toBe("/cdn-cgi/handler/scheduled");
+		expect(url.searchParams.get("cron")).toBe("* * * * *");
+		expect(url.searchParams.get("format")).toBe("json");
+		expect(warn).not.toHaveBeenCalled();
+
+		httpServer.emit("close");
+		await vi.advanceTimersByTimeAsync(2_000);
+		expect(fetchScheduled).toHaveBeenCalledOnce();
+	});
+
+	it("reports a missing scheduled handler and keeps polling", async () => {
+		vi.useFakeTimers();
+		const httpServer = createServer();
+		const fetchScheduled = vi
+			.fn()
+			.mockResolvedValueOnce(new Response(null, { status: 404 }))
+			.mockResolvedValue(new Response(null, { status: 200 }));
+		const warn = vi.fn();
+
+		startCloudflareDevScheduler(
+			{ httpServer: httpServer as never },
+			{ warn },
+			{ intervalMs: 1_000, fetch: fetchScheduled },
+		);
+		httpServer.emit("listening");
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining("status 404"));
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(fetchScheduled).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/core/tests/unit/astro/integration/cloudflare-dev-scheduler.test.ts
+++ b/packages/core/tests/unit/astro/integration/cloudflare-dev-scheduler.test.ts
@@ -9,20 +9,21 @@ afterEach(() => {
 });
 
 describe("Cloudflare dev scheduler", () => {
-	function createServer() {
+	function createServer(origin = "http://localhost:4323/") {
 		return Object.assign(new EventEmitter(), {
 			address: () => ({ address: "127.0.0.1", family: "IPv4", port: 4323 }),
+			resolvedUrls: { local: [origin], network: [] },
 		});
 	}
 
-	it("drives the Worker scheduled handler from the long-lived dev server", async () => {
+	it("drives the EmDash maintenance bridge from the long-lived dev server", async () => {
 		vi.useFakeTimers();
 		const httpServer = createServer();
 		const fetchScheduled = vi.fn(async () => new Response(null, { status: 200 }));
 		const warn = vi.fn();
 
 		startCloudflareDevScheduler(
-			{ httpServer: httpServer as never },
+			{ httpServer: httpServer as never, resolvedUrls: httpServer.resolvedUrls },
 			{ warn },
 			{ intervalMs: 1_000, fetch: fetchScheduled },
 		);
@@ -35,9 +36,9 @@ describe("Cloudflare dev scheduler", () => {
 		expect(fetchScheduled).toHaveBeenCalledOnce();
 		const url = new URL(String(fetchScheduled.mock.calls[0]?.[0]));
 		expect(url.origin).toBe("http://localhost:4323");
-		expect(url.pathname).toBe("/cdn-cgi/handler/scheduled");
-		expect(url.searchParams.get("cron")).toBe("* * * * *");
-		expect(url.searchParams.get("format")).toBe("json");
+		expect(url.pathname).toBe("/_emdash/api/dev/scheduled-tasks");
+		expect(url.search).toBe("");
+		expect(fetchScheduled.mock.calls[0]?.[1]).toEqual({ method: "POST" });
 		expect(warn).not.toHaveBeenCalled();
 
 		httpServer.emit("close");
@@ -45,7 +46,56 @@ describe("Cloudflare dev scheduler", () => {
 		expect(fetchScheduled).toHaveBeenCalledOnce();
 	});
 
-	it("reports a missing scheduled handler and keeps polling", async () => {
+	it("uses Vite's resolved HTTPS origin instead of reconstructing localhost", async () => {
+		vi.useFakeTimers();
+		const httpServer = createServer("https://dev.example.test:7443/");
+		const fetchScheduled = vi.fn(async () => new Response(null, { status: 204 }));
+
+		startCloudflareDevScheduler(
+			{ httpServer: httpServer as never, resolvedUrls: httpServer.resolvedUrls },
+			{ warn: vi.fn() },
+			{ intervalMs: 1_000, fetch: fetchScheduled },
+		);
+		httpServer.emit("listening");
+
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(String(fetchScheduled.mock.calls[0]?.[0])).toBe(
+			"https://dev.example.test:7443/_emdash/api/dev/scheduled-tasks",
+		);
+	});
+
+	it("does not dispatch custom generalCron or unrelated application scheduled jobs", async () => {
+		vi.useFakeTimers();
+		const httpServer = createServer();
+		const runEmDashMaintenance = vi.fn(async () => {});
+		const runApplicationScheduledHandler = vi.fn(async () => {});
+		const fetchScheduled = vi.fn(async (input: URL | RequestInfo) => {
+			const url = new URL(
+				typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+			);
+			if (url.pathname === "/cdn-cgi/handler/scheduled") {
+				await runApplicationScheduledHandler(url.searchParams.get("cron"));
+			} else if (url.pathname === "/_emdash/api/dev/scheduled-tasks") {
+				await runEmDashMaintenance();
+			}
+			return new Response(null, { status: 204 });
+		});
+
+		startCloudflareDevScheduler(
+			{ httpServer: httpServer as never, resolvedUrls: httpServer.resolvedUrls },
+			{ warn: vi.fn() },
+			{ intervalMs: 1_000, fetch: fetchScheduled },
+		);
+		httpServer.emit("listening");
+
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(runEmDashMaintenance).toHaveBeenCalledOnce();
+		expect(runApplicationScheduledHandler).not.toHaveBeenCalled();
+	});
+
+	it("reports a missing maintenance bridge and keeps polling", async () => {
 		vi.useFakeTimers();
 		const httpServer = createServer();
 		const fetchScheduled = vi
@@ -55,7 +105,7 @@ describe("Cloudflare dev scheduler", () => {
 		const warn = vi.fn();
 
 		startCloudflareDevScheduler(
-			{ httpServer: httpServer as never },
+			{ httpServer: httpServer as never, resolvedUrls: httpServer.resolvedUrls },
 			{ warn },
 			{ intervalMs: 1_000, fetch: fetchScheduled },
 		);

--- a/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
+++ b/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
@@ -100,30 +100,25 @@ describe("generateDialectModule", () => {
 
 describe("generateSchedulerModule", () => {
 	it("disables the timer for a Cloudflare production build (Cron Trigger drives it)", () => {
-		const out = generateSchedulerModule("@astrojs/cloudflare", "build");
+		const out = generateSchedulerModule("@astrojs/cloudflare");
 		expect(out).toContain("export const createScheduler = null");
 		expect(out).not.toContain("NodeCronScheduler");
 	});
 
-	it("keeps the Node timer in local dev even under the Cloudflare adapter", () => {
-		// No Cron Trigger fires in `astro dev`, so scheduled publishing/cron
-		// must still run via the in-process timer.
-		const out = generateSchedulerModule("@astrojs/cloudflare", "serve");
-		expect(out).toContain('import { NodeCronScheduler } from "emdash"');
-		expect(out).toContain("export function createScheduler(executor)");
-		expect(out).not.toContain("createScheduler = null");
+	it("does not emit a detached timer inside Cloudflare local dev", () => {
+		const out = generateSchedulerModule("@astrojs/cloudflare");
+		expect(out).toContain("export const createScheduler = null");
+		expect(out).not.toContain("NodeCronScheduler");
 	});
 
 	it("emits a NodeCronScheduler factory for non-Cloudflare adapters", () => {
-		for (const cmd of ["build", "serve", undefined] as const) {
-			const out = generateSchedulerModule("@astrojs/node", cmd);
-			expect(out).toContain('import { NodeCronScheduler } from "emdash"');
-			expect(out).not.toContain("createScheduler = null");
-		}
+		const out = generateSchedulerModule("@astrojs/node");
+		expect(out).toContain('import { NodeCronScheduler } from "emdash"');
+		expect(out).not.toContain("createScheduler = null");
 	});
 
 	it("emits a NodeCronScheduler factory when no adapter is configured", () => {
-		const out = generateSchedulerModule(undefined, "build");
+		const out = generateSchedulerModule(undefined);
 		expect(out).toContain("export function createScheduler(executor)");
 	});
 });
@@ -158,34 +153,27 @@ describe("createVirtualModulesPlugin scheduler wiring", () => {
 		return (fn as (...a: unknown[]) => T).call(context, ...args);
 	}
 
-	function buildPlugin(
-		adapterName: string | undefined,
-		command: "dev" | "build" | "preview" | "sync",
-	): Plugin {
+	function buildPlugin(adapterName: string | undefined): Plugin {
 		const options = {
 			serializableConfig: {},
 			resolvedConfig: {},
 			pluginDescriptors: [],
 			astroConfig: { adapter: adapterName ? { name: adapterName } : undefined },
 		} as unknown as VitePluginOptions;
-		return createVirtualModulesPlugin(options, command);
+		return createVirtualModulesPlugin(options);
 	}
 
-	it("keeps the Node timer under the Cloudflare adapter during `astro dev` even when Vite reports command 'build'", () => {
-		// The Cloudflare adapter produces the worker bundle via a nested Vite
-		// *build* pass during `astro dev`, so Vite's config.command resolves to
-		// "build". The scheduler decision must use Astro's command ("dev")
-		// instead, otherwise plugin cron silently no-ops in local dev (#1635).
-		const plugin = buildPlugin("@astrojs/cloudflare", "dev");
+	it("keeps the timer out of the Cloudflare worker during `astro dev`", () => {
+		const plugin = buildPlugin("@astrojs/cloudflare");
 		callHook(plugin.configResolved, { command: "build" });
 
 		const out = callHook<string>(plugin.load, RESOLVED_VIRTUAL_SCHEDULER_ID);
-		expect(out).toContain('import { NodeCronScheduler } from "emdash"');
-		expect(out).not.toContain("createScheduler = null");
+		expect(out).toContain("export const createScheduler = null");
+		expect(out).not.toContain("NodeCronScheduler");
 	});
 
 	it("disables the timer under the Cloudflare adapter for a production build", () => {
-		const plugin = buildPlugin("@astrojs/cloudflare", "build");
+		const plugin = buildPlugin("@astrojs/cloudflare");
 		callHook(plugin.configResolved, { command: "build" });
 
 		const out = callHook<string>(plugin.load, RESOLVED_VIRTUAL_SCHEDULER_ID);
@@ -194,7 +182,7 @@ describe("createVirtualModulesPlugin scheduler wiring", () => {
 	});
 
 	it("keeps the build timestamp stable across repeated loads", () => {
-		const plugin = buildPlugin("@astrojs/cloudflare", "build");
+		const plugin = buildPlugin("@astrojs/cloudflare");
 		callHook(plugin.configResolved, { command: "build" });
 
 		const first = callHook<string>(plugin.load, RESOLVED_VIRTUAL_BUILD_ID);
@@ -237,7 +225,7 @@ describe("createVirtualModulesPlugin scheduler wiring", () => {
 				pluginDescriptors: [],
 				astroConfig: { root: pathToFileURL(`${projectRoot}/`) },
 			} as unknown as VitePluginOptions;
-			const plugin = createVirtualModulesPlugin(options, "dev");
+			const plugin = createVirtualModulesPlugin(options);
 			const addWatchFile = vi.fn();
 
 			const source = callHookWithContext<string>(

--- a/packages/core/tests/unit/astro/routes.test.ts
+++ b/packages/core/tests/unit/astro/routes.test.ts
@@ -99,6 +99,25 @@ describe("core media route injection", () => {
 		expect(folder).toBeLessThan(mediaItem);
 	});
 
+	it("injects the maintenance bridge only when Cloudflare dev requests it", () => {
+		const defaultRoutes: Array<{ pattern: string; entrypoint: string }> = [];
+		injectCoreRoutes((route) => defaultRoutes.push(route));
+		expect(defaultRoutes).not.toContainEqual(
+			expect.objectContaining({ pattern: "/_emdash/api/dev/scheduled-tasks" }),
+		);
+
+		const cloudflareDevRoutes: Array<{ pattern: string; entrypoint: string }> = [];
+		injectCoreRoutes((route) => cloudflareDevRoutes.push(route), {
+			cloudflareDevScheduler: true,
+		});
+		expect(cloudflareDevRoutes).toContainEqual(
+			expect.objectContaining({
+				pattern: "/_emdash/api/dev/scheduled-tasks",
+				entrypoint: expect.stringContaining("api/dev/scheduled-tasks"),
+			}),
+		);
+	});
+
 	it("injects default root SEO routes when the site does not define them", () => {
 		const routes = collectRoutePatterns();
 

--- a/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
+++ b/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
@@ -95,6 +95,16 @@ async function runAuthMiddleware(opts: {
 }
 
 describe("MCP discovery auth middleware", () => {
+	it("allows the server-to-server Cloudflare dev maintenance bridge without auth", async () => {
+		const { response, next, session } = await runAuthMiddleware({
+			pathname: "/_emdash/api/dev/scheduled-tasks",
+		});
+
+		expect(response.status).toBe(200);
+		expect(next).toHaveBeenCalledOnce();
+		expect(session.get).not.toHaveBeenCalled();
+	});
+
 	it("returns 401 with discovery metadata for unauthenticated MCP POST requests", async () => {
 		const { response, next } = await runAuthMiddleware({
 			pathname: "/_emdash/api/mcp",


### PR DESCRIPTION
## What does this PR do?

Fixes Cloudflare `astro dev` maintenance stopping after the request that initializes EmDash.

This is separate from #1635/#1636. Those changes fixed scheduler-factory generation during Cloudflare development. With the compatible latest stable stack, the generated `NodeCronScheduler` still arms successfully, but workerd cancels its detached timer when the response completes.

During Cloudflare development, this change keeps the cadence in Astro's long-lived Node/Vite host. Each tick uses Vite's resolved server origin to POST to an EmDash-owned route that is injected only for Cloudflare `astro dev`; the route runs `runScheduledTasks()` directly inside workerd. It does not fabricate a Cron event or invoke the application's `scheduled()` handler, so custom `generalCron` values and unrelated scheduled jobs are unaffected.

Node and Bun scheduling are unchanged. Production Cloudflare continues to use its configured Cron Trigger and Worker `scheduled()` handler.

The lifecycle control was reproduced without EmDash or private application code on Node 22.23.2, Astro 7.2.9, `@astrojs/cloudflare` 14.2.5, and Wrangler 4.127.0:

- A raw one-second timer did not fire after an immediate response.
- The same timer fired while the request remained pending.
- Wrangler's local scheduled-event endpoint invoked the Worker's `scheduled()` handler.

Closes #2767

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable; no admin UI strings changed)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md)
- [ ] New features link to an approved Discussion: not applicable; this is a bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex; OpenClaw autoreview (`gpt-5.6-sol`)

## Screenshots / test output

```text
Focused repair coverage:       43 passed
Full core suite:            6,169 passed, 9 skipped
Cloudflare package suite:      386 passed, 2 skipped
pnpm typecheck:                passed across 34 packages
pnpm lint:                     passed
pnpm format:check:             passed
pnpm --filter emdash build:    passed
```

Four CLI harness checks in the full core run could not spawn `/bin/sh` in the managed sandbox (`EPERM`); all other core tests passed.

OpenClaw reviewed exact head `8ef91383b64ac342b7f0e1dc854680ed741d847a` against base `688257ff63f761fd07531a91233f0c49c3bb1c6b`: completed, clean, 0 findings.
