### PR TITLE
fix(core): pre-bundle Astro manifest in Cloudflare dev

### DIFF
--- a/.changeset/calm-workers-start.md
+++ b/.changeset/calm-workers-start.md
@@ -2,4 +2,4 @@
 "emdash": patch
 ---
 
-Fixes fresh Cloudflare projects failing to start `astro dev` with a missing file in Vite's `deps_ssr` directory after an Astro upgrade.
+Fixes fresh Cloudflare projects failing to start `astro dev` with a missing `node_modules/.vite/deps_ssr` file when Vite discovers `astro/app/manifest` after startup.

--- a/.changeset/calm-workers-start.md
+++ b/.changeset/calm-workers-start.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes fresh Cloudflare projects failing to start `astro dev` with a missing file in Vite's `deps_ssr` directory after an Astro upgrade.

--- a/e2e/fixture-cloudflare/astro.config.mjs
+++ b/e2e/fixture-cloudflare/astro.config.mjs
@@ -14,6 +14,21 @@ import emdash from "emdash/astro";
 
 const marketplaceUrl = process.env.EMDASH_MARKETPLACE_URL || undefined;
 
+// Mirrors Astro-generated virtual modules that the initial dependency scan cannot see.
+const lateManifestImport = {
+	name: "late-manifest-import",
+	resolveId(id) {
+		return id === "virtual:late-manifest" ? "\0virtual:late-manifest" : undefined;
+	},
+	load(id) {
+		if (id !== "\0virtual:late-manifest") return undefined;
+		return `
+			import * as manifest from "astro/app/manifest";
+			export const manifestExports = Object.keys(manifest).length;
+		`;
+	},
+};
+
 export default defineConfig({
 	output: "server",
 	adapter: cloudflare(),
@@ -35,6 +50,7 @@ export default defineConfig({
 	},
 	devToolbar: { enabled: false },
 	vite: {
+		plugins: [lateManifestImport],
 		server: {
 			fs: { strict: false },
 		},

--- a/e2e/fixture-cloudflare/astro.config.mjs
+++ b/e2e/fixture-cloudflare/astro.config.mjs
@@ -14,18 +14,14 @@ import emdash from "emdash/astro";
 
 const marketplaceUrl = process.env.EMDASH_MARKETPLACE_URL || undefined;
 
-// Mirrors Astro-generated virtual modules that the initial dependency scan cannot see.
+// Mirrors a server dependency introduced by Astro after the initial dependency scan.
 const lateManifestImport = {
 	name: "late-manifest-import",
-	resolveId(id) {
-		return id === "virtual:late-manifest" ? "\0virtual:late-manifest" : undefined;
-	},
-	load(id) {
-		if (id !== "\0virtual:late-manifest") return undefined;
-		return `
-			import * as manifest from "astro/app/manifest";
-			export const manifestExports = Object.keys(manifest).length;
-		`;
+	apply: "serve",
+	enforce: "post",
+	transform(code, id) {
+		if (!id.endsWith("/src/pages/index.astro")) return undefined;
+		return `import * as manifest from "astro/app/manifest";\nvoid manifest;\n${code}`;
 	},
 };
 

--- a/e2e/fixture-cloudflare/src/pages/index.astro
+++ b/e2e/fixture-cloudflare/src/pages/index.astro
@@ -1,9 +1,6 @@
 ---
 import { getEmDashCollection } from "emdash";
-// @ts-ignore - virtual module
-import { manifestExports } from "virtual:late-manifest";
 const { entries: posts } = await getEmDashCollection("posts");
-void manifestExports;
 ---
 
 <html>

--- a/e2e/fixture-cloudflare/src/pages/index.astro
+++ b/e2e/fixture-cloudflare/src/pages/index.astro
@@ -1,6 +1,9 @@
 ---
 import { getEmDashCollection } from "emdash";
+// @ts-ignore - virtual module
+import { manifestExports } from "virtual:late-manifest";
 const { entries: posts } = await getEmDashCollection("posts");
+void manifestExports;
 ---
 
 <html>

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -540,6 +540,7 @@ export function createViteConfig(
 							"emdash > zod",
 							"@emdash-cms/cloudflare > kysely-d1",
 							// Astro internal deps not covered by @astrojs/cloudflare adapter
+							"astro/app/manifest",
 							"astro/virtual-modules/middleware.js",
 							"astro/virtual-modules/live-config",
 							"astro/content/runtime",

--- a/packages/core/tests/integration/smoke/site-matrix-smoke.test.ts
+++ b/packages/core/tests/integration/smoke/site-matrix-smoke.test.ts
@@ -1,5 +1,5 @@
 import { execFile, spawn } from "node:child_process";
-import { readFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
@@ -307,12 +307,14 @@ describe.sequential("Cloudflare dependency optimizer", () => {
 
 			try {
 				const frontendRes = await fetchWithRetry(`${server.baseUrl}/`);
-				expect(frontendRes.status).toBeLessThan(500);
+				expect([200, 302, 307, 308]).toContain(frontendRes.status);
 				await frontendRes.text();
 				await new Promise((resolveSleep) => setTimeout(resolveSleep, 250));
-				expect(readFileSync(devLogPath, "utf8")).not.toMatch(
-					/dependenc(?:y|ies) optimized:.*astro\/app\/manifest/,
-				);
+				const optimizerOutput = [
+					server.output,
+					existsSync(devLogPath) ? readFileSync(devLogPath, "utf8") : "",
+				].join("\n");
+				expect(optimizerOutput).not.toMatch(/dependenc(?:y|ies) optimized:.*astro\/app\/manifest/);
 			} finally {
 				await killServer(server.process);
 				await execAsync("pnpm", ["exec", "astro", "dev", "stop"], {

--- a/packages/core/tests/integration/smoke/site-matrix-smoke.test.ts
+++ b/packages/core/tests/integration/smoke/site-matrix-smoke.test.ts
@@ -1,5 +1,5 @@
 import { execFile, spawn } from "node:child_process";
-import { rmSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
@@ -282,6 +282,45 @@ describe.sequential("Site runtime verification", () => {
 			},
 		);
 	}
+});
+
+const CLOUDFLARE_OPTIMIZER_SITE: SiteCase = {
+	name: "e2e/fixture-cloudflare",
+	dir: resolve(WORKSPACE_ROOT, "e2e/fixture-cloudflare"),
+	port: 4621,
+	startupTimeoutMs: 120_000,
+	waitPath: "/_emdash/api/setup/status",
+};
+
+describe.sequential("Cloudflare dependency optimizer", () => {
+	it(
+		"pre-bundles dependencies imported by transformed server modules",
+		{ timeout: CLOUDFLARE_OPTIMIZER_SITE.startupTimeoutMs + 120_000 },
+		async () => {
+			rmSync(join(CLOUDFLARE_OPTIMIZER_SITE.dir, "node_modules/.vite"), {
+				recursive: true,
+				force: true,
+			});
+			const devLogPath = join(CLOUDFLARE_OPTIMIZER_SITE.dir, ".astro/dev.log");
+			rmSync(devLogPath, { force: true });
+			const server = await bootSite(CLOUDFLARE_OPTIMIZER_SITE);
+
+			try {
+				const frontendRes = await fetchWithRetry(`${server.baseUrl}/`);
+				expect(frontendRes.status).toBeLessThan(500);
+				await frontendRes.text();
+				await new Promise((resolveSleep) => setTimeout(resolveSleep, 250));
+				expect(readFileSync(devLogPath, "utf8")).not.toMatch(
+					/dependenc(?:y|ies) optimized:.*astro\/app\/manifest/,
+				);
+			} finally {
+				await killServer(server.process);
+				await execAsync("pnpm", ["exec", "astro", "dev", "stop"], {
+					cwd: CLOUDFLARE_OPTIMIZER_SITE.dir,
+				});
+			}
+		},
+	);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/tests/integration/smoke/site-matrix-smoke.test.ts
+++ b/packages/core/tests/integration/smoke/site-matrix-smoke.test.ts
@@ -292,6 +292,9 @@ const CLOUDFLARE_OPTIMIZER_SITE: SiteCase = {
 	waitPath: "/_emdash/api/setup/status",
 };
 
+const LATE_MANIFEST_OPTIMIZATION =
+	/(?:new )?dependenc(?:y|ies) (?:found|optimized):.*astro\/app\/manifest/;
+
 describe.sequential("Cloudflare dependency optimizer", () => {
 	it(
 		"pre-bundles dependencies imported by transformed server modules",
@@ -309,12 +312,16 @@ describe.sequential("Cloudflare dependency optimizer", () => {
 				const frontendRes = await fetchWithRetry(`${server.baseUrl}/`);
 				expect([200, 302, 307, 308]).toContain(frontendRes.status);
 				await frontendRes.text();
-				await new Promise((resolveSleep) => setTimeout(resolveSleep, 250));
-				const optimizerOutput = [
-					server.output,
-					existsSync(devLogPath) ? readFileSync(devLogPath, "utf8") : "",
-				].join("\n");
-				expect(optimizerOutput).not.toMatch(/dependenc(?:y|ies) optimized:.*astro\/app\/manifest/);
+				const readOptimizerOutput = () =>
+					[server.output, existsSync(devLogPath) ? readFileSync(devLogPath, "utf8") : ""].join(
+						"\n",
+					);
+				const observationDeadline = Date.now() + 5_000;
+				while (Date.now() < observationDeadline) {
+					expect(readOptimizerOutput()).not.toMatch(LATE_MANIFEST_OPTIMIZATION);
+					await new Promise((resolveSleep) => setTimeout(resolveSleep, 100));
+				}
+				expect(readOptimizerOutput()).not.toMatch(LATE_MANIFEST_OPTIMIZATION);
 			} finally {
 				await killServer(server.process);
 				await execAsync("pnpm", ["exec", "astro", "dev", "stop"], {


### PR DESCRIPTION
## What does this PR do?

Pre-bundles `astro/app/manifest` before the Cloudflare development worker starts. Astro loads this entrypoint from generated virtual modules, so discovering it after startup could make Vite replace active `deps_ssr` chunks and crash fresh projects with a missing-file error.

Adds a workerd smoke test that imports the manifest through a virtual module, starts with an empty Vite cache, and verifies the request completes without late manifest optimization.

Closes #2806

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable: no admin UI changes)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: not applicable; this is a bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex (GPT-5)

## Screenshots / test output

Not visual.

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm --filter emdash exec vitest run tests/unit/astro/vite-config.test.ts`
- `pnpm --filter emdash exec vitest run --config vitest.smoke.config.ts -t 'pre-bundles dependencies imported by transformed server modules'`
- `pnpm --dir e2e/fixture-cloudflare exec astro check`
- `pnpm --filter emdash build`
- Packed the fixed local `emdash` package into a fresh Astro 7.2.9 / `@astrojs/cloudflare` 14.2.5 project and verified three cold starts plus frontend, dev-bypass, and admin requests.
