### PR TITLE
docs: add an update guide for existing sites

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -220,6 +220,7 @@ export default defineConfig({
 					items: [
 						{ label: "Deploy to Cloudflare", slug: "deployment/cloudflare" },
 						{ label: "Deploy to Node.js", slug: "deployment/nodejs" },
+						{ label: "Update EmDash", slug: "deployment/updating" },
 						{ label: "Core Database Migrations", slug: "deployment/core-migrations" },
 						{ label: "Evolving a Deployed Site", slug: "deployment/schema-evolution" },
 						{ label: "Database Options", slug: "deployment/database" },

--- a/docs/src/content/docs/deployment/updating.mdx
+++ b/docs/src/content/docs/deployment/updating.mdx
@@ -52,7 +52,7 @@ The commands below use pnpm and a site created from a Cloudflare template. For a
    pnpm build
    ```
 
-   The build regenerates `emdash-env.d.ts` and writes the migration manifest for the installed version. If the build fails, see [If the site breaks after an update](#if-the-site-breaks-after-an-update).
+   The build writes the migration manifest for the installed version. If the build fails, see [If the site breaks after an update](#if-the-site-breaks-after-an-update).
 
 4. Start the site locally and open the admin at `/_emdash/admin`.
 
@@ -60,7 +60,7 @@ The commands below use pnpm and a site created from a Cloudflare template. For a
    pnpm dev
    ```
 
-   In development, pending core migrations run on the first request.
+   The EmDash integration generates `emdash-env.d.ts` when the dev server starts. Pending core migrations run on the first request.
 
 </Steps>
 

--- a/docs/src/content/docs/deployment/updating.mdx
+++ b/docs/src/content/docs/deployment/updating.mdx
@@ -1,0 +1,84 @@
+---
+title: Update EmDash
+description: Move an existing site to a new EmDash release, from reading the release entries to verifying the deployed site.
+---
+
+import { Steps } from "@astrojs/starlight/components";
+
+This guide is for site operators: people who run a site built on EmDash and want it on a newer release. It covers the `emdash` package and `@emdash-cms/cloudflare`. Plugin packages have their own guide, [Upgrading plugins on your site](/plugins/upgrading-sites/), and changes to your own collections and fields are covered in [Evolving a Deployed Site](/deployment/schema-evolution/).
+
+## Releases and version numbers
+
+EmDash is released before version 1.0, and its version numbers follow two rules:
+
+- A patch release, for example 0.35.0 to 0.35.1, carries bug fixes and small improvements.
+- A minor release, for example 0.35 to 0.36, carries new features and any breaking change. A breaking change is marked **Breaking** in its release entry, and the entry states the action it requires from you.
+
+`emdash` and `@emdash-cms/cloudflare` are released together and share one version number. `@emdash-cms/cloudflare` depends on the exact matching `emdash` version, so update the two packages in one step. Plugin packages such as `@emdash-cms/plugin-forms` have their own version numbers and declare the minimum `emdash` version they need.
+
+The [releases page](https://github.com/emdash-cms/emdash/releases) has one entry per package and version. Before an update, read the `emdash` entries between your installed version and the target, and the same range for `@emdash-cms/cloudflare` if the site runs on Cloudflare.
+
+## Before you update
+
+Take a backup. Core migrations that a new release applies to the database have no undo step, so a backup is the only way back to the previous state. [Backups](/guides/backups/) describes the options for each database.
+
+Check the Node.js version on the machine that builds the site and, for a Node.js deployment, on the server. [Getting Started](/getting-started/#prerequisites) lists the supported versions.
+
+## Update the packages
+
+The commands below use pnpm and a site created from a Cloudflare template. For a Node.js deployment, leave out `@emdash-cms/cloudflare`.
+
+<Steps>
+
+1. Check the installed versions and the latest release.
+
+   ```bash
+   pnpm outdated emdash @emdash-cms/cloudflare
+   ```
+
+2. Move both packages to the latest release.
+
+   A template-generated `package.json` lists the packages with a caret range such as `^0.35.0`. For versions below 1.0, a caret range admits patch releases only (0.35.1, not 0.36.0), and `pnpm up` without further options stays inside the range. The `--latest` flag rewrites the range to the newest release and installs it.
+
+   ```bash
+   pnpm up --latest emdash @emdash-cms/cloudflare
+   ```
+
+   Add the plugin packages from your `package.json` to the same command.
+
+3. Build the site.
+
+   ```bash
+   pnpm build
+   ```
+
+   The build regenerates `emdash-env.d.ts` and writes the migration manifest for the installed version. If the build fails, see [If the site breaks after an update](#if-the-site-breaks-after-an-update).
+
+4. Start the site locally and open the admin at `/_emdash/admin`.
+
+   ```bash
+   pnpm dev
+   ```
+
+   In development, pending core migrations run on the first request.
+
+</Steps>
+
+## Deploy and verify
+
+Deploy the build the same way as any other change. The following command deploys a Cloudflare site; for a Node.js deployment, restart the server process with the new build.
+
+```bash
+pnpm wrangler deploy
+```
+
+With the default runtime migration mode, `auto`, the deployed site applies pending core migrations on its first request. To apply them before the new code receives traffic, and to verify the deployed database afterwards, follow [Manage Core Database Migrations](/deployment/core-migrations/). Its `emdash migrate --check` command exits non-zero when the deployed database has pending or unknown migrations for the installed version.
+
+After the deploy, open the admin and one public page of the site.
+
+## If the site breaks after an update
+
+- The build fails, or a page of your own errors at runtime: read the release entries marked **Breaking** for the versions you skipped and make the changes they state.
+- A plugin fails to load: read the plugin's own release entry and [Upgrading plugins on your site](/plugins/upgrading-sites/).
+- An error names an Astro API or an `@astrojs/*` package: EmDash requires Astro 6 or later. Astro's [upgrade guide](https://docs.astro.build/en/upgrade-astro/) explains how to update `astro` and its official integrations together.
+- To return to the previous release, reinstall the previous versions of the packages. Reinstalling does not undo core migrations; if the previous release fails against the migrated database, restore the backup taken before the update.

--- a/docs/src/content/docs/plugins/creating-plugins/migrating-to-the-cli.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/migrating-to-the-cli.mdx
@@ -12,7 +12,7 @@ This guide is for authors of **sandboxed** plugins written against the previous 
 	`PluginDefinition` shape. Nothing on this page applies to them.
 </Aside>
 
-For the full list of changes in each package, see the [EmDash changelog](https://github.com/emdash-cms/emdash/blob/main/CHANGELOG.md).
+For the full list of changes in each package, see its entry on the [releases page](https://github.com/emdash-cms/emdash/releases).
 
 ## Breaking changes
 

--- a/docs/src/content/docs/plugins/upgrading-sites.mdx
+++ b/docs/src/content/docs/plugins/upgrading-sites.mdx
@@ -12,13 +12,13 @@ This guide is for **site operators**: people who install plugins into a site. If
 Update `emdash` and your plugin packages to their latest versions, then reinstall and rebuild:
 
 ```sh
-pnpm up emdash @emdash-cms/plugin-audit-log @emdash-cms/plugin-webhook-notifier @emdash-cms/plugin-atproto
+pnpm up --latest emdash @emdash-cms/plugin-audit-log @emdash-cms/plugin-webhook-notifier @emdash-cms/plugin-atproto
 pnpm build
 ```
 
 After upgrading, your site may build and run without further changes. If the build fails or a plugin stops loading, work through the breaking changes below. Each one tells you exactly what to change.
 
-For the full list of changes in each package, see its entry in the [EmDash changelog](https://github.com/emdash-cms/emdash/blob/main/CHANGELOG.md).
+For the full list of changes in each package, see its entry on the [releases page](https://github.com/emdash-cms/emdash/releases).
 
 ## Breaking changes
 


### PR DESCRIPTION
## What does this PR do?

Adds a guide for site operators who want to move an existing site to a newer EmDash release. The docs cover core migrations, content-model changes and plugin upgrades, but not the step before them: which release entries to read, what a version number means before 1.0, and how to bump `emdash` and `@emdash-cms/cloudflare` so that the bump actually happens.

The new page `deployment/updating` states the pre-1.0 version rules that follow from `.changeset/README.md`, explains that the two packages share one version and that `@emdash-cms/cloudflare` depends on the exact matching `emdash` version, and walks through `pnpm outdated`, `pnpm up --latest`, build, deploy and `emdash migrate --check`. It links to the existing pages for everything they already cover.

Two fixes on sibling pages: `plugins/upgrading-sites` and `plugins/creating-plugins/migrating-to-the-cli` link to `blob/main/CHANGELOG.md`, which returns 404, and now point at the releases page; the `pnpm up emdash …` command on `plugins/upgrading-sites` stays inside a template's `^0.x` range and never reaches a new minor, and now carries `--latest`. Everything else on those pages is unchanged.

Part of #1888 (the update page; `npx @astrojs/upgrade` in the update path, the `emdash doctor` check and the Renovate template proposed there stay open).

### Revisions

- `e674af83`: step 3 said the build regenerates `emdash-env.d.ts`. The integration writes that file from `astro:server:setup` once the dev server is listening, so the sentence moved to step 4 with `pnpm dev`, in the terms `reference/cli` uses. The build does write the migration manifest (`astro:config:done`), and that half stays.
- Description: the summary above said the two packages depend on each other exactly. Only `@emdash-cms/cloudflare` declares the dependency, at the exact version; `packages/core` declares none on the adapter. The page always stated the one direction.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes (n/a: docs only)
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change) (n/a: docs only)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (n/a: docs only)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (n/a)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (n/a: no published package changes)
- [ ] New features link to an approved Discussion (n/a: documentation)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5, Claude Opus 5

## Screenshots / test output

- `pnpm lint` → clean; `pnpm format:check` → clean
- `pnpm --dir docs build` → complete; the new page, its links and anchors resolve
- `git diff --check` → clean
- Page commands run against a throwaway project on `emdash@^0.34.0`: `pnpm up` stays at 0.34.0, `pnpm up --latest` moves to `^0.35.0`
