### PR TITLE
fix(auth): reject disabled users during interactive sign-in

### DIFF
--- a/.changeset/quiet-otters-rest.md
+++ b/.changeset/quiet-otters-rest.md
@@ -4,4 +4,4 @@
 "emdash": patch
 ---
 
-Fixes disabled accounts being able to complete passkey, Magic Link, OAuth, or Atmosphere sign-in. Authentication attempts are rejected before credential usage, OAuth account links, invite acceptance, or login sessions are recorded.
+Fixes disabled accounts being able to complete passkey, Magic Link, OAuth, Atmosphere, or OAuth device sign-in. Rejected authentication no longer records passkey or API token usage, syncs external-auth profile data, creates OAuth account links, accepts invites, or leaves rejected Atmosphere provider sessions behind.

--- a/.changeset/quiet-otters-rest.md
+++ b/.changeset/quiet-otters-rest.md
@@ -1,0 +1,7 @@
+---
+"@emdash-cms/auth": patch
+"@emdash-cms/auth-atproto": patch
+"emdash": patch
+---
+
+Fixes disabled accounts being able to complete passkey, Magic Link, OAuth, or Atmosphere sign-in. Authentication attempts are rejected before credential usage, OAuth account links, invite acceptance, or login sessions are recorded.

--- a/.changeset/quiet-otters-rest.md
+++ b/.changeset/quiet-otters-rest.md
@@ -4,4 +4,4 @@
 "emdash": patch
 ---
 
-Fixes disabled accounts being able to complete passkey, Magic Link, OAuth, Atmosphere, or OAuth device sign-in. Rejected authentication no longer records passkey or API token usage, syncs external-auth profile data, creates OAuth account links, accepts invites, or leaves rejected Atmosphere provider sessions behind.
+Fixes disabled accounts being able to complete passkey, Magic Link, OAuth, external-auth, or Atmosphere sign-in. Rejected authentication no longer records passkey usage, syncs external-auth profile data, creates OAuth account links, accepts invites, or leaves rejected Atmosphere provider sessions behind.

--- a/packages/auth-atproto/src/oauth-client.ts
+++ b/packages/auth-atproto/src/oauth-client.ts
@@ -34,6 +34,7 @@ import {
 import {
 	MemoryStore,
 	OAuthClient,
+	type Store,
 	type OAuthSession,
 	type StoredSession,
 	type StoredState,
@@ -52,6 +53,26 @@ interface StorageCollectionLike<T = unknown> {
 }
 
 type AuthProviderStorageMap = Record<string, StorageCollectionLike>;
+
+export interface AtprotoOAuthClientOptions {
+	onSessionStored?: (did: Did, session: StoredSession) => void;
+}
+
+function observeSessionStore(
+	store: Store<Did, StoredSession>,
+	onSessionStored: AtprotoOAuthClientOptions["onSessionStored"],
+): Store<Did, StoredSession> {
+	if (!onSessionStored) return store;
+	return {
+		get: (key, options) => store.get(key, options),
+		set: (key, value) => {
+			onSessionStored(key, value);
+			return store.set(key, value);
+		},
+		delete: (key) => store.delete(key),
+		clear: () => store.clear(),
+	};
+}
 
 function isLoopback(url: string): boolean {
 	try {
@@ -82,6 +103,7 @@ function isLoopback(url: string): boolean {
 export async function getAtprotoOAuthClient(
 	baseUrl: string,
 	storage?: AuthProviderStorageMap | null,
+	options: AtprotoOAuthClientOptions = {},
 ): Promise<OAuthClient> {
 	// RFC 8252 §8.3: loopback redirect URIs MUST use an IP literal (127.0.0.1),
 	// not "localhost". The atcute library enforces this — see loopbackRedirectUriSchema.
@@ -109,29 +131,30 @@ export async function getAtprotoOAuthClient(
 	// Use plugin storage when available (required for multi-instance deployments
 	// like Cloudflare Workers where in-memory state doesn't survive across
 	// requests). Fall back to MemoryStore for local dev.
-	const stores = storage
-		? {
-				sessions: createDbStore<Did, StoredSession>(
-					() =>
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- plugin storage collections match StorageCollectionLike shape
-						storage.sessions as StorageCollectionLike<{
-							value: StoredSession;
-							expiresAt: number | null;
-						}>,
-				),
-				states: createDbStore<string, StoredState>(
-					() =>
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- plugin storage collections match StorageCollectionLike shape
-						storage.states as StorageCollectionLike<{
-							value: StoredState;
-							expiresAt: number | null;
-						}>,
-				),
-			}
-		: {
-				sessions: new MemoryStore<Did, StoredSession>(),
-				states: new MemoryStore<string, StoredState>(),
-			};
+	const sessionStore = storage
+		? createDbStore<Did, StoredSession>(
+				() =>
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- plugin storage collections match StorageCollectionLike shape
+					storage.sessions as StorageCollectionLike<{
+						value: StoredSession;
+						expiresAt: number | null;
+					}>,
+			)
+		: new MemoryStore<Did, StoredSession>();
+	const stateStore = storage
+		? createDbStore<string, StoredState>(
+				() =>
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- plugin storage collections match StorageCollectionLike shape
+					storage.states as StorageCollectionLike<{
+						value: StoredState;
+						expiresAt: number | null;
+					}>,
+			)
+		: new MemoryStore<string, StoredState>();
+	const stores = {
+		sessions: observeSessionStore(sessionStore, options.onSessionStored),
+		states: stateStore,
+	};
 
 	if (isLoopback(baseUrl)) {
 		// Loopback public client for local development.

--- a/packages/auth-atproto/src/routes/callback.ts
+++ b/packages/auth-atproto/src/routes/callback.ts
@@ -16,6 +16,7 @@ import type { APIRoute } from "astro";
 
 export const prerender = false;
 
+import type { StoredSession } from "@atcute/oauth-node-client";
 import {
 	AccountDisabledError,
 	Role,
@@ -26,15 +27,62 @@ import {
 	type OAuthProfile,
 } from "@emdash-cms/auth";
 import { createKyselyAdapter, type AuthTables } from "@emdash-cms/auth/adapters/kysely";
+import { after } from "emdash";
 import type { AuthProviderDescriptor } from "emdash";
 import { finalizeSetup, getPublicOrigin, OptionsRepository } from "emdash/api/route-utils";
 import type { Kysely } from "kysely";
 
+const REJECTED_PROVIDER_REVOCATION_TIMEOUT_MS = 5_000;
+
+async function waitForRejectedProviderRevocation(
+	server: { revoke(token: string): Promise<void> },
+	accessToken: string,
+): Promise<void> {
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<"timeout">((resolve) => {
+		timeoutId = setTimeout(resolve, REJECTED_PROVIDER_REVOCATION_TIMEOUT_MS, "timeout");
+	});
+	const revocation = Promise.resolve()
+		.then(() => server.revoke(accessToken))
+		.then(
+			() => "complete" as const,
+			(revokeError: unknown) => {
+				console.error("[atproto-auth] Failed to revoke rejected provider session:", revokeError);
+				return "failed" as const;
+			},
+		);
+
+	try {
+		if ((await Promise.race([revocation, timeout])) === "timeout") {
+			console.error("[atproto-auth] Rejected provider session revocation timed out");
+		}
+	} finally {
+		if (timeoutId !== undefined) clearTimeout(timeoutId);
+	}
+}
+
+function cleanupRejectedProviderSession(
+	server: { revoke(token: string): Promise<void> },
+	accessToken: string,
+): void {
+	after(() => waitForRejectedProviderRevocation(server, accessToken));
+}
+
+interface StoredSessionEntry {
+	value: StoredSession;
+	expiresAt: number | null;
+}
+
+interface ProviderSessionStorage {
+	deleteIfUnchanged?(id: string, data: StoredSessionEntry): Promise<boolean>;
+}
+
 export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 	const { emdash } = locals;
-	let providerSession: { signOut(): Promise<void> } | undefined;
+	let providerSession: { server: { revoke(token: string): Promise<void> } } | undefined;
 	let providerSessionDid: string | undefined;
-	let providerSessionStorage: { delete(id: string): Promise<unknown> } | undefined;
+	let providerSessionStorage: ProviderSessionStorage | undefined;
+	let providerStoredSession: StoredSession | undefined;
 	let authenticationComplete = false;
 
 	if (!emdash?.db) {
@@ -65,7 +113,12 @@ export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 		const storage = await getAtprotoStorage(emdash as Parameters<typeof getAtprotoStorage>[0]);
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- auth provider storage declares a sessions collection
 		providerSessionStorage = storage?.sessions as typeof providerSessionStorage;
-		const client = await getAtprotoOAuthClient(baseUrl, storage);
+		const client = await getAtprotoOAuthClient(baseUrl, storage, {
+			onSessionStored: (did, storedSession) => {
+				providerSessionDid = did;
+				providerStoredSession = storedSession;
+			},
+		});
 		const { session: atprotoSession } = await client.callback(url.searchParams);
 		providerSession = atprotoSession;
 
@@ -231,14 +284,23 @@ export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 			`/_emdash/admin/login?error=${errorCode}&message=${encodeURIComponent(message)}`,
 		);
 	} finally {
-		if (providerSession && !authenticationComplete) {
-			void providerSession.signOut().catch((signOutError: unknown) => {
-				console.error("[atproto-auth] Failed to remove rejected provider session:", signOutError);
-			});
-			if (providerSessionStorage && providerSessionDid) {
-				await providerSessionStorage.delete(providerSessionDid).catch((deleteError: unknown) => {
-					console.error("[atproto-auth] Failed to delete rejected provider session:", deleteError);
-				});
+		if (providerSession && providerStoredSession && !authenticationComplete) {
+			cleanupRejectedProviderSession(
+				providerSession.server,
+				providerStoredSession.tokenSet.access_token,
+			);
+			if (providerSessionStorage?.deleteIfUnchanged && providerSessionDid) {
+				await providerSessionStorage
+					.deleteIfUnchanged(providerSessionDid, {
+						value: providerStoredSession,
+						expiresAt: null,
+					})
+					.catch((deleteError: unknown) => {
+						console.error(
+							"[atproto-auth] Failed to delete rejected provider session:",
+							deleteError,
+						);
+					});
 			}
 		}
 	}

--- a/packages/auth-atproto/src/routes/callback.ts
+++ b/packages/auth-atproto/src/routes/callback.ts
@@ -33,6 +33,8 @@ import type { Kysely } from "kysely";
 export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 	const { emdash } = locals;
 	let providerSession: { signOut(): Promise<void> } | undefined;
+	let providerSessionDid: string | undefined;
+	let providerSessionStorage: { delete(id: string): Promise<unknown> } | undefined;
 	let authenticationComplete = false;
 
 	if (!emdash?.db) {
@@ -61,11 +63,14 @@ export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 		const { getAtprotoStorage } = await import("../storage.js");
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- emdash locals satisfy EmdashLocals shape required by getAtprotoStorage
 		const storage = await getAtprotoStorage(emdash as Parameters<typeof getAtprotoStorage>[0]);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- auth provider storage declares a sessions collection
+		providerSessionStorage = storage?.sessions as typeof providerSessionStorage;
 		const client = await getAtprotoOAuthClient(baseUrl, storage);
 		const { session: atprotoSession } = await client.callback(url.searchParams);
 		providerSession = atprotoSession;
 
 		const did = atprotoSession.did;
+		providerSessionDid = did;
 
 		// Resolve profile for display name and handle
 		const { displayName, handle } = await resolveAtprotoProfile(atprotoSession);
@@ -193,9 +198,8 @@ export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 		}
 
 		// Create Astro session
-		if (session) {
-			session.set("user", { id: user.id });
-		}
+		if (!session) throw new Error("Session unavailable");
+		session.set("user", { id: user.id });
 		authenticationComplete = true;
 
 		// Redirect to admin dashboard
@@ -228,9 +232,14 @@ export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 		);
 	} finally {
 		if (providerSession && !authenticationComplete) {
-			await providerSession.signOut().catch((signOutError: unknown) => {
+			void providerSession.signOut().catch((signOutError: unknown) => {
 				console.error("[atproto-auth] Failed to remove rejected provider session:", signOutError);
 			});
+			if (providerSessionStorage && providerSessionDid) {
+				await providerSessionStorage.delete(providerSessionDid).catch((deleteError: unknown) => {
+					console.error("[atproto-auth] Failed to delete rejected provider session:", deleteError);
+				});
+			}
 		}
 	}
 };

--- a/packages/auth-atproto/src/routes/callback.ts
+++ b/packages/auth-atproto/src/routes/callback.ts
@@ -17,6 +17,7 @@ import type { APIRoute } from "astro";
 export const prerender = false;
 
 import {
+	AccountDisabledError,
 	Role,
 	toRoleLevel,
 	findOrCreateOAuthUser,
@@ -167,6 +168,13 @@ export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 				return null;
 			}
 			return { allowed: true, role: defaultRole };
+		}).catch(async (authError: unknown) => {
+			if (authError instanceof AccountDisabledError) {
+				await atprotoSession.signOut().catch((signOutError: unknown) => {
+					console.error("[atproto-auth] Failed to remove disabled account session:", signOutError);
+				});
+			}
+			throw authError;
 		});
 
 		if (isFirstUser) {
@@ -201,7 +209,10 @@ export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 		let message = "AT Protocol authentication failed. Please try again.";
 		let errorCode = "atproto_error";
 
-		if (callbackError instanceof OAuthError) {
+		if (callbackError instanceof AccountDisabledError) {
+			errorCode = callbackError.code;
+			message = callbackError.message;
+		} else if (callbackError instanceof OAuthError) {
 			errorCode = callbackError.code;
 			switch (callbackError.code) {
 				case "signup_not_allowed":

--- a/packages/auth-atproto/src/routes/callback.ts
+++ b/packages/auth-atproto/src/routes/callback.ts
@@ -32,6 +32,8 @@ import type { Kysely } from "kysely";
 
 export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 	const { emdash } = locals;
+	let providerSession: { signOut(): Promise<void> } | undefined;
+	let authenticationComplete = false;
 
 	if (!emdash?.db) {
 		return redirect(
@@ -61,6 +63,7 @@ export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 		const storage = await getAtprotoStorage(emdash as Parameters<typeof getAtprotoStorage>[0]);
 		const client = await getAtprotoOAuthClient(baseUrl, storage);
 		const { session: atprotoSession } = await client.callback(url.searchParams);
+		providerSession = atprotoSession;
 
 		const did = atprotoSession.did;
 
@@ -168,13 +171,6 @@ export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 				return null;
 			}
 			return { allowed: true, role: defaultRole };
-		}).catch(async (authError: unknown) => {
-			if (authError instanceof AccountDisabledError) {
-				await atprotoSession.signOut().catch((signOutError: unknown) => {
-					console.error("[atproto-auth] Failed to remove disabled account session:", signOutError);
-				});
-			}
-			throw authError;
 		});
 
 		if (isFirstUser) {
@@ -200,6 +196,7 @@ export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 		if (session) {
 			session.set("user", { id: user.id });
 		}
+		authenticationComplete = true;
 
 		// Redirect to admin dashboard
 		return redirect("/_emdash/admin");
@@ -229,5 +226,11 @@ export const GET: APIRoute = async ({ request, locals, session, redirect }) => {
 		return redirect(
 			`/_emdash/admin/login?error=${errorCode}&message=${encodeURIComponent(message)}`,
 		);
+	} finally {
+		if (providerSession && !authenticationComplete) {
+			await providerSession.signOut().catch((signOutError: unknown) => {
+				console.error("[atproto-auth] Failed to remove rejected provider session:", signOutError);
+			});
+		}
 	}
 };

--- a/packages/auth-atproto/tests/callback.test.ts
+++ b/packages/auth-atproto/tests/callback.test.ts
@@ -78,4 +78,115 @@ describe("AT Protocol callback", () => {
 		expect(session.set).not.toHaveBeenCalled();
 		expect(response.headers.get("location")).toContain("error=account_disabled");
 	});
+
+	it("removes the provider session when the DID is not allowed", async () => {
+		const signOut = vi.fn().mockResolvedValue(undefined);
+		mocks.getAtprotoOAuthClient.mockResolvedValue({
+			callback: vi.fn().mockResolvedValue({
+				session: { did: "did:plc:denied", signOut },
+			}),
+		});
+		mocks.resolveAtprotoProfile.mockResolvedValue({
+			displayName: "Denied User",
+			handle: "denied.example.com",
+		});
+		const redirect = vi.fn((location: string) =>
+			Response.redirect(new URL(location, "https://example.com")),
+		);
+
+		const response = await GET({
+			request: new Request("https://example.com/_emdash/api/auth/atproto/callback?code=abc"),
+			locals: {
+				emdash: {
+					db: {},
+					config: {
+						authProviders: [
+							{
+								id: "atproto",
+								config: { allowedDIDs: ["did:plc:allowed"] },
+							},
+						],
+					},
+				},
+			},
+			redirect,
+		} as never);
+
+		expect(response.headers.get("location")).toContain("error=not_allowed");
+		expect(signOut).toHaveBeenCalledOnce();
+	});
+
+	it("removes the provider session when profile resolution fails", async () => {
+		const signOut = vi.fn().mockResolvedValue(undefined);
+		mocks.getAtprotoOAuthClient.mockResolvedValue({
+			callback: vi.fn().mockResolvedValue({
+				session: { did: "did:plc:error", signOut },
+			}),
+		});
+		mocks.resolveAtprotoProfile.mockRejectedValue(new Error("Profile lookup failed"));
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const redirect = vi.fn((location: string) =>
+			Response.redirect(new URL(location, "https://example.com")),
+		);
+
+		try {
+			const response = await GET({
+				request: new Request("https://example.com/_emdash/api/auth/atproto/callback?code=abc"),
+				locals: { emdash: { db: {}, config: {} } },
+				redirect,
+			} as never);
+
+			expect(response.headers.get("location")).toContain("error=atproto_error");
+			expect(signOut).toHaveBeenCalledOnce();
+		} finally {
+			consoleError.mockRestore();
+		}
+	});
+
+	it("keeps the provider session after authentication succeeds", async () => {
+		const signOut = vi.fn().mockResolvedValue(undefined);
+		mocks.getAtprotoOAuthClient.mockResolvedValue({
+			callback: vi.fn().mockResolvedValue({
+				session: { did: "did:plc:allowed", signOut },
+			}),
+		});
+		mocks.resolveAtprotoProfile.mockResolvedValue({
+			displayName: "Allowed User",
+			handle: "allowed.example.com",
+		});
+		mocks.findOrCreateOAuthUser.mockResolvedValue({
+			id: "user-1",
+			email: "user@example.com",
+			name: "Allowed User",
+			role: 10,
+			disabled: false,
+		});
+		const session = { set: vi.fn() };
+		const redirect = vi.fn((location: string) =>
+			Response.redirect(new URL(location, "https://example.com")),
+		);
+
+		const response = await GET({
+			request: new Request("https://example.com/_emdash/api/auth/atproto/callback?code=abc"),
+			locals: {
+				emdash: {
+					db: {},
+					config: {
+						authProviders: [
+							{
+								id: "atproto",
+								config: { allowedDIDs: ["did:plc:allowed"] },
+							},
+						],
+					},
+				},
+			},
+			session,
+			redirect,
+		} as never);
+
+		expect(response.headers.get("location")).toBe("https://example.com/_emdash/admin");
+		expect(session.set).toHaveBeenCalledWith("user", { id: "user-1" });
+		expect(signOut).not.toHaveBeenCalled();
+	});
 });

--- a/packages/auth-atproto/tests/callback.test.ts
+++ b/packages/auth-atproto/tests/callback.test.ts
@@ -1,0 +1,81 @@
+import { AccountDisabledError } from "@emdash-cms/auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	findOrCreateOAuthUser: vi.fn(),
+	getAtprotoOAuthClient: vi.fn(),
+	resolveAtprotoProfile: vi.fn(),
+}));
+
+vi.mock("@emdash-cms/auth", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@emdash-cms/auth")>()),
+	findOrCreateOAuthUser: mocks.findOrCreateOAuthUser,
+}));
+
+vi.mock("@emdash-cms/auth-atproto/oauth-client", () => ({
+	getAtprotoOAuthClient: mocks.getAtprotoOAuthClient,
+	resolveAtprotoProfile: mocks.resolveAtprotoProfile,
+}));
+
+vi.mock("../src/storage.js", () => ({
+	getAtprotoStorage: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("emdash/api/route-utils", () => ({
+	finalizeSetup: vi.fn(),
+	getPublicOrigin: vi.fn().mockReturnValue("https://example.com"),
+	OptionsRepository: class {
+		get() {
+			return true;
+		}
+	},
+}));
+
+import { GET } from "../src/routes/callback.js";
+
+describe("AT Protocol callback", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("removes the provider session when the EmDash account is disabled", async () => {
+		const signOut = vi.fn().mockResolvedValue(undefined);
+		mocks.getAtprotoOAuthClient.mockResolvedValue({
+			callback: vi.fn().mockResolvedValue({
+				session: { did: "did:plc:disabled", signOut },
+			}),
+		});
+		mocks.resolveAtprotoProfile.mockResolvedValue({
+			displayName: "Disabled User",
+			handle: "disabled.example.com",
+		});
+		mocks.findOrCreateOAuthUser.mockRejectedValue(new AccountDisabledError());
+
+		const session = { set: vi.fn() };
+		const redirect = vi.fn((location: string) =>
+			Response.redirect(new URL(location, "https://example.com")),
+		);
+		const response = await GET({
+			request: new Request("https://example.com/_emdash/api/auth/atproto/callback?code=abc"),
+			locals: {
+				emdash: {
+					db: {},
+					config: {
+						authProviders: [
+							{
+								id: "atproto",
+								config: { allowedDIDs: ["did:plc:disabled"] },
+							},
+						],
+					},
+				},
+			},
+			session,
+			redirect,
+		} as never);
+
+		expect(signOut).toHaveBeenCalledOnce();
+		expect(session.set).not.toHaveBeenCalled();
+		expect(response.headers.get("location")).toContain("error=account_disabled");
+	});
+});

--- a/packages/auth-atproto/tests/callback.test.ts
+++ b/packages/auth-atproto/tests/callback.test.ts
@@ -6,7 +6,8 @@ const mocks = vi.hoisted(() => ({
 	getAtprotoOAuthClient: vi.fn(),
 	getAtprotoStorage: vi.fn(),
 	resolveAtprotoProfile: vi.fn(),
-	deleteProviderSession: vi.fn(),
+	deleteProviderSessionIfUnchanged: vi.fn(),
+	after: vi.fn(),
 }));
 
 vi.mock("@emdash-cms/auth", async (importOriginal) => ({
@@ -23,6 +24,10 @@ vi.mock("../src/storage.js", () => ({
 	getAtprotoStorage: mocks.getAtprotoStorage,
 }));
 
+vi.mock("emdash", () => ({
+	after: mocks.after,
+}));
+
 vi.mock("emdash/api/route-utils", () => ({
 	finalizeSetup: vi.fn(),
 	getPublicOrigin: vi.fn().mockReturnValue("https://example.com"),
@@ -35,22 +40,55 @@ vi.mock("emdash/api/route-utils", () => ({
 
 import { GET } from "../src/routes/callback.js";
 
+function getDeferredCleanup(): () => Promise<void> {
+	const cleanup: unknown = mocks.after.mock.calls[0]?.[0];
+	if (typeof cleanup !== "function") throw new Error("Deferred cleanup was not scheduled");
+	return async () => cleanup();
+}
+
+async function runDeferredCleanup(): Promise<void> {
+	await getDeferredCleanup()();
+}
+
+function mockProviderSession(
+	did: string,
+	revoke = vi.fn().mockResolvedValue(undefined),
+): {
+	accessToken: string;
+	revoke: typeof revoke;
+	storedSession: { tokenSet: { access_token: string } };
+} {
+	const accessToken = `token:${did}`;
+	const storedSession = { tokenSet: { access_token: accessToken } };
+	const callback = vi.fn().mockResolvedValue({
+		session: { did, server: { revoke } },
+	});
+	mocks.getAtprotoOAuthClient.mockImplementation(
+		async (
+			_baseUrl: string,
+			_storage: unknown,
+			options?: {
+				onSessionStored?: (did: string, session: typeof storedSession) => void;
+			},
+		) => {
+			options?.onSessionStored?.(did, storedSession);
+			return { callback };
+		},
+	);
+	return { accessToken, revoke, storedSession };
+}
+
 describe("AT Protocol callback", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		mocks.deleteProviderSession.mockResolvedValue(true);
+		mocks.deleteProviderSessionIfUnchanged.mockResolvedValue(true);
 		mocks.getAtprotoStorage.mockResolvedValue({
-			sessions: { delete: mocks.deleteProviderSession },
+			sessions: { deleteIfUnchanged: mocks.deleteProviderSessionIfUnchanged },
 		});
 	});
 
 	it("removes the provider session when the EmDash account is disabled", async () => {
-		const signOut = vi.fn().mockResolvedValue(undefined);
-		mocks.getAtprotoOAuthClient.mockResolvedValue({
-			callback: vi.fn().mockResolvedValue({
-				session: { did: "did:plc:disabled", signOut },
-			}),
-		});
+		const { accessToken, revoke, storedSession } = mockProviderSession("did:plc:disabled");
 		mocks.resolveAtprotoProfile.mockResolvedValue({
 			displayName: "Disabled User",
 			handle: "disabled.example.com",
@@ -80,18 +118,18 @@ describe("AT Protocol callback", () => {
 			redirect,
 		} as never);
 
-		expect(signOut).toHaveBeenCalledOnce();
+		expect(mocks.deleteProviderSessionIfUnchanged).toHaveBeenCalledWith("did:plc:disabled", {
+			value: storedSession,
+			expiresAt: null,
+		});
+		await runDeferredCleanup();
+		expect(revoke).toHaveBeenCalledWith(accessToken);
 		expect(session.set).not.toHaveBeenCalled();
 		expect(response.headers.get("location")).toContain("error=account_disabled");
 	});
 
 	it("removes the provider session when the DID is not allowed", async () => {
-		const signOut = vi.fn().mockResolvedValue(undefined);
-		mocks.getAtprotoOAuthClient.mockResolvedValue({
-			callback: vi.fn().mockResolvedValue({
-				session: { did: "did:plc:denied", signOut },
-			}),
-		});
+		const { accessToken, revoke } = mockProviderSession("did:plc:denied");
 		mocks.resolveAtprotoProfile.mockResolvedValue({
 			displayName: "Denied User",
 			handle: "denied.example.com",
@@ -119,16 +157,14 @@ describe("AT Protocol callback", () => {
 		} as never);
 
 		expect(response.headers.get("location")).toContain("error=not_allowed");
-		expect(signOut).toHaveBeenCalledOnce();
+		await runDeferredCleanup();
+		expect(revoke).toHaveBeenCalledWith(accessToken);
 	});
 
 	it("removes the provider session when profile resolution fails", async () => {
-		const signOut = vi.fn().mockResolvedValue(undefined);
-		mocks.getAtprotoOAuthClient.mockResolvedValue({
-			callback: vi.fn().mockResolvedValue({
-				session: { did: "did:plc:error", signOut },
-			}),
-		});
+		const revokeError = new Error("Provider revocation failed");
+		const revoke = vi.fn().mockRejectedValue(revokeError);
+		const { accessToken } = mockProviderSession("did:plc:error", revoke);
 		mocks.resolveAtprotoProfile.mockRejectedValue(new Error("Profile lookup failed"));
 		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 		const redirect = vi.fn((location: string) =>
@@ -143,19 +179,20 @@ describe("AT Protocol callback", () => {
 			} as never);
 
 			expect(response.headers.get("location")).toContain("error=atproto_error");
-			expect(signOut).toHaveBeenCalledOnce();
+			await runDeferredCleanup();
+			expect(revoke).toHaveBeenCalledWith(accessToken);
+			expect(mocks.deleteProviderSessionIfUnchanged).toHaveBeenCalledOnce();
+			expect(consoleError).toHaveBeenCalledWith(
+				"[atproto-auth] Failed to revoke rejected provider session:",
+				revokeError,
+			);
 		} finally {
 			consoleError.mockRestore();
 		}
 	});
 
 	it("keeps the provider session after authentication succeeds", async () => {
-		const signOut = vi.fn().mockResolvedValue(undefined);
-		mocks.getAtprotoOAuthClient.mockResolvedValue({
-			callback: vi.fn().mockResolvedValue({
-				session: { did: "did:plc:allowed", signOut },
-			}),
-		});
+		const { revoke } = mockProviderSession("did:plc:allowed");
 		mocks.resolveAtprotoProfile.mockResolvedValue({
 			displayName: "Allowed User",
 			handle: "allowed.example.com",
@@ -193,17 +230,21 @@ describe("AT Protocol callback", () => {
 
 		expect(response.headers.get("location")).toBe("https://example.com/_emdash/admin");
 		expect(session.set).toHaveBeenCalledWith("user", { id: "user-1" });
-		expect(signOut).not.toHaveBeenCalled();
-		expect(mocks.deleteProviderSession).not.toHaveBeenCalled();
+		expect(revoke).not.toHaveBeenCalled();
+		expect(mocks.deleteProviderSessionIfUnchanged).not.toHaveBeenCalled();
+		expect(mocks.after).not.toHaveBeenCalled();
 	});
 
-	it("removes local provider credentials without waiting for remote sign-out", async () => {
-		const signOut = vi.fn(() => new Promise<void>(() => {}));
-		mocks.getAtprotoOAuthClient.mockResolvedValue({
-			callback: vi.fn().mockResolvedValue({
-				session: { did: "did:plc:denied", signOut },
-			}),
-		});
+	it("does not delete a newer provider session while revocation is pending", async () => {
+		let finishRevocation: (() => void) | undefined;
+		const revoke = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					finishRevocation = resolve;
+				}),
+		);
+		const { accessToken, storedSession } = mockProviderSession("did:plc:denied", revoke);
+		mocks.deleteProviderSessionIfUnchanged.mockResolvedValue(false);
 		mocks.resolveAtprotoProfile.mockResolvedValue({
 			displayName: "Denied User",
 			handle: "denied.example.com",
@@ -212,8 +253,57 @@ describe("AT Protocol callback", () => {
 			Response.redirect(new URL(location, "https://example.com")),
 		);
 
-		const result = await Promise.race([
-			GET({
+		const response = await GET({
+			request: new Request("https://example.com/_emdash/api/auth/atproto/callback?code=abc"),
+			locals: {
+				emdash: {
+					db: {},
+					config: {
+						authProviders: [
+							{
+								id: "atproto",
+								config: { allowedDIDs: ["did:plc:allowed"] },
+							},
+						],
+					},
+				},
+			},
+			redirect,
+		} as never);
+
+		expect(response.headers.get("location")).toContain("error=not_allowed");
+		expect(mocks.after).toHaveBeenCalledOnce();
+		expect(revoke).not.toHaveBeenCalled();
+		expect(mocks.deleteProviderSessionIfUnchanged).toHaveBeenCalledWith("did:plc:denied", {
+			value: storedSession,
+			expiresAt: null,
+		});
+
+		const cleanup = getDeferredCleanup();
+		const cleanupPromise = cleanup();
+		await Promise.resolve();
+		expect(revoke).toHaveBeenCalledWith(accessToken);
+
+		finishRevocation?.();
+		await cleanupPromise;
+		expect(mocks.deleteProviderSessionIfUnchanged).toHaveBeenCalledOnce();
+	});
+
+	it("bounds rejected provider revocation", async () => {
+		vi.useFakeTimers();
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const revoke = vi.fn(() => new Promise<void>(() => {}));
+			mockProviderSession("did:plc:denied", revoke);
+			mocks.resolveAtprotoProfile.mockResolvedValue({
+				displayName: "Denied User",
+				handle: "denied.example.com",
+			});
+			const redirect = vi.fn((location: string) =>
+				Response.redirect(new URL(location, "https://example.com")),
+			);
+
+			await GET({
 				request: new Request("https://example.com/_emdash/api/auth/atproto/callback?code=abc"),
 				locals: {
 					emdash: {
@@ -229,22 +319,24 @@ describe("AT Protocol callback", () => {
 					},
 				},
 				redirect,
-			} as never),
-			new Promise<"timeout">((resolve) => setTimeout(resolve, 50, "timeout")),
-		]);
+			} as never);
 
-		expect(result).not.toBe("timeout");
-		expect(signOut).toHaveBeenCalledOnce();
-		expect(mocks.deleteProviderSession).toHaveBeenCalledWith("did:plc:denied");
+			const cleanup = getDeferredCleanup();
+			const cleanupPromise = cleanup();
+			await vi.advanceTimersByTimeAsync(4_999);
+			expect(mocks.deleteProviderSessionIfUnchanged).toHaveBeenCalledOnce();
+
+			await vi.advanceTimersByTimeAsync(1);
+			await cleanupPromise;
+			expect(revoke).toHaveBeenCalledOnce();
+		} finally {
+			consoleError.mockRestore();
+			vi.useRealTimers();
+		}
 	});
 
 	it("rejects authentication when the Astro session is unavailable", async () => {
-		const signOut = vi.fn().mockResolvedValue(undefined);
-		mocks.getAtprotoOAuthClient.mockResolvedValue({
-			callback: vi.fn().mockResolvedValue({
-				session: { did: "did:plc:allowed", signOut },
-			}),
-		});
+		const { accessToken, revoke } = mockProviderSession("did:plc:allowed");
 		mocks.resolveAtprotoProfile.mockResolvedValue({
 			displayName: "Allowed User",
 			handle: "allowed.example.com",
@@ -279,7 +371,8 @@ describe("AT Protocol callback", () => {
 		} as never);
 
 		expect(response.headers.get("location")).toContain("error=atproto_error");
-		expect(signOut).toHaveBeenCalledOnce();
-		expect(mocks.deleteProviderSession).toHaveBeenCalledWith("did:plc:allowed");
+		await runDeferredCleanup();
+		expect(revoke).toHaveBeenCalledWith(accessToken);
+		expect(mocks.deleteProviderSessionIfUnchanged).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/auth-atproto/tests/callback.test.ts
+++ b/packages/auth-atproto/tests/callback.test.ts
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
 	findOrCreateOAuthUser: vi.fn(),
 	getAtprotoOAuthClient: vi.fn(),
+	getAtprotoStorage: vi.fn(),
 	resolveAtprotoProfile: vi.fn(),
+	deleteProviderSession: vi.fn(),
 }));
 
 vi.mock("@emdash-cms/auth", async (importOriginal) => ({
@@ -18,7 +20,7 @@ vi.mock("@emdash-cms/auth-atproto/oauth-client", () => ({
 }));
 
 vi.mock("../src/storage.js", () => ({
-	getAtprotoStorage: vi.fn().mockResolvedValue({}),
+	getAtprotoStorage: mocks.getAtprotoStorage,
 }));
 
 vi.mock("emdash/api/route-utils", () => ({
@@ -36,6 +38,10 @@ import { GET } from "../src/routes/callback.js";
 describe("AT Protocol callback", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mocks.deleteProviderSession.mockResolvedValue(true);
+		mocks.getAtprotoStorage.mockResolvedValue({
+			sessions: { delete: mocks.deleteProviderSession },
+		});
 	});
 
 	it("removes the provider session when the EmDash account is disabled", async () => {
@@ -188,5 +194,92 @@ describe("AT Protocol callback", () => {
 		expect(response.headers.get("location")).toBe("https://example.com/_emdash/admin");
 		expect(session.set).toHaveBeenCalledWith("user", { id: "user-1" });
 		expect(signOut).not.toHaveBeenCalled();
+		expect(mocks.deleteProviderSession).not.toHaveBeenCalled();
+	});
+
+	it("removes local provider credentials without waiting for remote sign-out", async () => {
+		const signOut = vi.fn(() => new Promise<void>(() => {}));
+		mocks.getAtprotoOAuthClient.mockResolvedValue({
+			callback: vi.fn().mockResolvedValue({
+				session: { did: "did:plc:denied", signOut },
+			}),
+		});
+		mocks.resolveAtprotoProfile.mockResolvedValue({
+			displayName: "Denied User",
+			handle: "denied.example.com",
+		});
+		const redirect = vi.fn((location: string) =>
+			Response.redirect(new URL(location, "https://example.com")),
+		);
+
+		const result = await Promise.race([
+			GET({
+				request: new Request("https://example.com/_emdash/api/auth/atproto/callback?code=abc"),
+				locals: {
+					emdash: {
+						db: {},
+						config: {
+							authProviders: [
+								{
+									id: "atproto",
+									config: { allowedDIDs: ["did:plc:allowed"] },
+								},
+							],
+						},
+					},
+				},
+				redirect,
+			} as never),
+			new Promise<"timeout">((resolve) => setTimeout(resolve, 50, "timeout")),
+		]);
+
+		expect(result).not.toBe("timeout");
+		expect(signOut).toHaveBeenCalledOnce();
+		expect(mocks.deleteProviderSession).toHaveBeenCalledWith("did:plc:denied");
+	});
+
+	it("rejects authentication when the Astro session is unavailable", async () => {
+		const signOut = vi.fn().mockResolvedValue(undefined);
+		mocks.getAtprotoOAuthClient.mockResolvedValue({
+			callback: vi.fn().mockResolvedValue({
+				session: { did: "did:plc:allowed", signOut },
+			}),
+		});
+		mocks.resolveAtprotoProfile.mockResolvedValue({
+			displayName: "Allowed User",
+			handle: "allowed.example.com",
+		});
+		mocks.findOrCreateOAuthUser.mockResolvedValue({
+			id: "user-1",
+			email: "user@example.com",
+			name: "Allowed User",
+			role: 10,
+			disabled: false,
+		});
+		const redirect = vi.fn((location: string) =>
+			Response.redirect(new URL(location, "https://example.com")),
+		);
+
+		const response = await GET({
+			request: new Request("https://example.com/_emdash/api/auth/atproto/callback?code=abc"),
+			locals: {
+				emdash: {
+					db: {},
+					config: {
+						authProviders: [
+							{
+								id: "atproto",
+								config: { allowedDIDs: ["did:plc:allowed"] },
+							},
+						],
+					},
+				},
+			},
+			redirect,
+		} as never);
+
+		expect(response.headers.get("location")).toContain("error=atproto_error");
+		expect(signOut).toHaveBeenCalledOnce();
+		expect(mocks.deleteProviderSession).toHaveBeenCalledWith("did:plc:allowed");
 	});
 });

--- a/packages/auth/src/magic-link/index.ts
+++ b/packages/auth/src/magic-link/index.ts
@@ -4,6 +4,7 @@
 
 import { escapeHtml } from "../invite.js";
 import { generateTokenWithHash, hashToken } from "../tokens.js";
+import { assertUserEnabled } from "../types.js";
 import type { AuthAdapter, User, EmailMessage } from "../types.js";
 
 const TOKEN_EXPIRY_MS = 15 * 60 * 1000; // 15 minutes
@@ -135,6 +136,7 @@ async function verifyTokenAndGetUser(
 	if (!user) {
 		throw new MagicLinkError("user_not_found", "User not found");
 	}
+	assertUserEnabled(user);
 
 	return user;
 }

--- a/packages/auth/src/oauth/consumer.test.ts
+++ b/packages/auth/src/oauth/consumer.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { Role } from "../types.js";
+import type { AuthAdapter, User } from "../types.js";
+import { findOrCreateOAuthUser } from "./consumer.js";
+import type { OAuthProfile } from "./types.js";
+
+function makeUser(disabled: boolean): User {
+	return {
+		id: "user_1",
+		email: "user@example.com",
+		name: "User",
+		avatarUrl: null,
+		role: Role.AUTHOR,
+		emailVerified: true,
+		disabled,
+		data: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	};
+}
+
+const profile: OAuthProfile = {
+	id: "provider-account-1",
+	email: "user@example.com",
+	name: "Provider User",
+	avatarUrl: null,
+	emailVerified: true,
+};
+
+describe("findOrCreateOAuthUser", () => {
+	it("rejects an already-linked disabled user", async () => {
+		const adapter = {
+			getOAuthAccount: vi.fn(async () => ({
+				provider: "google",
+				providerAccountId: profile.id,
+				userId: "user_1",
+				createdAt: new Date(),
+			})),
+			getUserById: vi.fn(async () => makeUser(true)),
+		} as unknown as AuthAdapter;
+
+		await expect(findOrCreateOAuthUser(adapter, "google", profile)).rejects.toMatchObject({
+			code: "account_disabled",
+		});
+	});
+
+	it("does not link a verified OAuth identity to a disabled user", async () => {
+		const createOAuthAccount = vi.fn();
+		const adapter = {
+			getOAuthAccount: vi.fn(async () => null),
+			getUserByEmail: vi.fn(async () => makeUser(true)),
+			createOAuthAccount,
+		} as unknown as AuthAdapter;
+
+		await expect(findOrCreateOAuthUser(adapter, "google", profile)).rejects.toMatchObject({
+			code: "account_disabled",
+		});
+		expect(createOAuthAccount).not.toHaveBeenCalled();
+	});
+
+	it("returns an enabled linked user", async () => {
+		const user = makeUser(false);
+		const adapter = {
+			getOAuthAccount: vi.fn(async () => ({
+				provider: "google",
+				providerAccountId: profile.id,
+				userId: user.id,
+				createdAt: new Date(),
+			})),
+			getUserById: vi.fn(async () => user),
+		} as unknown as AuthAdapter;
+
+		await expect(findOrCreateOAuthUser(adapter, "google", profile)).resolves.toBe(user);
+	});
+});

--- a/packages/auth/src/oauth/consumer.ts
+++ b/packages/auth/src/oauth/consumer.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 
 import { completeInvite, InviteError, validateInvite } from "../invite.js";
 import { hashToken } from "../tokens.js";
+import { assertUserEnabled } from "../types.js";
 import type { AuthAdapter, User, RoleLevel } from "../types.js";
 import { github, fetchGitHubEmail } from "./providers/github.js";
 import { google } from "./providers/google.js";
@@ -181,6 +182,7 @@ export async function acceptInviteViaOAuth(
 				"This invite was sent to a different email address than your account.",
 			);
 		}
+		assertUserEnabled(user);
 		await adapter.deleteToken(hashToken(inviteToken));
 		return user;
 	}
@@ -190,6 +192,7 @@ export async function acceptInviteViaOAuth(
 	// than failing, so the single-use token cannot be replayed.
 	const existingUser = await adapter.getUserByEmail(profile.email);
 	if (existingUser) {
+		assertUserEnabled(existingUser);
 		await adapter.createOAuthAccount({
 			provider: providerName,
 			providerAccountId: profile.id,
@@ -325,6 +328,7 @@ export async function findOrCreateOAuthUser(
 		if (!user) {
 			throw new OAuthError("user_not_found", "Linked user not found");
 		}
+		assertUserEnabled(user);
 		return user;
 	}
 
@@ -339,6 +343,7 @@ export async function findOrCreateOAuthUser(
 				"Cannot link account: email not verified by provider",
 			);
 		}
+		assertUserEnabled(existingUser);
 		await adapter.createOAuthAccount({
 			provider: providerName,
 			providerAccountId: profile.id,

--- a/packages/auth/src/passkey/authenticate.test.ts
+++ b/packages/auth/src/passkey/authenticate.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@oslojs/webauthn";
 import { describe, it, expect, vi } from "vitest";
 
-import type { AuthAdapter, Credential } from "../types.js";
+import type { AuthAdapter, Credential, User } from "../types.js";
 import { authenticateWithPasskey, PasskeyAuthenticationError } from "./authenticate.js";
 import type { ChallengeStore } from "./types.js";
 
@@ -160,6 +160,33 @@ function createValidRS256Assertion(opts: { rpId?: string; origin?: string } = {}
 }
 
 describe("authenticateWithPasskey", () => {
+	it("rejects a disabled user without updating credential usage", async () => {
+		const { credential: validCredential, response, challengeStore } = createValidAssertion();
+		const disabledUser: User = {
+			id: "user_1",
+			email: "disabled@example.com",
+			name: "Disabled User",
+			avatarUrl: null,
+			role: 30,
+			emailVerified: true,
+			disabled: true,
+			data: null,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+		const updateCredentialCounter = vi.fn(async () => undefined);
+		const adapter = {
+			getCredentialById: vi.fn(async () => validCredential),
+			updateCredentialCounter,
+			getUserById: vi.fn(async () => disabledUser),
+		} as unknown as AuthAdapter;
+
+		await expect(
+			authenticateWithPasskey(config, adapter, response, challengeStore),
+		).rejects.toMatchObject({ code: "account_disabled" });
+		expect(updateCredentialCounter).not.toHaveBeenCalled();
+	});
+
 	it("throws a typed passkey auth error for malformed assertion payloads", async () => {
 		try {
 			await authenticateWithPasskey(

--- a/packages/auth/src/passkey/authenticate.ts
+++ b/packages/auth/src/passkey/authenticate.ts
@@ -28,6 +28,7 @@ import {
 } from "@oslojs/webauthn";
 
 import { generateToken } from "../tokens.js";
+import { assertUserEnabled } from "../types.js";
 import type { Credential, AuthAdapter, User } from "../types.js";
 import type {
 	AuthenticationOptions,
@@ -257,14 +258,15 @@ export async function authenticateWithPasskey(
 	// Verify the response
 	const verified = await verifyAuthenticationResponse(config, response, credential, challengeStore);
 
-	// Update counter
-	await adapter.updateCredentialCounter(verified.credentialId, verified.newCounter);
-
 	// Get the user
 	const user = await adapter.getUserById(credential.userId);
 	if (!user) {
 		throw new PasskeyAuthenticationError("user_not_found", "User not found");
 	}
+	assertUserEnabled(user);
+
+	// Update counter
+	await adapter.updateCredentialCounter(verified.credentialId, verified.newCounter);
 
 	return user;
 }

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -336,8 +336,20 @@ export class AuthError extends Error {
 	}
 }
 
+export class AccountDisabledError extends AuthError {
+	constructor() {
+		super("account_disabled", "Account disabled");
+		this.name = "AccountDisabledError";
+	}
+}
+
+export function assertUserEnabled(user: User): void {
+	if (user.disabled) throw new AccountDisabledError();
+}
+
 export type AuthErrorCode =
 	| "invalid_credentials"
+	| "account_disabled"
 	| "invalid_token"
 	| "token_expired"
 	| "user_not_found"

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -64,6 +64,13 @@ function csrfRejectedResponse(): Response {
 	return apiError("CSRF_REJECTED", "Missing required header", 403);
 }
 
+function accountDisabledResponse(): Response {
+	return new Response("Account disabled", {
+		status: 403,
+		headers: { "Content-Type": "text/plain", ...MW_CACHE_HEADERS },
+	});
+}
+
 function mcpUnauthorizedResponse(
 	url: URL,
 	config?: Parameters<typeof getPublicOrigin>[1],
@@ -505,6 +512,7 @@ async function handleExternalAuth(
 		// Find or create user
 		const adapter = createKyselyAdapter(emdash.db);
 		let user = await adapter.getUserByEmail(authResult.email);
+		if (user?.disabled) return accountDisabledResponse();
 
 		if (!user) {
 			// User doesn't exist
@@ -563,7 +571,13 @@ async function handleExternalAuth(
 
 			if (Object.keys(updates).length > 0) {
 				updates.updated_at = new Date().toISOString();
-				await emdash.db.updateTable("users").set(updates).where("id", "=", user.id).execute();
+				const result = await emdash.db
+					.updateTable("users")
+					.set(updates)
+					.where("id", "=", user.id)
+					.where("disabled", "=", 0)
+					.executeTakeFirst();
+				if (Number(result.numUpdatedRows ?? 0) === 0) return accountDisabledResponse();
 
 				user = {
 					...user,
@@ -588,10 +602,7 @@ async function handleExternalAuth(
 
 		// Check if user is disabled locally
 		if (user.disabled) {
-			return new Response("Account disabled", {
-				status: 403,
-				headers: { "Content-Type": "text/plain", ...MW_CACHE_HEADERS },
-			});
+			return accountDisabledResponse();
 		}
 
 		// Set user in locals

--- a/packages/core/src/astro/routes/api/auth/magic-link/verify.ts
+++ b/packages/core/src/astro/routes/api/auth/magic-link/verify.ts
@@ -9,7 +9,7 @@ import type { APIRoute } from "astro";
 
 export const prerender = false;
 
-import { verifyMagicLink, MagicLinkError } from "@emdash-cms/auth";
+import { verifyMagicLink, AccountDisabledError, MagicLinkError } from "@emdash-cms/auth";
 import { createKyselyAdapter } from "@emdash-cms/auth/adapters/kysely";
 
 import { apiError } from "#api/error.js";
@@ -52,6 +52,12 @@ export const GET: APIRoute = async ({ url, locals, session, redirect }) => {
 		return redirect(redirectUrl);
 	} catch (error) {
 		console.error("Magic link verify error:", error);
+
+		if (error instanceof AccountDisabledError) {
+			return redirect(
+				`/_emdash/admin/login?error=${error.code}&message=${encodeURIComponent(error.message)}`,
+			);
+		}
 
 		// Handle specific errors
 		if (error instanceof MagicLinkError) {

--- a/packages/core/src/astro/routes/api/auth/oauth/[provider]/callback.ts
+++ b/packages/core/src/astro/routes/api/auth/oauth/[provider]/callback.ts
@@ -9,6 +9,7 @@ import type { APIRoute } from "astro";
 export const prerender = false;
 
 import {
+	AccountDisabledError,
 	handleOAuthCallback,
 	OAuthError,
 	Role,
@@ -212,7 +213,10 @@ export const GET: APIRoute = async ({ params, request, locals, session, redirect
 		let message = "Authentication failed";
 		let errorCode = "oauth_error";
 
-		if (callbackError instanceof OAuthError) {
+		if (callbackError instanceof AccountDisabledError) {
+			errorCode = callbackError.code;
+			message = callbackError.message;
+		} else if (callbackError instanceof OAuthError) {
 			errorCode = callbackError.code;
 
 			// Map all error codes to user-friendly messages (never expose raw error.message)

--- a/packages/core/src/astro/routes/api/auth/passkey/verify.ts
+++ b/packages/core/src/astro/routes/api/auth/passkey/verify.ts
@@ -8,6 +8,7 @@ import type { APIRoute } from "astro";
 
 export const prerender = false;
 
+import { AccountDisabledError } from "@emdash-cms/auth";
 import { createKyselyAdapter } from "@emdash-cms/auth/adapters/kysely";
 import { authenticateWithPasskey, PasskeyAuthenticationError } from "@emdash-cms/auth/passkey";
 
@@ -68,6 +69,9 @@ export const POST: APIRoute = async ({ request, locals, session }) => {
 			},
 		});
 	} catch (error) {
+		if (error instanceof AccountDisabledError) {
+			return apiError("ACCOUNT_DISABLED", error.message, 403);
+		}
 		if (error instanceof PasskeyAuthenticationError) {
 			return apiError("UNAUTHORIZED", "Authentication failed", 401);
 		}

--- a/packages/core/src/database/repositories/plugin-storage.ts
+++ b/packages/core/src/database/repositories/plugin-storage.ts
@@ -122,6 +122,21 @@ export class PluginStorageRepository<T = unknown> implements StorageCollection<T
 	}
 
 	/**
+	 * Delete a document only when its stored value has not changed.
+	 */
+	async deleteIfUnchanged(id: string, data: T): Promise<boolean> {
+		const result = await this.db
+			.deleteFrom("_plugin_storage")
+			.where("plugin_id", "=", this.pluginId)
+			.where("collection", "=", this.collection)
+			.where("id", "=", id)
+			.where("data", "=", JSON.stringify(data))
+			.executeTakeFirst();
+
+		return (result.numDeletedRows ?? 0) > 0;
+	}
+
+	/**
 	 * Check if a document exists
 	 */
 	async exists(id: string): Promise<boolean> {

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -120,6 +120,7 @@ function createStorageCollection<T>(
 		get: (id) => repo.get(id),
 		put: (id, data) => repo.put(id, data),
 		delete: (id) => repo.delete(id),
+		deleteIfUnchanged: (id, data) => repo.deleteIfUnchanged(id, data),
 		exists: (id) => repo.exists(id),
 		getMany: (ids) => repo.getMany(ids),
 		putMany: (items) => repo.putMany(items),

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -144,6 +144,7 @@ export interface StorageCollection<T = unknown> {
 	get(id: string): Promise<T | null>;
 	put(id: string, data: T): Promise<void>;
 	delete(id: string): Promise<boolean>;
+	deleteIfUnchanged?(id: string, data: T): Promise<boolean>;
 	exists(id: string): Promise<boolean>;
 
 	// Batch operations

--- a/packages/core/tests/integration/plugins/capabilities.test.ts
+++ b/packages/core/tests/integration/plugins/capabilities.test.ts
@@ -737,6 +737,24 @@ describe("Capability Enforcement Integration (v2)", () => {
 			expect(typeof collection.count).toBe("function");
 		});
 
+		it("exposes atomic comparison-delete through collection accessors", async () => {
+			const storage = createStorageAccess(db, "test-plugin", {
+				items: { indexes: [] },
+			});
+			const collection = storage.items;
+			const original = { value: "original" };
+			const replacement = { value: "replacement" };
+
+			await collection.put("doc-1", original);
+			await collection.put("doc-1", replacement);
+
+			if (!collection.deleteIfUnchanged) throw new Error("Comparison-delete is unavailable");
+			expect(await collection.deleteIfUnchanged("doc-1", original)).toBe(false);
+			expect(await collection.get("doc-1")).toEqual(replacement);
+			expect(await collection.deleteIfUnchanged("doc-1", replacement)).toBe(true);
+			expect(await collection.get("doc-1")).toBeNull();
+		});
+
 		it("isolates storage between plugins", async () => {
 			const storage1 = createStorageAccess(db, "plugin-1", {
 				items: { indexes: [] },

--- a/packages/core/tests/integration/plugins/storage-dialect.test.ts
+++ b/packages/core/tests/integration/plugins/storage-dialect.test.ts
@@ -96,4 +96,18 @@ describeEachDialect("plugin storage filtered query/count (#920)", (dialect) => {
 		expect(result.items.map((item) => item.id)).toEqual(["p1"]);
 		expect(await repo.count({ active: false })).toBe(2);
 	});
+
+	it("does not delete a document that has been replaced", async () => {
+		const repo = makeRepo();
+		const original = { provider: "resend", active: true, priority: 1 };
+		const replacement = { ...original, provider: "sendgrid", priority: 2 };
+
+		await repo.put("p1", original);
+		await repo.put("p1", replacement);
+
+		expect(await repo.deleteIfUnchanged("p1", original)).toBe(false);
+		expect(await repo.get("p1")).toEqual(replacement);
+		expect(await repo.deleteIfUnchanged("p1", replacement)).toBe(true);
+		expect(await repo.get("p1")).toBeNull();
+	});
 });

--- a/packages/core/tests/unit/astro/plugin-route-external-auth.test.ts
+++ b/packages/core/tests/unit/astro/plugin-route-external-auth.test.ts
@@ -45,15 +45,15 @@ afterAll(() => {
 	vi.unstubAllEnvs();
 });
 
-function createContext(path: string, isPublic: boolean) {
+function createContext(path: string, isPublic: boolean, db: unknown = {}) {
 	const locals: Record<string, unknown> & { user?: { id: string; email: string } } = {
 		emdash: {
-			db: {},
+			db,
 			config: {
 				auth: {
 					type: "cloudflare-access",
 					entrypoint: "@emdash-cms/cloudflare/auth",
-					config: { teamDomain: "example.cloudflareaccess.com" },
+					config: { teamDomain: "example.cloudflareaccess.com", syncRoles: true },
 				},
 			},
 			getPluginRouteMeta: vi.fn(() => ({ public: isPublic })),
@@ -112,6 +112,58 @@ describe("external auth on plugin API routes", () => {
 		} finally {
 			consoleError.mockRestore();
 		}
+	});
+
+	it("rejects a disabled user before syncing provider profile data", async () => {
+		getUserByEmail.mockResolvedValueOnce({
+			id: "user-1",
+			email: "admin@example.com",
+			name: "Old Name",
+			role: 10,
+			disabled: true,
+		});
+		const { context, locals, session } = createContext(
+			"/_emdash/api/plugins/ai-search/config",
+			false,
+		);
+		const next = vi.fn(async () => new Response("should not run"));
+
+		const response = await onRequest(context as never, next);
+
+		expect(response.status).toBe(403);
+		expect(session.set).not.toHaveBeenCalled();
+		expect(locals.user).toBeUndefined();
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("does not establish a session if the user is disabled during profile sync", async () => {
+		getUserByEmail.mockResolvedValueOnce({
+			id: "user-1",
+			email: "admin@example.com",
+			name: "Old Name",
+			role: 50,
+			disabled: false,
+		});
+		const executeTakeFirst = vi.fn(async () => ({ numUpdatedRows: 0n }));
+		const query = {
+			set: vi.fn(() => query),
+			where: vi.fn(() => query),
+			executeTakeFirst,
+		};
+		const db = { updateTable: vi.fn(() => query) };
+		const { context, locals, session } = createContext(
+			"/_emdash/api/plugins/ai-search/config",
+			false,
+			db,
+		);
+		const next = vi.fn(async () => new Response("should not run"));
+
+		const response = await onRequest(context as never, next);
+
+		expect(response.status).toBe(403);
+		expect(session.set).not.toHaveBeenCalled();
+		expect(locals.user).toBeUndefined();
+		expect(next).not.toHaveBeenCalled();
 	});
 
 	it("leaves explicitly public plugin routes unauthenticated", async () => {

--- a/packages/core/tests/unit/auth/magic-link.test.ts
+++ b/packages/core/tests/unit/auth/magic-link.test.ts
@@ -5,6 +5,7 @@ import { createKyselyAdapter } from "@emdash-cms/auth/adapters/kysely";
 import type { Kysely } from "kysely";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
+import { GET as verifyMagicLinkRoute } from "../../../src/astro/routes/api/auth/magic-link/verify.js";
 import type { Database } from "../../../src/database/types.js";
 import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
 
@@ -49,5 +50,40 @@ describe("Magic Link", () => {
 		expect(sentEmails[0]!.text).toContain(
 			"https://example.com/_emdash/api/auth/magic-link/verify?token=",
 		);
+	});
+
+	it("rejects a disabled user without creating a session", async () => {
+		const user = await adapter.createUser({
+			email: "disabled@example.com",
+			name: "Disabled User",
+			role: Role.AUTHOR,
+			emailVerified: true,
+		});
+
+		await sendMagicLink(
+			{
+				baseUrl: "https://example.com",
+				siteName: "Test Site",
+				email: mockEmailSend,
+			},
+			adapter,
+			user.email,
+		);
+		await adapter.updateUser(user.id, { disabled: true });
+
+		const verificationUrl = sentEmails[0]!.text.match(/https:\/\/\S+/)?.[0];
+		expect(verificationUrl).toBeDefined();
+		const set = vi.fn();
+		const response = await verifyMagicLinkRoute({
+			url: new URL(verificationUrl!),
+			locals: { emdash: { db, config: {} } },
+			session: { set },
+			redirect: (location: string) =>
+				new Response(null, { status: 302, headers: { Location: location } }),
+		} as never);
+
+		expect(response.status).toBe(302);
+		expect(response.headers.get("Location")).toContain("error=account_disabled");
+		expect(set).not.toHaveBeenCalled();
 	});
 });

--- a/packages/core/tests/unit/auth/oauth-invite.test.ts
+++ b/packages/core/tests/unit/auth/oauth-invite.test.ts
@@ -134,6 +134,55 @@ describe("acceptInviteViaOAuth", () => {
 		).rejects.toMatchObject({ code: "invite_invalid" });
 	});
 
+	it("does not link or consume an invite for a disabled existing user", async () => {
+		const token = await invite("invitee@example.com");
+		const user = await adapter.createUser({
+			email: "invitee@example.com",
+			name: "Invitee",
+			role: Role.AUTHOR,
+			emailVerified: true,
+		});
+		await adapter.updateUser(user.id, { disabled: true });
+
+		await expect(
+			acceptInviteViaOAuth(adapter, "google", makeProfile(), token),
+		).rejects.toMatchObject({ code: "account_disabled" });
+		expect(await adapter.getOAuthAccount("google", "google-123")).toBeNull();
+
+		await adapter.updateUser(user.id, { disabled: false });
+		await expect(
+			acceptInviteViaOAuth(adapter, "google", makeProfile(), token),
+		).resolves.toMatchObject({
+			id: user.id,
+		});
+	});
+
+	it("does not consume an invite for an already-linked disabled user", async () => {
+		const token = await invite("invitee@example.com");
+		const user = await adapter.createUser({
+			email: "invitee@example.com",
+			name: "Invitee",
+			role: Role.AUTHOR,
+			emailVerified: true,
+		});
+		await adapter.createOAuthAccount({
+			provider: "google",
+			providerAccountId: "google-linked",
+			userId: user.id,
+		});
+		await adapter.updateUser(user.id, { disabled: true });
+
+		const linkedProfile = makeProfile({ id: "google-linked" });
+		await expect(
+			acceptInviteViaOAuth(adapter, "google", linkedProfile, token),
+		).rejects.toMatchObject({ code: "account_disabled" });
+
+		await adapter.updateUser(user.id, { disabled: false });
+		await expect(
+			acceptInviteViaOAuth(adapter, "google", linkedProfile, token),
+		).resolves.toMatchObject({ id: user.id });
+	});
+
 	it("rejects (and does not consume) when the already-linked account's user has a different email", async () => {
 		const token = await invite("invitee@example.com");
 		// An OAuth identity is already linked to a user whose EmDash email differs


### PR DESCRIPTION
## What does this PR do?

Rejects disabled accounts before passkey, Magic Link, OAuth, external-auth, or Atmosphere sign-in can complete.

Rejected sign-ins do not record passkey usage, create OAuth account links, consume invites, or synchronize external profile data. Rejected Atmosphere callbacks also remove the stored provider session with a compare-and-delete guard and defer remote token revocation with a bounded timeout.

No linked issue.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable: this PR does not add admin UI strings)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: not applicable; this is a bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

No screenshots: this change has no visual UI impact.

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `@emdash-cms/auth`: 10 targeted tests passed
- `@emdash-cms/auth-atproto`: 34 tests passed
- `emdash`: 108 targeted tests passed
