### PR TITLE
fix(cli): keep export-seed's stdout parseable and its references resolvable

### DIFF
--- a/.changeset/export-seed-resolvable-refs.md
+++ b/.changeset/export-seed-resolvable-refs.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `emdash export-seed --with-content` so `reference` field values survive a round trip through `emdash seed`. The export now names a reference's target by the seed id it assigns that entry, and writes a referenced collection before the collection pointing at it. Previously the export emitted the source database's row id, which the restored database does not carry: the literal `$ref:<row-id>` string was stored in the column, the restore reported success, and the reference was lost wherever it was rendered.

--- a/.changeset/export-seed-stdout-only-json.md
+++ b/.changeset/export-seed-stdout-only-json.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `emdash export-seed` so its progress line goes to stderr and kysely's `orderBy` deprecation notice is no longer triggered, allowing `emdash export-seed > seed.json` to write a file that parses as JSON. Previously the redirected file began with `ℹ Database: …` and `orderBy(array) is deprecated…`, the command still exited `0` with an empty stderr, and the corruption surfaced only when `emdash seed` rejected the file at restore time.

--- a/packages/core/src/cli/commands/export-seed.ts
+++ b/packages/core/src/cli/commands/export-seed.ts
@@ -75,7 +75,10 @@ export const exportSeedCommand = defineCommand({
 
 		// Connect to database
 		const dbPath = resolve(cwd, args.database);
-		consola.info(`Database: ${dbPath}`);
+		// The seed document is this command's stdout payload, so anything else
+		// written there corrupts `emdash export-seed > seed.json`. Diagnostics
+		// go to stderr, where a redirect leaves them visible.
+		process.stderr.write(`Database: ${dbPath}\n`);
 
 		const db = createDatabase({ url: `file:${dbPath}` });
 
@@ -355,7 +358,11 @@ async function exportTaxonomies(
 	const defs = await db
 		.selectFrom("_emdash_taxonomy_defs")
 		.selectAll()
-		.orderBy(["name", "locale"])
+		// Chained, not `orderBy(["name", "locale"])`: kysely deprecated the array
+		// form and announces it with `console.log`, which lands in the seed
+		// document this command writes to stdout.
+		.orderBy("name")
+		.orderBy("locale")
 		.execute();
 
 	const result: SeedTaxonomy[] = [];
@@ -446,7 +453,11 @@ async function exportMenus(db: Kysely<Database>, i18nEnabled: boolean): Promise<
 	const menus = await db
 		.selectFrom("_emdash_menus")
 		.selectAll()
-		.orderBy(["name", "locale"])
+		// Chained, not `orderBy(["name", "locale"])`: kysely deprecated the array
+		// form and announces it with `console.log`, which lands in the seed
+		// document this command writes to stdout.
+		.orderBy("name")
+		.orderBy("locale")
 		.execute();
 
 	const result: SeedMenu[] = [];

--- a/packages/core/src/cli/commands/export-seed.ts
+++ b/packages/core/src/cli/commands/export-seed.ts
@@ -18,6 +18,7 @@ import { ContentRepository } from "../../database/repositories/content.js";
 import { MediaRepository } from "../../database/repositories/media.js";
 import { OptionsRepository } from "../../database/repositories/options.js";
 import { TaxonomyRepository } from "../../database/repositories/taxonomy.js";
+import type { ContentItem } from "../../database/repositories/types.js";
 import type { Database } from "../../database/types.js";
 import { validateIdentifier } from "../../database/validate.js";
 import { getI18nConfig, isI18nEnabled } from "../../i18n/config.js";
@@ -684,6 +685,83 @@ async function exportWidgetAreas(db: Kysely<Database>): Promise<SeedWidgetArea[]
 	return result;
 }
 
+/** An entry read for export, paired with the seed id it will be written under. */
+interface CollectedEntry {
+	item: ContentItem;
+	seedId: string;
+}
+
+/** A reference field holds a single entry id or an array of them. */
+function referenceValues(value: unknown): string[] {
+	if (typeof value === "string") return [value];
+	if (Array.isArray(value)) return value.filter((v): v is string => typeof v === "string");
+	return [];
+}
+
+/**
+ * For each exported collection, the other exported collections its entries
+ * point into. Read from the values rather than a field's declared target so a
+ * `reference` field without `options.collection` is still accounted for.
+ */
+function referenceTargets(
+	collected: Map<string, CollectedEntry[]>,
+	collectionsBySlug: Map<string, SeedCollection>,
+	entryIdToCollection: Map<string, string>,
+): Map<string, Set<string>> {
+	const targets = new Map<string, Set<string>>();
+
+	for (const [slug, items] of collected) {
+		const referenceFields = (collectionsBySlug.get(slug)?.fields ?? [])
+			.filter((field) => field.type === "reference")
+			.map((field) => field.slug);
+		if (referenceFields.length === 0) continue;
+
+		const found = new Set<string>();
+		for (const { item } of items) {
+			for (const fieldSlug of referenceFields) {
+				for (const value of referenceValues(item.data[fieldSlug])) {
+					const target = entryIdToCollection.get(value);
+					if (target && target !== slug) found.add(target);
+				}
+			}
+		}
+		if (found.size > 0) targets.set(slug, found);
+	}
+
+	return targets;
+}
+
+/**
+ * Order collections so a reference's target is written before the entry that
+ * points at it. `applySeed` fills its seed-id map as it walks the file, so a
+ * `$ref` into a collection further down resolves to nothing and is stored
+ * verbatim.
+ *
+ * Depth-first, with the caller's order as the tie-break so an export without
+ * references keeps the collection order it had. A cycle has no valid order;
+ * the collections on it stay where they were rather than failing the export.
+ */
+function orderByReferenceTargets(slugs: string[], targets: Map<string, Set<string>>): string[] {
+	const exported = new Set(slugs);
+	const ordered: string[] = [];
+	const placed = new Set<string>();
+	const visiting = new Set<string>();
+
+	const visit = (slug: string): void => {
+		if (placed.has(slug) || visiting.has(slug)) return;
+		visiting.add(slug);
+		for (const target of targets.get(slug) ?? []) {
+			if (exported.has(target)) visit(target);
+		}
+		visiting.delete(slug);
+		placed.add(slug);
+		ordered.push(slug);
+	};
+
+	for (const slug of slugs) visit(slug);
+	return ordered;
+}
+
 /**
  * Export content from collections
  */
@@ -726,19 +804,22 @@ async function exportContent(
 		// Media table might not exist or be empty
 	}
 
+	// Read every entry and assign its seed id before processing any data. A
+	// `reference` value holds a row id whose target can sit in a collection this
+	// loop has not reached yet, so the row id -> seed id map has to be complete
+	// before the first conversion.
+	const collected = new Map<string, CollectedEntry[]>();
+	const entryIdToSeedId = new Map<string, string>();
+	const entryIdToCollection = new Map<string, string>();
+
 	for (const collection of collections) {
 		// Skip if not in include list
 		if (includeCollections && !includeCollections.includes(collection.slug)) {
 			continue;
 		}
 
-		const entries: SeedContentEntry[] = [];
+		const items: CollectedEntry[] = [];
 		let cursor: string | undefined;
-
-		// When i18n is enabled, track translation_group -> seed ID so that
-		// translations can reference the source entry's seed-local ID.
-		// Key: EmDash translation_group ULID, Value: seed-local ID of the first entry in that group
-		const translationGroupToSeedId = new Map<string, string>();
 
 		// Paginate through all entries
 		do {
@@ -755,53 +836,85 @@ async function exportContent(
 						: `${collection.slug}:${item.slug}`
 					: item.id;
 
-				// Process data fields for $media conversion
-				const processedData = processDataForExport(item.data, collection.fields, mediaMap);
-
-				const entry: SeedContentEntry = {
-					id: seedId,
-					slug: item.slug?.trim() ? item.slug : collection.routable === false ? undefined : item.id,
-					status: item.status === "published" || item.status === "draft" ? item.status : undefined,
-					data: processedData,
-				};
-
-				// Add i18n fields when enabled
-				if (i18nEnabled && item.locale) {
-					entry.locale = item.locale;
-
-					if (item.translationGroup) {
-						const sourceSeedId = translationGroupToSeedId.get(item.translationGroup);
-						if (sourceSeedId) {
-							// This is a translation — reference the source entry
-							entry.translationOf = sourceSeedId;
-						} else {
-							// First entry in this translation group — track it
-							translationGroupToSeedId.set(item.translationGroup, seedId);
-						}
-					}
-				}
-
-				// Get taxonomy assignments
-				const taxonomies = await getTaxonomyAssignments(taxonomyRepo, collection.slug, item.id);
-				if (Object.keys(taxonomies).length > 0) {
-					entry.taxonomies = taxonomies;
-				}
-
-				// Get byline credits. Read the junction directly: its `byline_id`
-				// stores the translation_group, which is exactly the key in
-				// `bylineGroupToSeedId`. This is locale-agnostic (one row per
-				// credit) and avoids the locale-sibling fan-out a hydrated read
-				// would produce.
-				const bylines = await getBylineCredits(db, collection.slug, item.id, bylineGroupToSeedId);
-				if (bylines.length > 0) {
-					entry.bylines = bylines;
-				}
-
-				entries.push(entry);
+				items.push({ item, seedId });
+				entryIdToSeedId.set(item.id, seedId);
+				entryIdToCollection.set(item.id, collection.slug);
 			}
 
 			cursor = result.nextCursor;
 		} while (cursor);
+
+		collected.set(collection.slug, items);
+	}
+
+	const collectionsBySlug = new Map(collections.map((c) => [c.slug, c]));
+	const orderedSlugs = orderByReferenceTargets(
+		[...collected.keys()],
+		referenceTargets(collected, collectionsBySlug, entryIdToCollection),
+	);
+
+	for (const slug of orderedSlugs) {
+		const collection = collectionsBySlug.get(slug);
+		const items = collected.get(slug);
+		if (!collection || !items) continue;
+
+		const entries: SeedContentEntry[] = [];
+
+		// When i18n is enabled, track translation_group -> seed ID so that
+		// translations can reference the source entry's seed-local ID.
+		// Key: EmDash translation_group ULID, Value: seed-local ID of the first entry in that group
+		const translationGroupToSeedId = new Map<string, string>();
+
+		for (const { item, seedId } of items) {
+			// Process data fields for $media and $ref conversion
+			const processedData = processDataForExport(
+				item.data,
+				collection.fields,
+				mediaMap,
+				entryIdToSeedId,
+			);
+
+			const entry: SeedContentEntry = {
+				id: seedId,
+				slug: item.slug?.trim() ? item.slug : collection.routable === false ? undefined : item.id,
+				status: item.status === "published" || item.status === "draft" ? item.status : undefined,
+				data: processedData,
+			};
+
+			// Add i18n fields when enabled
+			if (i18nEnabled && item.locale) {
+				entry.locale = item.locale;
+
+				if (item.translationGroup) {
+					const sourceSeedId = translationGroupToSeedId.get(item.translationGroup);
+					if (sourceSeedId) {
+						// This is a translation — reference the source entry
+						entry.translationOf = sourceSeedId;
+					} else {
+						// First entry in this translation group — track it
+						translationGroupToSeedId.set(item.translationGroup, seedId);
+					}
+				}
+			}
+
+			// Get taxonomy assignments
+			const taxonomies = await getTaxonomyAssignments(taxonomyRepo, collection.slug, item.id);
+			if (Object.keys(taxonomies).length > 0) {
+				entry.taxonomies = taxonomies;
+			}
+
+			// Get byline credits. Read the junction directly: its `byline_id`
+			// stores the translation_group, which is exactly the key in
+			// `bylineGroupToSeedId`. This is locale-agnostic (one row per
+			// credit) and avoids the locale-sibling fan-out a hydrated read
+			// would produce.
+			const bylines = await getBylineCredits(db, collection.slug, item.id, bylineGroupToSeedId);
+			if (bylines.length > 0) {
+				entry.bylines = bylines;
+			}
+
+			entries.push(entry);
+		}
 
 		if (i18nEnabled && entries.length > 0) {
 			// Sort entries so source locale entries appear before their translations.
@@ -828,6 +941,7 @@ function processDataForExport(
 	data: Record<string, unknown>,
 	fields: SeedField[],
 	mediaMap: Map<string, { url: string; filename: string; alt?: string; caption?: string }>,
+	entryIdToSeedId: Map<string, string>,
 ): Record<string, unknown> {
 	const result: Record<string, unknown> = {};
 
@@ -860,13 +974,16 @@ function processDataForExport(
 			// Fallback: keep as-is if no media info found
 			result[key] = value;
 		} else if (fieldType === "reference" && typeof value === "string") {
-			// Convert reference to $ref syntax (assumes same collection for now)
-			result[key] = `$ref:${value}`;
+			// Convert reference to $ref syntax, naming the target by the seed id
+			// this export assigns it. The stored value is a row id, and `seed`
+			// renumbers rows on insert, so a row id matches nothing in the
+			// restored database and gets written to the column verbatim.
+			result[key] = `$ref:${entryIdToSeedId.get(value) ?? value}`;
 		} else if (Array.isArray(value)) {
 			// Process arrays (could contain references or images)
 			result[key] = value.map((item) => {
 				if (typeof item === "string" && fieldType === "reference") {
-					return `$ref:${item}`;
+					return `$ref:${entryIdToSeedId.get(item) ?? item}`;
 				}
 				return item;
 			});

--- a/packages/core/tests/integration/cli/export-seed-stdout.test.ts
+++ b/packages/core/tests/integration/cli/export-seed-stdout.test.ts
@@ -1,0 +1,82 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createDatabase } from "../../../src/database/connection.js";
+import { runMigrations } from "../../../src/database/migrations/runner.js";
+import { ensureBuilt } from "../server.js";
+
+const CLI_BIN = resolve(import.meta.dirname, "../../../dist/cli/index.mjs");
+
+interface CliResult {
+	code: number | null;
+	stdout: string;
+	stderr: string;
+}
+
+/**
+ * Regression for #2774 (1): `export-seed` writes the seed document to stdout
+ * with `console.log`, but also announced the resolved database path there via
+ * `consola.info`, and an internal `orderBy(array)` call made kysely print a
+ * deprecation notice to the same stream. `emdash export-seed > backup.json`
+ * therefore produced a file that is not JSON while the command exited 0 with
+ * an empty stderr, so the corruption only surfaced at restore time.
+ *
+ * Runs the built binary rather than calling `run()` in-process: the stream a
+ * value lands on is the thing under test, and only a real process has real
+ * streams to separate.
+ */
+describe("export-seed stdout is the seed document alone (#2774)", () => {
+	let projectRoot: string;
+	let dbPath: string;
+
+	beforeAll(async () => {
+		await ensureBuilt();
+		projectRoot = await mkdtemp(join(tmpdir(), "emdash-export-seed-cli-"));
+		dbPath = join(projectRoot, "data.db");
+
+		// Migrate up front so the export runs against a ready database. The
+		// command migrating its own source is a separate defect in the same
+		// issue; this test must not depend on it either way.
+		const db = createDatabase({ url: `file:${dbPath}` });
+		await runMigrations(db);
+		await db.destroy();
+	});
+
+	afterAll(async () => {
+		if (projectRoot) await rm(projectRoot, { force: true, recursive: true });
+	});
+
+	function run(...args: string[]): CliResult {
+		const result = spawnSync("node", [CLI_BIN, "export-seed", "-d", dbPath, ...args], {
+			cwd: projectRoot,
+			encoding: "utf8",
+			env: { ...process.env, NO_COLOR: "1" },
+		});
+		if (result.error) throw result.error;
+		return { code: result.status, stdout: result.stdout, stderr: result.stderr };
+	}
+
+	it("redirects to a file that parses as JSON", () => {
+		const result = run("--with-content", "all");
+
+		expect(result.code).toBe(0);
+		expect(() => JSON.parse(result.stdout)).not.toThrow();
+	});
+
+	it("reports the database path on stderr, not stdout", () => {
+		const result = run();
+
+		expect(result.stderr).toContain(dbPath);
+		expect(result.stdout).not.toContain(dbPath);
+	});
+
+	it("keeps kysely's orderBy deprecation notice off stdout", () => {
+		const result = run();
+
+		expect(result.stdout).not.toContain("deprecated");
+	});
+});

--- a/packages/core/tests/unit/seed/export-seed-references.test.ts
+++ b/packages/core/tests/unit/seed/export-seed-references.test.ts
@@ -1,0 +1,152 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { exportSeed } from "../../../src/cli/commands/export-seed.js";
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { Database } from "../../../src/database/types.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { applySeed } from "../../../src/seed/apply.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+/**
+ * Regression for #2774 (3): every entity in an exported seed is keyed by a
+ * derived seed id (`groups:soumu`), but `reference` field *values* kept the
+ * source database's row id (`$ref:01M0…`). `seed` assigns fresh ids on insert,
+ * so no row in the restored database carries that id: `resolveValue` finds no
+ * entry in `seedIdMap` and stores the literal `$ref:01M0…` string in the
+ * column. The reference is neither resolved nor cleared, and the restore
+ * reports success — so the loss shows up only wherever the field was rendered.
+ */
+
+/**
+ * A referenced collection and a referencing one. `groups` is created first so
+ * it is exported first: `applySeed` fills `seedIdMap` as it walks the file, so
+ * a reference only resolves when its target appears earlier — the shape a real
+ * export produces here.
+ */
+async function createSchema(db: Kysely<Database>): Promise<void> {
+	const registry = new SchemaRegistry(db);
+
+	await registry.createCollection({ slug: "groups", label: "Groups" });
+	await registry.createField("groups", { slug: "name", label: "Name", type: "string" });
+
+	await registry.createCollection({ slug: "events", label: "Events" });
+	await registry.createField("events", { slug: "title", label: "Title", type: "string" });
+	await registry.createField("events", {
+		slug: "organizer",
+		label: "Organizer",
+		type: "reference",
+	});
+}
+
+/** Insert a group and an event pointing at it. Returns the group's row id. */
+async function seedSourceContent(db: Kysely<Database>): Promise<string> {
+	const contentRepo = new ContentRepository(db);
+	const group = await contentRepo.create({
+		type: "groups",
+		slug: "soumu",
+		data: { name: "General Affairs" },
+	});
+	await contentRepo.create({
+		type: "events",
+		slug: "briefing",
+		data: { title: "Briefing", organizer: group.id },
+	});
+	return group.id;
+}
+
+describe("exportSeed: reference values (#2774)", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("exports a reference as the target's seed id, not its row id", async () => {
+		await createSchema(db);
+		const groupId = await seedSourceContent(db);
+
+		const seed = await exportSeed(db, "all");
+
+		const event = seed.content?.events?.[0];
+		expect(event?.data.organizer).toBe("$ref:groups:soumu");
+		expect(event?.data.organizer).not.toContain(groupId);
+	});
+
+	it("resolves the reference to the restored row on export → apply", async () => {
+		await createSchema(db);
+		await seedSourceContent(db);
+
+		const seed = await exportSeed(db, "all");
+
+		const restored = await setupTestDatabase();
+		try {
+			await applySeed(restored, seed, { includeContent: true });
+
+			const restoredRepo = new ContentRepository(restored);
+			const group = await restoredRepo.findBySlug("groups", "soumu");
+			const event = await restoredRepo.findBySlug("events", "briefing");
+
+			expect(group?.id).toBeDefined();
+			expect(event?.data.organizer).toBe(group?.id);
+		} finally {
+			await teardownTestDatabase(restored);
+		}
+	});
+
+	it("writes the referenced collection before the one pointing at it", async () => {
+		await createSchema(db);
+		await seedSourceContent(db);
+
+		const seed = await exportSeed(db, "all");
+
+		// Both collections sort under the same rank, so `events` comes first by
+		// slug -- the order that leaves the reference unresolvable on apply.
+		expect(Object.keys(seed.content ?? {})).toEqual(["groups", "events"]);
+	});
+
+	it("still exports when two collections reference each other", async () => {
+		await createSchema(db);
+		const registry = new SchemaRegistry(db);
+		await registry.createField("groups", {
+			slug: "flagship_event",
+			label: "Flagship Event",
+			type: "reference",
+		});
+
+		const contentRepo = new ContentRepository(db);
+		const group = await contentRepo.create({
+			type: "groups",
+			slug: "soumu",
+			data: { name: "General Affairs" },
+		});
+		const event = await contentRepo.create({
+			type: "events",
+			slug: "briefing",
+			data: { title: "Briefing", organizer: group.id },
+		});
+		await contentRepo.update("groups", group.id, { data: { flagship_event: event.id } });
+
+		// No order satisfies a cycle. The export must still produce both
+		// collections rather than looping or dropping one.
+		const seed = await exportSeed(db, "all");
+
+		expect(Object.keys(seed.content ?? {}).toSorted()).toEqual(["events", "groups"]);
+	});
+
+	it("leaves a reference to an entry outside the export unresolved rather than mislabelled", async () => {
+		await createSchema(db);
+		const groupId = await seedSourceContent(db);
+
+		// Only `events` is exported, so the target carries no seed id in this
+		// file. Nothing can resolve it; the value must not claim otherwise.
+		const seed = await exportSeed(db, "events");
+
+		expect(seed.content?.groups).toBeUndefined();
+		expect(seed.content?.events?.[0]?.data.organizer).toBe(`$ref:${groupId}`);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes two of the three problems reported in #2774 — the two that are unambiguous bugs with one obvious correct behaviour. The third (`export-seed` running migrations against the database it is exporting) is deliberately left out: fixing it means choosing between failing on an out-of-date schema and adding an opt-in flag, and that call is yours to make.

Refs #2774

### 1. stdout carried more than the seed document

`emdash export-seed > seed.json` produced a file that is not JSON. The document is written with `console.log`, but the resolved database path went to the same stream via `consola.info`, and `orderBy(["name", "locale"])` made kysely print its array-form deprecation notice there too. The command still exited `0` with an empty stderr, so nothing signalled the corruption until `emdash seed` rejected the file at restore time.

The path now goes to stderr — the same thing `emdash migrate --json`, `auth` and `secrets` already do — and the ordering calls are chained so kysely stops warning at all, rather than warning somewhere quieter.

### 3. `reference` values were exported as source row ids

Every other entity in the file is keyed by a derived seed id (`groups:soumu`), but reference *values* kept the source database's ULID. `emdash seed` assigns fresh ids on insert, so the lookup misses and the literal `$ref:01M0…` string is written into the column. The restore reports success; the reference is simply gone wherever it was rendered.

A reference is now named by the seed id this export assigns its target. Two things follow:

- The row-id → seed-id map has to be complete before any entry's data is converted, because a reference can point into a collection the loop has not reached yet. Reading and converting are therefore separate passes. This re-indentation is most of the diff — `git diff -w` is much smaller than the line count suggests.
- Emitting the right id is not sufficient on its own. `applySeed` fills its seed-id map as it walks the file, so a `$ref` into a collection further down still resolves to nothing. Collections are now ordered by their reference targets, depth-first, with the existing order as the tie-break. A cycle has no valid order, so those collections stay where they were rather than failing the export.

A reference whose target sits outside the export (`--with-content events` when the target lives in `groups`) keeps the row id. Nothing in the file can resolve it either way, and minting a seed id for an entry that is not in the file would only make the dangling reference harder to spot.

### Not addressed here

- Problem 2 in the issue: `export-seed` runs `runMigrations` on the database it exports.
- `applySeed` resolving `$ref` in a single forward pass. Ordering the export sidesteps it for exported files, but a hand-written seed with a forward reference still silently stores the literal string, and [the seed docs](https://docs.emdashcms.com/themes/seed-files/) don't mention the ordering constraint. Happy to file that separately if you want it tightened.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Two changesets, one per problem, so each lands as its own CHANGELOG entry. No admin-UI strings are touched.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 via Claude Code

## Screenshots / test output

Both tests were written first and watched fail against `main`.

`tests/integration/cli/export-seed-stdout.test.ts` runs the built binary, because the stream a value lands on is the thing under test and only a real process has real streams to separate. Against `main`:

```
 × redirects to a file that parses as JSON
   → "SyntaxError: Unexpected token 'o', \"orderBy(ar\"... is not valid JSON"
 × reports the database path on stderr, not stdout
   → expected '' to contain '…/data.db'
 × keeps kysely's orderBy deprecation notice off stdout
```

`tests/unit/seed/export-seed-references.test.ts` against `main`:

```
 × exports a reference as the target's seed id, not its row id
   Expected: "$ref:groups:soumu"
   Received: "$ref:01M1524FNY8AWFKQ8ZHEHYB1VA"
 × resolves the reference to the restored row on export → apply
   Expected: "01M1524FRFF0590BC2Z9V1FY88"
   Received: "$ref:01M1524FQ8JZ8S5JM9ZN2DF66J"
```

That second failure is the whole defect in one line: the restored row holds the string, not a reference.

The issue's own reproduction, after the change:

```console
$ npx emdash export-seed -d ./data.db --with-content all > backup.json
$ head -1 backup.json
{
$ node -e "JSON.parse(require('fs').readFileSync('backup.json','utf8'))" && echo ok
ok
```

Full runs on this branch:

```
pnpm typecheck                                          ✓
pnpm lint                                               ✓
pnpm format:check                                       ✓
pnpm --filter emdash exec vitest run                     6171 passed | 9 skipped
pnpm --filter emdash exec vitest run --config vitest.integration.config.ts
                                                         100 passed
```
