### PR TITLE
Fix audit-log hooks skipped at registration; add read-only observe mode for content:beforeSave

### DIFF
--- a/.changeset/audit-log-hook-capabilities.md
+++ b/.changeset/audit-log-hook-capabilities.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/plugin-audit-log": patch
+---
+
+Fixes the `content:beforeSave` and `media:afterUpload` hooks being skipped at registration, which logged "[hooks] Plugin \"audit-log\" declares ... hook without ... capability — skipping" warnings on startup. Update entries now include before/after diffs again, and media uploads are audited. The manifest adds the `media:read` capability, and the before-save hook registers as a read-only observer, so the plugin still requests no write access. Restoring the hooks and the update diffs needs the `emdash` release that ships alongside this update (the `observe` hook option and the before-save event `id`); on older versions the plugin behaves as before.

--- a/.changeset/observe-before-save.md
+++ b/.changeset/observe-before-save.md
@@ -1,0 +1,21 @@
+---
+"emdash": minor
+"@emdash-cms/plugin-cli": patch
+---
+
+Adds an `observe` option to the `content:beforeSave` hook config so plugins can watch saves without requesting write access. An observe hook registers with the `content:read` capability instead of `content:write`; its return value is discarded, so it cannot modify the content being saved.
+
+```ts
+hooks: {
+	"content:beforeSave": {
+		observe: true,
+		handler: async (event, ctx) => {
+			// read event.content, capture state, log — but never mutate
+		},
+	},
+},
+```
+
+Hooks that return modified content are unchanged and still require `content:write`. The warning logged when a `content:beforeSave` hook is skipped for a missing capability now mentions the `observe` option.
+
+The `content:beforeSave` event also gains an `id` field, set when updating existing content. The update payload's `content` carries only the submitted field data, so this is the only way for a hook to know which item is being saved; it is absent on creates, where the id is generated after the hook runs.

--- a/.changeset/observe-before-save.md
+++ b/.changeset/observe-before-save.md
@@ -3,7 +3,7 @@
 "@emdash-cms/plugin-cli": patch
 ---
 
-Adds an `observe` option to the `content:beforeSave` hook config so plugins can watch saves without requesting write access. An observe hook registers with the `content:read` capability instead of `content:write`; its return value is discarded, so it cannot modify the content being saved.
+Adds an `observe` option to the `content:beforeSave` hook config so plugins can watch saves without requesting write access. An observe hook registers with the `content:read` capability instead of `content:write`; it receives a copy of the content, its return value is discarded, and errors it throws are logged without blocking the save, so it cannot affect what is saved.
 
 ```ts
 hooks: {

--- a/docs/src/content/docs/plugins/creating-plugins/hooks.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/hooks.mdx
@@ -159,7 +159,7 @@ Runs before content is saved. Return modified content, or `void` to leave it unc
 
 On updates, `event.id` is the id of the item being saved; `content` carries only the submitted field data. On creates, `id` is absent because it is generated after the hook runs.
 
-Requires `content:write` capability, because the returned content replaces what is saved. A plugin that only watches saves — an audit trail capturing before-state, for example — can set `observe: true` in the hook config. An observe hook registers with `content:read`; its return value is discarded, so it cannot modify the content.
+Requires `content:write` capability, because the returned content replaces what is saved. A plugin that only watches saves — an audit trail capturing before-state, for example — can set `observe: true` in the hook config. An observe hook registers with `content:read`; its return value is discarded and errors it throws never block the save, so it cannot affect the content.
 
 The following hook records every save without requesting write access.
 
@@ -169,7 +169,7 @@ The following hook records every save without requesting write access.
 	handler: async (event, ctx) => {
 		await ctx.storage.log.put(`${Date.now()}`, {
 			collection: event.collection,
-			id: event.content.id,
+			id: event.id,
 		});
 	},
 },

--- a/docs/src/content/docs/plugins/creating-plugins/hooks.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/hooks.mdx
@@ -62,6 +62,7 @@ hooks: {
 | `dependencies` | `string[]`              | `[]`      | Plugin ids that must run before this hook.                                                   |
 | `errorPolicy`  | `"abort" \| "continue"` | `"abort"` | Whether to stop the pipeline on error.                                                       |
 | `exclusive`    | `boolean`               | `false`   | Only one plugin can be the active provider. Used for `email:deliver` and `comment:moderate`. |
+| `observe`      | `boolean`               | `false`   | Read-only observer: the return value is discarded. `content:beforeSave` only.                |
 | `handler`      | `function`              | —         | The hook handler function. Required.                                                         |
 
 <Aside type="tip">
@@ -154,7 +155,25 @@ Runs before content is saved. Return modified content, or `void` to leave it unc
 },
 ```
 
-**Event:** `{ content, collection, isNew }` — **Returns:** modified content or `void`.
+**Event:** `{ content, collection, isNew, id? }` — **Returns:** modified content or `void`.
+
+On updates, `event.id` is the id of the item being saved; `content` carries only the submitted field data. On creates, `id` is absent because it is generated after the hook runs.
+
+Requires `content:write` capability, because the returned content replaces what is saved. A plugin that only watches saves — an audit trail capturing before-state, for example — can set `observe: true` in the hook config. An observe hook registers with `content:read`; its return value is discarded, so it cannot modify the content.
+
+The following hook records every save without requesting write access.
+
+```typescript
+"content:beforeSave": {
+	observe: true,
+	handler: async (event, ctx) => {
+		await ctx.storage.log.put(`${Date.now()}`, {
+			collection: event.collection,
+			id: event.content.id,
+		});
+	},
+},
+```
 
 ### `content:afterSave`
 
@@ -175,6 +194,8 @@ Runs after content is successfully saved. Use for side effects like notification
 
 **Event:** `{ content, collection, isNew }` — **Returns:** `Promise<void>`
 
+Requires `content:read` capability.
+
 ### `content:beforeDelete`
 
 Runs before content is deleted. Return `false` to cancel; `true` or `void` allows it.
@@ -191,6 +212,8 @@ Runs before content is deleted. Return `false` to cancel; `true` or `void` allow
 
 **Event:** `{ id, collection }` — **Returns:** `boolean | void`
 
+Requires `content:read` capability.
+
 ### `content:afterDelete`
 
 Runs after content is successfully deleted.
@@ -202,6 +225,8 @@ Runs after content is successfully deleted.
 ```
 
 **Event:** `{ id, collection }` — **Returns:** `Promise<void>`
+
+Requires `content:read` capability.
 
 ### `content:afterPublish`
 
@@ -253,9 +278,11 @@ Runs before a file is uploaded. Return modified file metadata or throw to cancel
 
 **Event:** `{ file: { name, type, size } }` — **Returns:** modified file or `void`
 
+Requires `media:write` capability.
+
 ### `media:afterUpload`
 
-Runs after a file is successfully uploaded.
+Runs after a file is successfully uploaded. Requires `media:read` capability.
 
 **Event:** `{ media: { id, filename, mimeType, size, url, createdAt } }` — **Returns:** `Promise<void>`
 

--- a/docs/src/content/docs/reference/hooks.mdx
+++ b/docs/src/content/docs/reference/hooks.mdx
@@ -86,7 +86,7 @@ interface ContentHookEvent {
 
 #### Capability
 
-Requires `content:write` capability, because the returned content replaces what is saved. A plugin that only watches saves can set `observe: true` in the hook config: the hook then registers with `content:read` and its return value is discarded, so it cannot modify the content.
+Requires `content:write` capability, because the returned content replaces what is saved. A plugin that only watches saves can set `observe: true` in the hook config: the hook then registers with `content:read`, its return value is discarded, and errors it throws are logged without blocking the save, so it cannot affect the content.
 
 ```ts
 hooks: {

--- a/docs/src/content/docs/reference/hooks.mdx
+++ b/docs/src/content/docs/reference/hooks.mdx
@@ -75,6 +75,7 @@ interface ContentHookEvent {
 	content: Record<string, unknown>; // Content data
 	collection: string; // Collection slug
 	isNew: boolean; // True for creates, false for updates
+	id?: string; // Item id on updates; absent on creates (id not yet generated)
 }
 ```
 
@@ -82,6 +83,21 @@ interface ContentHookEvent {
 
 - Return modified content object to apply changes
 - Return `void` to pass through unchanged
+
+#### Capability
+
+Requires `content:write` capability, because the returned content replaces what is saved. A plugin that only watches saves can set `observe: true` in the hook config: the hook then registers with `content:read` and its return value is discarded, so it cannot modify the content.
+
+```ts
+hooks: {
+	"content:beforeSave": {
+		observe: true,
+		handler: async (event, ctx) => {
+			ctx.log.info(`Saving ${event.collection}`);
+		},
+	},
+}
+```
 
 ### `content:afterSave`
 
@@ -250,9 +266,11 @@ interface MediaUploadEvent {
 - Return `void` to pass through unchanged
 - Throw to reject the upload
 
+Requires `media:write` capability.
+
 ### `media:afterUpload`
 
-Runs after a file is uploaded. Use for processing, thumbnails, or metadata extraction.
+Runs after a file is uploaded. Use for processing, thumbnails, or metadata extraction. Requires `media:read` capability.
 
 ```ts
 hooks: {
@@ -709,6 +727,7 @@ hooks: {
 | `dependencies` | `string[]` | `[]`      | Plugin IDs that must run first                       |
 | `errorPolicy`  | `string`   | `"abort"` | `"continue"` to ignore errors                        |
 | `exclusive`    | `boolean`  | `false`   | Only one plugin can be the active provider (for provider-pattern hooks like `email:deliver`, `comment:moderate`) |
+| `observe`      | `boolean`  | `false`   | Read-only observer: the return value is discarded. `content:beforeSave` only, where it drops the required capability to `content:read` |
 
 ## Plugin Context
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"typecheck:templates": "pnpm run --workspace-concurrency=1 --filter {./templates/*} typecheck",
 		"check": "pnpm run typecheck && pnpm run --filter {./packages/*} check",
 		"test": "pnpm run --filter {./packages/*} test",
-		"test:unit": "pnpm run --filter emdash --filter @emdash-cms/aggregator --filter @emdash-cms/auth --filter @emdash-cms/blocks --filter @emdash-cms/gutenberg-to-portable-text --filter @emdash-cms/labeler --filter @emdash-cms/marketplace --filter @emdash-cms/plugin-cli --filter @emdash-cms/plugin-forms --filter @emdash-cms/plugin-types --filter @emdash-cms/registry-client --filter @emdash-cms/registry-lexicons --filter @emdash-cms/registry-moderation test",
+		"test:unit": "pnpm run --filter emdash --filter @emdash-cms/aggregator --filter @emdash-cms/auth --filter @emdash-cms/blocks --filter @emdash-cms/gutenberg-to-portable-text --filter @emdash-cms/labeler --filter @emdash-cms/marketplace --filter @emdash-cms/plugin-audit-log --filter @emdash-cms/plugin-cli --filter @emdash-cms/plugin-forms --filter @emdash-cms/plugin-types --filter @emdash-cms/registry-client --filter @emdash-cms/registry-lexicons --filter @emdash-cms/registry-moderation test",
 		"test:browser": "pnpm run --filter @emdash-cms/admin test",
 		"test:e2e": "playwright test",
 		"test:e2e:ui": "playwright test --ui",

--- a/packages/core/src/cli/commands/bundle.ts
+++ b/packages/core/src/cli/commands/bundle.ts
@@ -296,6 +296,7 @@ export const bundleCommand = defineCommand({
 												dependencies: (config.dependencies as string[]) ?? [],
 												errorPolicy: (config.errorPolicy as string) ?? "abort",
 												exclusive: (config.exclusive as boolean) ?? false,
+												observe: (config.observe as boolean) ?? false,
 												pluginId: result.id,
 											};
 										}

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2990,7 +2990,7 @@ export class EmDashRuntime {
 					bodyWithoutRev.data,
 					collection,
 					false,
-					resolvedId,
+					resolvedItem?.id,
 				);
 				processedData = hookResult.content;
 			}
@@ -3000,7 +3000,7 @@ export class EmDashRuntime {
 				processedData!,
 				collection,
 				false,
-				resolvedId,
+				resolvedItem?.id,
 			);
 
 			// Normalize media fields (fill dimensions, storageKey, etc.)

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2990,12 +2990,18 @@ export class EmDashRuntime {
 					bodyWithoutRev.data,
 					collection,
 					false,
+					resolvedId,
 				);
 				processedData = hookResult.content;
 			}
 
 			// Run sandboxed beforeSave hooks
-			processedData = await this.runSandboxedBeforeSave(processedData!, collection, false);
+			processedData = await this.runSandboxedBeforeSave(
+				processedData!,
+				collection,
+				false,
+				resolvedId,
+			);
 
 			// Normalize media fields (fill dimensions, storageKey, etc.)
 			processedData = await this.normalizeMediaFields(collection, processedData);
@@ -4034,6 +4040,7 @@ export class EmDashRuntime {
 		content: Record<string, unknown>,
 		collection: string,
 		isNew: boolean,
+		contentId?: string,
 	): Promise<Record<string, unknown>> {
 		let result = content;
 
@@ -4046,6 +4053,7 @@ export class EmDashRuntime {
 					content: result,
 					collection,
 					isNew,
+					id: contentId,
 				});
 				if (hookResult && typeof hookResult === "object" && !Array.isArray(hookResult)) {
 					// Sandbox returns unknown; convert to record by iterating own properties

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -137,6 +137,13 @@ export interface HookConfig<K extends keyof HookHandlers> {
 	dependencies?: string[];
 	errorPolicy?: "continue" | "abort";
 	exclusive?: boolean;
+	/**
+	 * Register this hook as a read-only observer: the handler's return value
+	 * is discarded, so it cannot modify the pipeline payload. Only supported
+	 * on `content:beforeSave`, where it drops the required capability from
+	 * `content:write` to `content:read`.
+	 */
+	observe?: boolean;
 }
 
 /**

--- a/packages/core/src/plugins/adapt-sandbox-entry.ts
+++ b/packages/core/src/plugins/adapt-sandbox-entry.ts
@@ -13,7 +13,7 @@
 import type { PluginDescriptor } from "../astro/integration/runtime.js";
 import type { RouteEntry, RouteHandler, SandboxedPlugin } from "../plugin-types.js";
 import { PLUGIN_CAPABILITIES, HOOK_NAMES } from "./manifest-schema.js";
-import { normalizeCapabilities } from "./types.js";
+import { normalizeCapabilities, OBSERVABLE_HOOKS } from "./types.js";
 import type {
 	ResolvedPlugin,
 	ResolvedPluginHooks,
@@ -45,6 +45,7 @@ type AnyHookEntry =
 			dependencies?: string[];
 			errorPolicy?: "continue" | "abort";
 			exclusive?: boolean;
+			observe?: boolean;
 	  };
 
 /**
@@ -71,14 +72,24 @@ function isHookConfig(entry: AnyHookEntry): entry is Exclude<AnyHookEntry, AnyHo
  * so the handler is compatible as-is — we just normalise the
  * surrounding config (priority, timeout, etc.) to its defaults.
  */
-function resolveSandboxedHook(entry: AnyHookEntry, pluginId: string): ResolvedHook<AnyHookHandler> {
+function resolveSandboxedHook(
+	entry: AnyHookEntry,
+	pluginId: string,
+	hookName: string,
+): ResolvedHook<AnyHookHandler> {
 	if (isHookConfig(entry)) {
+		if (entry.observe && !OBSERVABLE_HOOKS.has(hookName)) {
+			throw new Error(
+				`Invalid "observe" in ${hookName} hook config for plugin "${pluginId}". Only content:beforeSave supports observe.`,
+			);
+		}
 		return {
 			priority: entry.priority ?? DEFAULT_PRIORITY,
 			timeout: entry.timeout ?? DEFAULT_TIMEOUT,
 			dependencies: entry.dependencies ?? [],
 			errorPolicy: entry.errorPolicy ?? DEFAULT_ERROR_POLICY,
 			exclusive: entry.exclusive ?? false,
+			observe: entry.observe ?? false,
 			handler: entry.handler,
 			pluginId,
 		};
@@ -91,6 +102,7 @@ function resolveSandboxedHook(entry: AnyHookEntry, pluginId: string): ResolvedHo
 		dependencies: [],
 		errorPolicy: DEFAULT_ERROR_POLICY,
 		exclusive: false,
+		observe: false,
 		handler: entry,
 		pluginId,
 	};
@@ -184,7 +196,11 @@ export function adaptSandboxEntry(
 			// We store it as the generic type and let HookPipeline's typed dispatch
 			// methods handle the type narrowing at call time.
 			// eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- bridging untyped map to typed interface
-			(resolvedHooks as Record<string, unknown>)[hookName] = resolveSandboxedHook(entry, pluginId);
+			(resolvedHooks as Record<string, unknown>)[hookName] = resolveSandboxedHook(
+				entry,
+				pluginId,
+				hookName,
+			);
 		}
 	}
 

--- a/packages/core/src/plugins/adapt-sandbox-entry.ts
+++ b/packages/core/src/plugins/adapt-sandbox-entry.ts
@@ -78,9 +78,19 @@ function resolveSandboxedHook(
 	hookName: string,
 ): ResolvedHook<AnyHookHandler> {
 	if (isHookConfig(entry)) {
+		if (entry.observe !== undefined && typeof entry.observe !== "boolean") {
+			throw new Error(
+				`Invalid "observe" value in hook config for plugin "${pluginId}". Must be boolean.`,
+			);
+		}
 		if (entry.observe && !OBSERVABLE_HOOKS.has(hookName)) {
 			throw new Error(
 				`Invalid "observe" in ${hookName} hook config for plugin "${pluginId}". Only content:beforeSave supports observe.`,
+			);
+		}
+		if (entry.observe && entry.exclusive) {
+			throw new Error(
+				`Invalid hook config for plugin "${pluginId}": "observe" cannot be combined with "exclusive".`,
 			);
 		}
 		return {

--- a/packages/core/src/plugins/define-plugin.ts
+++ b/packages/core/src/plugins/define-plugin.ts
@@ -276,6 +276,11 @@ function resolveHook<THandler>(
 				`Invalid "observe" in ${name} hook config for plugin "${pluginId}". Only content:beforeSave supports observe.`,
 			);
 		}
+		if (hook.observe && hook.exclusive) {
+			throw new Error(
+				`Invalid hook config for plugin "${pluginId}": "observe" cannot be combined with "exclusive".`,
+			);
+		}
 		return {
 			priority: hook.priority ?? 100,
 			timeout: hook.timeout ?? 5000,

--- a/packages/core/src/plugins/define-plugin.ts
+++ b/packages/core/src/plugins/define-plugin.ts
@@ -10,7 +10,7 @@
  * authoring shape.
  */
 
-import { normalizeCapabilities } from "./types.js";
+import { normalizeCapabilities, OBSERVABLE_HOOKS } from "./types.js";
 import type {
 	PluginDefinition,
 	ResolvedPlugin,
@@ -235,7 +235,7 @@ function resolveHooks(hooks: PluginHooks, pluginId: string): ResolvedPluginHooks
 	for (const key of Object.keys(hooks) as Array<keyof PluginHooks>) {
 		const hook = hooks[key];
 		if (hook) {
-			(resolved as Record<string, unknown>)[key] = resolveHook(hook, pluginId);
+			(resolved as Record<string, unknown>)[key] = resolveHook(hook, pluginId, key);
 		}
 	}
 
@@ -257,6 +257,7 @@ function isHookConfig<THandler>(
 function resolveHook<THandler>(
 	hook: HookConfig<THandler> | THandler,
 	pluginId: string,
+	name: keyof PluginHooks,
 ): ResolvedHook<THandler> {
 	// If it's a config object with handler property
 	if (isHookConfig(hook)) {
@@ -265,12 +266,23 @@ function resolveHook<THandler>(
 				`Invalid "exclusive" value in hook config for plugin "${pluginId}". Must be boolean.`,
 			);
 		}
+		if (hook.observe !== undefined && typeof hook.observe !== "boolean") {
+			throw new Error(
+				`Invalid "observe" value in hook config for plugin "${pluginId}". Must be boolean.`,
+			);
+		}
+		if (hook.observe && !OBSERVABLE_HOOKS.has(name)) {
+			throw new Error(
+				`Invalid "observe" in ${name} hook config for plugin "${pluginId}". Only content:beforeSave supports observe.`,
+			);
+		}
 		return {
 			priority: hook.priority ?? 100,
 			timeout: hook.timeout ?? 5000,
 			dependencies: hook.dependencies ?? [],
 			errorPolicy: hook.errorPolicy ?? "abort",
 			exclusive: hook.exclusive ?? false,
+			observe: hook.observe ?? false,
 			handler: hook.handler,
 			pluginId,
 		};
@@ -283,6 +295,7 @@ function resolveHook<THandler>(
 		dependencies: [],
 		errorPolicy: "abort",
 		exclusive: false,
+		observe: false,
 		handler: hook,
 		pluginId,
 	};

--- a/packages/core/src/plugins/hooks.ts
+++ b/packages/core/src/plugins/hooks.ts
@@ -276,6 +276,8 @@ export class HookPipeline {
 		["email:afterSend", "hooks.email-events:register"],
 		["email:deliver", "hooks.email-transport:register"],
 		// Content — beforeSave can mutate content, so requires content:write.
+		// An observe-mode beforeSave (HookConfig.observe) has its return value
+		// discarded and needs only content:read — see registerPluginHook.
 		// afterSave is read-only notification, so content:read suffices.
 		["content:beforeSave", "content:write"],
 		["content:afterSave", "content:read"],
@@ -308,10 +310,17 @@ export class HookPipeline {
 		// Hooks that expose sensitive data or inject into pages require specific
 		// capabilities. Plugins without the required capability have the hook
 		// silently skipped to prevent unauthorized data access or page injection.
-		const requiredCapability = HookPipeline.HOOK_REQUIRED_CAPABILITY.get(name);
+		const requiredCapability =
+			name === "content:beforeSave" && hook.observe
+				? "content:read"
+				: HookPipeline.HOOK_REQUIRED_CAPABILITY.get(name);
 		if (requiredCapability && !plugin.capabilities.includes(requiredCapability as never)) {
+			const observeHint =
+				name === "content:beforeSave" && !hook.observe
+					? " (set observe: true on the hook to register it read-only with content:read)"
+					: "";
 			console.warn(
-				`[hooks] Plugin "${plugin.id}" declares ${name} hook without ${requiredCapability} capability — skipping`,
+				`[hooks] Plugin "${plugin.id}" declares ${name} hook without ${requiredCapability} capability — skipping${observeHint}`,
 			);
 			return;
 		}
@@ -493,6 +502,7 @@ export class HookPipeline {
 		content: Record<string, unknown>,
 		collection: string,
 		isNew: boolean,
+		id?: string,
 	): Promise<{
 		content: Record<string, unknown>;
 		results: HookResult<Record<string, unknown>>[];
@@ -504,17 +514,21 @@ export class HookPipeline {
 		for (const hook of hooks) {
 			const { handler } = hook;
 			const event: ContentHookEvent = {
-				content: currentContent,
+				// Observers get a shallow clone so in-place mutation can't leak
+				// into the saved content (mirrors the email:beforeSend clone).
+				content: hook.observe ? { ...currentContent } : currentContent,
 				collection,
 				isNew,
+				id,
 			};
 			const ctx = this.getContext(hook.pluginId);
 			const start = Date.now();
 
 			try {
 				const result = await this.executeWithTimeout(() => handler(event, ctx), hook.timeout);
-				// Handler can return modified content or void (keep current)
-				if (result !== undefined) {
+				// Handler can return modified content or void (keep current).
+				// Observe hooks are read-only — their return value is discarded.
+				if (result !== undefined && !hook.observe) {
 					currentContent = result;
 				}
 				results.push({

--- a/packages/core/src/plugins/hooks.ts
+++ b/packages/core/src/plugins/hooks.ts
@@ -514,9 +514,10 @@ export class HookPipeline {
 		for (const hook of hooks) {
 			const { handler } = hook;
 			const event: ContentHookEvent = {
-				// Observers get a shallow clone so in-place mutation can't leak
-				// into the saved content (mirrors the email:beforeSend clone).
-				content: hook.observe ? { ...currentContent } : currentContent,
+				// Observers get a deep copy so mutation of the event — including
+				// nested values like portable text blocks — can't leak into the
+				// saved content.
+				content: hook.observe ? structuredClone(currentContent) : currentContent,
 				collection,
 				isNew,
 				id,
@@ -545,7 +546,9 @@ export class HookPipeline {
 					duration: Date.now() - start,
 				});
 
-				if (hook.errorPolicy === "abort") {
+				// An observer that could abort the pipeline would be a veto, not
+				// an observer — its failures are recorded but never block the save.
+				if (hook.errorPolicy === "abort" && !hook.observe) {
 					throw error;
 				}
 			}

--- a/packages/core/src/plugins/manager.ts
+++ b/packages/core/src/plugins/manager.ts
@@ -305,12 +305,13 @@ export class PluginManager {
 		content: Record<string, unknown>,
 		collection: string,
 		isNew: boolean,
+		id?: string,
 	): Promise<{
 		content: Record<string, unknown>;
 		results: HookResult<Record<string, unknown>>[];
 	}> {
 		this.ensureInitialized();
-		return this.hookPipeline!.runContentBeforeSave(content, collection, isNew);
+		return this.hookPipeline!.runContentBeforeSave(content, collection, isNew, id);
 	}
 
 	/**

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -1175,7 +1175,7 @@ export interface ResolvedHook<THandler> {
 	/** Whether this hook is exclusive (provider pattern) */
 	exclusive: boolean;
 	/** Whether this hook is a read-only observer (see HookConfig.observe) */
-	observe: boolean;
+	observe?: boolean;
 	handler: THandler;
 	pluginId: string;
 }

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -800,9 +800,19 @@ export interface HookConfig<THandler> {
 	 * admin-selected provider. Used for email:deliver, search, image optimization, etc.
 	 */
 	exclusive?: boolean;
+	/**
+	 * Register this hook as a read-only observer: the handler's return value
+	 * is discarded, so it cannot modify the pipeline payload. Only supported
+	 * on `content:beforeSave`, where it drops the required capability from
+	 * `content:write` to `content:read`.
+	 */
+	observe?: boolean;
 	/** The hook handler */
 	handler: THandler;
 }
+
+/** Hook names that support `HookConfig.observe`. */
+export const OBSERVABLE_HOOKS: ReadonlySet<string> = new Set(["content:beforeSave"]);
 
 /**
  * Content hook event
@@ -811,6 +821,13 @@ export interface ContentHookEvent {
 	content: Record<string, unknown>;
 	collection: string;
 	isNew: boolean;
+	/**
+	 * ID of the item being saved. Set on `content:beforeSave` when updating
+	 * existing content — the update payload's `content` carries only field
+	 * data, no id. Absent when creating (the id is generated after the hook
+	 * runs). After-save handlers read `content.id` instead.
+	 */
+	id?: string;
 }
 
 /**
@@ -1157,6 +1174,8 @@ export interface ResolvedHook<THandler> {
 	errorPolicy: "continue" | "abort";
 	/** Whether this hook is exclusive (provider pattern) */
 	exclusive: boolean;
+	/** Whether this hook is a read-only observer (see HookConfig.observe) */
+	observe: boolean;
 	handler: THandler;
 	pluginId: string;
 }

--- a/packages/core/tests/unit/plugins/adapt-sandbox-entry.test.ts
+++ b/packages/core/tests/unit/plugins/adapt-sandbox-entry.test.ts
@@ -294,6 +294,42 @@ describe("adaptSandboxEntry", () => {
 			expect(() => adaptSandboxEntry(def, descriptor)).toThrow("unknown hook");
 		});
 
+		it("passes the observe flag through for content:beforeSave", () => {
+			const def: SandboxedPlugin = {
+				hooks: {
+					"content:beforeSave": { observe: true, handler: mockHandler() },
+				},
+			};
+
+			const result = adaptSandboxEntry(def, createDescriptor());
+
+			expect(result.hooks["content:beforeSave"]!.observe).toBe(true);
+		});
+
+		it("throws when observe is set on a hook other than content:beforeSave", () => {
+			const def: SandboxedPlugin = {
+				hooks: {
+					"media:beforeUpload": { observe: true, handler: mockHandler() },
+				},
+			};
+
+			expect(() => adaptSandboxEntry(def, createDescriptor())).toThrow(
+				"Only content:beforeSave supports observe",
+			);
+		});
+
+		it("throws when observe is combined with exclusive", () => {
+			const def: SandboxedPlugin = {
+				hooks: {
+					"content:beforeSave": { observe: true, exclusive: true, handler: mockHandler() },
+				},
+			};
+
+			expect(() => adaptSandboxEntry(def, createDescriptor())).toThrow(
+				'"observe" cannot be combined with "exclusive"',
+			);
+		});
+
 		it("applies default config for partial config objects", () => {
 			const handler = vi.fn();
 			const def: SandboxedPlugin = {

--- a/packages/core/tests/unit/plugins/hooks.test.ts
+++ b/packages/core/tests/unit/plugins/hooks.test.ts
@@ -53,6 +53,7 @@ function createTestHook<T>(
 		dependencies: [],
 		errorPolicy: "continue",
 		exclusive: false,
+		observe: false,
 		...overrides,
 	};
 }
@@ -617,6 +618,124 @@ describe("HookPipeline", () => {
 
 			const pipeline = new HookPipeline([plugin]);
 			expect(pipeline.hasHooks("content:afterUnschedule")).toBe(true);
+		});
+	});
+
+	describe("content:beforeSave event id", () => {
+		it("passes the item id through to the hook event", async () => {
+			const seenIds: Array<string | undefined> = [];
+			const plugin = createTestPlugin({
+				id: "test",
+				capabilities: ["content:write"],
+				hooks: {
+					"content:beforeSave": createTestHook("test", async (event: ContentHookEvent) => {
+						seenIds.push(event.id);
+					}),
+				},
+			});
+
+			const pipeline = new HookPipeline([plugin], { db });
+			await pipeline.runContentBeforeSave({ title: "x" }, "posts", false, "item-1");
+			await pipeline.runContentBeforeSave({ title: "y" }, "posts", true);
+
+			expect(seenIds).toEqual(["item-1", undefined]);
+		});
+	});
+
+	describe("observe mode — content:beforeSave", () => {
+		it("registers an observe content:beforeSave with only content:read", () => {
+			const plugin = createTestPlugin({
+				id: "observer",
+				capabilities: ["content:read"],
+				hooks: {
+					"content:beforeSave": createTestHook("observer", vi.fn(), { observe: true }),
+				},
+			});
+
+			const pipeline = new HookPipeline([plugin]);
+			expect(pipeline.hasHooks("content:beforeSave")).toBe(true);
+		});
+
+		it("skips an observe content:beforeSave without content:read", () => {
+			const plugin = createTestPlugin({
+				id: "no-cap",
+				capabilities: [],
+				hooks: {
+					"content:beforeSave": createTestHook("no-cap", vi.fn(), { observe: true }),
+				},
+			});
+
+			const pipeline = new HookPipeline([plugin]);
+			expect(pipeline.hasHooks("content:beforeSave")).toBe(false);
+		});
+
+		it("discards the return value of an observe hook", async () => {
+			const handler = vi.fn(async () => ({ title: "hijacked" }));
+			const plugin = createTestPlugin({
+				id: "observer",
+				capabilities: ["content:read"],
+				hooks: {
+					"content:beforeSave": createTestHook("observer", handler, { observe: true }),
+				},
+			});
+
+			const pipeline = new HookPipeline([plugin], { db });
+			const { content } = await pipeline.runContentBeforeSave({ title: "original" }, "posts", true);
+
+			expect(handler).toHaveBeenCalledOnce();
+			expect(content).toEqual({ title: "original" });
+		});
+
+		it("does not leak in-place event mutation from an observe hook", async () => {
+			const handler = vi.fn(async (event: ContentHookEvent) => {
+				event.content.title = "mutated";
+			});
+			const plugin = createTestPlugin({
+				id: "observer",
+				capabilities: ["content:read"],
+				hooks: {
+					"content:beforeSave": createTestHook("observer", handler, { observe: true }),
+				},
+			});
+
+			const pipeline = new HookPipeline([plugin], { db });
+			const { content } = await pipeline.runContentBeforeSave({ title: "original" }, "posts", true);
+
+			expect(content).toEqual({ title: "original" });
+		});
+
+		it("observers see the pipeline content while mutating hooks still apply", async () => {
+			const seen: Record<string, unknown>[] = [];
+			const observer = createTestPlugin({
+				id: "observer",
+				capabilities: ["content:read"],
+				hooks: {
+					"content:beforeSave": createTestHook(
+						"observer",
+						async (event: ContentHookEvent) => {
+							seen.push(event.content);
+						},
+						{ observe: true, priority: 200 },
+					),
+				},
+			});
+			const mutator = createTestPlugin({
+				id: "mutator",
+				capabilities: ["content:write"],
+				hooks: {
+					"content:beforeSave": createTestHook(
+						"mutator",
+						async (event: ContentHookEvent) => ({ ...event.content, slugged: true }),
+						{ priority: 100 },
+					),
+				},
+			});
+
+			const pipeline = new HookPipeline([observer, mutator], { db });
+			const { content } = await pipeline.runContentBeforeSave({ title: "x" }, "posts", true);
+
+			expect(content).toEqual({ title: "x", slugged: true });
+			expect(seen).toEqual([{ title: "x", slugged: true }]);
 		});
 	});
 

--- a/packages/core/tests/unit/plugins/hooks.test.ts
+++ b/packages/core/tests/unit/plugins/hooks.test.ts
@@ -686,9 +686,11 @@ describe("HookPipeline", () => {
 			expect(content).toEqual({ title: "original" });
 		});
 
-		it("does not leak in-place event mutation from an observe hook", async () => {
+		it("does not leak in-place event mutation from an observe hook, including nested values", async () => {
 			const handler = vi.fn(async (event: ContentHookEvent) => {
 				event.content.title = "mutated";
+				(event.content.body as Array<{ text: string }>)[0]!.text = "mutated";
+				(event.content.seo as Record<string, unknown>).title = "mutated";
 			});
 			const plugin = createTestPlugin({
 				id: "observer",
@@ -699,9 +701,55 @@ describe("HookPipeline", () => {
 			});
 
 			const pipeline = new HookPipeline([plugin], { db });
-			const { content } = await pipeline.runContentBeforeSave({ title: "original" }, "posts", true);
+			const original = {
+				title: "original",
+				body: [{ text: "original" }],
+				seo: { title: "original" },
+			};
+			const { content } = await pipeline.runContentBeforeSave(original, "posts", true);
 
-			expect(content).toEqual({ title: "original" });
+			expect(content).toEqual({
+				title: "original",
+				body: [{ text: "original" }],
+				seo: { title: "original" },
+			});
+		});
+
+		it("does not abort the pipeline when an observe hook throws under errorPolicy abort", async () => {
+			const observer = createTestPlugin({
+				id: "observer",
+				capabilities: ["content:read"],
+				hooks: {
+					"content:beforeSave": createTestHook(
+						"observer",
+						async () => {
+							throw new Error("observer exploded");
+						},
+						{ observe: true, errorPolicy: "abort", priority: 100 },
+					),
+				},
+			});
+			const mutator = createTestPlugin({
+				id: "mutator",
+				capabilities: ["content:write"],
+				hooks: {
+					"content:beforeSave": createTestHook(
+						"mutator",
+						async (event: ContentHookEvent) => ({ ...event.content, slugged: true }),
+						{ priority: 200 },
+					),
+				},
+			});
+
+			const pipeline = new HookPipeline([observer, mutator], { db });
+			const { content, results } = await pipeline.runContentBeforeSave(
+				{ title: "x" },
+				"posts",
+				true,
+			);
+
+			expect(content).toEqual({ title: "x", slugged: true });
+			expect(results[0]?.success).toBe(false);
 		});
 
 		it("observers see the pipeline content while mutating hooks still apply", async () => {

--- a/packages/plugin-cli/src/build/pipeline.ts
+++ b/packages/plugin-cli/src/build/pipeline.ts
@@ -328,6 +328,20 @@ export async function probeAndAssemble(ctx: ProbeAndAssembleContext): Promise<Re
 
 	if (parsed.hooks) {
 		for (const [hookName, hookEntry] of Object.entries(parsed.hooks)) {
+			// Mirrors the runtime's checks in adaptSandboxEntry so a bad
+			// `observe` fails the author's build, not the user's site boot.
+			if (hookEntry.observe && hookName !== "content:beforeSave") {
+				throw new BuildPipelineError(
+					"INVALID_PLUGIN_FORMAT",
+					`Invalid "observe" in ${hookName} hook config. Only content:beforeSave supports observe.`,
+				);
+			}
+			if (hookEntry.observe && hookEntry.exclusive) {
+				throw new BuildPipelineError(
+					"INVALID_PLUGIN_FORMAT",
+					`Invalid hook config for ${hookName}: "observe" cannot be combined with "exclusive".`,
+				);
+			}
 			resolvedPlugin.hooks[hookName] = assembleHook(hookEntry, resolvedPlugin.id);
 		}
 	}

--- a/packages/plugin-cli/src/build/pipeline.ts
+++ b/packages/plugin-cli/src/build/pipeline.ts
@@ -474,6 +474,7 @@ function assembleHook(entry: ProbedHookEntry, pluginId: string): ResolvedPlugin[
 		dependencies: entry.dependencies ?? [],
 		errorPolicy: entry.errorPolicy ?? "abort",
 		exclusive: entry.exclusive ?? false,
+		observe: entry.observe ?? false,
 		pluginId,
 	};
 }

--- a/packages/plugin-cli/src/build/probe-schema.ts
+++ b/packages/plugin-cli/src/build/probe-schema.ts
@@ -82,6 +82,7 @@ const HookEntryConfigSchema = z.looseObject({
 		})
 		.optional(),
 	exclusive: z.boolean().optional(),
+	observe: z.boolean().optional(),
 });
 
 export const HookEntrySchema = z.preprocess(normaliseEntry, HookEntryConfigSchema);

--- a/packages/plugin-cli/src/bundle/types.ts
+++ b/packages/plugin-cli/src/bundle/types.ts
@@ -68,6 +68,7 @@ export interface ResolvedPlugin {
 			dependencies?: string[];
 			errorPolicy?: string;
 			exclusive?: boolean;
+			observe?: boolean;
 			pluginId?: string;
 		}
 	>;

--- a/packages/plugins/audit-log/emdash-plugin.jsonc
+++ b/packages/plugins/audit-log/emdash-plugin.jsonc
@@ -10,9 +10,10 @@
 	"description": "Tracks content and media changes (create / update / delete) for compliance and debugging.",
 
 	// Trust contract. Reads content to capture before-state in
-	// update audit entries; declares the `entries` storage collection
-	// where audit log lives. No outbound network.
-	"capabilities": ["content:read"],
+	// update audit entries and media records to log uploads; declares
+	// the `entries` storage collection where audit log lives.
+	// No outbound network, no write access.
+	"capabilities": ["content:read", "media:read"],
 	"allowedHosts": [],
 	"storage": {
 		"entries": { "indexes": ["timestamp", "action", "resourceType", "collection"] },

--- a/packages/plugins/audit-log/package.json
+++ b/packages/plugins/audit-log/package.json
@@ -30,12 +30,15 @@
 	},
 	"devDependencies": {
 		"@emdash-cms/plugin-cli": "workspace:*",
+		"jsonc-parser": "catalog:",
 		"tsdown": "catalog:",
-		"typescript": "catalog:"
+		"typescript": "catalog:",
+		"vitest": "catalog:"
 	},
 	"scripts": {
 		"build": "node node_modules/@emdash-cms/plugin-cli/dist/index.mjs build",
 		"dev": "emdash-plugin dev",
+		"test": "vitest run",
 		"typecheck": "tsgo --noEmit"
 	},
 	"repository": {

--- a/packages/plugins/audit-log/src/plugin.ts
+++ b/packages/plugins/audit-log/src/plugin.ts
@@ -58,6 +58,19 @@ function isAuditEntry(value: unknown): value is AuditEntry {
 // Works within a single request lifecycle if the isolate persists.
 const beforeSaveCache = new Map<string, unknown>();
 
+// Entries are consumed by the matching after-hook, which never fires for
+// failed saves, so cap the cache and evict the oldest entry to keep a
+// long-lived isolate from accumulating stale state.
+const MAX_CACHED_STATES = 100;
+
+function cacheBeforeState(key: string, value: unknown): void {
+	beforeSaveCache.set(key, value);
+	if (beforeSaveCache.size > MAX_CACHED_STATES) {
+		const oldest = beforeSaveCache.keys().next().value;
+		if (oldest !== undefined) beforeSaveCache.delete(oldest);
+	}
+}
+
 // ── Plugin definition ──
 
 export default {
@@ -88,8 +101,11 @@ export default {
 					try {
 						if (ctx.content) {
 							const existing = await ctx.content.get(event.collection, contentId);
-							if (existing) {
-								beforeSaveCache.set(`${event.collection}:${contentId}`, existing);
+							// Cache the field data, not the item envelope, so the
+							// entry's `before` matches the shape of `after`
+							// (afterSave stores event.content.data).
+							if (existing && isRecord(existing.data)) {
+								cacheBeforeState(`${event.collection}:${contentId}`, existing.data);
 							}
 						}
 					} catch {
@@ -137,7 +153,7 @@ export default {
 					try {
 						const existing = await ctx.content.get(event.collection, event.id);
 						if (existing) {
-							beforeSaveCache.set(`delete:${event.collection}:${event.id}`, existing);
+							cacheBeforeState(`delete:${event.collection}:${event.id}`, existing);
 						}
 					} catch {
 						// Ignore

--- a/packages/plugins/audit-log/src/plugin.ts
+++ b/packages/plugins/audit-log/src/plugin.ts
@@ -79,8 +79,11 @@ export default {
 		},
 
 		"content:beforeSave": {
+			// Read-only observer: captures before-state with content:read,
+			// without requesting write access to drafts.
+			observe: true,
 			handler: async (event, ctx) => {
-				const contentId = stringifyId(event.content.id);
+				const contentId = stringifyId(event.id ?? event.content.id);
 				if (!event.isNew && contentId) {
 					try {
 						if (ctx.content) {
@@ -93,7 +96,6 @@ export default {
 						// Ignore -- best effort
 					}
 				}
-				return event.content;
 			},
 		},
 

--- a/packages/plugins/audit-log/tests/before-state.test.ts
+++ b/packages/plugins/audit-log/tests/before-state.test.ts
@@ -12,7 +12,20 @@ import plugin from "../src/plugin.js";
 function createCtx() {
 	return {
 		content: {
-			get: vi.fn(async () => ({ title: "old title" })),
+			// Shape matches ContentAccess.get(): the item envelope with the
+			// field data under `data`.
+			get: vi.fn(async () => ({
+				id: "post-1",
+				type: "posts",
+				slug: "audit-test",
+				status: "draft",
+				data: { title: "old title" },
+				createdAt: "2026-08-30T00:00:00.000Z",
+				updatedAt: "2026-08-30T00:00:00.000Z",
+				locale: "en",
+				publishedAt: null,
+				scheduledAt: null,
+			})),
 		},
 		storage: {
 			entries: {

--- a/packages/plugins/audit-log/tests/before-state.test.ts
+++ b/packages/plugins/audit-log/tests/before-state.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Exercises the real hook handlers with a stubbed context to verify the
+ * before/after diff flow: beforeSave observes the prior state (keyed by
+ * the event's id, since the update payload carries no id of its own) and
+ * afterSave writes it into the audit entry.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import plugin from "../src/plugin.js";
+
+function createCtx() {
+	return {
+		content: {
+			get: vi.fn(async () => ({ title: "old title" })),
+		},
+		storage: {
+			entries: {
+				put: vi.fn(async () => undefined),
+			},
+		},
+		log: {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		},
+	};
+}
+
+describe("update audit entries", () => {
+	it("records the prior state as changes.before", async () => {
+		const ctx = createCtx();
+		// eslint-disable-next-line typescript-eslint/no-explicit-any -- stub context stands in for PluginContext
+		const hooks = plugin.hooks as any;
+
+		await hooks["content:beforeSave"].handler(
+			{ content: { title: "new title" }, collection: "posts", isNew: false, id: "post-1" },
+			ctx,
+		);
+		await hooks["content:afterSave"].handler(
+			{
+				content: { id: "post-1", data: { title: "new title" } },
+				collection: "posts",
+				isNew: false,
+			},
+			ctx,
+		);
+
+		expect(ctx.content.get).toHaveBeenCalledWith("posts", "post-1");
+		const entry = ctx.storage.entries.put.mock.calls[0]?.[1] as {
+			action: string;
+			changes?: { before?: unknown; after?: unknown };
+		};
+		expect(entry.action).toBe("update");
+		expect(entry.changes?.before).toEqual({ title: "old title" });
+		expect(entry.changes?.after).toEqual({ title: "new title" });
+	});
+});

--- a/packages/plugins/audit-log/tests/hook-registration.test.ts
+++ b/packages/plugins/audit-log/tests/hook-registration.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Registers the real plugin definition with the real manifest's trust
+ * contract, the same way a scaffolded site loads it in-process. Catches
+ * the manifest and the code drifting apart: a hook declared in plugin.ts
+ * whose required capability is missing from emdash-plugin.jsonc gets
+ * silently skipped at registration with only a console warning.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { adaptSandboxEntry, HookPipeline, type PluginDescriptor } from "emdash";
+import { parse } from "jsonc-parser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import plugin from "../src/plugin.js";
+
+interface Manifest {
+	slug: string;
+	capabilities: string[];
+	allowedHosts?: string[];
+	storage?: Record<string, { indexes?: string[] }>;
+}
+
+const manifest = parse(
+	readFileSync(join(import.meta.dirname, "..", "emdash-plugin.jsonc"), "utf-8"),
+) as Manifest;
+
+const descriptor: PluginDescriptor = {
+	id: manifest.slug,
+	version: "0.0.0",
+	entrypoint: "@emdash-cms/plugin-audit-log/sandbox",
+	format: "standard",
+	capabilities: manifest.capabilities,
+	allowedHosts: manifest.allowedHosts ?? [],
+	storage: manifest.storage,
+};
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("hook registration", () => {
+	it("registers every declared hook under the manifest's capabilities", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		const resolved = adaptSandboxEntry(plugin, descriptor);
+		const pipeline = new HookPipeline([resolved]);
+
+		for (const hookName of Object.keys(plugin.hooks)) {
+			expect
+				.soft(pipeline.getHookCount(hookName as never), `${hookName} should be registered`)
+				.toBe(1);
+		}
+		expect(warn).not.toHaveBeenCalled();
+	});
+});

--- a/packages/plugins/audit-log/vitest.config.ts
+++ b/packages/plugins/audit-log/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: "node",
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1398,12 +1398,12 @@ importers:
       react:
         specifier: ^18.0.0 || ^19.0.0
         version: 19.2.4
-      react-dom:
-        specifier: ^18.0.0 || ^19.0.0
-        version: 19.2.4(react@19.2.4)
       react-day-picker:
         specifier: 'catalog:'
         version: 9.14.0(react@19.2.4)
+      react-dom:
+        specifier: ^18.0.0 || ^19.0.0
+        version: 19.2.4(react@19.2.4)
       react-hotkeys-hook:
         specifier: ^5.2.4
         version: 5.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2274,12 +2274,18 @@ importers:
       '@emdash-cms/plugin-cli':
         specifier: workspace:*
         version: link:../../plugin-cli
+      jsonc-parser:
+        specifier: 'catalog:'
+        version: 3.3.1
       tsdown:
         specifier: 'catalog:'
         version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.16.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3))(publint@0.3.17)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugins/color:
     dependencies:
@@ -5744,12 +5750,15 @@ packages:
 
   '@oslojs/asn1@1.0.0':
     resolution: {integrity: sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oslojs/binary@1.0.0':
     resolution: {integrity: sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oslojs/cbor@1.0.0':
     resolution: {integrity: sha512-AY6Lknexs7n2xp8Cgey95c+975VG7XOk4UEdRdNFxHmDDbuf47OC/LAVRsl14DeTLwo8W6xr3HLFwUFmKcndTQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oslojs/crypto@1.0.0':
     resolution: {integrity: sha512-dVz8TkkgYdr3tlwxHd7SCYGxoN7ynwHLA0nei/Aq9C+ERU0BK+U8+/3soEzBUxUNKYBf42351DyJUZ2REla50w==}
@@ -5770,6 +5779,7 @@ packages:
 
   '@oslojs/jwt@0.2.0':
     resolution: {integrity: sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oslojs/webauthn@1.0.0':
     resolution: {integrity: sha512-2ZRpbt3msNURwvjmavzq9vrNlxUnWFBGMYqbC1kO3fYBLskL7r4DiLJT1wbtLoI+hclFwjhl48YhRFBl6RWg1A==}
@@ -24715,6 +24725,35 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.9.1
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(jsdom@26.1.0)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 26.1.1
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw

--- a/skills/creating-plugins/references/hooks.md
+++ b/skills/creating-plugins/references/hooks.md
@@ -121,13 +121,13 @@ Returns: `Record<string, unknown> | void`
 
 On updates `event.id` is the item's id (`content` carries only submitted field data); on creates it is absent because the id is generated after the hook runs.
 
-Requires the `content:write` capability, because the return value replaces the saved content. A plugin that only needs to watch saves (audit logging, capturing before-state) can set `observe: true` in the hook config: the handler's return value is discarded and the hook registers with just `content:read`.
+Requires the `content:write` capability, because the return value replaces the saved content. A plugin that only needs to watch saves (audit logging, capturing before-state) can set `observe: true` in the hook config: the hook registers with just `content:read`, the handler's return value is discarded, and errors it throws never block the save.
 
 ```typescript
 "content:beforeSave": {
 	observe: true,
 	handler: async (event, ctx) => {
-		await ctx.storage.log.put(`${Date.now()}`, { saved: event.content.id });
+		await ctx.storage.log.put(`${Date.now()}`, { saved: event.id });
 	}
 }
 ```

--- a/skills/creating-plugins/references/hooks.md
+++ b/skills/creating-plugins/references/hooks.md
@@ -471,26 +471,26 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 
 ## Quick Reference
 
-| Hook                      | Trigger              | Capability Required              | Return                       |
-| ------------------------- | -------------------- | -------------------------------- | ---------------------------- |
-| `plugin:install`          | First install        | —                                | `void`                       |
-| `plugin:activate`         | Plugin enabled       | —                                | `void`                       |
-| `plugin:deactivate`       | Plugin disabled      | —                                | `void`                       |
-| `plugin:uninstall`        | Plugin removed       | —                                | `void`                       |
+| Hook                      | Trigger              | Capability Required                                   | Return                       |
+| ------------------------- | -------------------- | ----------------------------------------------------- | ---------------------------- |
+| `plugin:install`          | First install        | —                                                     | `void`                       |
+| `plugin:activate`         | Plugin enabled       | —                                                     | `void`                       |
+| `plugin:deactivate`       | Plugin disabled      | —                                                     | `void`                       |
+| `plugin:uninstall`        | Plugin removed       | —                                                     | `void`                       |
 | `content:beforeSave`      | Before save          | `content:write` (`content:read` with `observe: true`) | Modified content or `void`   |
-| `content:afterSave`       | After save           | `content:read`                   | `void`                       |
-| `content:beforeDelete`    | Before delete        | `content:read`                   | `false` to cancel            |
-| `content:afterDelete`     | After delete         | `content:read`                   | `void`                       |
-| `content:afterPublish`    | After publish        | `content:read`                   | `void`                       |
-| `content:afterUnpublish`  | After unpublish      | `content:read`                   | `void`                       |
-| `content:afterRestore`    | After restore        | `content:read`                   | `void`                       |
-| `content:afterSchedule`   | After schedule       | `content:read`                   | `void`                       |
-| `content:afterUnschedule` | After unschedule     | `content:read`                   | `void`                       |
-| `media:beforeUpload`      | Before upload        | `media:write`                    | Modified file info or `void` |
-| `media:afterUpload`       | After upload         | `media:read`                     | `void`                       |
-| `email:beforeSend`        | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |
-| `email:deliver`           | Email delivery       | `hooks.email-transport:register` | `void` (exclusive)           |
-| `email:afterSend`         | After email send     | `hooks.email-events:register`    | `void`                       |
-| `cron`                    | Scheduled task fires | —                                | `void`                       |
-| `page:metadata`           | Page render          | —                                | Metadata contributions       |
-| `page:fragments`          | Page render          | — (trusted only)                 | Fragment contributions       |
+| `content:afterSave`       | After save           | `content:read`                                        | `void`                       |
+| `content:beforeDelete`    | Before delete        | `content:read`                                        | `false` to cancel            |
+| `content:afterDelete`     | After delete         | `content:read`                                        | `void`                       |
+| `content:afterPublish`    | After publish        | `content:read`                                        | `void`                       |
+| `content:afterUnpublish`  | After unpublish      | `content:read`                                        | `void`                       |
+| `content:afterRestore`    | After restore        | `content:read`                                        | `void`                       |
+| `content:afterSchedule`   | After schedule       | `content:read`                                        | `void`                       |
+| `content:afterUnschedule` | After unschedule     | `content:read`                                        | `void`                       |
+| `media:beforeUpload`      | Before upload        | `media:write`                                         | Modified file info or `void` |
+| `media:afterUpload`       | After upload         | `media:read`                                          | `void`                       |
+| `email:beforeSend`        | Before email send    | `hooks.email-events:register`                         | Modified message or `false`  |
+| `email:deliver`           | Email delivery       | `hooks.email-transport:register`                      | `void` (exclusive)           |
+| `email:afterSend`         | After email send     | `hooks.email-events:register`                         | `void`                       |
+| `cron`                    | Scheduled task fires | —                                                     | `void`                       |
+| `page:metadata`           | Page render          | —                                                     | Metadata contributions       |
+| `page:fragments`          | Page render          | — (trusted only)                                      | Fragment contributions       |

--- a/skills/creating-plugins/references/hooks.md
+++ b/skills/creating-plugins/references/hooks.md
@@ -27,6 +27,7 @@ hooks: {
 		timeout: 5000,      // Max execution time ms (default: 5000)
 		dependencies: [],   // Plugin IDs that must run first
 		errorPolicy: "abort", // "abort" | "continue"
+		observe: false,     // content:beforeSave only: read-only observer (see below)
 		handler: async (event, ctx) => {
 			ctx.log.info("Saved");
 		}
@@ -115,8 +116,21 @@ Runs before save. Return modified content, void to keep unchanged, or throw to c
 }
 ```
 
-Event: `{ content: Record<string, unknown>, collection: string, isNew: boolean }`
+Event: `{ content: Record<string, unknown>, collection: string, isNew: boolean, id?: string }`
 Returns: `Record<string, unknown> | void`
+
+On updates `event.id` is the item's id (`content` carries only submitted field data); on creates it is absent because the id is generated after the hook runs.
+
+Requires the `content:write` capability, because the return value replaces the saved content. A plugin that only needs to watch saves (audit logging, capturing before-state) can set `observe: true` in the hook config: the handler's return value is discarded and the hook registers with just `content:read`.
+
+```typescript
+"content:beforeSave": {
+	observe: true,
+	handler: async (event, ctx) => {
+		await ctx.storage.log.put(`${Date.now()}`, { saved: event.content.id });
+	}
+}
+```
 
 ### `content:afterSave`
 
@@ -463,7 +477,7 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `plugin:activate`         | Plugin enabled       | —                                | `void`                       |
 | `plugin:deactivate`       | Plugin disabled      | —                                | `void`                       |
 | `plugin:uninstall`        | Plugin removed       | —                                | `void`                       |
-| `content:beforeSave`      | Before save          | `content:write`                  | Modified content or `void`   |
+| `content:beforeSave`      | Before save          | `content:write` (`content:read` with `observe: true`) | Modified content or `void`   |
 | `content:afterSave`       | After save           | `content:read`                   | `void`                       |
 | `content:beforeDelete`    | Before delete        | `content:read`                   | `false` to cancel            |
 | `content:afterDelete`     | After delete         | `content:read`                   | `void`                       |
@@ -472,8 +486,8 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `content:afterRestore`    | After restore        | `content:read`                   | `void`                       |
 | `content:afterSchedule`   | After schedule       | `content:read`                   | `void`                       |
 | `content:afterUnschedule` | After unschedule     | `content:read`                   | `void`                       |
-| `media:beforeUpload`      | Before upload        | —                                | Modified file info or `void` |
-| `media:afterUpload`       | After upload         | —                                | `void`                       |
+| `media:beforeUpload`      | Before upload        | `media:write`                    | Modified file info or `void` |
+| `media:afterUpload`       | After upload         | `media:read`                     | `void`                       |
 | `email:beforeSend`        | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |
 | `email:deliver`           | Email delivery       | `hooks.email-transport:register` | `void` (exclusive)           |
 | `email:afterSend`         | After email send     | `hooks.email-events:register`    | `void`                       |


### PR DESCRIPTION
## What does this PR do?

Fixes the audit-log plugin's hooks being skipped at registration on every scaffolded-site boot:

```
[hooks] Plugin "audit-log" declares content:beforeSave hook without content:write capability — skipping
[hooks] Plugin "audit-log" declares media:afterUpload hook without media:read capability — skipping
```

The manifest declared only `content:read`, but `HOOK_REQUIRED_CAPABILITY` requires `content:write` for `content:beforeSave` and `media:read` for `media:afterUpload`. Update audit entries lost their before/after diffs and media uploads were never audited.

**Resolution of the design fork** (over-grant `content:write` vs. teach core about read-only observation): the capability system's own design leans hard toward legible least-privilege (`hooks.email-events:register` exists precisely so "reads email events" is visible separately from "can send email"), and `content:write` hands a plugin the full `ctx.content` write API. Granting write access to an audit plugin whose manifest is documented as a read-only trust contract seemed wrong, so core gets the distinction:

- **`observe: true` on `content:beforeSave`** registers the hook with `content:read`. It's enforced, not honor-system: the handler gets a `structuredClone` of the content (nested mutation can't leak), its return value is discarded, and its errors are logged without aborting the pipeline — an observer cannot alter or veto a save through any path. `observe` on any other hook, or combined with `exclusive`, is rejected at `definePlugin`, `adaptSandboxEntry`, and `plugin-cli` build time.
- **`ContentHookEvent` gains an optional `id`**, set on updates. This turned out to be a second, hidden blocker: the update payload's `content` carries only field data (`id` is a reserved field slug), so the audit plugin's before-state cache could never be keyed — diffs were broken even with the hook registered. The id passed is `resolvedItem?.id`, never a raw slug.
- **audit-log** adds `media:read`, registers `beforeSave` as an observer keyed by `event.id`, caches the prior *field data* so `changes.before` matches the shape of `changes.after`, and bounds the before-state cache (the consuming after-hook never fires for failed saves).

Verified live on the blog template: no `[hooks]` warnings on boot, and an authenticated post update produces an audit entry with both `before` and `after`.

An adversarial review pass (see disclosure) ran before pushing; its three blocking findings (shallow clone was mutable through nested references, an observer could veto saves via the default `errorPolicy: "abort"`, and the before/after shapes mismatched) are fixed in the last commit, along with most minors.

**Notes / consciously not done:**

- The isolate-sandbox dispatch (`runSandboxedBeforeSave`) applies hook results without any capability gating and ignores `observe` — pre-existing for that tier, unchanged here. Worth its own issue.
- audit-log's `emdash` peer floor stays at `>=0.15.0`: on older cores the plugin degrades to exactly today's behavior (skip + warning), which seemed better than a hard install failure; the changeset spells it out.
- On revision-enabled collections `ctx.content.get` reads the published record, so `changes.before` is the last published state rather than the previous draft — existing accessor semantics, noted here for reviewers.
- The observer costs 1–2 extra reads per authenticated content update when audit-log is installed. Logged-out routes are untouched (hooks fire on writes only).

Closes # — no issue; direct maintainer instruction.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — full `emdash` suite plus new targeted tests; audit-log's new test package is wired into `test:unit`
- [x] `pnpm format` has been run (scoped to touched files to avoid unrelated repo drift)
- [x] I have added/updated tests for my changes (if applicable) — all written failing-first: observer registration/discard/clone/no-veto and event-id tests in core; a manifest↔code coupling test that loads the real audit-log plugin and manifest through `adaptSandboxEntry` + `HookPipeline` (fails with exactly the two projector warnings on the old code); a before/after diff-flow test against the real handlers
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a, no admin UI changes
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package) — `emdash` minor + `@emdash-cms/plugin-cli` patch, and `@emdash-cms/plugin-audit-log` patch
- [ ] New features link to an approved Discussion — n/a: bug fix executed on direct maintainer instruction (the `observe` option is the fix mechanism)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (implementation) with a Claude Opus adversarial-review pass before push

## Screenshots / test output

```
packages/core plugin unit tests:  31 files, 658 passed
emdash full suite:                6172 passed, 9 skipped
@emdash-cms/plugin-audit-log:     2 passed
pnpm typecheck:                   clean
pnpm lint:                        clean
docs build:                       clean
```

Live blog-template check (dev server, authenticated update via API):

```
{"action":"update","before":{"title":"Audit test post"},"afterTitle":"Audit shape check"}
```
