### PR TITLE
Fix config plugin display metadata

### DIFF
--- a/.changeset/plugin-config-metadata.md
+++ b/.changeset/plugin-config-metadata.md
@@ -1,0 +1,7 @@
+---
+"emdash": patch
+"@emdash-cms/plugin-cli": patch
+"@emdash-cms/plugin-audit-log": patch
+---
+
+Fixes config-registered plugins showing their identifier instead of their display name and omitting their description in the admin Plugins list.

--- a/packages/core/src/api/handlers/plugins.ts
+++ b/packages/core/src/api/handlers/plugins.ts
@@ -75,7 +75,7 @@ function buildPluginInfo(
 
 	return {
 		id: plugin.id,
-		name: state?.displayName || plugin.id,
+		name: state?.displayName || plugin.displayName || plugin.id,
 		version: plugin.version,
 		package: undefined, // v2 doesn't have package field
 		enabled,
@@ -92,7 +92,7 @@ function buildPluginInfo(
 		installedAt: state?.installedAt?.toISOString(),
 		activatedAt: state?.activatedAt?.toISOString() ?? undefined,
 		deactivatedAt: state?.deactivatedAt?.toISOString() ?? undefined,
-		description: state?.description ?? undefined,
+		description: state?.description ?? plugin.description,
 		iconUrl:
 			isMarketplace && marketplaceUrl ? marketplaceIconUrl(marketplaceUrl, plugin.id) : undefined,
 		mcpToolsEnabled: state?.mcpToolsEnabled ?? false,
@@ -125,7 +125,7 @@ function buildSandboxedPluginInfo(
 
 	return {
 		id: entry.id,
-		name: state?.displayName || entry.id,
+		name: state?.displayName || entry.displayName || entry.id,
 		version: entry.version,
 		package: undefined, // v2 doesn't have package field
 		enabled,
@@ -140,7 +140,7 @@ function buildSandboxedPluginInfo(
 		installedAt: state?.installedAt?.toISOString(),
 		activatedAt: state?.activatedAt?.toISOString() ?? undefined,
 		deactivatedAt: state?.deactivatedAt?.toISOString() ?? undefined,
-		description: state?.description ?? undefined,
+		description: state?.description ?? entry.description,
 		mcpToolsEnabled: state?.mcpToolsEnabled ?? false,
 		mcpTools: entry.mcp?.tools.map(({ inputSchema: _, outputSchema: __, ...tool }) => tool) ?? [],
 	};

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -78,6 +78,10 @@ export interface StorageCollectionDeclaration {
 export interface PluginDescriptor<TOptions = Record<string, unknown>> {
 	/** Unique plugin identifier */
 	id: string;
+	/** Human-readable plugin name */
+	displayName?: string;
+	/** Description shown in plugin management UI */
+	description?: string;
 	/** Plugin version (semver) */
 	version: string;
 	/** Module specifier to import (e.g., "@emdash-cms/plugin-api-test") */

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -284,6 +284,8 @@ export function generatePluginsModule(descriptors: PluginDescriptor[]): string {
 			instantiations.push(
 				`adaptSandboxEntry(${varName}, ${JSON.stringify({
 					id: descriptor.id,
+					displayName: descriptor.displayName,
+					description: descriptor.description,
 					version: descriptor.version,
 					capabilities: descriptor.capabilities,
 					allowedHosts: descriptor.allowedHosts,
@@ -299,7 +301,12 @@ export function generatePluginsModule(descriptors: PluginDescriptor[]): string {
 			// Native format: import createPlugin and call with options
 			const varName = `createPlugin${index}`;
 			imports.push(`import { createPlugin as ${varName} } from "${descriptor.entrypoint}";`);
-			instantiations.push(`${varName}(${JSON.stringify(descriptor.options ?? {})})`);
+			instantiations.push(
+				`({ ...${varName}(${JSON.stringify(descriptor.options ?? {})}), ...${JSON.stringify({
+					displayName: descriptor.displayName,
+					description: descriptor.description,
+				})} })`,
+			);
 		}
 	});
 
@@ -691,6 +698,8 @@ export const sandboxedPlugins = [];
 		// Create the plugin entry with embedded code and sandbox config
 		pluginEntries.push(`{
     id: ${JSON.stringify(descriptor.id)},
+		displayName: ${JSON.stringify(descriptor.displayName)},
+		description: ${JSON.stringify(descriptor.description)},
     version: ${JSON.stringify(descriptor.version)},
     options: ${JSON.stringify(descriptor.options ?? {})},
     capabilities: ${JSON.stringify(descriptor.capabilities ?? [])},

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -266,6 +266,8 @@ const LIST_COLUMN_FIELD_TYPES: ReadonlySet<FieldType> = new Set([
  */
 export interface SandboxedPluginEntry {
 	id: string;
+	displayName?: string;
+	description?: string;
 	version: string;
 	options: Record<string, unknown>;
 	code: string;

--- a/packages/core/src/plugins/adapt-sandbox-entry.ts
+++ b/packages/core/src/plugins/adapt-sandbox-entry.ts
@@ -333,6 +333,8 @@ export function adaptSandboxEntry(
 
 	return {
 		id: pluginId,
+		displayName: descriptor.displayName,
+		description: descriptor.description,
 		version,
 		capabilities,
 		allowedHosts,

--- a/packages/core/src/plugins/define-plugin.ts
+++ b/packages/core/src/plugins/define-plugin.ts
@@ -107,6 +107,8 @@ function defineNativePlugin<TStorage extends PluginStorageConfig>(
 
 	const {
 		id,
+		displayName,
+		description,
 		version,
 		capabilities = [],
 		allowedHosts = [],
@@ -211,6 +213,8 @@ function defineNativePlugin<TStorage extends PluginStorageConfig>(
 
 	return {
 		id,
+		displayName,
+		description,
 		version,
 		capabilities: normalizedCapabilities,
 		allowedHosts,

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -1413,6 +1413,10 @@ export interface PluginAdminConfig {
 export interface PluginDefinition<TStorage extends PluginStorageConfig = PluginStorageConfig> {
 	/** Unique plugin identifier */
 	id: string;
+	/** Human-readable plugin name */
+	displayName?: string;
+	/** Description shown in plugin management UI */
+	description?: string;
 	/** Plugin version (semver) */
 	version: string;
 
@@ -1443,6 +1447,8 @@ export interface PluginDefinition<TStorage extends PluginStorageConfig = PluginS
  */
 export interface ResolvedPlugin<TStorage extends PluginStorageConfig = PluginStorageConfig> {
 	id: string;
+	displayName?: string;
+	description?: string;
 	version: string;
 	capabilities: PluginCapability[];
 	allowedHosts: string[];

--- a/packages/core/tests/integration/api/plugins.test.ts
+++ b/packages/core/tests/integration/api/plugins.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { handlePluginList } from "../../../src/api/handlers/plugins.js";
 import type { Database } from "../../../src/database/types.js";
 import type { SandboxedPluginEntry } from "../../../src/emdash-runtime.js";
+import { definePlugin } from "../../../src/plugins/define-plugin.js";
 import { PluginStateRepository } from "../../../src/plugins/state.js";
 import type { ResolvedPlugin } from "../../../src/plugins/types.js";
 import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
@@ -92,5 +93,37 @@ describe("plugin admin handlers: sandboxed plugins", () => {
 		const withoutSettings = result.data.items.find((p) => p.id === "mp-without-settings");
 		expect(withSettings?.hasSettings).toBe(true);
 		expect(withoutSettings?.hasSettings).toBe(false);
+	});
+
+	it("surfaces metadata declared by configured plugins", async () => {
+		const trusted = definePlugin({
+			id: "trusted-plugin",
+			version: "1.0.0",
+			displayName: "Trusted Plugin",
+			description: "Runs in the application process",
+		});
+		const sandboxed = createSandboxedEntry({
+			displayName: "Sandboxed Plugin",
+			description: "Runs in an isolated worker",
+		});
+
+		const result = await handlePluginList(db, [trusted], [sandboxed]);
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data.items).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "trusted-plugin",
+					name: "Trusted Plugin",
+					description: "Runs in the application process",
+				}),
+				expect.objectContaining({
+					id: "sandboxed-plugin",
+					name: "Sandboxed Plugin",
+					description: "Runs in an isolated worker",
+				}),
+			]),
+		);
 	});
 });

--- a/packages/core/tests/unit/astro/virtual-modules-sandbox.test.ts
+++ b/packages/core/tests/unit/astro/virtual-modules-sandbox.test.ts
@@ -76,6 +76,23 @@ describe("generateSandboxedPluginsModule", () => {
 		expect(result).toContain("export default { hooks: {} };");
 	});
 
+	it("embeds plugin display metadata", async () => {
+		await setupFakeProject("dist/sandbox-entry.mjs", "export default { hooks: {} };");
+
+		const result = generateSandboxedPluginsModule(
+			[
+				descriptor({
+					displayName: "Test Plugin",
+					description: "Tests sandbox behavior",
+				}),
+			],
+			tmpDir,
+		);
+
+		expect(result).toContain('displayName: "Test Plugin"');
+		expect(result).toContain('description: "Tests sandbox behavior"');
+	});
+
 	it("throws for .ts source files", async () => {
 		await setupFakeProject("src/sandbox-entry.ts", "export default {};");
 

--- a/packages/core/tests/unit/plugins/standard-format.test.ts
+++ b/packages/core/tests/unit/plugins/standard-format.test.ts
@@ -83,6 +83,8 @@ describe("generatePluginsModule() standard format", () => {
 		const descriptors: PluginDescriptor[] = [
 			{
 				id: "my-native-plugin",
+				displayName: "My Native Plugin",
+				description: "Runs natively",
 				version: "1.0.0",
 				entrypoint: "@my/native-plugin",
 				options: { debug: true },
@@ -94,6 +96,8 @@ describe("generatePluginsModule() standard format", () => {
 		expect(code).not.toContain("adaptSandboxEntry");
 		expect(code).toContain('import { createPlugin as createPlugin0 } from "@my/native-plugin"');
 		expect(code).toContain('createPlugin0({"debug":true})');
+		expect(code).toContain('...{"displayName":"My Native Plugin","description":"Runs natively"}');
+		expect(code).not.toContain("Object.assign");
 	});
 
 	it("handles mixed standard and native plugins", () => {
@@ -189,6 +193,8 @@ describe("generatePluginsModule() standard format", () => {
 		const descriptors: PluginDescriptor[] = [
 			{
 				id: "my-plugin",
+				displayName: "My Plugin",
+				description: "Does useful things",
 				version: "1.0.0",
 				entrypoint: "@my/plugin",
 				format: "standard",
@@ -203,6 +209,8 @@ describe("generatePluginsModule() standard format", () => {
 
 		// The descriptor metadata should be serialized into the adapter call
 		expect(code).toContain('"id":"my-plugin"');
+		expect(code).toContain('"displayName":"My Plugin"');
+		expect(code).toContain('"description":"Does useful things"');
 		expect(code).toContain('"version":"1.0.0"');
 		expect(code).toContain('"capabilities":["content:read","network:request"]');
 		expect(code).toContain('"allowedHosts":["api.example.com"]');

--- a/packages/plugin-cli/src/build/api.ts
+++ b/packages/plugin-cli/src/build/api.ts
@@ -270,6 +270,8 @@ async function writeDescriptor(ctx: WriteDescriptorContext): Promise<DescriptorF
 
 	const descriptorObject = {
 		id: manifest.slug,
+		displayName: manifest.name,
+		description: manifest.description,
 		version: manifest.version,
 		format: "standard" as const,
 		entrypoint: `${packageName}/sandbox`,

--- a/packages/plugins/audit-log/emdash-plugin.jsonc
+++ b/packages/plugins/audit-log/emdash-plugin.jsonc
@@ -2,6 +2,7 @@
 	"$schema": "../../plugin-cli/schemas/emdash-plugin.schema.json",
 
 	"slug": "audit-log",
+	"name": "Audit Log",
 	"publisher": "did:plc:xyraubanwc5fwemkduw3upi6", // plugins.emdashcms.com
 
 	"license": "MIT",


### PR DESCRIPTION
## What does this PR do?

Allows config-registered trusted and sandboxed plugins to surface a display name and description in the admin Plugins list. Plugin build output now carries `name` and `description` from `emdash-plugin.jsonc`, and the first-party audit-log plugin declares its display name. Database-backed marketplace or registry metadata still takes precedence.

Closes #2815

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode with GPT-5.6 Sol

## Screenshots / test output

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec vitest run tests/integration/api/plugins.test.ts tests/unit/plugins/standard-format.test.ts tests/unit/astro/virtual-modules-sandbox.test.ts` (20 tests)