### PR TITLE
docs: add a plugin sandbox operations guide for Cloudflare and Node.js

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -225,6 +225,7 @@ export default defineConfig({
 						{ label: "Database Options", slug: "deployment/database" },
 						{ label: "Storage Options", slug: "deployment/storage" },
 						{ label: "Object Cache", slug: "deployment/object-cache" },
+						{ label: "Plugin Sandbox", slug: "deployment/plugin-sandbox" },
 						{ label: "Secrets & Key Management", slug: "deployment/secrets" },
 					],
 				},

--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -43,6 +43,8 @@ Provision the production D1 database and R2 bucket, then create `wrangler.jsonc`
 
 These are the bindings you configure yourself. The `@astrojs/cloudflare` adapter adds more of its own when it generates the deployed Worker config. One of them is the `IMAGES` binding that media transforms use — see [Image Transformation](#image-transformation).
 
+Sandboxed plugins — marketplace installs and the plugins under `sandboxed: []` — need a `worker_loaders` binding and a Worker entry point that exports `PluginBridge`. See [Plugin Sandbox](/deployment/plugin-sandbox/#cloudflare-workers).
+
 ## Configure EmDash
 
 The following Astro configuration uses the D1 and R2 bindings.

--- a/docs/src/content/docs/deployment/nodejs.mdx
+++ b/docs/src/content/docs/deployment/nodejs.mdx
@@ -65,6 +65,10 @@ The built-in scheduler runs only while a Node.js process is running. It handles 
 
 Keep at least one Node.js process running continuously in production. Scheduled tasks pause when every process stops or sleeps.
 
+## Plugin sandbox
+
+Marketplace plugins and the plugins listed under `sandboxed: []` need a sandbox runner. On Node.js, the runner is `@emdash-cms/sandbox-workerd`, which runs plugins in a `workerd` child process. [Plugin Sandbox](/deployment/plugin-sandbox/#nodejs) covers the installation, how the `workerd` process runs, and its failure modes.
+
 ## Production Storage
 
 For production, use S3-compatible storage instead of local filesystem:

--- a/docs/src/content/docs/deployment/plugin-sandbox.mdx
+++ b/docs/src/content/docs/deployment/plugin-sandbox.mdx
@@ -88,6 +88,8 @@ Dynamic Workers are available on the [Workers Paid plan](https://developers.clou
 2. Select the runner in the `emdash()` integration:
 
    ```js title="astro.config.mjs"
+   import { sqlite } from "emdash/db";
+
    emdash({
    	database: sqlite({ url: "file:./data/emdash.db" }),
    	sandboxRunner: "@emdash-cms/sandbox-workerd/sandbox",

--- a/docs/src/content/docs/deployment/plugin-sandbox.mdx
+++ b/docs/src/content/docs/deployment/plugin-sandbox.mdx
@@ -1,0 +1,179 @@
+---
+title: Plugin Sandbox
+description: Run sandboxed plugins on Cloudflare Workers or Node.js, with the bindings, resource limits, and failure modes of each sandbox runner.
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+Sandboxed plugins run in an isolated runtime that a sandbox runner provides. Marketplace and registry installs always run sandboxed, and so do the plugins listed under `sandboxed: []` in the `emdash()` integration. Plugins listed under `plugins: []` run in the server process and do not use the runner.
+
+The runner depends on the deployment platform. On Cloudflare Workers, each plugin runs as a [Dynamic Worker](https://developers.cloudflare.com/dynamic-workers/) created through the Worker Loader binding. On Node.js, the server starts [`workerd`](https://github.com/cloudflare/workerd), the open-source Workers runtime, as a child process and runs each plugin as a service inside it. The `sandboxRunner` option of `emdash()` selects the runner. Without it, the plugins under `sandboxed: []` are never loaded, and a configured `marketplace` fails the build with "Marketplace requires `sandboxRunner` to be configured".
+
+The following table summarizes what each runner needs and enforces.
+
+|                    | Cloudflare Workers                                                                                | Node.js                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `sandboxRunner`    | `sandbox()` from `@emdash-cms/cloudflare`                                                          | `"@emdash-cms/sandbox-workerd/sandbox"` |
+| Requirements       | Workers Paid plan, a `worker_loaders` binding, `PluginBridge` exported from the Worker entry point | The `workerd` package                   |
+| Database access    | The `DB` D1 binding, independent of the configured adapter                                        | The configured database                 |
+| Enforced limits    | CPU time, subrequests, wall time                                                                  | Wall time                               |
+
+## Cloudflare Workers
+
+Dynamic Workers are available on the [Workers Paid plan](https://developers.cloudflare.com/dynamic-workers/pricing/). The runner needs the binding and the entry point export below; the `*-cloudflare` templates ship both.
+
+<Steps>
+
+1. Add the Worker Loader binding to `wrangler.jsonc`. The runner reads it under the name `LOADER`:
+
+   ```jsonc title="wrangler.jsonc"
+   {
+   	"worker_loaders": [
+   		{
+   			"binding": "LOADER",
+   		},
+   	],
+   }
+   ```
+
+2. Export `PluginBridge` from the Worker entry point, and point `main` at that file. `PluginBridge` is the entrypoint through which sandboxed plugins reach content, media, storage, and email; the runner looks it up on the exports of the entry module:
+
+   ```ts title="src/worker.ts"
+   import handler, { createScheduledHandler, PluginBridge } from "@emdash-cms/cloudflare/worker";
+
+   export { PluginBridge };
+
+   export default {
+   	...handler,
+   	scheduled: createScheduledHandler(),
+   } satisfies ExportedHandler;
+   ```
+
+   ```jsonc title="wrangler.jsonc"
+   {
+   	"main": "./src/worker.ts",
+   }
+   ```
+
+3. Select the runner in the `emdash()` integration:
+
+   ```js title="astro.config.mjs"
+   import { d1, r2, sandbox } from "@emdash-cms/cloudflare";
+
+   emdash({
+   	database: d1({ binding: "DB" }),
+   	storage: r2({ binding: "MEDIA" }),
+   	sandboxRunner: sandbox(),
+   });
+   ```
+
+</Steps>
+
+<Aside>
+	The bridge that sandboxed plugins use for database access talks to the D1 binding named `DB` directly, independent of the configured adapter. Sandboxed plugins are not available on a [Hyperdrive deployment](/deployment/database/).
+</Aside>
+
+## Node.js
+
+<Steps>
+
+1. Install the runner together with `workerd`, which is a peer dependency:
+
+   ```bash
+   npm install @emdash-cms/sandbox-workerd workerd
+   ```
+
+   The `workerd` package installs the binary for the current platform (Linux, macOS, and Windows on x64; Linux and macOS on arm64) through an optional dependency. Install with optional dependencies enabled, on the platform the server runs on. In a multi-stage Docker build, run the install in a stage with the same platform as the runtime stage.
+
+2. Select the runner in the `emdash()` integration:
+
+   ```js title="astro.config.mjs"
+   emdash({
+   	database: sqlite({ url: "file:./data/emdash.db" }),
+   	sandboxRunner: "@emdash-cms/sandbox-workerd/sandbox",
+   });
+   ```
+
+3. For development, install `miniflare` as a dev dependency:
+
+   ```bash
+   npm install -D miniflare
+   ```
+
+   When `NODE_ENV` is `development`, which `astro dev` sets, and `miniflare` is installed, the runner hands the plugins to Miniflare, which manages its own `workerd` process; the crash policy below does not apply. `astro preview` sets `NODE_ENV` to `production` and `node ./dist/server/entry.mjs` leaves it unset; both use `workerd`.
+
+</Steps>
+
+### How the `workerd` process runs
+
+EmDash starts `workerd` while it initializes on the first request to the site, once the sandboxed plugins are loaded, and waits up to 10 seconds for the plugin services to answer. Installing or updating a plugin from the admin restarts it. Everything `workerd` writes to stdout or stderr appears in the server's output with the prefix `[emdash:workerd]`.
+
+Plugin services listen on `127.0.0.1`, and the channel back to the server is a Unix domain socket (a `127.0.0.1` TCP port on Windows). No inbound port needs to be opened.
+
+The child process receives only `PATH`, `HOME`, `TMPDIR`, `TMP`, `TEMP`, `LANG`, and `LC_ALL` from the server's environment, so secrets in the server's environment stay out of the sandbox. To pass more variables, set `EMDASH_WORKERD_PASSTHROUGH_ENV` to a comma-separated list of variable names.
+
+If `workerd` exits unexpectedly, the runner logs `[emdash:workerd] workerd exited with <reason>` and restarts it on the next invocation, with a delay that starts at 1 second and doubles up to 30 seconds. When `workerd` crashes more than five times within 60 seconds, the runner stops restarting it and logs `[emdash:workerd] workerd crashed 5 times in 60 seconds, giving up`. From then on, every sandboxed plugin hook and route fails with `Plugin sandbox unavailable for <plugin>: workerd is not running` until the server restarts. A `SIGTERM` to the server terminates `workerd` with it.
+
+## Resource limits
+
+Each runner applies the same set of limits per plugin invocation. The limits are fixed; the `emdash()` integration has no option for them.
+
+| Limit       | Value  | Cloudflare Workers                                                        | Node.js                |
+| ----------- | ------ | ------------------------------------------------------------------------- | ---------------------- |
+| CPU time    | 50 ms  | Enforced by the Worker Loader; the plugin throws when it hits the limit   | Not enforced           |
+| Subrequests | 10     | Enforced by the Worker Loader; the plugin throws when it hits the limit   | Not enforced           |
+| Memory      | 128 MB | Not enforced per plugin; the platform's isolate memory ceiling applies    | Not enforced           |
+| Wall time   | 30 s   | Enforced by the runner                                                    | Enforced by the runner |
+
+When a hook or route exceeds the wall-time limit, the invocation fails with `Plugin <id> exceeded wall-time limit of 30000ms during hook:<name>` (or `route:<name>`). For a hook, EmDash logs the failure with the prefix `EmDash: Sandboxed plugin <id>` and continues the request without that plugin's result. A plugin route that exceeds the limit fails for its caller.
+
+## When the runner is unavailable
+
+A configured runner can still be unavailable: on Cloudflare Workers when the `worker_loaders` binding or the `PluginBridge` export is missing, on Node.js when `workerd` is not installed or its binary does not run. EmDash then logs the following warning when the runtime starts:
+
+```plain
+EmDash: Plugin sandbox is configured but not available on this platform. Sandboxed plugins will not be loaded. If using @emdash-cms/sandbox-workerd/sandbox, ensure workerd is installed.
+```
+
+Plugins under `sandboxed: []` are not loaded, installed marketplace and registry plugins do not run, and a new install from the admin fails with the error code `SANDBOX_NOT_AVAILABLE`. The rest of the site is unaffected.
+
+### Running sandboxed plugins in-process
+
+Set `sandbox: false` in `emdash()` to run the plugins under `sandboxed: []` and installed marketplace plugins in the server process, without isolation or limits. It is a debugging option that tells a bug in a plugin from a bug in the sandbox. The following configuration turns the sandbox off on a Node.js site:
+
+```js title="astro.config.mjs"
+emdash({
+	sandboxRunner: "@emdash-cms/sandbox-workerd/sandbox",
+	sandbox: false,
+});
+```
+
+On Cloudflare Workers, the runtime refuses to start with `sandbox: false is not supported in Cloudflare Workers`.
+
+## Troubleshooting
+
+Each entry is headed by the message as the server logs it, or by the error code the admin returns.
+
+### "Plugin sandbox is configured but not available on this platform"
+
+On Cloudflare Workers, check both requirements: `wrangler.jsonc` has a `worker_loaders` binding named `LOADER`, and `main` points to a file that exports `PluginBridge`. Deploying the binding needs the Workers Paid plan.
+
+On Node.js, run the binary the runner uses:
+
+```bash
+npx workerd --version
+```
+
+If the command fails, `workerd` is missing from `node_modules` or the installed binary does not run on this platform. Reinstall on the target platform with optional dependencies enabled.
+
+### "workerd failed to start within 10 seconds"
+
+The child process started, but its plugin services did not answer within 10 seconds. The lines prefixed `[emdash:workerd]` before this message carry the output of `workerd` itself, including configuration and startup errors. The runner retries on the next invocation.
+
+### "workerd crashed 5 times in 60 seconds, giving up"
+
+The runner has stopped restarting `workerd`. The `[emdash:workerd] workerd exited with <reason>` lines before this message name the exit code or signal of each crash. Fix the cause, then restart the server.
+
+### `SANDBOX_NOT_AVAILABLE` when installing a plugin
+
+The admin's install request was refused because the runner is missing or unavailable. Configure the runner for the platform, or fix the cause of the startup warning above, and redeploy.

--- a/docs/src/content/docs/plugins/creating-plugins/choosing-a-format.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/choosing-a-format.mdx
@@ -67,9 +67,9 @@ If you're not sure, go sandboxed. You can always migrate to native later — but
 
 The sandbox itself is pluggable. EmDash exposes a `sandboxRunner` config option and the runner decides how plugin code is isolated — there's nothing Cloudflare-specific in the plugin format itself.
 
-The runner most sites use today is `sandbox()` from `@emdash-cms/cloudflare`, which uses Cloudflare Workers' [Dynamic Worker Loader](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/). Worker Loader caches the V8 isolate per plugin id so the isolate cold-start cost is only paid once; the runner constructs a fresh worker stub and bridge bindings on each invocation, since stubs and bindings are tied to the calling request's I/O context. Runners for other platforms (Node.js via workerd, and potentially Deno) are in development.
+Two runners ship with EmDash: `sandbox()` from `@emdash-cms/cloudflare`, which runs each plugin as a Dynamic Worker through Cloudflare's Worker Loader, and `@emdash-cms/sandbox-workerd/sandbox`, which runs plugins in a `workerd` child process on Node.js. [Plugin Sandbox](/deployment/plugin-sandbox/) covers the setup of each runner, the resource limits it enforces, and the differences between the two.
 
-If no runner is configured, or if the configured runner reports as unavailable on the current platform, plugins listed under `sandboxed: []` are skipped at startup with a debug-level log.
+If no runner is configured, plugins listed under `sandboxed: []` are not loaded. If the configured runner is unavailable on the current platform, they are not loaded either, and EmDash logs a warning at startup.
 
 If you want a sandboxed plugin to run on a platform without a sandbox runner, move it from `sandboxed: []` into the `plugins: []` array — it'll execute in-process. Capability declarations are still honoured (the same `PluginContext` factory gates `ctx.content`, `ctx.http`, and friends), but there is no isolation boundary, no resource limits, and a buggy or malicious plugin can call `fetch()` directly, read environment variables, or block the event loop. Without a sandbox runner active, treat every plugin as a native plugin for trust purposes.
 

--- a/docs/src/content/docs/plugins/installing.mdx
+++ b/docs/src/content/docs/plugins/installing.mdx
@@ -56,6 +56,8 @@ To install marketplace plugins, your site needs:
    npm install -D miniflare
    ```
 
+   The bindings, resource limits, and failure modes of each runner are described in [Plugin Sandbox](/deployment/plugin-sandbox/).
+
 2. **Admin access** — Only administrators can install or remove plugins.
 
 ### Browse and Install

--- a/docs/src/content/docs/plugins/registry.mdx
+++ b/docs/src/content/docs/plugins/registry.mdx
@@ -32,18 +32,19 @@ You configure one or the other for a given site. When `experimental.registry` is
 
 ## Enable the registry
 
-The registry requires a `sandboxRunner`, because registry plugins always run sandboxed. See [Installing Plugins](/plugins/installing/#prerequisites) for the runner setup.
+The registry requires a `sandboxRunner`, because registry plugins always run sandboxed. See [Plugin Sandbox](/deployment/plugin-sandbox/) for the runner setup.
 
 The following configuration points a site at the reference aggregator:
 
 ```typescript title="astro.config.mjs"
 import { defineConfig } from "astro/config";
+import { sandbox } from "@emdash-cms/cloudflare";
 import emdash from "emdash/astro";
 
 export default defineConfig({
   integrations: [
     emdash({
-      sandboxRunner: "@emdash-cms/sandbox-cloudflare",
+      sandboxRunner: sandbox(),
       experimental: {
         registry: "https://registry.emdashcms.com",
       },
@@ -56,7 +57,7 @@ The bare URL string is shorthand. Use the object form when you need to declare a
 
 ```typescript title="astro.config.mjs"
 emdash({
-  sandboxRunner: "@emdash-cms/sandbox-cloudflare",
+  sandboxRunner: sandbox(),
   experimental: {
     registry: {
       aggregatorUrl: "https://registry.emdashcms.com",

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -479,13 +479,13 @@ In every mode, the toolbar can be dismissed in the browser via its × button (pe
 
 #### `experimental.registry`
 
-**Optional.** Point the admin dashboard's plugin browse and install flows at a federated [plugin registry](/plugins/registry/) instead of the central marketplace. Requires `sandboxRunner`, because registry plugins run sandboxed.
+**Optional.** Point the admin dashboard's plugin browse and install flows at a federated [plugin registry](/plugins/registry/) instead of the central marketplace. Requires a [`sandboxRunner`](/deployment/plugin-sandbox/), because registry plugins run sandboxed.
 
 Pass a bare aggregator URL string, or an object when you need a labeller or a release-age policy. The following example uses the object form:
 
 ```js title="astro.config.mjs"
 emdash({
-	sandboxRunner: "@emdash-cms/sandbox-cloudflare",
+	sandboxRunner: sandbox(),
 	experimental: {
 		registry: {
 			aggregatorUrl: "https://registry.emdashcms.com",

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -484,6 +484,8 @@ In every mode, the toolbar can be dismissed in the browser via its × button (pe
 Pass a bare aggregator URL string, or an object when you need a labeller or a release-age policy. The following example uses the object form:
 
 ```js title="astro.config.mjs"
+import { sandbox } from "@emdash-cms/cloudflare";
+
 emdash({
 	sandboxRunner: sandbox(),
 	experimental: {


### PR DESCRIPTION
## What does this PR do?

Adds a Plugin Sandbox page under Deployment: enabling each runner, the four resource limits and which runner enforces each, and troubleshooting keyed by the messages users see.

It also corrects three pages. Two configured a `sandboxRunner` string naming a package that has never been published; the runner is `sandbox()` from `@emdash-cms/cloudflare`. The third called the Node.js runner unreleased and its unavailability a debug-level log, where the package ships and the runtime warns. Pages holding fragments now link here; the same string in the installing guide belongs to the block #2351 rewrites.

The crash-limit section follows the code, not its log line: that promises unsandboxed plugins while every later call throws `SandboxUnavailableError` until restart. Fixing the log is a separate change.

Part of #1680; its diagnostics item stays with #2351 and #1686.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change) (n/a: docs only)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (n/a: docs only)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (n/a: no admin change)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (n/a: docs-only PR, no published package changed)
- [ ] New features link to an approved Discussion (n/a: documentation for the maintainer-filed #1680)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5

## Screenshots / test output

Docs-only change.

- `pnpm --dir docs build` → completes; `/deployment/plugin-sandbox/` renders with its sidebar entry
- `pnpm format` → no changes
- `pnpm build && pnpm lint:json | jq '.diagnostics | length'` → `0`
- `pnpm lint`, `pnpm typecheck` → exit 0
