### PR TITLE
fix(core): avoid recording disabled API token use

### DIFF
--- a/.changeset/disabled-api-token-history.md
+++ b/.changeset/disabled-api-token-history.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes personal API tokens recording a new last-used timestamp when authentication is rejected because the owning account is disabled.

--- a/packages/core/src/api/handlers/api-tokens.ts
+++ b/packages/core/src/api/handlers/api-tokens.ts
@@ -238,6 +238,7 @@ export function recordApiTokenUse(db: Kysely<Database>, tokenId: string): void {
 				.set({ last_used_at: lastUsedAt })
 				.where("id", "=", tokenId)
 				.where("user_id", "in", db.selectFrom("users").select("id").where("disabled", "=", 0))
+				.where((eb) => eb.or([eb("last_used_at", "is", null), eb("last_used_at", "<", lastUsedAt)]))
 				.execute();
 		} catch (error) {
 			console.error("[api-tokens] Failed to record token use:", error);

--- a/packages/core/src/api/handlers/api-tokens.ts
+++ b/packages/core/src/api/handlers/api-tokens.ts
@@ -193,19 +193,25 @@ export async function deleteApiTokensByName(
 
 /**
  * Resolve a raw API token (ec_pat_...) to a user ID and scopes.
- * Updates last_used_at on successful lookup.
- * Returns null if the token is invalid or expired.
+ * Returns null if the token is invalid, expired, or belongs to a disabled user.
  */
 export async function resolveApiToken(
 	db: Kysely<Database>,
 	rawToken: string,
-): Promise<{ userId: string; scopes: string[] } | null> {
+): Promise<{ tokenId: string; userId: string; scopes: string[] } | null> {
 	const hash = hashApiToken(rawToken);
 
 	const row = await db
-		.selectFrom("_emdash_api_tokens")
-		.select(["id", "user_id", "scopes", "expires_at"])
-		.where("token_hash", "=", hash)
+		.selectFrom("_emdash_api_tokens as token")
+		.innerJoin("users as user", "user.id", "token.user_id")
+		.select([
+			"token.id as id",
+			"token.user_id as user_id",
+			"token.scopes as scopes",
+			"token.expires_at as expires_at",
+		])
+		.where("token.token_hash", "=", hash)
+		.where("user.disabled", "=", 0)
 		.executeTakeFirst();
 
 	if (!row) return null;
@@ -215,17 +221,20 @@ export async function resolveApiToken(
 		return null;
 	}
 
-	// Update last_used_at (fire-and-forget, don't block the request)
-	db.updateTable("_emdash_api_tokens")
-		.set({ last_used_at: new Date().toISOString() })
-		.where("id", "=", row.id)
-		.execute()
-		.catch(() => {}); // Non-critical, swallow errors
-
 	return {
+		tokenId: row.id,
 		userId: row.user_id,
 		scopes: JSON.parse(row.scopes) as string[],
 	};
+}
+
+export function recordApiTokenUse(db: Kysely<Database>, tokenId: string): void {
+	db.updateTable("_emdash_api_tokens")
+		.set({ last_used_at: new Date().toISOString() })
+		.where("id", "=", tokenId)
+		.where("user_id", "in", db.selectFrom("users").select("id").where("disabled", "=", 0))
+		.execute()
+		.catch(() => {}); // Non-critical, swallow errors
 }
 
 /**

--- a/packages/core/src/api/handlers/api-tokens.ts
+++ b/packages/core/src/api/handlers/api-tokens.ts
@@ -9,6 +9,7 @@
 import type { Kysely } from "kysely";
 import { ulid } from "ulidx";
 
+import { after } from "../../after.js";
 import { hashApiToken, generatePrefixedToken } from "../../auth/api-tokens.js";
 import type { Database } from "../../database/types.js";
 import type { ApiResult } from "../types.js";
@@ -229,12 +230,19 @@ export async function resolveApiToken(
 }
 
 export function recordApiTokenUse(db: Kysely<Database>, tokenId: string): void {
-	db.updateTable("_emdash_api_tokens")
-		.set({ last_used_at: new Date().toISOString() })
-		.where("id", "=", tokenId)
-		.where("user_id", "in", db.selectFrom("users").select("id").where("disabled", "=", 0))
-		.execute()
-		.catch(() => {}); // Non-critical, swallow errors
+	const lastUsedAt = new Date().toISOString();
+	after(async () => {
+		try {
+			await db
+				.updateTable("_emdash_api_tokens")
+				.set({ last_used_at: lastUsedAt })
+				.where("id", "=", tokenId)
+				.where("user_id", "in", db.selectFrom("users").select("id").where("disabled", "=", 0))
+				.execute();
+		} catch (error) {
+			console.error("[api-tokens] Failed to record token use:", error);
+		}
+	});
 }
 
 /**

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -28,7 +28,11 @@ import { getPublicOrigin } from "../../api/public-url.js";
 const MW_CACHE_HEADERS = {
 	"Cache-Control": "private, no-store",
 } as const;
-import { resolveApiToken, resolveOAuthToken } from "../../api/handlers/api-tokens.js";
+import {
+	recordApiTokenUse,
+	resolveApiToken,
+	resolveOAuthToken,
+} from "../../api/handlers/api-tokens.js";
 import { hasScope } from "../../auth/api-tokens.js";
 import { getAuthMode, type ExternalAuthMode } from "../../auth/mode.js";
 import type { ExternalAuthConfig } from "../../auth/types.js";
@@ -636,9 +640,12 @@ async function handleBearerAuth(
 
 	// Resolve token based on prefix
 	let resolved: { userId: string; scopes: string[] } | null = null;
+	let apiTokenId: string | null = null;
 
 	if (token.startsWith("ec_pat_")) {
-		resolved = await resolveApiToken(emdash.db, token);
+		const apiToken = await resolveApiToken(emdash.db, token);
+		resolved = apiToken;
+		apiTokenId = apiToken?.tokenId ?? null;
 	} else if (token.startsWith("ec_oat_")) {
 		resolved = await resolveOAuthToken(emdash.db, token);
 	} else {
@@ -653,6 +660,7 @@ async function handleBearerAuth(
 	const user = await adapter.getUserById(resolved.userId);
 
 	if (!user || user.disabled) return "invalid";
+	if (apiTokenId) recordApiTokenUse(emdash.db, apiTokenId);
 
 	// Set user and scopes on locals
 	locals.user = user;

--- a/packages/core/tests/unit/astro/media-usage-read-auth.test.ts
+++ b/packages/core/tests/unit/astro/media-usage-read-auth.test.ts
@@ -106,6 +106,36 @@ describe("media usage detail auth middleware", () => {
 		expect(stored.last_used_at).not.toBeNull();
 	});
 
+	it("does not let an older deferred update replace a newer last-used timestamp", async () => {
+		const token = await createToken("contributor-1", ["admin"]);
+		const older = "2026-08-30T00:00:00.000Z";
+		const newer = "2026-08-30T00:00:01.000Z";
+		let responses: Response[];
+
+		vi.useFakeTimers({ toFake: ["Date"] });
+		try {
+			vi.setSystemTime(older);
+			const first = await invokeThroughAuth(token);
+			vi.setSystemTime(newer);
+			const second = await invokeThroughAuth(token);
+			responses = [first, second];
+		} finally {
+			vi.useRealTimers();
+		}
+
+		expect(responses.map((response) => response.status)).toEqual([200, 200]);
+		expect(deferredTasks).toHaveLength(2);
+		await deferredTasks.pop()!();
+		await deferredTasks.pop()!();
+		const stored = await db!
+			.selectFrom("_emdash_api_tokens")
+			.select("last_used_at")
+			.where("user_id", "=", "contributor-1")
+			.executeTakeFirstOrThrow();
+
+		expect(stored.last_used_at).toBe(newer);
+	});
+
 	it("lets a media-read token reach the route before rejecting its missing admin scope", async () => {
 		const context = usageContext(await createToken("contributor-1", ["media:read"]));
 		const next = vi.fn(() => GET(context as never));

--- a/packages/core/tests/unit/astro/media-usage-read-auth.test.ts
+++ b/packages/core/tests/unit/astro/media-usage-read-auth.test.ts
@@ -22,6 +22,16 @@ vi.mock(
 	{ virtual: true },
 );
 
+const { deferredTasks } = vi.hoisted(() => ({
+	deferredTasks: [] as Array<() => void | Promise<void>>,
+}));
+
+vi.mock("../../../src/after.js", () => ({
+	after: vi.fn((fn: () => void | Promise<void>) => {
+		deferredTasks.push(fn);
+	}),
+}));
+
 import { handleApiTokenCreate } from "../../../src/api/handlers/api-tokens.js";
 import { onRequest as authMiddleware } from "../../../src/astro/middleware/auth.js";
 import { GET } from "../../../src/astro/routes/api/media/[id]/usage.js";
@@ -73,13 +83,16 @@ describe("media usage detail auth middleware", () => {
 	});
 
 	afterEach(async () => {
+		await flushDeferredTasks();
 		if (db) await teardownTestDatabase(db);
 		db = undefined;
 	});
 
 	it("allows an admin-scoped token for a contributor to read usage details", async () => {
 		const response = await invokeThroughAuth(await createToken("contributor-1", ["admin"]));
-		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(deferredTasks).toHaveLength(1);
+		await flushDeferredTasks();
 		const stored = await db!
 			.selectFrom("_emdash_api_tokens")
 			.select("last_used_at")
@@ -126,7 +139,7 @@ describe("media usage detail auth middleware", () => {
 		const next = vi.fn(async () => new Response("should not run"));
 
 		const response = await authMiddleware(usageContext(token), next);
-		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(deferredTasks).toHaveLength(0);
 		const stored = await db!
 			.selectFrom("_emdash_api_tokens")
 			.select("last_used_at")
@@ -183,6 +196,12 @@ describe("media usage detail auth middleware", () => {
 		} as unknown as AuthContext;
 	}
 });
+
+async function flushDeferredTasks(): Promise<void> {
+	while (deferredTasks.length > 0) {
+		await deferredTasks.shift()!();
+	}
+}
 
 async function expectError(response: Response, status: number, code: string): Promise<void> {
 	expect(response.status).toBe(status);

--- a/packages/core/tests/unit/astro/media-usage-read-auth.test.ts
+++ b/packages/core/tests/unit/astro/media-usage-read-auth.test.ts
@@ -79,11 +79,18 @@ describe("media usage detail auth middleware", () => {
 
 	it("allows an admin-scoped token for a contributor to read usage details", async () => {
 		const response = await invokeThroughAuth(await createToken("contributor-1", ["admin"]));
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const stored = await db!
+			.selectFrom("_emdash_api_tokens")
+			.select("last_used_at")
+			.where("user_id", "=", "contributor-1")
+			.executeTakeFirstOrThrow();
 
 		expect(response.status).toBe(200);
 		expect((await response.json()) as { data: { items: unknown[] } }).toEqual(
 			expect.objectContaining({ data: expect.objectContaining({ items: [] }) }),
 		);
+		expect(stored.last_used_at).not.toBeNull();
 	});
 
 	it("lets a media-read token reach the route before rejecting its missing admin scope", async () => {
@@ -111,6 +118,24 @@ describe("media usage detail auth middleware", () => {
 		const response = await invokeThroughAuth(await createToken("subscriber-1", ["admin"]));
 
 		await expectError(response, 403, "FORBIDDEN");
+	});
+
+	it("does not record rejected API-token use for a disabled user", async () => {
+		const token = await createToken("contributor-1", ["admin"]);
+		await db!.updateTable("users").set({ disabled: 1 }).where("id", "=", "contributor-1").execute();
+		const next = vi.fn(async () => new Response("should not run"));
+
+		const response = await authMiddleware(usageContext(token), next);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const stored = await db!
+			.selectFrom("_emdash_api_tokens")
+			.select("last_used_at")
+			.where("user_id", "=", "contributor-1")
+			.executeTakeFirstOrThrow();
+
+		expect(next).not.toHaveBeenCalled();
+		await expectError(response, 401, "INVALID_TOKEN");
+		expect(stored.last_used_at).toBeNull();
 	});
 
 	it("rejects an unauthenticated request before the route runs", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes personal API token usage history so authentication rejected for a disabled owner account does not record a new `last_used_at` timestamp.

- Resolves personal API tokens only for existing, enabled owners while retaining the internal token ID.
- Records usage only after the auth middleware reloads and accepts the owner.
- Rechecks owner state in the deferred update and prevents an older deferred write from replacing a newer timestamp.

Closes: N/A — no issue filed.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (targeted tests for this change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [ ] User-visible strings in the admin UI are wrapped for translation — N/A: no user-visible strings are changed.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md)
- [ ] New features link to an approved Discussion — N/A: this is a focused bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5.6 Sol)

## Screenshots / test output

No visual changes.

- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`
- `pnpm --dir packages/core exec vitest run tests/unit/astro/media-usage-read-auth.test.ts tests/integration/auth/api-tokens.test.ts` — 23 tests passed
- `git diff --check upstream/main...HEAD`