### PR TITLE
fix(db): survive an idle-client error and bound the Postgres connect wait

### DIFF
--- a/.changeset/postgres-pool-timeouts-and-error-listener.md
+++ b/.changeset/postgres-pool-timeouts-and-error-listener.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes two Postgres pool faults that could hang requests or end the server process. An error raised on an idle pooled client — what a managed-database failover produces — was an unhandled event, which Node turns into an uncaught error that exits the process; the pool now logs it and keeps running, because node-postgres discards the bad client on its own. The `database` adapter's `pool` option also accepts `connectionTimeoutMillis` and `idleTimeoutMillis`, so a request that cannot reach the database fails on a bound you choose instead of waiting on the operating system's TCP timeout. Both are unset by default and node-postgres's own defaults still apply.

--- a/packages/core/src/db/adapters.ts
+++ b/packages/core/src/db/adapters.ts
@@ -199,7 +199,21 @@ export interface PostgresConfig {
 	user?: string;
 	password?: string;
 	ssl?: boolean;
-	pool?: { min?: number; max?: number };
+	pool?: {
+		min?: number;
+		max?: number;
+		/**
+		 * How long to wait for a connection before failing, in milliseconds.
+		 * Left unset, a request that cannot reach the database waits on the
+		 * operating system's TCP timeout instead. Passed through to `pg`.
+		 */
+		connectionTimeoutMillis?: number;
+		/**
+		 * How long an idle client stays in the pool before being closed, in
+		 * milliseconds. Passed through to `pg`.
+		 */
+		idleTimeoutMillis?: number;
+	};
 	migrationConnectionStringEnv?: string;
 }
 

--- a/packages/core/src/db/postgres.ts
+++ b/packages/core/src/db/postgres.ts
@@ -25,6 +25,19 @@ export function createDialect(config: PostgresConfig): PostgresDialect {
 		ssl: config.ssl,
 		min: config.pool?.min ?? 0,
 		max: config.pool?.max ?? 10,
+		// Left undefined when unset, which preserves node-postgres's own
+		// defaults rather than imposing new ones.
+		connectionTimeoutMillis: config.pool?.connectionTimeoutMillis,
+		idleTimeoutMillis: config.pool?.idleTimeoutMillis,
+	});
+
+	// node-postgres emits `error` on the pool for a fault raised on an IDLE
+	// client — a managed-database failover is the common cause. That is an
+	// EventEmitter `error` event, so with no listener attached Node throws and
+	// the server process exits. The pool itself recovers: pg discards the bad
+	// client. Logging is therefore the whole handler.
+	pool.on("error", (error) => {
+		console.error("[emdash] idle Postgres client error; the pool discarded it", error);
 	});
 
 	// Fail-fast migration locking instead of Kysely's blocking advisory

--- a/packages/core/tests/unit/db/postgres-pool.test.ts
+++ b/packages/core/tests/unit/db/postgres-pool.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+const poolInstances: Array<{
+	options: Record<string, unknown>;
+	listeners: Map<string, Array<(...args: unknown[]) => void>>;
+}> = [];
+
+vi.mock("pg", () => ({
+	Pool: class {
+		options: Record<string, unknown>;
+		listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+		constructor(options: Record<string, unknown>) {
+			this.options = options;
+			poolInstances.push(this);
+		}
+
+		on(event: string, listener: (...args: unknown[]) => void) {
+			const existing = this.listeners.get(event) ?? [];
+			existing.push(listener);
+			this.listeners.set(event, existing);
+			return this;
+		}
+	},
+}));
+
+vi.mock("../../../src/database/pg-migration-lock.js", () => ({
+	FailFastPostgresDialect: class {
+		constructor(public config: unknown) {}
+	},
+}));
+
+const { createDialect } = await import("../../../src/db/postgres.js");
+
+function makePool(config: Parameters<typeof createDialect>[0]) {
+	poolInstances.length = 0;
+	createDialect(config);
+	const pool = poolInstances[0];
+	if (!pool) throw new Error("createDialect did not construct a Pool");
+	return pool;
+}
+
+describe("createDialect pool timeouts", () => {
+	it("passes connect and idle timeouts through to pg", () => {
+		const pool = makePool({
+			connectionString: "postgres://localhost/db",
+			pool: { connectionTimeoutMillis: 2_000, idleTimeoutMillis: 10_000 },
+		});
+
+		expect(pool.options.connectionTimeoutMillis).toBe(2_000);
+		expect(pool.options.idleTimeoutMillis).toBe(10_000);
+	});
+
+	it("leaves both undefined when unset, so pg keeps its own defaults", () => {
+		// Not zero and not an invented default: an unset option must stay
+		// absent, or this change would silently alter behaviour for every
+		// existing deployment.
+		const pool = makePool({ connectionString: "postgres://localhost/db" });
+
+		expect(pool.options.connectionTimeoutMillis).toBeUndefined();
+		expect(pool.options.idleTimeoutMillis).toBeUndefined();
+	});
+
+	it("still applies the existing min and max defaults", () => {
+		const pool = makePool({ connectionString: "postgres://localhost/db" });
+
+		expect(pool.options.min).toBe(0);
+		expect(pool.options.max).toBe(10);
+	});
+});
+
+describe("createDialect idle-client error handling", () => {
+	it("attaches an error listener to the pool", () => {
+		const pool = makePool({ connectionString: "postgres://localhost/db" });
+
+		expect(pool.listeners.get("error") ?? []).toHaveLength(1);
+	});
+
+	it("swallows an idle-client error instead of letting it reach the process", () => {
+		// The reason this listener exists. `error` on an EventEmitter with no
+		// listener makes Node throw, which ends a server process. A failover
+		// raises exactly that event on an idle client, and pg recovers on its
+		// own, so logging is the whole job.
+		const pool = makePool({ connectionString: "postgres://localhost/db" });
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const listener = pool.listeners.get("error")?.[0];
+
+		expect(listener).toBeTypeOf("function");
+		expect(() => listener?.(new Error("terminating connection due to failover"))).not.toThrow();
+		expect(consoleError).toHaveBeenCalledOnce();
+
+		consoleError.mockRestore();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the two faults reported in #2752, both in `createDialect` in `packages/core/src/db/postgres.ts`.

**A failover can end the process.** node-postgres emits `error` on the pool for a fault raised on an *idle* client, which is what a managed-database failover produces. No listener is attached anywhere in the file, and an EventEmitter `error` event with no listener makes Node throw — in a server process, that is an exit. The pool itself is fine: pg discards the bad client and carries on. So the listener is the whole fix, and logging is the whole handler.

**A request that cannot reach the database waits on the OS.** With no `connectionTimeoutMillis`, the wait is the operating system's TCP timeout rather than a bound the application chose — minutes on a default Linux configuration, on a request a user is watching.

`config.pool` already carried `min` and `max`, so the configuration seam existed and the values were simply never read. This adds `connectionTimeoutMillis` and `idleTimeoutMillis` alongside them.

**Both stay unset by default**, which leaves node-postgres's own defaults in place. Nobody who has not asked for a timeout sees any change in behaviour.

Closes #2752

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — see the note below; one **pre-existing** error remains, unrelated to this change
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — not applicable, no admin UI strings
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — not applicable, this is a bug fix

### Note on `pnpm typecheck`

It reports one error in `packages/core/src/utils/slugify.ts`:

```
src/utils/slugify.ts(1,25): error TS2307: Cannot find module '@emdash-cms/admin/slugify' or its corresponding type declarations.
```

That file is not touched by this PR. I checked out pristine `main` (`688257f`) after a full `pnpm install && pnpm build` and ran the identical command: the same single error appears. So it is pre-existing in my environment rather than introduced here, and this change adds no new type errors. Flagging it rather than leaving a reviewer to wonder — happy to be told it is environment-specific on my side.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code). Authored and verified with the runs shown below; the submitter is responsible for correctness.

## Screenshots / test output

New tests: `packages/core/tests/unit/db/postgres-pool.test.ts`, five cases covering both timeouts passing through, both staying `undefined` when unset, the existing `min`/`max` defaults surviving, the listener being attached, and an idle-client error being swallowed rather than reaching the process.

**With the fix:**

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

**Same tests against unmodified `createDialect`,** to show they fail for the right reason:

```
 × passes connect and idle timeouts through to pg
 × attaches an error listener to the pool
 × swallows an idle-client error instead of letting it reach the process

 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)
```

Three of the five fail. The two that still pass assert behaviour that already worked — the existing `min`/`max` defaults, and that an unset option stays absent — so they are guards against this change altering something it should not, not evidence of the bug.

**No regression in the surrounding area** (`tests/unit/db` and `tests/unit/migrations`):

```
 Test Files  10 passed (10)
      Tests  78 passed (78)
```

`oxlint --type-aware --deny-warnings`, `prettier --check` and `oxfmt --check` are all clean on the changed files.