### PR TITLE
Fix plugin timestamp timezone skew

### DIFF
--- a/.changeset/plugin-installed-at-timezone.md
+++ b/.changeset/plugin-installed-at-timezone.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes plugin installation and activation times shifting by the server's local UTC offset when SQLite stores a zone-less timestamp.

--- a/packages/core/src/plugins/state.ts
+++ b/packages/core/src/plugins/state.ts
@@ -12,6 +12,16 @@ import type { Database } from "../database/types.js";
 export type PluginStatus = "active" | "inactive";
 export type PluginSource = "config" | "marketplace" | "registry";
 
+const TIMEZONE_SUFFIX = /(?:z|[+-]\d{2}(?::?\d{2})?)$/i;
+const HOUR_OFFSET_SUFFIX = /[+-]\d{2}$/;
+
+function parseDatabaseTimestamp(value: string): Date {
+	let normalized = value.trim().replace(" ", "T");
+	if (HOUR_OFFSET_SUFFIX.test(normalized)) normalized += ":00";
+	else if (!TIMEZONE_SUFFIX.test(normalized)) normalized += "Z";
+	return new Date(normalized);
+}
+
 function toPluginStatus(value: string): PluginStatus {
 	if (value === "active") return "active";
 	return "inactive";
@@ -255,9 +265,9 @@ function rowToPluginState(row: PluginStateRow): PluginState {
 		pluginId: row.plugin_id,
 		status: toPluginStatus(row.status),
 		version: row.version,
-		installedAt: new Date(row.installed_at),
-		activatedAt: row.activated_at ? new Date(row.activated_at) : null,
-		deactivatedAt: row.deactivated_at ? new Date(row.deactivated_at) : null,
+		installedAt: parseDatabaseTimestamp(row.installed_at),
+		activatedAt: row.activated_at ? parseDatabaseTimestamp(row.activated_at) : null,
+		deactivatedAt: row.deactivated_at ? parseDatabaseTimestamp(row.deactivated_at) : null,
 		source: toPluginSource(row.source),
 		marketplaceVersion: row.marketplace_version ?? null,
 		displayName: row.display_name ?? null,

--- a/packages/core/src/plugins/state.ts
+++ b/packages/core/src/plugins/state.ts
@@ -13,7 +13,7 @@ export type PluginStatus = "active" | "inactive";
 export type PluginSource = "config" | "marketplace" | "registry";
 
 const TIMEZONE_SUFFIX = /(?:z|[+-]\d{2}(?::?\d{2})?)$/i;
-const HOUR_OFFSET_SUFFIX = /[+-]\d{2}$/;
+const HOUR_OFFSET_SUFFIX = /\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?[+-]\d{2}$/i;
 
 function parseDatabaseTimestamp(value: string): Date {
 	let normalized = value.trim().replace(" ", "T");

--- a/packages/core/tests/unit/plugins/state.test.ts
+++ b/packages/core/tests/unit/plugins/state.test.ts
@@ -92,6 +92,53 @@ describe("PluginStateRepository", () => {
 			expect(state!.deactivatedAt).toBeInstanceOf(Date);
 		});
 
+		it("parses zone-less database timestamps as UTC", async () => {
+			const previousTimezone = process.env.TZ;
+			process.env.TZ = "America/Los_Angeles";
+
+			try {
+				await db
+					.insertInto("_plugin_state")
+					.values({
+						plugin_id: "test-plugin",
+						status: "active",
+						version: "1.0.0",
+						installed_at: "2026-08-31 12:34:56",
+						activated_at: "2026-08-31 12:34:56",
+						deactivated_at: null,
+						data: null,
+					})
+					.execute();
+
+				const state = await repo.get("test-plugin");
+
+				expect(state!.installedAt.toISOString()).toBe("2026-08-31T12:34:56.000Z");
+				expect(state!.activatedAt!.toISOString()).toBe("2026-08-31T12:34:56.000Z");
+			} finally {
+				if (previousTimezone === undefined) delete process.env.TZ;
+				else process.env.TZ = previousTimezone;
+			}
+		});
+
+		it("parses PostgreSQL hour-only timezone offsets", async () => {
+			await db
+				.insertInto("_plugin_state")
+				.values({
+					plugin_id: "test-plugin",
+					status: "active",
+					version: "1.0.0",
+					installed_at: "2026-08-31 12:34:56.123456+00",
+					activated_at: null,
+					deactivated_at: null,
+					data: null,
+				})
+				.execute();
+
+			const state = await repo.get("test-plugin");
+
+			expect(state!.installedAt.toISOString()).toBe("2026-08-31T12:34:56.123Z");
+		});
+
 		it("handles null dates", async () => {
 			await db
 				.insertInto("_plugin_state")


### PR DESCRIPTION
## What does this PR do?

Parses zone-less SQLite plugin timestamps as UTC instead of server-local time, preventing `installedAt`, `activatedAt`, and `deactivatedAt` from shifting by the server offset. It also preserves PostgreSQL timestamp compatibility, including hour-only offsets such as `+00`.

Addresses #2815

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode with GPT-5.6 Sol

## Screenshots / test output

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec vitest run tests/unit/plugins/state.test.ts` (20 tests)