### PR TITLE
fix(admin): theme locale switcher menu

### DIFF
--- a/.changeset/dark-locale-menu.md
+++ b/.changeset/dark-locale-menu.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes locale switcher menus appearing with a light background in dark mode and displays the default-language indicator consistently in both the closed switcher and its menu.

--- a/e2e/tests/i18n.spec.ts
+++ b/e2e/tests/i18n.spec.ts
@@ -55,17 +55,13 @@ test.describe("i18n", () => {
 			await admin.goToContent("posts");
 			await admin.waitForLoading();
 
-			// Should have a select element for locale filtering
-			const select = admin.page.locator("select").first();
+			const select = admin.page.getByRole("combobox", { name: "Locale" });
 			await expect(select).toBeVisible();
+			await select.click();
 
-			// Should show available locale options
-			const options = select.locator("option");
-			const optionTexts = await options.allTextContents();
-			// Expect EN, FR, ES options (may also have "All locales")
-			expect(optionTexts.some((t) => t.includes("EN"))).toBe(true);
-			expect(optionTexts.some((t) => t.includes("FR"))).toBe(true);
-			expect(optionTexts.some((t) => t.includes("ES"))).toBe(true);
+			await expect(admin.page.getByRole("option", { name: "EN (default)" })).toBeVisible();
+			await expect(admin.page.getByRole("option", { name: "FR" })).toBeVisible();
+			await expect(admin.page.getByRole("option", { name: "ES" })).toBeVisible();
 		});
 	});
 

--- a/e2e/tests/visual-regression.spec.ts
+++ b/e2e/tests/visual-regression.spec.ts
@@ -64,6 +64,7 @@ interface PageCase {
 	path: (info: ServerInfo) => string;
 	viewport?: { width: number; height: number };
 	fixedTime?: string;
+	theme?: "light" | "dark";
 	extraMasks?: (admin: AdminPage) => Locator[];
 	prepare?: (admin: AdminPage) => Promise<void>;
 }
@@ -126,7 +127,23 @@ const PAGES: PageCase[] = [
 	{ name: "content-new", path: () => "/content/posts/new" },
 	{ name: "media", path: () => "/media" },
 	{ name: "media-mobile", path: () => "/media", viewport: { width: 320, height: 800 } },
-	{ name: "menus", path: () => "/menus" },
+	{
+		name: "menus",
+		path: () => "/menus",
+		prepare: openFilter(
+			'[data-kumo-component="Select"][data-kumo-part="trigger"]',
+			'[role="listbox"]:visible',
+		),
+	},
+	{
+		name: "menus-dark",
+		path: () => "/menus",
+		theme: "dark",
+		prepare: openFilter(
+			'[data-kumo-component="Select"][data-kumo-part="trigger"]',
+			'[role="listbox"]:visible',
+		),
+	},
 	{ name: "settings", path: () => "/settings" },
 ];
 
@@ -187,9 +204,17 @@ test.describe("visual regression", () => {
 		for (const pageCase of PAGES) {
 			test(`${pageCase.name} @${locale.name}`, async ({ admin, serverInfo }) => {
 				await setLocale(admin, locale.code);
+				if (pageCase.theme) {
+					await admin.page.addInitScript((theme) => {
+						localStorage.setItem("emdash-theme", theme);
+					}, pageCase.theme);
+				}
 				if (pageCase.viewport) await admin.page.setViewportSize(pageCase.viewport);
 				if (pageCase.fixedTime) await admin.page.clock.setFixedTime(pageCase.fixedTime);
 				await openAdmin(admin, pageCase.path(serverInfo), locale.dir);
+				if (pageCase.theme) {
+					await expect(admin.page.locator("html")).toHaveAttribute("data-mode", pageCase.theme);
+				}
 				await stabilize(admin);
 				await pageCase.prepare?.(admin);
 

--- a/packages/admin/src/components/LocaleSwitcher.tsx
+++ b/packages/admin/src/components/LocaleSwitcher.tsx
@@ -7,6 +7,7 @@
  * Only renders when i18n is configured (manifest.i18n is present).
  */
 
+import { Select } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { GlobeSimple } from "@phosphor-icons/react";
 import React from "react";
@@ -48,31 +49,40 @@ export function LocaleSwitcher({
 	size = "md",
 }: LocaleSwitcherProps) {
 	const { t } = useLingui();
+	const formatLocaleLabel = (locale: string) => {
+		const code = locale.toUpperCase();
+		return locale === defaultLocale ? (
+			<>
+				{code}
+				{t` (default)`}
+			</>
+		) : (
+			code
+		);
+	};
+
 	return (
 		<div className={cn("flex items-center gap-1.5", className)}>
 			<GlobeSimple
 				className={cn("text-kumo-subtle shrink-0", size === "sm" ? "size-3.5" : "size-4")}
 				weight="bold"
 			/>
-			<select
+			<Select<string>
 				value={value}
-				onChange={(e) => onChange(e.target.value)}
+				onValueChange={(nextValue) => {
+					if (typeof nextValue === "string") onChange(nextValue);
+				}}
+				renderValue={(locale) => (locale ? formatLocaleLabel(locale) : t`All locales`)}
 				aria-label={t`Locale`}
-				className={cn(
-					"rounded-md border bg-transparent font-medium transition-colors",
-					"focus:ring-kumo-ring focus:outline-none focus:ring-2 focus:ring-offset-1",
-					"hover:bg-kumo-tint/50 cursor-pointer",
-					size === "sm" ? "px-1.5 py-0.5 text-xs" : "px-2 py-1 text-sm",
-				)}
+				size={size === "sm" ? "sm" : "base"}
 			>
-				{showAll && <option value="">{t`All locales`}</option>}
+				{showAll && <Select.Option value="">{t`All locales`}</Select.Option>}
 				{locales.map((locale) => (
-					<option key={locale} value={locale}>
-						{locale.toUpperCase()}
-						{locale === defaultLocale ? t` (default)` : ""}
-					</option>
+					<Select.Option key={locale} value={locale}>
+						{formatLocaleLabel(locale)}
+					</Select.Option>
 				))}
-			</select>
+			</Select>
 		</div>
 	);
 }

--- a/packages/admin/tests/components/LocaleSwitcher.test.tsx
+++ b/packages/admin/tests/components/LocaleSwitcher.test.tsx
@@ -1,0 +1,85 @@
+import { setupI18n } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
+import { I18nProvider } from "@lingui/react";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { userEvent } from "vitest/browser";
+
+import { LocaleSwitcher } from "../../src/components/LocaleSwitcher.js";
+// oxlint-disable-next-line import/no-unassigned-import -- Browser test verifies Kumo's computed theme surface.
+import "@cloudflare/kumo/styles/standalone";
+
+import { render } from "../utils/render.tsx";
+
+const defaultLocaleIndicator = msg` (default)`;
+
+describe("LocaleSwitcher", () => {
+	it("uses the existing translation for the default-locale indicator", async () => {
+		const arabicI18n = setupI18n();
+		arabicI18n.load("ar", { [defaultLocaleIndicator.id]: " الافتراضي" });
+		arabicI18n.activate("ar");
+		const screen = await render(
+			<LocaleSwitcher locales={["en", "fr"]} defaultLocale="en" value="en" onChange={vi.fn()} />,
+			{
+				wrapper: ({ children }) => <I18nProvider i18n={arabicI18n}>{children}</I18nProvider>,
+			},
+		);
+
+		const localeSwitcher = screen.getByRole("combobox", { name: "Locale" });
+		await expect.element(localeSwitcher).toHaveTextContent(/^EN الافتراضي$/);
+		await userEvent.click(localeSwitcher);
+		await expect.element(screen.getByRole("option", { name: "EN الافتراضي" })).toBeVisible();
+	});
+
+	it("opens the locale menu and changes the selected locale", async () => {
+		const onChange = vi.fn();
+		const screen = await render(
+			<LocaleSwitcher locales={["en", "fr"]} defaultLocale="en" value="en" onChange={onChange} />,
+		);
+
+		const localeSwitcher = screen.getByRole("combobox", { name: "Locale" });
+		await expect.element(localeSwitcher).toHaveTextContent(/^EN \(default\)$/);
+		await userEvent.click(localeSwitcher);
+
+		await expect.element(screen.getByRole("listbox")).toBeInTheDocument();
+		await expect.element(screen.getByRole("option", { name: "EN (default)" })).toBeVisible();
+		await userEvent.click(screen.getByRole("option", { name: "FR" }));
+		expect(onChange).toHaveBeenCalledWith("fr");
+	});
+
+	it("renders the open locale menu with the dark theme surface", async () => {
+		const previousMode = document.documentElement.getAttribute("data-mode");
+		document.documentElement.setAttribute("data-mode", "dark");
+
+		try {
+			const screen = await render(
+				<LocaleSwitcher locales={["en", "fr"]} defaultLocale="en" value="en" onChange={vi.fn()} />,
+			);
+
+			await userEvent.click(screen.getByRole("combobox", { name: "Locale" }));
+			const listbox = screen.getByRole("listbox");
+			await expect.element(listbox).toBeVisible();
+
+			const popup = listbox.element().parentElement;
+			expect(popup).not.toBeNull();
+
+			const surfaceProbe = document.createElement("div");
+			surfaceProbe.style.backgroundColor = "var(--color-kumo-base)";
+			document.body.append(surfaceProbe);
+			const darkSurface = getComputedStyle(surfaceProbe).backgroundColor;
+			document.documentElement.setAttribute("data-mode", "light");
+			const lightSurface = getComputedStyle(surfaceProbe).backgroundColor;
+			document.documentElement.setAttribute("data-mode", "dark");
+			surfaceProbe.remove();
+
+			expect(darkSurface).not.toBe(lightSurface);
+			expect(getComputedStyle(popup!).backgroundColor).toBe(darkSurface);
+		} finally {
+			if (previousMode) {
+				document.documentElement.setAttribute("data-mode", previousMode);
+			} else {
+				document.documentElement.removeAttribute("data-mode");
+			}
+		}
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Replaces the native locale selector with Kumo `Select` so its popup uses the admin theme instead of appearing with a light background in dark mode. It preserves the existing localized ` (default)` translation unit in both the closed switcher and the option list.

Updates the locale-switcher browser and E2E coverage for Kumo interaction, including a computed dark-surface assertion and open-menu visual regression cases in LTR and RTL.

Related issue: none.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... — N/A, this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm --filter @emdash-cms/admin test` — 140 files, 1,758 tests passed
- `pnpm exec playwright test e2e/tests/i18n.spec.ts --grep "has a locale filter switcher" --project=chromium --reporter=line` — 1 test passed

The visual regression workflow will generate the Linux light/dark LTR/RTL menu snapshots. Any intended baseline update remains subject to maintainer review through `/accept-baselines`.
