### PR TITLE
feat(forms): secure private attachments

### DIFF
--- a/.changeset/private-form-attachments.md
+++ b/.changeset/private-form-attachments.md
@@ -1,0 +1,8 @@
+---
+"emdash": minor
+"@emdash-cms/plugin-forms": minor
+"@emdash-cms/cloudflare": patch
+"@emdash-cms/sandbox-workerd": patch
+---
+
+Add private plugin media uploads and authenticated form attachments. Private objects use a separate editor-only, non-cacheable download route, stay out of general media lists, and remain retryable when storage cleanup fails. Native forms now parse multipart submissions, validate PDF, JPEG, PNG, and MP4 signatures, enforce five-file and size limits, retain authenticated download links, and delete attachment objects with manual or scheduled submission cleanup.

--- a/docs/src/content/docs/deployment/storage.mdx
+++ b/docs/src/content/docs/deployment/storage.mdx
@@ -89,6 +89,13 @@ storage: r2({
 	adapter with R2 credentials instead.
 </Aside>
 
+<Aside type="caution" title="Private plugin media">
+	A bucket that stores private plugin uploads must not have public access or a configured
+	`publicUrl`. Private downloads are authorized through EmDash; a public R2 or CDN URL would
+	bypass that check. Use a separate private bucket when the same deployment also requires
+	direct public bucket URLs.
+</Aside>
+
 ## S3-Compatible Storage
 
 The S3 adapter works with Cloudflare R2 (via S3 API), MinIO, and other S3-compatible services.
@@ -209,6 +216,10 @@ storage: s3({
 ```
 
 Generate R2 API credentials in the Cloudflare dashboard under R2 > Manage R2 API Tokens.
+
+For private plugin media, omit `publicUrl` and leave `S3_PUBLIC_URL` unset. EmDash will serve
+public objects through its public media route and private objects through the authenticated
+private-media route.
 
 ### MinIO
 

--- a/docs/src/content/docs/plugins/creating-plugins/capabilities.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/capabilities.mdx
@@ -49,6 +49,20 @@ A few things worth knowing:
 - **`network:request:unrestricted` exists for user-configured URLs.** A webhook plugin where the operator types in the destination URL needs to reach hosts that aren't in the manifest. Plugins that always call known APIs should use `network:request` + `allowedHosts`.
 - **`email:send` is gated by configuration, not just the capability.** A plugin can declare `email:send`, but `ctx.email` will only be populated if some other plugin has registered an `email:deliver` transport.
 
+### Private media uploads
+
+Pass `visibility: "private"` when a plugin stores a file that must not use the public media route:
+
+```ts
+const attachment = await ctx.media.upload(filename, contentType, bytes, {
+	visibility: "private",
+});
+```
+
+The returned `attachment.url` uses the authenticated private-media route. Only editors and administrators can download it, responses use `Cache-Control: private, no-store`, and the object does not appear in general media lists. Call `ctx.media.delete(attachment.mediaId)` when the owning record is removed. A storage failure rejects the deletion and leaves the media row available for a later retry.
+
+Private media also requires private storage. Do not configure a bucket public URL or CDN that can serve the object key directly; application authorization cannot protect a second public path to the same object.
+
 ### Creating content in a locale
 
 `ctx.content.create()` accepts an optional third argument for the new entry's locale:

--- a/packages/cloudflare/src/sandbox/bridge.ts
+++ b/packages/cloudflare/src/sandbox/bridge.ts
@@ -824,6 +824,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 		size: number | null;
 		url: string;
 		createdAt: string;
+		visibility?: "public" | "private";
 	} | null> {
 		const { capabilities } = this.ctx.props;
 		if (!capabilities.includes("media:read")) {
@@ -836,6 +837,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 			size: number | null;
 			storage_key: string;
 			created_at: string;
+			visibility: "public" | "private";
 		}>();
 		if (!result) return null;
 		return {
@@ -843,8 +845,12 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 			filename: result.filename,
 			mimeType: result.mime_type,
 			size: result.size,
-			url: `/_emdash/api/media/file/${result.storage_key}`,
+			url:
+				result.visibility === "private"
+					? `/_emdash/api/media/private/${result.storage_key.slice("private/".length)}`
+					: `/_emdash/api/media/file/${result.storage_key}`,
 			createdAt: result.created_at,
+			visibility: result.visibility,
 		};
 	}
 
@@ -866,7 +872,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 		}
 		const limit = Math.min(opts.limit ?? 50, 100);
 		// Only return ready items (matching core's MediaRepository.findMany default)
-		let sql = "SELECT * FROM media WHERE status = 'ready'";
+		let sql = "SELECT * FROM media WHERE status = 'ready' AND visibility = 'public'";
 		const params: unknown[] = [];
 
 		if (opts.mimeType) {
@@ -926,6 +932,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 		filename: string,
 		contentType: string,
 		bytes: ArrayBuffer,
+		options?: { visibility?: "public" | "private" },
 	): Promise<{ mediaId: string; storageKey: string; url: string }> {
 		const { capabilities } = this.ctx.props;
 		if (!capabilities.includes("media:write")) {
@@ -945,6 +952,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 		}
 
 		const mediaId = ulid();
+		const visibility = options?.visibility ?? "public";
 		// Derive extension from basename only, validate it's a simple extension
 		const basename = filename.includes("/")
 			? filename.slice(filename.lastIndexOf("/") + 1)
@@ -952,7 +960,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 		const rawExt = basename.includes(".") ? basename.slice(basename.lastIndexOf(".")) : "";
 		const ext = FILE_EXT_REGEX.test(rawExt) ? rawExt : "";
 		// Flat storage key matching core convention: ${ulid}${ext}
-		const storageKey = `${mediaId}${ext}`;
+		const storageKey = `${visibility === "private" ? "private/" : ""}${mediaId}${ext}`;
 		const now = new Date().toISOString();
 
 		// Write bytes to R2 first, then create DB record.
@@ -964,9 +972,9 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 		try {
 			// Create confirmed media record with ISO timestamp (matching core)
 			await this.env.DB.prepare(
-				"INSERT INTO media (id, filename, mime_type, size, storage_key, status, created_at) VALUES (?, ?, ?, ?, ?, 'ready', ?)",
+				"INSERT INTO media (id, filename, mime_type, size, storage_key, status, created_at, visibility) VALUES (?, ?, ?, ?, ?, 'ready', ?, ?)",
 			)
-				.bind(mediaId, filename, contentType, bytes.byteLength, storageKey, now)
+				.bind(mediaId, filename, contentType, bytes.byteLength, storageKey, now, visibility)
 				.run();
 		} catch (error) {
 			// Clean up R2 object on DB failure to prevent orphans
@@ -982,7 +990,10 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 		return {
 			mediaId,
 			storageKey,
-			url: `/_emdash/api/media/file/${storageKey}`,
+			url:
+				visibility === "private"
+					? `/_emdash/api/media/private/${storageKey.slice("private/".length)}`
+					: `/_emdash/api/media/file/${storageKey}`,
 		};
 	}
 
@@ -999,18 +1010,10 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 
 		if (!media) return false;
 
-		// Delete the DB row
+		// Keep the row retryable until object cleanup succeeds.
+		if (!this.env.MEDIA) throw new Error("Media storage (R2) is not configured");
+		await this.env.MEDIA.delete(media.storage_key);
 		const result = await this.env.DB.prepare("DELETE FROM media WHERE id = ?").bind(id).run();
-
-		// Delete from R2 if the binding is available
-		if (this.env.MEDIA && media.storage_key) {
-			try {
-				await this.env.MEDIA.delete(media.storage_key);
-			} catch {
-				// Log but don't fail - the DB row is already deleted
-				console.warn(`[plugin-bridge] Failed to delete R2 object: ${media.storage_key}`);
-			}
-		}
 
 		return (result.meta?.changes ?? 0) > 0;
 	}

--- a/packages/cloudflare/src/sandbox/types.ts
+++ b/packages/cloudflare/src/sandbox/types.ts
@@ -149,6 +149,7 @@ interface BridgeMediaItem {
 	size: number | null;
 	url: string;
 	createdAt: string;
+	visibility?: "public" | "private";
 }
 
 /**
@@ -209,6 +210,7 @@ export interface PluginBridgeBinding {
 		filename: string,
 		contentType: string,
 		bytes: ArrayBuffer,
+		options?: { visibility?: "public" | "private" },
 	): Promise<{ mediaId: string; storageKey: string; url: string }>;
 	mediaDelete(id: string): Promise<boolean>;
 	// Network

--- a/packages/cloudflare/src/sandbox/wrapper.ts
+++ b/packages/cloudflare/src/sandbox/wrapper.ts
@@ -140,7 +140,8 @@ function createContext(env) {
 	const media = {
 		get: (id) => bridge.mediaGet(id),
 		list: (opts) => bridge.mediaList(opts),
-		upload: (filename, contentType, bytes) => bridge.mediaUpload(filename, contentType, bytes),
+		upload: (filename, contentType, bytes, options) =>
+			bridge.mediaUpload(filename, contentType, bytes, options),
 		getUploadUrl: () => { throw new Error("getUploadUrl is not available in sandbox mode. Use media.upload(filename, contentType, bytes) instead."); },
 		delete: (id) => bridge.mediaDelete(id)
 	};

--- a/packages/core/src/astro/integration/routes.ts
+++ b/packages/core/src/astro/integration/routes.ts
@@ -219,6 +219,11 @@ export function injectCoreRoutes(
 	});
 
 	injectRoute({
+		pattern: "/_emdash/api/media/private/[...key]",
+		entrypoint: resolveRoute("api/media/private/[...key].ts"),
+	});
+
+	injectRoute({
 		pattern: "/_emdash/api/media/[id]",
 		entrypoint: resolveRoute("api/media/[id].ts"),
 	});

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -99,6 +99,7 @@ const PUBLIC_API_PREFIXES = [
 	"/_emdash/api/oauth/register",
 	"/_emdash/api/comments/",
 	"/_emdash/api/media/file/",
+	"/_emdash/api/media/private/",
 	"/_emdash/.well-known/",
 ];
 
@@ -178,6 +179,13 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	const isPublicApiRoute = isPublicEmDashRoute(url.pathname);
 
 	const isPublicRoute = !isAdminRoute && !isApiRoute;
+	const isPrivateMediaRoute = url.pathname.startsWith("/_emdash/api/media/private/");
+
+	// Private downloads deliberately return a non-disclosing 404 from the route
+	// when credentials are absent or insufficient, so auth here is soft.
+	if (isPrivateMediaRoute) {
+		return handlePrivateMediaRouteAuth(context, next);
+	}
 
 	// Public API routes skip auth but still need CSRF protection on state-changing methods.
 	// We check Origin header against the request host (same approach as Astro's checkOrigin).
@@ -472,6 +480,19 @@ async function handlePublicRouteAuth(
 	}
 
 	return next();
+}
+
+async function handlePrivateMediaRouteAuth(
+	context: Parameters<Parameters<typeof defineMiddleware>[0]>[0],
+	next: Parameters<Parameters<typeof defineMiddleware>[0]>[1],
+): Promise<Response> {
+	try {
+		if ((await handleBearerAuth(context)) === "authenticated") return next();
+	} catch {
+		// The route returns the same 404 as every other unauthorized request.
+	}
+
+	return handlePublicRouteAuth(context, next);
 }
 
 /**

--- a/packages/core/src/astro/routes/api/media/[id].ts
+++ b/packages/core/src/astro/routes/api/media/[id].ts
@@ -6,6 +6,7 @@
  * DELETE /_emdash/api/media/:id - Delete media item
  */
 
+import { hasPermission } from "@emdash-cms/auth";
 import type { APIRoute } from "astro";
 
 import { canReadMediaUsageCount, requireOwnerPerm, requirePerm } from "#api/authorize.js";
@@ -39,6 +40,13 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
 	if (isParseError(query)) return query;
 
 	const result = await emdash.handleMediaGet(id);
+	if (
+		result.success &&
+		result.data.item.visibility === "private" &&
+		!hasPermission(user, "plugins:read")
+	) {
+		return apiError("NOT_FOUND", "Media item not found", 404);
+	}
 	if (!result.success || query.includeUsage !== "1") return unwrapResult(result);
 
 	const includeCount = canReadMediaUsageCount(user, locals.tokenScopes);

--- a/packages/core/src/astro/routes/api/media/file/[...key].ts
+++ b/packages/core/src/astro/routes/api/media/file/[...key].ts
@@ -6,27 +6,10 @@
 
 import type { APIRoute } from "astro";
 
-import { apiError, handleError } from "#api/error.js";
+import { apiError } from "#api/error.js";
+import { serveStoredMedia } from "#media/serve-file.js";
 
 export const prerender = false;
-
-/**
- * Content types that are safe to display inline (simple raster/vector images, video, audio).
- * Everything else gets Content-Disposition: attachment to prevent script execution.
- */
-const SAFE_INLINE_TYPES = new Set([
-	"image/jpeg",
-	"image/png",
-	"image/gif",
-	"image/webp",
-	"image/avif",
-	"image/x-icon",
-	"video/mp4",
-	"video/webm",
-	"audio/mpeg",
-	"audio/wav",
-	"audio/ogg",
-]);
 
 export const GET: APIRoute = async ({ params, locals }) => {
 	const { key } = params;
@@ -40,7 +23,7 @@ export const GET: APIRoute = async ({ params, locals }) => {
 	// content export — they must never be reachable through the public,
 	// unauthenticated media route. Admins download them via the
 	// authenticated backups API.
-	if (key.startsWith("backups/")) {
+	if (key.startsWith("backups/") || key.startsWith("private/")) {
 		return apiError("NOT_FOUND", "File not found", 404);
 	}
 
@@ -48,40 +31,5 @@ export const GET: APIRoute = async ({ params, locals }) => {
 		return apiError("NOT_CONFIGURED", "Storage not configured", 500);
 	}
 
-	try {
-		const result = await emdash.storage.download(key);
-
-		const headers: Record<string, string> = {
-			"Content-Type": result.contentType,
-			"Cache-Control": "public, max-age=31536000, immutable",
-			"X-Content-Type-Options": "nosniff",
-			// Sandbox CSP on all user-uploaded content — prevents script execution
-			// even for SVGs navigated to directly or content types that support scripting.
-			"Content-Security-Policy":
-				"sandbox; default-src 'none'; img-src 'self'; style-src 'unsafe-inline'",
-		};
-
-		if (result.size) {
-			headers["Content-Length"] = String(result.size);
-		}
-
-		// Safe image/media types can render inline; everything else (SVG, PDF,
-		// HTML, JS, etc.) must be downloaded to prevent stored XSS.
-		if (SAFE_INLINE_TYPES.has(result.contentType)) {
-			headers["Content-Disposition"] = "inline";
-		} else {
-			headers["Content-Disposition"] = "attachment";
-		}
-
-		return new Response(result.body, { status: 200, headers });
-	} catch (error) {
-		// Check if it's a "not found" error
-		if (
-			error instanceof Error &&
-			(error.message.includes("not found") || error.message.includes("NOT_FOUND"))
-		) {
-			return apiError("NOT_FOUND", "File not found", 404);
-		}
-		return handleError(error, "Failed to serve file", "FILE_SERVE_ERROR");
-	}
+	return serveStoredMedia(emdash.storage, key, "public, max-age=31536000, immutable");
 };

--- a/packages/core/src/astro/routes/api/media/private/[...key].ts
+++ b/packages/core/src/astro/routes/api/media/private/[...key].ts
@@ -1,0 +1,27 @@
+import { hasPermission, hasScope } from "@emdash-cms/auth";
+import type { APIRoute } from "astro";
+
+import { apiError } from "#api/error.js";
+import { serveStoredMedia } from "#media/serve-file.js";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ params, locals }) => {
+	const key = params.key;
+	const { emdash, user, tokenScopes } = locals;
+
+	if (
+		!key ||
+		key.includes("\\") ||
+		key.split("/").some((segment) => !segment || segment === "." || segment === "..") ||
+		!hasPermission(user, "plugins:read") ||
+		(tokenScopes !== undefined && !hasScope(tokenScopes, "media:read"))
+	) {
+		return apiError("NOT_FOUND", "File not found", 404);
+	}
+	if (!emdash?.storage) {
+		return apiError("NOT_CONFIGURED", "Storage not configured", 500);
+	}
+
+	return serveStoredMedia(emdash.storage, `private/${key}`, "private, no-store");
+};

--- a/packages/core/src/database/migrations/074_media_visibility.ts
+++ b/packages/core/src/database/migrations/074_media_visibility.ts
@@ -1,0 +1,18 @@
+import type { Kysely } from "kysely";
+
+import { columnExists } from "../dialect-helpers.js";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+	if (!(await columnExists(db, "media", "visibility"))) {
+		await db.schema
+			.alterTable("media")
+			.addColumn("visibility", "text", (col) => col.notNull().defaultTo("public"))
+			.execute();
+	}
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	if (await columnExists(db, "media", "visibility")) {
+		await db.schema.alterTable("media").dropColumn("visibility").execute();
+	}
+}

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -76,6 +76,7 @@ import * as m070 from "./070_collection_routable.js";
 import * as m071 from "./071_restore_content_bylines_table.js";
 import * as m072 from "./072_media_folders.js";
 import * as m073 from "./073_media_focal_point.js";
+import * as m074 from "./074_media_visibility.js";
 
 const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"001_initial": m001,
@@ -150,6 +151,7 @@ const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"071_restore_content_bylines_table": m071,
 	"072_media_folders": m072,
 	"073_media_focal_point": m073,
+	"074_media_visibility": m074,
 });
 
 /** Ordered names from the statically registered migration set. */

--- a/packages/core/src/database/repositories/media.ts
+++ b/packages/core/src/database/repositories/media.ts
@@ -47,6 +47,7 @@ function mimeMatchExpr(eb: ExpressionBuilder<Database, "media">, filters: string
 }
 
 export type MediaStatus = "pending" | "ready" | "failed";
+export type MediaVisibility = "public" | "private";
 
 export interface MediaItem {
 	id: string;
@@ -66,7 +67,8 @@ export interface MediaItem {
 	dominantColor: string | null;
 	createdAt: string;
 	authorId: string | null;
-	folderId?: string | null;
+	folderId: string | null;
+	visibility: MediaVisibility;
 }
 
 export interface CreateMediaInput {
@@ -83,6 +85,7 @@ export interface CreateMediaInput {
 	dominantColor?: string;
 	status?: MediaStatus;
 	authorId?: string;
+	visibility?: MediaVisibility;
 }
 
 export interface FindManyMediaOptions {
@@ -95,6 +98,7 @@ export interface FindManyMediaOptions {
 	q?: string;
 	/** Omit for all media, pass null for the Main library, or pass a folder ID. */
 	folderId?: string | null;
+	visibility?: MediaVisibility | "all";
 }
 
 export interface UpdateMediaInput extends FocalPointUpdate {
@@ -149,6 +153,7 @@ export class MediaRepository {
 			created_at: now,
 			author_id: input.authorId ?? null,
 			folder_id: null,
+			visibility: input.visibility ?? "public",
 		};
 
 		await this.db.insertInto("media").values(row).execute();
@@ -385,6 +390,7 @@ export class MediaRepository {
 			.selectAll()
 			.where("content_hash", "=", contentHash)
 			.where("status", "=", "ready")
+			.where("visibility", "=", "public")
 			.executeTakeFirst();
 
 		return row ? this.rowToItem(row) : null;
@@ -541,6 +547,10 @@ export class MediaRepository {
 			query = query.where("folder_id", "=", options.folderId);
 		}
 
+		if (options.visibility !== "all") {
+			query = query.where("visibility", "=", options.visibility ?? "public");
+		}
+
 		return query;
 	}
 
@@ -589,6 +599,8 @@ export class MediaRepository {
 			createdAt: row.created_at,
 			authorId: row.author_id,
 			folderId: row.folder_id,
+			// eslint-disable-next-line typescript/no-unsafe-type-assertion -- migration constrains stored values
+			visibility: row.visibility as MediaVisibility,
 		};
 	}
 }

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -79,6 +79,7 @@ export interface MediaTable {
 	created_at: Generated<string>;
 	author_id: string | null;
 	folder_id: Generated<string | null>;
+	visibility: Generated<string>; // 'public' | 'private'
 }
 
 export interface MediaFolderTable {
@@ -707,6 +708,7 @@ export type MediaRow = {
 	created_at: string;
 	author_id: string | null;
 	folder_id: string | null;
+	visibility: string; // 'public' | 'private'
 };
 
 export interface RedirectTable {

--- a/packages/core/src/media/serve-file.ts
+++ b/packages/core/src/media/serve-file.ts
@@ -1,0 +1,45 @@
+import { apiError, handleError } from "../api/error.js";
+import type { Storage } from "../storage/types.js";
+
+const SAFE_INLINE_TYPES = new Set([
+	"image/jpeg",
+	"image/png",
+	"image/gif",
+	"image/webp",
+	"image/avif",
+	"image/x-icon",
+	"video/mp4",
+	"video/webm",
+	"audio/mpeg",
+	"audio/wav",
+	"audio/ogg",
+]);
+
+export async function serveStoredMedia(
+	storage: Storage,
+	key: string,
+	cacheControl: string,
+): Promise<Response> {
+	try {
+		const result = await storage.download(key);
+		const headers: Record<string, string> = {
+			"Content-Type": result.contentType,
+			"Cache-Control": cacheControl,
+			"X-Content-Type-Options": "nosniff",
+			"Content-Security-Policy":
+				"sandbox; default-src 'none'; img-src 'self'; style-src 'unsafe-inline'",
+			"Content-Disposition": SAFE_INLINE_TYPES.has(result.contentType) ? "inline" : "attachment",
+		};
+
+		if (result.size) headers["Content-Length"] = String(result.size);
+		return new Response(result.body, { status: 200, headers });
+	} catch (error) {
+		if (
+			error instanceof Error &&
+			(error.message.includes("not found") || error.message.includes("NOT_FOUND"))
+		) {
+			return apiError("NOT_FOUND", "File not found", 404);
+		}
+		return handleError(error, "Failed to serve file", "FILE_SERVE_ERROR");
+	}
+}

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -528,8 +528,12 @@ export function createMediaAccess(db: Kysely<Database>): MediaAccess {
 				mimeType: item.mimeType,
 				size: item.size,
 				// Construct URL from storage key (or use a sensible default path)
-				url: `/media/${item.id}/${item.filename}`,
+				url:
+					item.visibility === "private"
+						? `/_emdash/api/media/private/${item.storageKey.slice("private/".length)}`
+						: `/_emdash/api/media/file/${item.storageKey}`,
 				createdAt: item.createdAt,
+				visibility: item.visibility,
 			};
 		},
 
@@ -546,8 +550,9 @@ export function createMediaAccess(db: Kysely<Database>): MediaAccess {
 					filename: item.filename,
 					mimeType: item.mimeType,
 					size: item.size,
-					url: `/media/${item.id}/${item.filename}`,
+					url: `/_emdash/api/media/file/${item.storageKey}`,
 					createdAt: item.createdAt,
+					visibility: item.visibility,
 				})),
 				cursor: result.nextCursor,
 				hasMore: !!result.nextCursor,
@@ -612,6 +617,7 @@ export function createMediaAccessWithWrite(
 			filename: string,
 			contentType: string,
 			bytes: ArrayBuffer,
+			options,
 		): Promise<{ mediaId: string; storageKey: string; url: string }> {
 			if (!storage) {
 				throw new Error(
@@ -625,7 +631,8 @@ export function createMediaAccessWithWrite(
 			const basename = filename.split("/").pop() ?? filename;
 			const dotIdx = basename.lastIndexOf(".");
 			const ext = dotIdx > 0 ? basename.slice(dotIdx).toLowerCase() : "";
-			const storageKey = `${keyPrefix}${ext}`;
+			const visibility = options?.visibility ?? "public";
+			const storageKey = `${visibility === "private" ? "private/" : ""}${keyPrefix}${ext}`;
 
 			// Upload to storage first
 			await storage.upload({
@@ -646,6 +653,7 @@ export function createMediaAccessWithWrite(
 					size: bytes.byteLength,
 					storageKey,
 					status: "ready",
+					visibility,
 					width: enriched.width,
 					height: enriched.height,
 					blurhash: enriched.blurhash,
@@ -663,11 +671,22 @@ export function createMediaAccessWithWrite(
 			return {
 				mediaId: media.id,
 				storageKey,
-				url: `/_emdash/api/media/file/${storageKey}`,
+				url:
+					visibility === "private"
+						? `/_emdash/api/media/private/${storageKey.slice("private/".length)}`
+						: `/_emdash/api/media/file/${storageKey}`,
 			};
 		},
 
 		async delete(id: string): Promise<boolean> {
+			if (!storage) {
+				throw new Error(
+					"Media delete() requires a storage backend. Configure storage in PluginContextFactoryOptions.",
+				);
+			}
+			const item = await mediaRepo.findById(id);
+			if (!item) return false;
+			await storage.delete(item.storageKey);
 			const deleted = await mediaRepo.delete(id);
 			// Plugins can delete media that's referenced by site settings
 			// (`logo`, `favicon`, `seo.defaultOgImage`); the worker-scoped

--- a/packages/core/src/plugins/routes.ts
+++ b/packages/core/src/plugins/routes.ts
@@ -100,6 +100,32 @@ const BODY_METHODS = new Set(["POST", "PUT", "PATCH"]);
  */
 export async function parseRouteInput(request: Request): Promise<unknown> {
 	if (BODY_METHODS.has(request.method.toUpperCase())) {
+		if (request.headers.get("content-type")?.startsWith("multipart/form-data")) {
+			const formData = await request.formData();
+			const input: Record<string, unknown> = {};
+			const files: Record<string, { filename: string; contentType: string; bytes: ArrayBuffer }> =
+				{};
+
+			for (const [key, value] of formData) {
+				if (value instanceof File) {
+					if (value.size > 0) {
+						files[key] = {
+							filename: value.name,
+							contentType: value.type,
+							bytes: await value.arrayBuffer(),
+						};
+					}
+				} else if (input[key] === undefined) {
+					input[key] = value;
+				} else {
+					input[key] = Array.isArray(input[key]) ? [...input[key], value] : [input[key], value];
+				}
+			}
+
+			if (Object.keys(files).length > 0) input.files = files;
+			return input;
+		}
+
 		try {
 			return await request.json();
 		} catch {

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -365,6 +365,13 @@ export interface MediaItem {
 	size: number | null;
 	url: string;
 	createdAt: string;
+	visibility?: MediaVisibility;
+}
+
+export type MediaVisibility = "public" | "private";
+
+export interface MediaUploadOptions {
+	visibility?: MediaVisibility;
 }
 
 /**
@@ -398,6 +405,7 @@ export interface MediaAccess {
 		filename: string,
 		contentType: string,
 		bytes: ArrayBuffer,
+		options?: MediaUploadOptions,
 	): Promise<{ mediaId: string; storageKey: string; url: string }>;
 	delete?(id: string): Promise<boolean>;
 }
@@ -414,6 +422,7 @@ export interface MediaAccessWithWrite extends MediaAccess {
 		filename: string,
 		contentType: string,
 		bytes: ArrayBuffer,
+		options?: MediaUploadOptions,
 	): Promise<{ mediaId: string; storageKey: string; url: string }>;
 	delete(id: string): Promise<boolean>;
 }

--- a/packages/core/tests/integration/database/media-visibility.test.ts
+++ b/packages/core/tests/integration/database/media-visibility.test.ts
@@ -1,0 +1,37 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { MediaRepository } from "../../../src/database/repositories/media.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+describe("media visibility migration", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("defaults existing upload paths to public and hides private rows from general lists", async () => {
+		const repo = new MediaRepository(db);
+		const publicItem = await repo.create({
+			filename: "photo.jpg",
+			mimeType: "image/jpeg",
+			storageKey: "photo.jpg",
+		});
+		const privateItem = await repo.create({
+			filename: "brief.pdf",
+			mimeType: "application/pdf",
+			storageKey: "private/brief.pdf",
+			visibility: "private",
+		});
+
+		expect(publicItem.visibility).toBe("public");
+		expect(privateItem.visibility).toBe("private");
+		expect((await repo.findMany()).items.map((item) => item.id)).toEqual([publicItem.id]);
+	});
+});

--- a/packages/core/tests/integration/database/migrations.test.ts
+++ b/packages/core/tests/integration/database/migrations.test.ts
@@ -187,6 +187,7 @@ describe("Database Migrations (Integration)", () => {
 			"071_restore_content_bylines_table",
 			"072_media_folders",
 			"073_media_focal_point",
+			"074_media_visibility",
 		];
 
 		await db.deleteFrom("_emdash_migrations").where("name", "in", trailing).execute();

--- a/packages/core/tests/integration/runtime/plugin-media-enrich.test.ts
+++ b/packages/core/tests/integration/runtime/plugin-media-enrich.test.ts
@@ -82,4 +82,37 @@ describe("plugin ctx.media.upload — metadata enrichment", () => {
 		expect(row?.width).toBeNull();
 		expect(row?.blurhash).toBeNull();
 	});
+
+	it("stores private plugin uploads outside the public media route", async () => {
+		const media = createMediaAccessWithWrite(db, undefined, fakeStorage());
+		const result = await media.upload(
+			"brief.pdf",
+			"application/pdf",
+			new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]).buffer,
+			{ visibility: "private" },
+		);
+
+		const row = await new MediaRepository(db).findById(result.mediaId);
+		expect(row?.visibility).toBe("private");
+		expect(result.storageKey).toMatch(/^private\//);
+		expect(result.url).toBe(
+			`/_emdash/api/media/private/${result.storageKey.slice("private/".length)}`,
+		);
+	});
+
+	it("deletes the storage object before removing a plugin media record", async () => {
+		const storage = fakeStorage();
+		const media = createMediaAccessWithWrite(db, undefined, storage);
+		const result = await media.upload(
+			"brief.pdf",
+			"application/pdf",
+			new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]).buffer,
+			{ visibility: "private" },
+		);
+
+		expect(await storage.exists(result.storageKey)).toBe(true);
+		await expect(media.delete(result.mediaId)).resolves.toBe(true);
+		expect(await storage.exists(result.storageKey)).toBe(false);
+		expect(await new MediaRepository(db).findById(result.mediaId)).toBeNull();
+	});
 });

--- a/packages/core/tests/unit/astro/routes.test.ts
+++ b/packages/core/tests/unit/astro/routes.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../src/astro/integration/routes.js";
 import * as mediaUploadRoute from "../../../src/astro/routes/api/media/[id]/upload.js";
 import { GET as getMediaFile } from "../../../src/astro/routes/api/media/file/[...key].js";
+import { GET as getPrivateMediaFile } from "../../../src/astro/routes/api/media/private/[...key].js";
 
 function mockMediaContext(key: string | undefined) {
 	const download = vi.fn().mockResolvedValue({
@@ -71,6 +72,14 @@ describe("core media route injection", () => {
 				// output placeholders can't mangle dynamic-route filenames.
 				entrypoint: expect.stringContaining("api/media/file/_...key_"),
 			}),
+		);
+	});
+
+	it("registers a separate authenticated private-media route", () => {
+		const routes: Array<{ pattern: string; entrypoint: string }> = [];
+		injectCoreRoutes((route) => routes.push(route));
+		expect(routes).toContainEqual(
+			expect.objectContaining({ pattern: "/_emdash/api/media/private/[...key]" }),
 		);
 	});
 
@@ -187,5 +196,50 @@ describe("media file catch-all route", () => {
 		const response = await getMediaFile(context);
 		expect(response.status).toBe(404);
 		expect(download).not.toHaveBeenCalled();
+	});
+
+	it("does not serve private keys through the public route", async () => {
+		const { context, download } = mockMediaContext("private/brief.pdf");
+		const response = await getMediaFile(context);
+		expect(response.status).toBe(404);
+		expect(download).not.toHaveBeenCalled();
+	});
+});
+
+describe("private media route", () => {
+	function privateContext(role?: number) {
+		const download = vi.fn().mockResolvedValue({
+			body: new Uint8Array([1, 2, 3]),
+			contentType: "application/pdf",
+			size: 3,
+		});
+		return {
+			context: {
+				params: { key: "brief.pdf" },
+				locals: {
+					emdash: { storage: { download } },
+					user: role === undefined ? null : { id: "u1", role },
+				},
+			} as Parameters<typeof getPrivateMediaFile>[0],
+			download,
+		};
+	}
+
+	it("returns the same 404 to anonymous and insufficient-role callers", async () => {
+		for (const role of [undefined, 10]) {
+			const { context, download } = privateContext(role);
+			const response = await getPrivateMediaFile(context);
+			expect(response.status).toBe(404);
+			expect(download).not.toHaveBeenCalled();
+		}
+	});
+
+	it("serves editors without public caching", async () => {
+		const { context, download } = privateContext(40);
+		const response = await getPrivateMediaFile(context);
+		expect(response.status).toBe(200);
+		expect(download).toHaveBeenCalledWith("private/brief.pdf");
+		expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+		expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
 	});
 });

--- a/packages/core/tests/unit/plugins/routes.test.ts
+++ b/packages/core/tests/unit/plugins/routes.test.ts
@@ -727,6 +727,35 @@ describe("parseRouteInput (#2146)", () => {
 		}
 	});
 
+	it("parses multipart fields and files without losing binary bytes", async () => {
+		const body = new FormData();
+		body.set("formId", "project-estimate");
+		body.set("data", JSON.stringify({ email: "ada@example.com" }));
+		body.set(
+			"upload",
+			new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], "brief.pdf", {
+				type: "application/pdf",
+			}),
+		);
+
+		const input = await parseRouteInput(new Request("http://test.com/x", { method: "POST", body }));
+
+		expect(input).toEqual({
+			formId: "project-estimate",
+			data: JSON.stringify({ email: "ada@example.com" }),
+			files: {
+				upload: {
+					filename: "brief.pdf",
+					contentType: "application/pdf",
+					bytes: expect.any(ArrayBuffer),
+				},
+			},
+		});
+		expect(new Uint8Array((input as any).files.upload.bytes)).toEqual(
+			new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+		);
+	});
+
 	it("returns undefined for a body method with no/invalid JSON", async () => {
 		expect(
 			await parseRouteInput(new Request("http://test.com/x", { method: "POST" })),

--- a/packages/plugins/forms/src/admin.tsx
+++ b/packages/plugins/forms/src/admin.tsx
@@ -104,6 +104,14 @@ interface SubmissionItem {
 	starred: boolean;
 	notes?: string;
 	createdAt: string;
+	files?: Array<{
+		fieldName: string;
+		filename: string;
+		contentType: string;
+		size: number;
+		mediaId: string;
+		downloadUrl: string;
+	}>;
 	meta: {
 		ip: string | null;
 		country: string | null;
@@ -1176,6 +1184,25 @@ function SubmissionsPage() {
 								</div>
 							))}
 						</dl>
+
+						{selectedSub.files && selectedSub.files.length > 0 && (
+							<div>
+								<p className="text-xs font-medium text-muted-foreground mb-1">Attachments</p>
+								<ul className="space-y-1">
+									{selectedSub.files.map((file) => (
+										<li key={file.mediaId}>
+											<a
+												href={file.downloadUrl}
+												className="text-sm underline break-all"
+												download={file.filename}
+											>
+												{file.filename}
+											</a>
+										</li>
+									))}
+								</ul>
+							</div>
+						)}
 
 						{selectedSub.meta.country && (
 							<p className="text-xs text-muted-foreground">Country: {selectedSub.meta.country}</p>

--- a/packages/plugins/forms/src/cleanup.ts
+++ b/packages/plugins/forms/src/cleanup.ts
@@ -1,0 +1,28 @@
+import type { PluginContext } from "emdash";
+
+import type { SubmissionFile } from "./types.js";
+
+export async function deleteSubmissionFiles(
+	ctx: PluginContext,
+	files: SubmissionFile[] | undefined,
+): Promise<boolean> {
+	if (!files?.length) return true;
+	if (!ctx.media?.delete) {
+		ctx.log.error("Cannot delete submission attachments: media storage is unavailable");
+		return false;
+	}
+
+	let deleted = true;
+	for (const file of files) {
+		try {
+			await ctx.media.delete(file.mediaId);
+		} catch (error) {
+			deleted = false;
+			ctx.log.error("Failed to delete submission attachment", {
+				mediaId: file.mediaId,
+				error: String(error),
+			});
+		}
+	}
+	return deleted;
+}

--- a/packages/plugins/forms/src/client/index.ts
+++ b/packages/plugins/forms/src/client/index.ts
@@ -104,40 +104,19 @@ async function handleSubmit(e: Event) {
 	clearStatus(form);
 
 	try {
-		const hasFiles = form.querySelector<HTMLInputElement>('input[type="file"]');
+		const payload = collectSubmissionPayload(form);
 		let body: BodyInit;
 		const headers: Record<string, string> = {};
 
-		if (hasFiles) {
-			body = new FormData(form);
+		if (payload.files.length > 0) {
+			const multipart = new FormData();
+			multipart.set("formId", payload.formId);
+			multipart.set("data", JSON.stringify(payload.data));
+			for (const [name, file] of payload.files) multipart.set(name, file);
+			body = multipart;
 		} else {
 			headers["Content-Type"] = "application/json";
-			const formData = new FormData(form);
-			let formId = "";
-			const data: Record<string, unknown> = {};
-			// Track keys we've seen to detect multi-value fields (checkbox-group)
-			const seen = new Set<string>();
-			for (const [key, val] of formData) {
-				if (typeof val !== "string") continue;
-				if (key === "formId") {
-					formId = val;
-				} else if (key === "_hp" || key === "cf-turnstile-response") {
-					// Include spam fields at top level for server-side checks
-					data[key] = val;
-				} else if (seen.has(key)) {
-					// Multi-value field (checkbox-group) — collect into array
-					const existing = data[key];
-					if (Array.isArray(existing)) {
-						existing.push(val);
-					} else {
-						data[key] = [existing, val];
-					}
-				} else {
-					seen.add(key);
-					data[key] = val;
-				}
-			}
-			body = JSON.stringify({ formId, data });
+			body = JSON.stringify({ formId: payload.formId, data: payload.data });
 		}
 
 		const res = await fetch(form.action, {
@@ -175,6 +154,31 @@ async function handleSubmit(e: Event) {
 			submitBtn.textContent = form.dataset.submitLabel || "Submit";
 		}
 	}
+}
+
+function collectSubmissionPayload(form: HTMLFormElement) {
+	let formId = "";
+	const data: Record<string, unknown> = {};
+	const files: Array<[string, File]> = [];
+	const seen = new Set<string>();
+
+	for (const [key, value] of new FormData(form)) {
+		if (value instanceof File) {
+			if (value.size > 0) files.push([key, value]);
+			continue;
+		}
+		if (key === "formId") {
+			formId = value;
+		} else if (seen.has(key)) {
+			const existing = data[key];
+			data[key] = Array.isArray(existing) ? [...existing, value] : [existing, value];
+		} else {
+			seen.add(key);
+			data[key] = value;
+		}
+	}
+
+	return { formId, data, files };
 }
 
 /** validates that a redirect url uses a safe protocol */

--- a/packages/plugins/forms/src/file-validation.ts
+++ b/packages/plugins/forms/src/file-validation.ts
@@ -1,0 +1,55 @@
+import { PluginRouteError } from "emdash";
+
+export interface SubmissionFileInput {
+	filename: string;
+	contentType: string;
+	bytes: ArrayBuffer;
+}
+
+const MAX_FILES = 5;
+const MAX_FILE_SIZE = 25 * 1024 * 1024;
+const MAX_TOTAL_SIZE = 125 * 1024 * 1024;
+
+const signatures: Record<string, (bytes: Uint8Array) => boolean> = {
+	"application/pdf": (b) => startsWith(b, [0x25, 0x50, 0x44, 0x46, 0x2d]),
+	"image/jpeg": (b) => startsWith(b, [0xff, 0xd8, 0xff]),
+	"image/png": (b) => startsWith(b, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+	"video/mp4": (b) =>
+		b.length >= 8 && b[4] === 0x66 && b[5] === 0x74 && b[6] === 0x79 && b[7] === 0x70,
+};
+
+const extensions: Record<string, Set<string>> = {
+	"application/pdf": new Set(["pdf"]),
+	"image/jpeg": new Set(["jpg", "jpeg"]),
+	"image/png": new Set(["png"]),
+	"video/mp4": new Set(["mp4"]),
+};
+
+function startsWith(bytes: Uint8Array, expected: number[]): boolean {
+	return expected.every((byte, index) => bytes[index] === byte);
+}
+
+export function validateSubmissionFiles(files: Record<string, SubmissionFileInput>): void {
+	const entries = Object.values(files);
+	if (entries.length > MAX_FILES) {
+		throw PluginRouteError.badRequest("A submission may include at most five files");
+	}
+
+	let total = 0;
+	for (const file of entries) {
+		const contentType = file.contentType.split(";")[0]!.trim().toLowerCase();
+		const extension = file.filename.split(".").pop()?.toLowerCase() ?? "";
+		const bytes = new Uint8Array(file.bytes);
+
+		if (file.bytes.byteLength > MAX_FILE_SIZE) {
+			throw PluginRouteError.badRequest(`${file.filename} exceeds the 25 MB file limit`);
+		}
+		total += file.bytes.byteLength;
+		if (total > MAX_TOTAL_SIZE) {
+			throw PluginRouteError.badRequest("Attachments exceed the 125 MB submission limit");
+		}
+		if (!extensions[contentType]?.has(extension) || !signatures[contentType]?.(bytes)) {
+			throw PluginRouteError.badRequest(`File signature does not match ${file.filename}`);
+		}
+	}
+}

--- a/packages/plugins/forms/src/handlers/cron.ts
+++ b/packages/plugins/forms/src/handlers/cron.ts
@@ -7,6 +7,7 @@
 
 import type { PluginContext, StorageCollection } from "emdash";
 
+import { deleteSubmissionFiles } from "../cleanup.js";
 import { formatDigestText } from "../format.js";
 import type { FormDefinition, Submission } from "../types.js";
 
@@ -49,19 +50,10 @@ export async function handleCleanup(ctx: PluginContext) {
 					cursor,
 				});
 
-				// Delete media files
-				if (ctx.media && "delete" in ctx.media) {
-					const mediaWithDelete = ctx.media as { delete(id: string): Promise<boolean> };
-					for (const item of batch.items) {
-						if (item.data.files) {
-							for (const file of item.data.files) {
-								await mediaWithDelete.delete(file.mediaId).catch(() => {});
-							}
-						}
-					}
+				const ids: string[] = [];
+				for (const item of batch.items) {
+					if (await deleteSubmissionFiles(ctx, item.data.files)) ids.push(item.id);
 				}
-
-				const ids = batch.items.map((item) => item.id);
 				if (ids.length > 0) {
 					await submissions(ctx).deleteMany(ids);
 					deletedCount += ids.length;

--- a/packages/plugins/forms/src/handlers/forms.ts
+++ b/packages/plugins/forms/src/handlers/forms.ts
@@ -8,21 +8,22 @@ import type { RouteContext, StorageCollection } from "emdash";
 import { PluginRouteError } from "emdash";
 import { ulid } from "ulidx";
 
+import { deleteSubmissionFiles } from "../cleanup.js";
 import type {
 	FormCreateInput,
 	FormDeleteInput,
 	FormDuplicateInput,
 	FormUpdateInput,
 } from "../schemas.js";
-import type { FormDefinition } from "../types.js";
+import type { FormDefinition, Submission } from "../types.js";
 
 /** Typed access to plugin storage collections */
 function forms(ctx: RouteContext): StorageCollection<FormDefinition> {
 	return ctx.storage.forms as StorageCollection<FormDefinition>;
 }
 
-function submissions(ctx: RouteContext): StorageCollection {
-	return ctx.storage.submissions as StorageCollection;
+function submissions(ctx: RouteContext): StorageCollection<Submission> {
+	return ctx.storage.submissions as StorageCollection<Submission>;
 }
 
 // ─── List Forms ──────────────────────────────────────────────────
@@ -246,16 +247,11 @@ async function deleteFormSubmissions(formId: string, ctx: RouteContext) {
 			cursor,
 		});
 
-		// Delete associated media files
-		if (ctx.media && "delete" in ctx.media) {
-			const mediaWithDelete = ctx.media as { delete(id: string): Promise<boolean> };
-			for (const item of batch.items) {
-				const sub = item.data as { files?: Array<{ mediaId: string }> };
-				if (sub.files) {
-					for (const file of sub.files) {
-						await mediaWithDelete.delete(file.mediaId).catch(() => {});
-					}
-				}
+		for (const item of batch.items) {
+			if (!(await deleteSubmissionFiles(ctx, item.data.files))) {
+				throw PluginRouteError.internal(
+					"Attachment cleanup failed; form submissions were retained for retry",
+				);
 			}
 		}
 

--- a/packages/plugins/forms/src/handlers/submissions.ts
+++ b/packages/plugins/forms/src/handlers/submissions.ts
@@ -7,6 +7,7 @@
 import type { RouteContext, StorageCollection } from "emdash";
 import { PluginRouteError } from "emdash";
 
+import { deleteSubmissionFiles } from "../cleanup.js";
 import { formatCsv } from "../format.js";
 import type {
 	ExportInput,
@@ -92,12 +93,10 @@ export async function submissionDeleteHandler(ctx: RouteContext<SubmissionDelete
 		throw PluginRouteError.notFound("Submission not found");
 	}
 
-	// Delete associated media files
-	if (existing.files && ctx.media && "delete" in ctx.media) {
-		const mediaWithDelete = ctx.media as { delete(id: string): Promise<boolean> };
-		for (const file of existing.files) {
-			await mediaWithDelete.delete(file.mediaId).catch(() => {});
-		}
+	if (!(await deleteSubmissionFiles(ctx, existing.files))) {
+		throw PluginRouteError.internal(
+			"Attachment cleanup failed; the submission was retained for retry",
+		);
 	}
 
 	await submissions(ctx).delete(input.id);

--- a/packages/plugins/forms/src/handlers/submit.ts
+++ b/packages/plugins/forms/src/handlers/submit.ts
@@ -9,6 +9,7 @@ import type { RouteContext, StorageCollection } from "emdash";
 import { PluginRouteError } from "emdash";
 import { ulid } from "ulidx";
 
+import { validateSubmissionFiles } from "../file-validation.js";
 import { formatSubmissionText, formatWebhookPayload } from "../format.js";
 import type { SubmitInput } from "../schemas.js";
 import { verifyTurnstile } from "../turnstile.js";
@@ -94,7 +95,18 @@ export async function submitHandler(ctx: RouteContext<SubmitInput>) {
 
 	// 3. Validate submission data
 	const allFields = getFormFields(form);
-	const result = validateSubmission(allFields, input.data);
+	const suppliedFiles = input.files ?? {};
+	validateSubmissionFiles(suppliedFiles);
+	const fileFields = new Map(
+		allFields.filter((field) => field.type === "file").map((f) => [f.name, f]),
+	);
+	for (const name of Object.keys(suppliedFiles)) {
+		if (!fileFields.has(name)) throw PluginRouteError.badRequest(`Unknown file field: ${name}`);
+	}
+
+	const validationData = { ...input.data };
+	for (const [name, file] of Object.entries(suppliedFiles)) validationData[name] = file.filename;
+	const result = validateSubmission(allFields, validationData);
 
 	if (!result.valid) {
 		return { success: false, errors: result.errors };
@@ -102,17 +114,11 @@ export async function submitHandler(ctx: RouteContext<SubmitInput>) {
 
 	// 4. Upload files
 	const files: SubmissionFile[] = [];
-	if (input.files && ctx.media && "upload" in ctx.media) {
-		const mediaWithWrite = ctx.media as {
-			upload(
-				filename: string,
-				contentType: string,
-				bytes: ArrayBuffer,
-			): Promise<{ mediaId: string; storageKey: string; url: string }>;
-		};
+	if (Object.keys(suppliedFiles).length > 0) {
+		if (!ctx.media?.upload) throw PluginRouteError.internal("File storage is not configured");
 
-		for (const field of allFields.filter((f) => f.type === "file")) {
-			const fileData = input.files[field.name];
+		for (const field of fileFields.values()) {
+			const fileData = suppliedFiles[field.name];
 			if (!fileData) continue;
 
 			// Validate file type
@@ -139,20 +145,37 @@ export async function submitHandler(ctx: RouteContext<SubmitInput>) {
 					`File too large for ${field.label}. Maximum: ${Math.round(field.validation.maxFileSize / 1024)} KB`,
 				);
 			}
+		}
 
-			const uploaded = await mediaWithWrite.upload(
-				fileData.filename,
-				fileData.contentType,
-				fileData.bytes,
-			);
-
-			files.push({
-				fieldName: field.name,
-				filename: fileData.filename,
-				contentType: fileData.contentType,
-				size: fileData.bytes.byteLength,
-				mediaId: uploaded.mediaId,
-			});
+		try {
+			for (const field of fileFields.values()) {
+				const fileData = suppliedFiles[field.name];
+				if (!fileData) continue;
+				const uploaded = await ctx.media.upload(
+					fileData.filename,
+					fileData.contentType,
+					fileData.bytes,
+					{ visibility: "private" },
+				);
+				files.push({
+					fieldName: field.name,
+					filename: fileData.filename,
+					contentType: fileData.contentType,
+					size: fileData.bytes.byteLength,
+					mediaId: uploaded.mediaId,
+					downloadUrl: uploaded.url,
+				});
+			}
+		} catch (error) {
+			for (const file of files) {
+				await ctx.media.delete?.(file.mediaId).catch((cleanupError: unknown) => {
+					ctx.log.error("Failed to roll back form attachment", {
+						mediaId: file.mediaId,
+						error: String(cleanupError),
+					});
+				});
+			}
+			throw error;
 		}
 	}
 

--- a/packages/plugins/forms/src/index.ts
+++ b/packages/plugins/forms/src/index.ts
@@ -141,6 +141,7 @@ export function createPlugin(_options: FormsPluginOptions = {}): ResolvedPlugin 
 			// --- Admin routes (require auth) ---
 
 			"forms/list": {
+				permission: "plugins:read",
 				handler: formsListHandler,
 			},
 			"forms/create": {
@@ -161,22 +162,27 @@ export function createPlugin(_options: FormsPluginOptions = {}): ResolvedPlugin 
 			},
 
 			"submissions/list": {
+				permission: "plugins:read",
 				input: submissionsListSchema,
 				handler: submissionsListHandler as never,
 			},
 			"submissions/get": {
+				permission: "plugins:read",
 				input: submissionGetSchema,
 				handler: submissionGetHandler as never,
 			},
 			"submissions/update": {
+				permission: "plugins:read",
 				input: submissionUpdateSchema,
 				handler: submissionUpdateHandler as never,
 			},
 			"submissions/delete": {
+				permission: "plugins:read",
 				input: submissionDeleteSchema,
 				handler: submissionDeleteHandler as never,
 			},
 			"submissions/export": {
+				permission: "plugins:read",
 				input: exportSchema,
 				handler: exportHandler as never,
 			},

--- a/packages/plugins/forms/src/schemas.ts
+++ b/packages/plugins/forms/src/schemas.ts
@@ -157,7 +157,17 @@ export type DefinitionInput = z.infer<typeof definitionSchema>;
 
 export const submitSchema = z.object({
 	formId: z.string().min(1),
-	data: z.record(z.string(), z.unknown()),
+	data: z.preprocess(
+		(value) => {
+			if (typeof value !== "string") return value;
+			try {
+				return JSON.parse(value);
+			} catch {
+				return value;
+			}
+		},
+		z.record(z.string(), z.unknown()),
+	),
 	files: z
 		.record(
 			z.string(),

--- a/packages/plugins/forms/src/types.ts
+++ b/packages/plugins/forms/src/types.ts
@@ -137,6 +137,8 @@ export interface SubmissionFile {
 	size: number;
 	/** Reference to media library item */
 	mediaId: string;
+	/** Authenticated download route for private attachments */
+	downloadUrl: string;
 }
 
 export interface SubmissionMeta {

--- a/packages/plugins/forms/tests/file-validation.test.ts
+++ b/packages/plugins/forms/tests/file-validation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { validateSubmissionFiles } from "../src/file-validation.js";
+
+const mb = 1024 * 1024;
+
+function file(filename: string, contentType: string, bytes: number[]) {
+	return { filename, contentType, bytes: new Uint8Array(bytes).buffer };
+}
+
+describe("validateSubmissionFiles", () => {
+	it("accepts PDF, JPEG, PNG, and MP4 signatures", () => {
+		expect(() =>
+			validateSubmissionFiles({
+				pdf: file("brief.pdf", "application/pdf", [0x25, 0x50, 0x44, 0x46, 0x2d]),
+				jpg: file("photo.jpg", "image/jpeg", [0xff, 0xd8, 0xff]),
+				png: file("plan.png", "image/png", [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+				mp4: file("walkthrough.mp4", "video/mp4", [0, 0, 0, 24, 0x66, 0x74, 0x79, 0x70]),
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects mismatched signatures", () => {
+		expect(() =>
+			validateSubmissionFiles({
+				brief: file("brief.pdf", "application/pdf", [0x3c, 0x68, 0x74, 0x6d, 0x6c]),
+			}),
+		).toThrow(/signature/i);
+	});
+
+	it("enforces five files, 25 MB each, and 125 MB total", () => {
+		const tinyPdf = file("brief.pdf", "application/pdf", [0x25, 0x50, 0x44, 0x46, 0x2d]);
+		expect(() =>
+			validateSubmissionFiles({
+				a: tinyPdf,
+				b: tinyPdf,
+				c: tinyPdf,
+				d: tinyPdf,
+				e: tinyPdf,
+				f: tinyPdf,
+			}),
+		).toThrow(/five files/i);
+
+		expect(() =>
+			validateSubmissionFiles({
+				brief: { ...tinyPdf, bytes: new ArrayBuffer(25 * mb + 1) },
+			}),
+		).toThrow(/25 MB/i);
+	});
+});

--- a/packages/plugins/forms/tests/submit-files.test.ts
+++ b/packages/plugins/forms/tests/submit-files.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { deleteSubmissionFiles } from "../src/cleanup.js";
+import { submitHandler } from "../src/handlers/submit.js";
+import { createPlugin } from "../src/index.js";
+import type { FormDefinition } from "../src/types.js";
+
+const form: FormDefinition = {
+	name: "Estimate",
+	slug: "project-estimate",
+	pages: [
+		{
+			fields: [
+				{
+					id: "brief",
+					name: "brief",
+					label: "Project brief",
+					type: "file",
+					required: true,
+					width: "full",
+					validation: { accept: ".pdf", maxFileSize: 25 * 1024 * 1024 },
+				},
+			],
+		},
+	],
+	settings: {
+		confirmationMessage: "Thanks",
+		notifyEmails: [],
+		digestEnabled: false,
+		digestHour: 8,
+		retentionDays: 365,
+		spamProtection: "none",
+		submitLabel: "Send",
+	},
+	status: "active",
+	submissionCount: 0,
+	lastSubmissionAt: null,
+	createdAt: "2026-01-01T00:00:00.000Z",
+	updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+function context(bytes = [0x25, 0x50, 0x44, 0x46, 0x2d]) {
+	const upload = vi.fn(async () => ({
+		mediaId: "media-1",
+		storageKey: "private/media-1.pdf",
+		url: "/_emdash/api/media/private/media-1.pdf",
+	}));
+	const putSubmission = vi.fn();
+	return {
+		ctx: {
+			input: {
+				formId: "project-estimate",
+				data: {},
+				files: {
+					brief: {
+						filename: "brief.pdf",
+						contentType: "application/pdf",
+						bytes: new Uint8Array(bytes).buffer,
+					},
+				},
+			},
+			storage: {
+				forms: {
+					get: vi.fn(async () => form),
+					put: vi.fn(),
+					query: vi.fn(),
+				},
+				submissions: {
+					put: putSubmission,
+					count: vi.fn(async () => 1),
+				},
+			},
+			media: { upload, delete: vi.fn() },
+			requestMeta: { ip: null, userAgent: null, referer: null },
+			log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		},
+		upload,
+		putSubmission,
+	};
+}
+
+describe("private form attachments", () => {
+	it("grants editors submission access without granting form or plugin configuration", () => {
+		const routes = createPlugin().routes;
+		expect(routes["submissions/list"]?.permission).toBe("plugins:read");
+		expect(routes["submissions/get"]?.permission).toBe("plugins:read");
+		expect(routes["submissions/delete"]?.permission).toBe("plugins:read");
+		expect(routes["forms/update"]?.permission).toBeUndefined();
+		expect(routes["settings/turnstile-status"]?.permission).toBeUndefined();
+	});
+
+	it("uploads validated files as private and stores the authenticated download URL", async () => {
+		const { ctx, upload, putSubmission } = context();
+		await expect(submitHandler(ctx as never)).resolves.toMatchObject({ success: true });
+		expect(upload).toHaveBeenCalledWith("brief.pdf", "application/pdf", expect.any(ArrayBuffer), {
+			visibility: "private",
+		});
+		expect(putSubmission).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({
+				files: [
+					expect.objectContaining({
+						mediaId: "media-1",
+						downloadUrl: "/_emdash/api/media/private/media-1.pdf",
+					}),
+				],
+			}),
+		);
+	});
+
+	it("rejects spoofed files before media storage is called", async () => {
+		const { ctx, upload } = context([0x3c, 0x68, 0x74, 0x6d, 0x6c]);
+		await expect(submitHandler(ctx as never)).rejects.toThrow(/signature/i);
+		expect(upload).not.toHaveBeenCalled();
+	});
+
+	it("retains submission records when attachment cleanup fails", async () => {
+		const error = vi.fn();
+		const result = await deleteSubmissionFiles(
+			{
+				media: { delete: vi.fn(async () => Promise.reject(new Error("R2 unavailable"))) },
+				log: { error },
+			} as never,
+			[
+				{
+					fieldName: "brief",
+					filename: "brief.pdf",
+					contentType: "application/pdf",
+					size: 5,
+					mediaId: "media-1",
+					downloadUrl: "/private/media-1",
+				},
+			],
+		);
+		expect(result).toBe(false);
+		expect(error).toHaveBeenCalled();
+	});
+});

--- a/packages/workerd/src/sandbox/bridge-handler.ts
+++ b/packages/workerd/src/sandbox/bridge-handler.ts
@@ -273,6 +273,7 @@ async function dispatch(
 				requireString(body, "contentType"),
 				requireMediaBytes(body, "bytes"),
 				optionalString(body, "encoding"),
+				optionalString(body, "visibility"),
 				opts.storage,
 			);
 		case "media/delete":
@@ -1074,14 +1075,19 @@ function rowToMediaItem(row: {
 	size: number | null;
 	storage_key: string;
 	created_at: string;
+	visibility: string;
 }) {
 	return {
 		id: row.id,
 		filename: row.filename,
 		mimeType: row.mime_type,
 		size: row.size,
-		url: `/_emdash/api/media/file/${row.storage_key}`,
+		url:
+			row.visibility === "private"
+				? `/_emdash/api/media/private/${row.storage_key.slice("private/".length)}`
+				: `/_emdash/api/media/file/${row.storage_key}`,
 		createdAt: row.created_at,
+		visibility: row.visibility,
 	};
 }
 
@@ -1122,6 +1128,7 @@ async function mediaList(
 	let query = db
 		.selectFrom("media")
 		.where("status", "=", "ready")
+		.where("visibility", "=", "public")
 		.selectAll()
 		.orderBy("id", "desc");
 
@@ -1154,6 +1161,7 @@ async function mediaUpload(
 	contentType: string,
 	bytes: string | number[],
 	encoding: string | undefined,
+	visibilityInput: string | undefined,
 	storage?: BridgeStorage | null,
 ): Promise<{ mediaId: string; storageKey: string; url: string }> {
 	if (!storage) {
@@ -1170,12 +1178,20 @@ async function mediaUpload(
 
 	const { ulid } = await import("ulidx");
 	const mediaId = ulid();
+	if (
+		visibilityInput !== undefined &&
+		visibilityInput !== "public" &&
+		visibilityInput !== "private"
+	) {
+		throw new Error("media/upload: visibility must be public or private");
+	}
+	const visibility = visibilityInput ?? "public";
 	const basename = filename.includes("/")
 		? filename.slice(filename.lastIndexOf("/") + 1)
 		: filename;
 	const rawExt = basename.includes(".") ? basename.slice(basename.lastIndexOf(".")) : "";
 	const ext = FILE_EXT_RE.test(rawExt) ? rawExt : "";
-	const storageKey = `${mediaId}${ext}`;
+	const storageKey = `${visibility === "private" ? "private/" : ""}${mediaId}${ext}`;
 	const now = new Date().toISOString();
 	let byteArray: Uint8Array;
 	if (encoding === "base64" && typeof bytes === "string") {
@@ -1205,6 +1221,7 @@ async function mediaUpload(
 				storage_key: storageKey,
 				status: "ready",
 				created_at: now,
+				visibility,
 			})
 			.execute();
 	} catch (error) {
@@ -1225,7 +1242,10 @@ async function mediaUpload(
 	return {
 		mediaId,
 		storageKey,
-		url: `/_emdash/api/media/file/${storageKey}`,
+		url:
+			visibility === "private"
+				? `/_emdash/api/media/private/${storageKey.slice("private/".length)}`
+				: `/_emdash/api/media/file/${storageKey}`,
 	};
 }
 
@@ -1243,19 +1263,10 @@ async function mediaDelete(
 
 	if (!media) return false;
 
-	// Delete the DB row first
+	// Keep the row retryable until object cleanup succeeds.
+	if (!storage) throw new Error("Media storage is not configured");
+	await storage.delete(media.storage_key);
 	const result = await db.deleteFrom("media").where("id", "=", id).executeTakeFirst();
-
-	// Delete the storage object. If this fails, log but don't throw —
-	// the DB row is already deleted and the orphan cleanup cron will
-	// catch it. Matches the Cloudflare bridge's behavior.
-	if (storage && media.storage_key) {
-		try {
-			await storage.delete(media.storage_key);
-		} catch (error) {
-			console.warn(`[bridge] Failed to delete storage object ${media.storage_key}:`, error);
-		}
-	}
 
 	return BigInt(result.numDeletedRows) > 0n;
 }

--- a/packages/workerd/src/sandbox/wrapper.ts
+++ b/packages/workerd/src/sandbox/wrapper.ts
@@ -181,7 +181,7 @@ function createContext() {
 	const media = {
 		get: (id) => bridgeCall("media/get", { id }),
 		list: (opts) => bridgeCall("media/list", opts || {}),
-		upload: (filename, contentType, bytes) => {
+		upload: (filename, contentType, bytes, options) => {
 			// Convert any binary input into a Uint8Array view pointing at the
 			// SAME underlying bytes (not reinterpreted). For ArrayBufferView
 			// inputs (Uint16Array, Int32Array, DataView, etc.) we must use
@@ -204,6 +204,7 @@ function createContext() {
 				contentType,
 				bytes: btoa(binary),
 				encoding: "base64",
+				visibility: options?.visibility,
 			});
 		},
 		getUploadUrl: () => { throw new Error("getUploadUrl is not available in sandbox mode. Use media.upload() instead."); },

--- a/packages/workerd/test/bridge-handler.test.ts
+++ b/packages/workerd/test/bridge-handler.test.ts
@@ -81,6 +81,10 @@ describe("Bridge Handler Conformance", () => {
 		allowedHosts?: string[];
 		storageCollections?: string[];
 		beforeContentWrite?: () => Promise<void>;
+		storage?: {
+			upload(options: { key: string; body: Uint8Array; contentType: string }): Promise<unknown>;
+			delete(key: string): Promise<unknown>;
+		};
 	}) {
 		return createBridgeHandler({
 			pluginId: "test-plugin",
@@ -91,6 +95,7 @@ describe("Bridge Handler Conformance", () => {
 			db,
 			emailSend: () => null,
 			beforeContentWrite: opts.beforeContentWrite,
+			storage: opts.storage,
 		});
 	}
 
@@ -528,6 +533,7 @@ describe("Bridge Handler Conformance", () => {
 				.addColumn("storage_key", "text", (col) => col.notNull())
 				.addColumn("status", "text", (col) => col.notNull().defaultTo("ready"))
 				.addColumn("created_at", "text", (col) => col.notNull())
+				.addColumn("visibility", "text", (col) => col.notNull().defaultTo("public"))
 				.execute();
 			for (const id of ["m-1", "m-2", "m-3"]) {
 				await db
@@ -550,6 +556,55 @@ describe("Bridge Handler Conformance", () => {
 			const list = result.result as { items: unknown[] };
 			expect(list.items.length).toBeGreaterThanOrEqual(1);
 			expect(list.items.length).toBeLessThanOrEqual(1);
+		});
+
+		it("stores private media outside public listings and keeps failed deletes retryable", async () => {
+			await db.schema
+				.createTable("media")
+				.addColumn("id", "text", (col) => col.primaryKey())
+				.addColumn("filename", "text", (col) => col.notNull())
+				.addColumn("mime_type", "text", (col) => col.notNull())
+				.addColumn("size", "integer")
+				.addColumn("storage_key", "text", (col) => col.notNull())
+				.addColumn("status", "text", (col) => col.notNull().defaultTo("ready"))
+				.addColumn("created_at", "text", (col) => col.notNull())
+				.addColumn("visibility", "text", (col) => col.notNull().defaultTo("public"))
+				.execute();
+
+			const objects = new Map<string, Uint8Array>();
+			const storage = {
+				async upload(options: { key: string; body: Uint8Array }) {
+					objects.set(options.key, options.body);
+				},
+				async delete() {
+					throw new Error("R2 unavailable");
+				},
+			};
+			const handler = makeHandler({ capabilities: ["write:media", "read:media"], storage });
+			const uploaded = await call(handler, "media/upload", {
+				filename: "brief.pdf",
+				contentType: "application/pdf",
+				bytes: "JVBERi0=",
+				encoding: "base64",
+				visibility: "private",
+			});
+			const media = uploaded.result as { mediaId: string; storageKey: string; url: string };
+			expect(media.storageKey).toMatch(/^private\//);
+			expect(media.url).toContain("/_emdash/api/media/private/");
+			expect(objects.has(media.storageKey)).toBe(true);
+
+			const listed = await call(handler, "media/list");
+			expect((listed.result as { items: unknown[] }).items).toEqual([]);
+
+			const deletion = await call(handler, "media/delete", { id: media.mediaId });
+			expect(deletion.error).toContain("R2 unavailable");
+			expect(
+				await db
+					.selectFrom("media" as any)
+					.select("id")
+					.where("id", "=", media.mediaId)
+					.executeTakeFirst(),
+			).toBeDefined();
 		});
 
 		it("storage/query clamps negative limit to 1", async () => {


### PR DESCRIPTION
## Summary
- store native form uploads as private media while preserving public-media defaults
- require editor/admin authorization for private downloads and return non-disclosing 404s
- validate PDF, JPEG, PNG, and MP4 signatures plus per-file/count/total limits
- retain submissions when object cleanup fails so deletion and retention cleanup are retryable

## Security invariants
- anonymous and insufficient-role callers cannot read private attachments
- private responses use `private, no-store` and `X-Content-Type-Options: nosniff`
- private files are excluded from public listing, deduplication, optimization, feeds, and SEO paths

## Verification
- core private-media/routes/plugin tests: 65 passed
- forms typecheck: passed
- forms validation/upload tests: 7 passed
- `git diff --check`: passed

Current upstream `main` has three unrelated registry-client type errors in the full core typecheck; the focused core and forms checks above pass.