### PR TITLE
fix(auth): reject disabled passkey users

### DIFF
--- a/.changeset/reject-disabled-passkey-users.md
+++ b/.changeset/reject-disabled-passkey-users.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/auth": patch
+"emdash": patch
+---
+
+Fixes disabled accounts being able to complete passkey sign-in. Rejected attempts no longer update passkey usage or create an admin session.

--- a/.changeset/reject-disabled-passkey-users.md
+++ b/.changeset/reject-disabled-passkey-users.md
@@ -1,6 +1,7 @@
 ---
 "@emdash-cms/auth": patch
+"@emdash-cms/admin": patch
 "emdash": patch
 ---
 
-Fixes disabled accounts being able to complete passkey sign-in. Rejected attempts no longer update passkey usage or create an admin session.
+Fixes disabled accounts being able to complete passkey sign-in. Rejected attempts no longer update passkey usage or create an admin session, and the admin shows a localized authentication error.

--- a/packages/admin/src/components/auth/PasskeyLogin.tsx
+++ b/packages/admin/src/components/auth/PasskeyLogin.tsx
@@ -15,7 +15,7 @@ import { Button, Input } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import * as React from "react";
 
-import { apiFetch, parseApiResponse } from "../../lib/api/client";
+import { ApiResponseError, apiFetch, parseApiResponse } from "../../lib/api/client";
 import {
 	isPasskeyEnvironmentUsable,
 	isWebAuthnSecureContext,
@@ -255,7 +255,10 @@ export function PasskeyLogin({
 				const message = error instanceof Error ? error.message : t`Authentication failed`;
 
 				// Handle specific WebAuthn errors
-				let userMessage = message;
+				let userMessage =
+					error instanceof ApiResponseError && error.code === "ACCOUNT_DISABLED"
+						? t`Authentication failed`
+						: message;
 				if (error instanceof DOMException) {
 					switch (error.name) {
 						case "NotAllowedError":

--- a/packages/admin/tests/components/PasskeyLogin.test.tsx
+++ b/packages/admin/tests/components/PasskeyLogin.test.tsx
@@ -1,0 +1,99 @@
+import { i18n } from "@lingui/core";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { PasskeyLogin } from "../../src/components/auth/PasskeyLogin.js";
+import { messages as jaMessages } from "../../src/locales/ja/messages.mjs";
+import { render } from "../utils/render.js";
+
+const publicKeyCredentialDescriptor = Object.getOwnPropertyDescriptor(
+	window,
+	"PublicKeyCredential",
+);
+const credentialsDescriptor = Object.getOwnPropertyDescriptor(navigator, "credentials");
+
+beforeAll(() => {
+	Object.defineProperty(window, "PublicKeyCredential", {
+		configurable: true,
+		value: function PublicKeyCredential() {},
+	});
+	Object.defineProperty(navigator, "credentials", {
+		configurable: true,
+		value: {
+			get: vi.fn().mockResolvedValue({
+				id: "credential-id",
+				rawId: new Uint8Array([1]).buffer,
+				type: "public-key",
+				response: {
+					clientDataJSON: new Uint8Array([2]).buffer,
+					authenticatorData: new Uint8Array([3]).buffer,
+					signature: new Uint8Array([4]).buffer,
+					userHandle: null,
+				},
+			}),
+		},
+	});
+	i18n.loadAndActivate({ locale: "ja", messages: jaMessages });
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+afterAll(() => {
+	if (publicKeyCredentialDescriptor) {
+		Object.defineProperty(window, "PublicKeyCredential", publicKeyCredentialDescriptor);
+	} else {
+		Reflect.deleteProperty(window, "PublicKeyCredential");
+	}
+	if (credentialsDescriptor) {
+		Object.defineProperty(navigator, "credentials", credentialsDescriptor);
+	} else {
+		Reflect.deleteProperty(navigator, "credentials");
+	}
+	i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+
+describe("PasskeyLogin", () => {
+	it("localizes disabled-account verification errors", async () => {
+		vi.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						data: {
+							options: {
+								challenge: "AQ==",
+								rpId: "localhost",
+							},
+						},
+					}),
+					{ status: 200 },
+				),
+			)
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						success: false,
+						error: { code: "ACCOUNT_DISABLED", message: "Account disabled" },
+					}),
+					{ status: 403 },
+				),
+			);
+		const onSuccess = vi.fn();
+		const onError = vi.fn();
+		const screen = await render(
+			<PasskeyLogin
+				optionsEndpoint="/options"
+				verifyEndpoint="/verify"
+				onSuccess={onSuccess}
+				onError={onError}
+			/>,
+		);
+
+		await screen.getByRole("button", { name: "パスキーでサインイン" }).click();
+
+		await expect.element(screen.getByText("認証に失敗しました")).toBeInTheDocument();
+		expect(screen.getByText("Account disabled").query()).toBeNull();
+		expect(onSuccess).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledWith(new Error("認証に失敗しました"));
+	});
+});

--- a/packages/auth/src/passkey/authenticate.test.ts
+++ b/packages/auth/src/passkey/authenticate.test.ts
@@ -7,7 +7,8 @@ import {
 } from "@oslojs/webauthn";
 import { describe, it, expect, vi } from "vitest";
 
-import type { AuthAdapter, Credential } from "../types.js";
+import { AccountDisabledError, Role } from "../types.js";
+import type { AuthAdapter, Credential, User } from "../types.js";
 import { authenticateWithPasskey, PasskeyAuthenticationError } from "./authenticate.js";
 import type { ChallengeStore } from "./types.js";
 
@@ -201,6 +202,38 @@ describe("authenticateWithPasskey", () => {
 		}
 	});
 
+	it("rejects a disabled user before recording credential usage", async () => {
+		const { credential: validCredential, response, challengeStore } = createValidAssertion();
+		const disabledUser: User = {
+			id: "user_1",
+			email: "disabled@example.com",
+			name: null,
+			avatarUrl: null,
+			role: Role.ADMIN,
+			emailVerified: true,
+			disabled: true,
+			data: null,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+		const updateCredentialCounter = vi.fn(async () => undefined);
+		const adapter = {
+			getCredentialById: vi.fn(async () => validCredential),
+			updateCredentialCounter,
+			getUserById: vi.fn(async () => disabledUser),
+		} as unknown as AuthAdapter;
+
+		try {
+			await authenticateWithPasskey(config, adapter, response, challengeStore);
+			expect.fail("Expected disabled account rejection");
+		} catch (error) {
+			expect(error).toBeInstanceOf(AccountDisabledError);
+			expect(error).toMatchObject({ code: "account_disabled" });
+		}
+		expect(updateCredentialCounter).not.toHaveBeenCalled();
+		expect(challengeStore.delete).toHaveBeenCalledOnce();
+	});
+
 	it("rejects an origin that is not in the accepted list", async () => {
 		// Single-origin config; assertion arrives from a different subdomain.
 		const singleOriginConfig = {
@@ -250,9 +283,10 @@ describe("authenticateWithPasskey", () => {
 			rpId: "example.com",
 			origin: "https://preview.example.com",
 		});
+		const updateCredentialCounter = vi.fn(async () => undefined);
 		const adapter = {
 			getCredentialById: vi.fn(async () => validCredential),
-			updateCredentialCounter: vi.fn(async () => undefined),
+			updateCredentialCounter,
 			getUserById: vi.fn(async () => ({
 				id: "user_1",
 				email: "u@example.com",
@@ -269,6 +303,7 @@ describe("authenticateWithPasskey", () => {
 			challengeStore,
 		);
 		expect(user).toMatchObject({ id: "user_1" });
+		expect(updateCredentialCounter).toHaveBeenCalledWith(validCredential.id, 1);
 	});
 
 	it("accepts an RS256 (RSA) assertion with a PKIX-encoded public key", async () => {

--- a/packages/auth/src/passkey/authenticate.ts
+++ b/packages/auth/src/passkey/authenticate.ts
@@ -28,6 +28,7 @@ import {
 } from "@oslojs/webauthn";
 
 import { generateToken } from "../tokens.js";
+import { AccountDisabledError } from "../types.js";
 import type { Credential, AuthAdapter, User } from "../types.js";
 import type {
 	AuthenticationOptions,
@@ -257,14 +258,17 @@ export async function authenticateWithPasskey(
 	// Verify the response
 	const verified = await verifyAuthenticationResponse(config, response, credential, challengeStore);
 
-	// Update counter
-	await adapter.updateCredentialCounter(verified.credentialId, verified.newCounter);
-
 	// Get the user
 	const user = await adapter.getUserById(credential.userId);
 	if (!user) {
 		throw new PasskeyAuthenticationError("user_not_found", "User not found");
 	}
+	if (user.disabled) {
+		throw new AccountDisabledError();
+	}
+
+	// Update counter
+	await adapter.updateCredentialCounter(verified.credentialId, verified.newCounter);
 
 	return user;
 }

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -336,7 +336,15 @@ export class AuthError extends Error {
 	}
 }
 
+export class AccountDisabledError extends AuthError {
+	constructor() {
+		super("account_disabled", "Account disabled");
+		this.name = "AccountDisabledError";
+	}
+}
+
 export type AuthErrorCode =
+	| "account_disabled"
 	| "invalid_credentials"
 	| "invalid_token"
 	| "token_expired"

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -336,15 +336,16 @@ export class AuthError extends Error {
 	}
 }
 
-export class AccountDisabledError extends AuthError {
+export class AccountDisabledError extends Error {
+	readonly code = "account_disabled" as const;
+
 	constructor() {
-		super("account_disabled", "Account disabled");
+		super("Account disabled");
 		this.name = "AccountDisabledError";
 	}
 }
 
 export type AuthErrorCode =
-	| "account_disabled"
 	| "invalid_credentials"
 	| "invalid_token"
 	| "token_expired"

--- a/packages/core/src/astro/routes/api/auth/passkey/verify.ts
+++ b/packages/core/src/astro/routes/api/auth/passkey/verify.ts
@@ -8,6 +8,7 @@ import type { APIRoute } from "astro";
 
 export const prerender = false;
 
+import { AccountDisabledError } from "@emdash-cms/auth";
 import { createKyselyAdapter } from "@emdash-cms/auth/adapters/kysely";
 import { authenticateWithPasskey, PasskeyAuthenticationError } from "@emdash-cms/auth/passkey";
 
@@ -68,6 +69,9 @@ export const POST: APIRoute = async ({ request, locals, session }) => {
 			},
 		});
 	} catch (error) {
+		if (error instanceof AccountDisabledError) {
+			return apiError("ACCOUNT_DISABLED", error.message, 403);
+		}
 		if (error instanceof PasskeyAuthenticationError) {
 			return apiError("UNAUTHORIZED", "Authentication failed", 401);
 		}

--- a/packages/core/tests/unit/auth/passkey-disabled-route.test.ts
+++ b/packages/core/tests/unit/auth/passkey-disabled-route.test.ts
@@ -1,0 +1,73 @@
+import { AccountDisabledError } from "@emdash-cms/auth";
+import type { Kysely } from "kysely";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	authenticateWithPasskey: vi.fn(),
+}));
+
+vi.mock("@emdash-cms/auth/passkey", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@emdash-cms/auth/passkey")>()),
+	authenticateWithPasskey: mocks.authenticateWithPasskey,
+}));
+
+import { POST as verifyPasskey } from "../../../src/astro/routes/api/auth/passkey/verify.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+describe("passkey verify route for disabled accounts", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		mocks.authenticateWithPasskey.mockRejectedValue(new AccountDisabledError());
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+		vi.clearAllMocks();
+	});
+
+	it("returns account disabled without creating a session", async () => {
+		const request = new Request("http://localhost:4321/_emdash/api/auth/passkey/verify", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				credential: {
+					id: "registered-credential",
+					rawId: "registered-credential",
+					type: "public-key",
+					response: {
+						clientDataJSON: "AA",
+						authenticatorData: "AA",
+						signature: "AA",
+					},
+				},
+			}),
+		});
+		const setSession = vi.fn();
+
+		const response = await verifyPasskey({
+			request,
+			locals: {
+				emdash: {
+					db,
+					config: {},
+				},
+			},
+			session: {
+				set: setSession,
+			},
+		} as Parameters<typeof verifyPasskey>[0]);
+
+		expect(response.status).toBe(403);
+		await expect(response.json()).resolves.toEqual({
+			success: false,
+			error: {
+				code: "ACCOUNT_DISABLED",
+				message: "Account disabled",
+			},
+		});
+		expect(setSession).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Prevents disabled users with an existing passkey from completing passkey sign-in.

- Checks the resolved user's disabled status after WebAuthn verification and before updating the credential counter.
- Returns a stable `ACCOUNT_DISABLED` response without creating an admin session.
- Shows a translated generic authentication failure in the admin instead of exposing the server error message.
- Adds regression coverage at the auth package, API route, and admin UI boundaries.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — this is a bug fix with reproducing tests.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

No screenshots: this changes authentication error handling without changing layout.

Verified locally:

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --dir packages/auth exec vitest run` — 59 tests passed
- `pnpm --dir packages/core exec vitest run tests/unit/auth/passkey-disabled-route.test.ts` — 1 test passed
- `pnpm --dir packages/admin exec vitest run tests/components/PasskeyLogin.test.tsx` — 1 browser test passed
