### PR TITLE
fix(core): make a stored focal point readable from an image field

### DIFF
--- a/.changeset/image-field-focal-point-type.md
+++ b/.changeset/image-field-focal-point-type.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the image field type so a stored focal point is readable. `focalX` and `focalY` reach content entries but were missing from the generated collection types, so reading them from an image field was a type error. The dark-variant slot shares the media shape, so its focal point is readable on the same terms.

--- a/packages/core/src/fields/image.ts
+++ b/packages/core/src/fields/image.ts
@@ -12,6 +12,8 @@ const mediaSchema = z.object({
 	mimeType: z.string().optional(),
 	blurhash: z.string().optional(),
 	dominantColor: z.string().optional(),
+	focalX: z.number().optional(),
+	focalY: z.number().optional(),
 	provider: z.string().optional(),
 	previewUrl: z.string().optional(),
 	meta: z.record(z.string(), z.unknown()).optional(),

--- a/packages/core/src/schema/zod-generator.ts
+++ b/packages/core/src/schema/zod-generator.ts
@@ -146,6 +146,9 @@ function getBaseSchema(type: FieldType, field: Pick<Field, "validation">): ZodTy
 				mimeType: z.string().optional(),
 				blurhash: z.string().optional(),
 				dominantColor: z.string().optional(),
+				/** Focal point as 0..1 fractions of width and height */
+				focalX: z.number().optional(),
+				focalY: z.number().optional(),
 				/** Provider ID (e.g. "local", "cloudflare-images") */
 				provider: z.string().optional(),
 				/** Admin-side preview URL for external providers (not persisted by plugins) */
@@ -490,7 +493,7 @@ function fieldTypeToTypeScript(field: {
 
 		case "image": {
 			const media =
-				"{ id: string; src?: string; alt?: string; width?: number; height?: number; filename?: string; mimeType?: string; blurhash?: string; dominantColor?: string; provider?: string; previewUrl?: string; meta?: Record<string, unknown> }";
+				"{ id: string; src?: string; alt?: string; width?: number; height?: number; filename?: string; mimeType?: string; blurhash?: string; dominantColor?: string; focalX?: number; focalY?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> }";
 			return `${media.slice(0, -2)}; darkVariant?: ${media} }`;
 		}
 

--- a/packages/core/tests/unit/fields/file-image-builders.test.ts
+++ b/packages/core/tests/unit/fields/file-image-builders.test.ts
@@ -31,3 +31,24 @@ describe("image builder", () => {
 		expect(def.validation?.allowedMimeTypes).toBeUndefined();
 	});
 });
+
+describe("image field schema", () => {
+	it("keeps the focal point on the value", () => {
+		const value = {
+			id: "img123",
+			provider: "local",
+			focalX: 0.25,
+			focalY: 0.75,
+		};
+		expect(image().schema.parse(value)).toEqual(value);
+	});
+
+	it("keeps the focal point on a dark variant", () => {
+		const value = {
+			id: "img123",
+			provider: "local",
+			darkVariant: { id: "img456", provider: "local", focalX: 0.5, focalY: 0.1 },
+		};
+		expect(image().schema.parse(value)).toEqual(value);
+	});
+});

--- a/packages/core/tests/unit/schema/zod-generator.test.ts
+++ b/packages/core/tests/unit/schema/zod-generator.test.ts
@@ -289,6 +289,8 @@ describe("Zod Generator", () => {
 				height: 800,
 				blurhash: "LEHV6nWB2yk8pyo0adR*.7kCMdnj",
 				dominantColor: "#d9d2c5",
+				focalX: 0.25,
+				focalY: 0.75,
 				meta: { storageKey: "photo.webp" },
 			};
 			expect(schema.parse(validImage)).toEqual(validImage);
@@ -609,7 +611,7 @@ describe("Zod Generator", () => {
 			expect(ts).toContain("featured?: boolean;");
 			expect(ts).toContain('status: "draft" | "published";');
 			expect(ts).toContain(
-				"hero: { id: string; src?: string; alt?: string; width?: number; height?: number; filename?: string; mimeType?: string; blurhash?: string; dominantColor?: string; provider?: string; previewUrl?: string; meta?: Record<string, unknown>; darkVariant?: { id: string; src?: string; alt?: string; width?: number; height?: number; filename?: string; mimeType?: string; blurhash?: string; dominantColor?: string; provider?: string; previewUrl?: string; meta?: Record<string, unknown> } };",
+				"hero: { id: string; src?: string; alt?: string; width?: number; height?: number; filename?: string; mimeType?: string; blurhash?: string; dominantColor?: string; focalX?: number; focalY?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown>; darkVariant?: { id: string; src?: string; alt?: string; width?: number; height?: number; filename?: string; mimeType?: string; blurhash?: string; dominantColor?: string; focalX?: number; focalY?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> } };",
 			);
 			// Hydrated by getEmDashCollection/getEmDashEntry
 			expect(ts).toContain("bylines?: ContentBylineCredit[];");
@@ -706,7 +708,7 @@ describe("Zod Generator", () => {
 		// The literal the top-level `image` case emits. An `image` sub-field must
 		// emit the same shape.
 		const MEDIA_LITERAL =
-			"{ id: string; src?: string; alt?: string; width?: number; height?: number; filename?: string; mimeType?: string; blurhash?: string; dominantColor?: string; provider?: string; previewUrl?: string; meta?: Record<string, unknown>; darkVariant?: { id: string; src?: string; alt?: string; width?: number; height?: number; filename?: string; mimeType?: string; blurhash?: string; dominantColor?: string; provider?: string; previewUrl?: string; meta?: Record<string, unknown> } }";
+			"{ id: string; src?: string; alt?: string; width?: number; height?: number; filename?: string; mimeType?: string; blurhash?: string; dominantColor?: string; focalX?: number; focalY?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown>; darkVariant?: { id: string; src?: string; alt?: string; width?: number; height?: number; filename?: string; mimeType?: string; blurhash?: string; dominantColor?: string; focalX?: number; focalY?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> } }";
 
 		// A collection with a single `specs` repeater. Passing `undefined` omits
 		// `validation` entirely, which is how a repeater with no declared rows


### PR DESCRIPTION
## What does this PR do?

Makes a stored focal point readable from an image field. Reading one was a type error on a value that carries it:

```ts
// Property 'focalX' does not exist on type '{ id: string; src?: string; ... }'
const pos = post.data.featured_image?.focalX;
```

The documented `MediaValue` shape promises `focalX` and `focalY`, but the image field declared neither, so the generated collection types omitted them. `<Image>` from `emdash/ui` reads exactly those two keys to place the image.

The shape is written out three times: the image field's schema, the generated Zod schema, and a hand-maintained TypeScript literal. All three gain the two optional numbers, and the dark variant slot reuses that shape, so its focal point becomes readable on the same terms. Nothing changes at runtime: the loader copies every stored key and the write path discards what `safeParse` returns.

Closes: N/A

Tests: the focal point is pinned through `generateFieldSchema`, `generateTypeScript`, the repeater image sub-field literal, and `image().schema` for the primary value and a dark variant. All six fail without the change.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (n/a: no admin strings)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a: bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5

## Screenshots / test output

```
packages/core  zod-generator + file-image-builders     64 passed
               without the change                       6 failed, 58 passed
pnpm test:unit                                          core 6199 passed, 9 skipped
pnpm typecheck / pnpm lint / pnpm format:check / build clean
```
