### PR TITLE
fix(api): restore collection reordering in the admin sidebar

### DIFF
--- a/.changeset/fix-collection-reorder.md
+++ b/.changeset/fix-collection-reorder.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes reordering content types in the admin sidebar, which failed with a server error instead of saving the new order. Reordering fields within a content type was unaffected.

--- a/packages/core/src/api/handlers/index.ts
+++ b/packages/core/src/api/handlers/index.ts
@@ -110,6 +110,7 @@ export {
 	handleSchemaFieldCreate,
 	handleSchemaFieldUpdate,
 	handleSchemaFieldDelete,
+	handleSchemaCollectionReorder,
 	handleSchemaFieldReorder,
 	handleOrphanedTableList,
 	handleOrphanedTableRegister,

--- a/packages/core/tests/unit/api/schema-collections-reorder-route.test.ts
+++ b/packages/core/tests/unit/api/schema-collections-reorder-route.test.ts
@@ -1,0 +1,51 @@
+import { Role } from "@emdash-cms/auth";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { POST } from "../../../src/astro/routes/api/schema/collections/reorder.js";
+import type { Database } from "../../../src/database/types.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+type RouteContext = Parameters<typeof POST>[0];
+
+describe("schema collections reorder route", () => {
+	let db: Kysely<Database>;
+	let registry: SchemaRegistry;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		registry = new SchemaRegistry(db);
+		await registry.createCollection({ slug: "posts", label: "Posts" });
+		await registry.createCollection({ slug: "pages", label: "Pages" });
+		await registry.createCollection({ slug: "authors", label: "Authors" });
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("persists the requested sidebar order", async () => {
+		const response = await POST(reorderContext(["posts", "authors", "pages"]));
+
+		expect(response.status).toBe(200);
+
+		const collections = await registry.listCollections();
+		expect(collections.map((collection) => collection.slug)).toEqual(["posts", "authors", "pages"]);
+		expect(collections.map((collection) => collection.sortOrder)).toEqual([0, 1, 2]);
+	});
+
+	function reorderContext(slugs: string[]): RouteContext {
+		return {
+			request: new Request("http://localhost/_emdash/api/schema/collections/reorder", {
+				method: "POST",
+				headers: { "Content-Type": "application/json", "X-EmDash-Request": "1" },
+				body: JSON.stringify({ slugs }),
+			}),
+			locals: {
+				emdash: { db },
+				user: { id: "admin-1", role: Role.ADMIN },
+			},
+		} as RouteContext;
+	}
+});


### PR DESCRIPTION
## What does this PR do?

Fixes reordering content types in the admin sidebar, which returned a 500 instead of saving the new order. The row animated into place and then snapped back on the next refetch, with nothing surfaced to the user.

`packages/core/src/api/handlers/index.ts` re-exports the schema handlers by explicit name and `handleSchemaCollectionReorder` was never added to the list. The route at `packages/core/src/astro/routes/api/schema/collections/reorder.ts` imports it through that barrel (`import { handleSchemaCollectionReorder } from "#api/index.js";`), so the binding resolved to nothing and `POST /_emdash/api/schema/collections/reorder` threw before doing any work. Field reordering was unaffected because `handleSchemaFieldReorder` is two lines further down the same list.

The fix is one line: add `handleSchemaCollectionReorder` to that export list. The handler itself (`packages/core/src/api/handlers/schema.ts:435`) and `SchemaRegistry.reorderCollections` were already correct and are unchanged.

Notes for reviewers:

- **`pnpm typecheck` could not have caught this.** `packages/core/tsconfig.json` excludes `src/astro/**`, so the route file is outside the typecheck program, and a green typecheck is identical with and without the fix. The added test is the only thing that guards it, which is why it drives the route's `POST` export against a real in-memory SQLite database rather than asserting on the export.
- **Verified in the production bundle, not just under Vite's SSR transform.** Before the fix, `dist/astro/routes/api/schema/collections/reorder.mjs` imported the schema chunk for side effects only and called `handleSchemaCollectionReorder` as a bare undefined identifier, which is the `ReferenceError` in the issue. After the fix the same file emits a real named import from the schema chunk. Under vitest the same root cause surfaces as `TypeError: handleSchemaCollectionReorder is not a function`, because Vite yields `undefined` for the missing named import where Rollup drops the binding entirely.
- **Scope.** Seven other handlers are also absent from that barrel (`handleMenuGetById`, `handleMenuTranslations`, `handleTaxonomyCreate`, `handleTermReorder`, `handleTermTranslations`, `handleMediaUsageCollectionDeletionList`, `handleMediaUsageCollectionDeletionRetry`). None of them are bugs: every consumer imports those directly from `#api/handlers/<module>.js`, and I checked every `#api/index.js` import under `src/astro/routes` against the barrel's value exports. Collection reorder was the only caller reaching for the barrel and coming up short, so nothing else is touched here.
- **The issue's secondary finding is deliberately out of scope.** The admin reorder mutation (`packages/admin/src/router.tsx`) has only `onSettled` and no `onError`, which is what turned the 500 into a silent snap-back. That is a separate change in a separate package and is left for its own PR rather than bundled in.

Closes #2813

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — ran `vitest run tests/unit/api tests/unit/schema` in `packages/core`: 50 files, 778 tests, all passing. I did not run the full `pnpm test`, `pnpm test:e2e`, or the workerd/integration configs locally; leaving those to CI.
- [x] `pnpm format` has been run — `pnpm format:check` is clean (oxfmt over 3126 files, plus prettier).
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — **n/a**: no admin UI or user-visible strings change; no `messages.po` changes are included.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package) — `.changeset/fix-collection-reorder.md`, `"emdash": patch`.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... — **n/a**: this is a bug fix, not a feature.

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (via Claude Code)

## Screenshots / test output

Red, with the test in place and the barrel line removed:

```
 FAIL  tests/unit/api/schema-collections-reorder-route.test.ts > schema collections reorder route > persists the requested sidebar order
TypeError: handleSchemaCollectionReorder is not a function
 ❯ POST src/astro/routes/api/schema/collections/reorder.ts:29:23
     29|  const result = await handleSchemaCollectionReorder(emdash.db, body.sl…
       |                       ^

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

Green, with the one-line fix applied:

```
 ✓ tests/unit/api/schema-collections-reorder-route.test.ts > schema collections reorder route > persists the requested sidebar order

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Surrounding suites, unchanged:

```
$ packages/core/node_modules/.bin/vitest run tests/unit/api tests/unit/schema
 Test Files  50 passed (50)
      Tests  778 passed (778)
```
