### PR TITLE
Keep sidebar section dragging anchored to the pointer

### DIFF
--- a/.changeset/anchor-sidebar-section-drag.md
+++ b/.changeset/anchor-sidebar-section-drag.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes content editor sidebar sections jumping away from the pointer when reordering. Sections now collapse around the grabbed heading and expand smoothly after release.

--- a/packages/admin/src/components/SortableContentSettingsSections.tsx
+++ b/packages/admin/src/components/SortableContentSettingsSections.tsx
@@ -1,5 +1,6 @@
 import {
 	closestCenter,
+	type CollisionDetection,
 	DndContext,
 	type DragEndEvent,
 	type DragStartEvent,
@@ -7,6 +8,7 @@ import {
 	MeasuringStrategy,
 	type Modifier,
 	PointerSensor,
+	pointerWithin,
 	useSensor,
 	useSensors,
 } from "@dnd-kit/core";
@@ -31,11 +33,27 @@ import {
 import { cn } from "../lib/utils.js";
 
 const STORAGE_PREFIX = "emdash:content-settings-layout:v1";
+const COLLAPSED_SECTION_HEIGHT = 48;
+const SECTION_ANIMATION_DURATION = 180;
+const SECTION_ANIMATION_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
+
+type SortAnimationPhase = "preparing" | "collapsed" | "expanding";
+
+interface SortAnimationState {
+	phase: SortAnimationPhase;
+	heights: Map<ContentSettingsSectionId, number>;
+	anchorOffset: number;
+}
 
 const restrictToVerticalAxis: Modifier = ({ transform }) => ({
 	...transform,
 	x: 0,
 });
+
+const sectionCollisionDetection: CollisionDetection = (args) => {
+	const pointerCollisions = pointerWithin(args);
+	return pointerCollisions.length > 0 ? pointerCollisions : closestCenter(args);
+};
 
 export interface SortableContentSettingsSectionProps {
 	id: ContentSettingsSectionId;
@@ -45,6 +63,9 @@ export interface SortableContentSettingsSectionProps {
 	children: React.ReactNode;
 	/** Internal state supplied by the sortable group while any section is moving. */
 	isSorting?: boolean;
+	sortAnimationPhase?: SortAnimationPhase;
+	expandedHeight?: number;
+	registerNode?: (id: ContentSettingsSectionId, node: HTMLElement | null) => void;
 }
 
 interface SortableContentSettingsSectionsProps {
@@ -84,7 +105,11 @@ export function SortableContentSettingsSections({
 	// Keep the server and first client render identical. Browser preferences
 	// are restored after hydration so a saved order cannot cause a mismatch.
 	const [storedLayout, setStoredLayout] = React.useState<ContentSettingsLayout | null>(null);
-	const [activeId, setActiveId] = React.useState<ContentSettingsSectionId | null>(null);
+	const [sortAnimation, setSortAnimation] = React.useState<SortAnimationState | null>(null);
+	const sectionNodesRef = React.useRef(new Map<ContentSettingsSectionId, HTMLElement>());
+	const listRef = React.useRef<HTMLDivElement>(null);
+	const animationFrameRef = React.useRef<number | null>(null);
+	const finishTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	React.useEffect(() => {
 		setStoredLayout(readStoredLayout(storageKey));
@@ -110,22 +135,89 @@ export function SortableContentSettingsSections({
 		useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
 		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
 	);
-	const handleDragStart = React.useCallback(
-		(event: DragStartEvent) => {
-			setActiveId(String(event.active.id));
-			onSortingChange?.(true);
+	const registerNode = React.useCallback(
+		(id: ContentSettingsSectionId, node: HTMLElement | null) => {
+			if (node) sectionNodesRef.current.set(id, node);
+			else sectionNodesRef.current.delete(id);
 		},
-		[onSortingChange],
+		[],
 	);
-	const handleDragCancel = React.useCallback(() => {
-		setActiveId(null);
+	const finishExpansion = React.useCallback(() => {
+		if (finishTimerRef.current !== null) {
+			clearTimeout(finishTimerRef.current);
+			finishTimerRef.current = null;
+		}
+		setSortAnimation(null);
 		onSortingChange?.(false);
 	}, [onSortingChange]);
+	const beginExpansion = React.useCallback(() => {
+		setSortAnimation((current) =>
+			current
+				? {
+						...current,
+						phase: "expanding",
+					}
+				: null,
+		);
+		if (finishTimerRef.current !== null) clearTimeout(finishTimerRef.current);
+		finishTimerRef.current = setTimeout(finishExpansion, SECTION_ANIMATION_DURATION + 50);
+	}, [finishExpansion]);
+
+	React.useLayoutEffect(() => {
+		if (sortAnimation?.phase !== "preparing") return;
+		void listRef.current?.offsetHeight;
+		animationFrameRef.current = window.requestAnimationFrame(() => {
+			setSortAnimation((current) =>
+				current?.phase === "preparing" ? { ...current, phase: "collapsed" } : current,
+			);
+		});
+		return () => {
+			if (animationFrameRef.current !== null) {
+				window.cancelAnimationFrame(animationFrameRef.current);
+				animationFrameRef.current = null;
+			}
+		};
+	}, [sortAnimation?.phase]);
+
+	React.useEffect(
+		() => () => {
+			if (animationFrameRef.current !== null) {
+				window.cancelAnimationFrame(animationFrameRef.current);
+			}
+			if (finishTimerRef.current !== null) clearTimeout(finishTimerRef.current);
+		},
+		[],
+	);
+
+	const handleDragStart = React.useCallback(
+		(event: DragStartEvent) => {
+			const movedId = String(event.active.id);
+			const heights = new Map<ContentSettingsSectionId, number>();
+			for (const id of visibleIds) {
+				const node = sectionNodesRef.current.get(id);
+				const height = node?.getBoundingClientRect().height ?? COLLAPSED_SECTION_HEIGHT;
+				heights.set(id, Math.max(height, COLLAPSED_SECTION_HEIGHT));
+			}
+			const activeIndex = visibleIds.indexOf(movedId);
+			const anchorOffset = visibleIds
+				.slice(0, Math.max(activeIndex, 0))
+				.reduce(
+					(total, id) =>
+						total + (heights.get(id) ?? COLLAPSED_SECTION_HEIGHT) - COLLAPSED_SECTION_HEIGHT,
+					0,
+				);
+
+			setSortAnimation({ phase: "preparing", heights, anchorOffset });
+			onSortingChange?.(true);
+		},
+		[onSortingChange, visibleIds],
+	);
+	const handleDragCancel = React.useCallback(() => {
+		beginExpansion();
+	}, [beginExpansion]);
 
 	const handleDragEnd = React.useCallback(
 		(event: DragEndEvent) => {
-			setActiveId(null);
-			onSortingChange?.(false);
 			if (event.over && event.active.id !== event.over.id) {
 				const movedId = String(event.active.id);
 				const overId = String(event.over.id);
@@ -139,28 +231,63 @@ export function SortableContentSettingsSections({
 					return next;
 				});
 			}
+			beginExpansion();
 		},
-		[onSortingChange, sectionIds, storageKey],
+		[beginExpansion, sectionIds, storageKey],
+	);
+	const listAnchorOffset = sortAnimation?.phase === "collapsed" ? sortAnimation.anchorOffset : 0;
+	const listStyle = {
+		"--sort-anchor-offset": `${listAnchorOffset}px`,
+		transform: "translate3d(0, var(--sort-anchor-offset), 0)",
+		transition:
+			sortAnimation && sortAnimation.phase !== "preparing"
+				? `transform ${SECTION_ANIMATION_DURATION}ms ${SECTION_ANIMATION_EASING}`
+				: "none",
+	} as React.CSSProperties;
+	const handleTransitionEnd = React.useCallback(
+		(event: React.TransitionEvent<HTMLDivElement>) => {
+			if (
+				sortAnimation?.phase === "expanding" &&
+				(event.propertyName === "transform" || event.propertyName === "height")
+			) {
+				finishExpansion();
+			}
+		},
+		[finishExpansion, sortAnimation?.phase],
 	);
 
 	return (
 		<DndContext
 			sensors={sensors}
-			collisionDetection={closestCenter}
+			collisionDetection={sectionCollisionDetection}
 			modifiers={[restrictToVerticalAxis]}
 			measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
 			onDragStart={handleDragStart}
 			onDragCancel={handleDragCancel}
 			onDragEnd={handleDragEnd}
 		>
-			<SortableContext items={visibleIds} strategy={verticalListSortingStrategy}>
-				{visibleIds.map((id) => {
-					const section = sectionsById.get(id);
-					return section
-						? React.cloneElement(section, { key: id, isSorting: activeId !== null })
-						: null;
-				})}
-			</SortableContext>
+			<div
+				ref={listRef}
+				data-sortable-sections
+				style={listStyle}
+				onTransitionEnd={handleTransitionEnd}
+				className="motion-reduce:transition-none"
+			>
+				<SortableContext items={visibleIds} strategy={verticalListSortingStrategy}>
+					{visibleIds.map((id) => {
+						const section = sectionsById.get(id);
+						return section
+							? React.cloneElement(section, {
+									key: id,
+									isSorting: sortAnimation !== null,
+									sortAnimationPhase: sortAnimation?.phase,
+									expandedHeight: sortAnimation?.heights.get(id),
+									registerNode,
+								})
+							: null;
+					})}
+				</SortableContext>
+			</div>
 		</DndContext>
 	);
 }
@@ -171,34 +298,61 @@ export function SortableContentSettingsSection({
 	disclosure = false,
 	children,
 	isSorting = false,
+	sortAnimationPhase,
+	expandedHeight,
+	registerNode,
 }: SortableContentSettingsSectionProps) {
 	const { t } = useLingui();
 	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
 		id,
 	});
+	const setSectionNodeRef = React.useCallback(
+		(node: HTMLElement | null) => {
+			setNodeRef(node);
+			registerNode?.(id, node);
+		},
+		[id, registerNode, setNodeRef],
+	);
+	const sectionHeight =
+		sortAnimationPhase === "collapsed" ? COLLAPSED_SECTION_HEIGHT : expandedHeight;
 	const style: React.CSSProperties = {
-		transform: transform ? CSS.Transform.toString({ ...transform, x: 0 }) : undefined,
-		transition,
+		transform: transform
+			? CSS.Transform.toString({ ...transform, x: 0, scaleX: 1, scaleY: 1 })
+			: undefined,
+		transition: [
+			transition,
+			isSorting && sortAnimationPhase !== "preparing"
+				? `height ${SECTION_ANIMATION_DURATION}ms ${SECTION_ANIMATION_EASING}`
+				: null,
+		]
+			.filter(Boolean)
+			.join(", "),
 		zIndex: isDragging ? 10 : undefined,
 		inlineSize: "100%",
+		height: isSorting && sectionHeight ? sectionHeight : undefined,
 	};
 
 	return (
 		<section
-			ref={setNodeRef}
+			ref={setSectionNodeRef}
 			style={style}
+			data-sortable-section={id}
 			data-sorting={isSorting ? "true" : "false"}
+			data-sort-animation={sortAnimationPhase}
 			data-disclosure={disclosure ? "true" : "false"}
 			className={cn(
 				"relative min-w-0 border-t bg-kumo-base first:border-t-0",
-				isSorting && "[&>*:not([data-sortable-heading]):not([data-sortable-handle])]:hidden",
+				isSorting &&
+					"overflow-hidden [&>*:not([data-sortable-heading]):not([data-sortable-handle])]:invisible [&>*:not([data-sortable-heading]):not([data-sortable-handle])]:pointer-events-none",
 				isDragging && "bg-kumo-tint opacity-60",
+				"motion-reduce:transition-none",
 			)}
 		>
 			{isSorting && (
 				<div
 					data-sortable-heading
-					className="flex items-center px-4 pe-12"
+					aria-hidden="true"
+					className="absolute inset-x-0 top-0 flex h-12 items-center px-4 pe-12"
 					style={{ minHeight: 48 }}
 				>
 					<span className="text-[15px] font-semibold">{label}</span>
@@ -214,7 +368,7 @@ export function SortableContentSettingsSection({
 				className={cn(
 					"absolute z-10 grid size-7 touch-none cursor-grab place-items-center rounded-md text-kumo-subtle hover:bg-kumo-tint hover:text-kumo-default focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kumo-accent active:cursor-grabbing",
 					"end-5",
-					isSorting ? "top-1/2 -translate-y-1/2" : disclosure ? "top-5" : "top-3",
+					isSorting ? "top-6 -translate-y-1/2" : disclosure ? "top-5" : "top-3",
 				)}
 				aria-label={t`Drag to reorder ${label}`}
 				title={t`Drag to reorder ${label}`}

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { i18n } from "@lingui/core";
-import { act, fireEvent } from "@testing-library/react";
+import { act, fireEvent, waitFor } from "@testing-library/react";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -721,8 +721,10 @@ describe("ContentSettingsPanel", () => {
 			fireEvent.keyDown(document, { key: "Escape", code: "Escape" });
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
-		expect(trashActions).not.toHaveClass("invisible", "pointer-events-none");
-		expect(trashActions).not.toHaveAttribute("aria-hidden");
+		await waitFor(() => {
+			expect(trashActions).not.toHaveClass("invisible", "pointer-events-none");
+			expect(trashActions).not.toHaveAttribute("aria-hidden");
+		});
 	});
 });
 

--- a/packages/admin/tests/components/SortableContentSettingsSections.test.tsx
+++ b/packages/admin/tests/components/SortableContentSettingsSections.test.tsx
@@ -87,10 +87,12 @@ describe("SortableContentSettingsSections", () => {
 			const sectionHandle = section.querySelector<HTMLElement>("[data-sortable-handle]");
 
 			expect(heading?.style.minHeight).toBe("48px");
+			expect(section.style.height).toBe("48px");
+			expect(section.classList.contains("overflow-hidden")).toBe(true);
 			expect(section.className).toContain(
-				"[&>*:not([data-sortable-heading]):not([data-sortable-handle])]:hidden",
+				"[&>*:not([data-sortable-heading]):not([data-sortable-handle])]:invisible",
 			);
-			expect(sectionHandle?.classList.contains("top-1/2")).toBe(true);
+			expect(sectionHandle?.classList.contains("top-6")).toBe(true);
 			expect(sectionHandle?.classList.contains("-translate-y-1/2")).toBe(true);
 		}
 
@@ -100,11 +102,57 @@ describe("SortableContentSettingsSections", () => {
 			expect(sections.every((section) => section.dataset.sorting === "false")).toBe(true);
 		});
 		expect(container.querySelector("[data-sortable-heading]")).toBeNull();
-		expect(sections[0]?.className).not.toContain(
-			"[&>*:not([data-sortable-heading]):not([data-sortable-handle])]:hidden",
-		);
+		expect(sections[0]?.classList.contains("overflow-hidden")).toBe(false);
 		expect(screen.getByTestId("publish-section").parentElement).toBe(sections[0]);
 		expect(screen.getByTestId("seo-section").parentElement).toBe(sections[1]);
+	});
+
+	it("keeps the grabbed section anchored while surrounding sections collapse toward it", async () => {
+		const { container } = render(
+			<I18nProvider i18n={i18n}>
+				<SortableContentSettingsSections collection="posts" userId="user-1">
+					<SortableContentSettingsSection id="publish" label="Publish">
+						<div style={{ height: 120 }}>Publish content</div>
+					</SortableContentSettingsSection>
+					<SortableContentSettingsSection id="ownership" label="Ownership">
+						<div style={{ height: 200 }}>Ownership content</div>
+					</SortableContentSettingsSection>
+					<SortableContentSettingsSection id="seo" label="SEO">
+						<div style={{ height: 160 }}>SEO content</div>
+					</SortableContentSettingsSection>
+				</SortableContentSettingsSections>
+			</I18nProvider>,
+		);
+		const sections = [...container.querySelectorAll<HTMLElement>("section")];
+		const initialRects = sections.map((section) => section.getBoundingClientRect());
+
+		const handle = screen.getByRole("button", { name: "Drag to reorder Ownership" });
+		handle.focus();
+		await pressKey(handle, " ", "Space");
+		await waitFor(() => {
+			expect(sections.every((section) => section.dataset.sortAnimation === "collapsed")).toBe(true);
+		});
+		await act(async () => new Promise((resolve) => setTimeout(resolve, 200)));
+		const collapsedRects = sections.map((section) => section.getBoundingClientRect());
+
+		expect(collapsedRects[0]?.top).toBeGreaterThan(initialRects[0]?.top ?? 0);
+		expect(collapsedRects[1]?.top).toBeCloseTo(initialRects[1]?.top ?? 0, 0);
+		expect(collapsedRects[2]?.top).toBeLessThan(initialRects[2]?.top ?? 0);
+		expect(collapsedRects.every((rect) => Math.round(rect.height) === 48)).toBe(true);
+	});
+
+	it("never overlaps the original and sortable headings", async () => {
+		const { container } = renderSections();
+		const handle = screen.getByRole("button", { name: "Drag to reorder Publish" });
+
+		handle.focus();
+		await pressKey(handle, " ", "Space");
+
+		const sortableHeading = container.querySelector<HTMLElement>("[data-sortable-heading]");
+		expect(screen.getByTestId("publish-section").parentElement?.className).toContain(
+			"[&>*:not([data-sortable-heading]):not([data-sortable-handle])]:invisible",
+		);
+		expect(sortableHeading).toBeTruthy();
 	});
 
 	it("persists a keyboard reorder and restores expanded section content", async () => {


### PR DESCRIPTION
## What does this PR do?

Dragging a lower section in the content editor sidebar currently collapses every panel into a compact list at the top of the sidebar. The grabbed heading jumps away from the pointer before the user moves it, so reordering feels disconnected from the drag gesture.

This change anchors the compact list around the grabbed section. Sections above collapse downward, sections below collapse upward, and the grabbed heading remains under the pointer. Releasing or cancelling the drag reverses the transition into the resulting order.

The interaction remains keyboard accessible, preserves saved section ordering, and uses pointer position for pointer-drag collision detection while retaining the existing keyboard strategy.

No linked issue.

### Current interaction

The section headings move to the top of the sidebar when dragging begins. The pointer remains where the expanded panel was, separated from the grabbed heading.

![Current sidebar drag behavior: the grabbed SEO heading jumps above the pointer when the panels collapse](https://github.com/markjaquith/emdash/blob/480614923dc3e56f20593a3019147d0b112baabc/.github/assets/sidebar-drag-current.svg?raw=true)

### Anchored interaction

The surrounding sections converge on the grabbed SEO heading. Its handle remains aligned with the pointer throughout the transition.

![Anchored sidebar drag behavior: surrounding sections collapse toward SEO while its heading remains under the pointer](https://github.com/markjaquith/emdash/blob/480614923dc3e56f20593a3019147d0b112baabc/.github/assets/sidebar-drag-anchored.svg?raw=true)

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable: no user-visible strings changed)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: not applicable; this is a bug fix

`pnpm lint:quick` passes. Full type-aware lint reports two existing `no-unnecessary-type-assertion` warnings in `packages/plugins/forms/src/admin.tsx`, which this PR does not change.

## AI-generated code disclosure

- [x] This PR includes AI-generated code - model/tool: OpenCode with GPT-5.6 Sol

## Screenshots / test output

Verified with:

- `pnpm typecheck`
- `pnpm --filter @emdash-cms/admin test --run` - 1,757 tests passed
- `pnpm lint:quick`
- `pnpm format`
- Live pointer-drag testing in the simple demo
- Keyboard reorder and cancellation tests in Chromium

The SVG diagrams above are committed with accessible titles and descriptions so the interaction can be reviewed without running the demo.
