### PR TITLE
Fix boolean field runtime values in Astro loader

### DIFF
--- a/.changeset/clean-booleans-load.md
+++ b/.changeset/clean-booleans-load.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `getEmDashCollection()` and `getEmDashEntry()` returning SQLite-backed boolean fields as `0` or `1`. Boolean fields now return `true` or `false`, matching their generated TypeScript types, while integer fields retain numeric values.

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -59,6 +59,9 @@ const SEO_ALIAS_COLUMNS = Object.values(SEO_COLUMN_ALIASES);
 /** Folded SEO JSON column name in the result set (expanded onto aliases in JS). */
 const SEO_FOLDED_COLUMN = "_emdash_seo";
 
+/** Folded boolean field slugs used to restore SQLite integer values. */
+const BOOLEAN_FIELDS_FOLDED_COLUMN = "_emdash_boolean_fields";
+
 /**
  * System columns excluded from entry.data
  * Note: slug is intentionally NOT excluded - it's useful as data.slug in templates
@@ -91,6 +94,7 @@ const SYSTEM_COLUMNS = new Set([
 	"_emdash_bylines",
 	"_emdash_bylines_exist",
 	SEO_FOLDED_COLUMN,
+	BOOLEAN_FIELDS_FOLDED_COLUMN,
 ]);
 
 /** Markers for byline/taxonomy hydration folded into the content query. */
@@ -183,6 +187,19 @@ function foldedSeoSelect(db: Kysely<any>, type: string, outer: string) {
 		"'seo_title', s.seo_title, 'seo_description', s.seo_description, 'seo_image', s.seo_image, 'seo_canonical', s.seo_canonical, 'seo_no_index', s.seo_no_index";
 	const obj = pg ? sql.raw(`json_build_object(${pairs})`) : sql.raw(`json_object(${pairs})`);
 	return sql`(SELECT ${obj} FROM ${sql.ref("_emdash_seo")} AS s WHERE s.collection = ${type} AND s.content_id = ${o}.id LIMIT 1) AS ${sql.ref(SEO_FOLDED_COLUMN)}`;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- any Kysely instance
+function foldedBooleanFieldsSelect(db: Kysely<any>, type: string) {
+	const aggregate = isPostgres(db)
+		? sql`coalesce(json_agg(f.slug), '[]'::json)`
+		: sql`json_group_array(f.slug)`;
+	return sql`(
+		SELECT ${aggregate}
+		FROM ${sql.ref("_emdash_fields")} AS f
+		INNER JOIN ${sql.ref("_emdash_collections")} AS c ON c.id = f.collection_id
+		WHERE c.slug = ${type} AND f.type = ${"boolean"}
+	) AS ${sql.ref(BOOLEAN_FIELDS_FOLDED_COLUMN)}`;
 }
 
 /**
@@ -493,7 +510,10 @@ function normalizeLocalMediaValue(value: unknown): unknown {
  * Extracts content fields (non-system columns) and parses JSON where needed.
  * System columns needed for templates (id, status, dates) are included with camelCase names.
  */
-function mapRowToData(row: Record<string, unknown>): Record<string, unknown> {
+function mapRowToData(
+	row: Record<string, unknown>,
+	booleanFields: ReadonlySet<string>,
+): Record<string, unknown> {
 	const data: Record<string, unknown> = {};
 	const rawDateValues: Record<string, string> = {};
 
@@ -515,6 +535,11 @@ function mapRowToData(row: Record<string, unknown>): Record<string, unknown> {
 		}
 
 		if (SYSTEM_COLUMNS.has(key)) continue;
+
+		if (booleanFields.has(key) && (typeof value === "boolean" || value === 0 || value === 1)) {
+			data[key] = Boolean(value);
+			continue;
+		}
 
 		// Try to parse JSON strings (for portableText, json fields, etc.)
 		if (typeof value === "string") {
@@ -541,6 +566,23 @@ function mapRowToData(row: Record<string, unknown>): Record<string, unknown> {
 	});
 
 	return data;
+}
+
+function parseFoldedBooleanFields(row: Record<string, unknown> | undefined): Set<string> {
+	const raw = row?.[BOOLEAN_FIELDS_FOLDED_COLUMN];
+	let values: unknown;
+	if (typeof raw === "string") {
+		try {
+			values = JSON.parse(raw);
+		} catch {
+			return new Set();
+		}
+	} else {
+		values = raw;
+	}
+
+	if (!Array.isArray(values)) return new Set();
+	return new Set(values.filter((value): value is string => typeof value === "string"));
 }
 
 /**
@@ -904,6 +946,7 @@ export function buildTaxonomyPivotQuery(
 		bylines: bylinesSelect,
 		bylinesExist: bylinesExistSelect,
 	} = foldedHydrationSelects(db, collection, "r");
+	const booleanFieldsSelect = foldedBooleanFieldsSelect(db, collection);
 
 	// Authoritative re-check on the joined `ec_*` row.
 	const deletedR = deletedIsNull ? sql`r.deleted_at IS NULL` : sql`r.deleted_at IS NOT NULL`;
@@ -945,7 +988,7 @@ export function buildTaxonomyPivotQuery(
 				ORDER BY sortval ${dir}, r.id ${dir}
 				${limitClause}
 			)
-			SELECT r.*, ${termsSelect}, ${bylinesSelect}, ${bylinesExistSelect}
+			SELECT r.*, ${termsSelect}, ${bylinesSelect}, ${bylinesExistSelect}, ${booleanFieldsSelect}
 			FROM picked JOIN ${sql.ref(tableName)} AS r ON r.id = picked.entry_id
 			WHERE ${deletedR} ${statusR} ${localeR}
 			ORDER BY picked.sortval ${dir}, picked.entry_id ${dir}
@@ -969,7 +1012,7 @@ export function buildTaxonomyPivotQuery(
 				${residual}
 				${bylineCt}
 		)
-		SELECT r.*, ${termsSelect}, ${bylinesSelect}, ${bylinesExistSelect}
+		SELECT r.*, ${termsSelect}, ${bylinesSelect}, ${bylinesExistSelect}, ${booleanFieldsSelect}
 		FROM picked JOIN ${sql.ref(tableName)} AS r ON r.id = picked.entry_id
 		WHERE ${deletedR} ${statusR} ${localeR}
 			${cursorCond}
@@ -1337,6 +1380,7 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 						bylines: bylinesSelect,
 						bylinesExist: bylinesExistSelect,
 					} = foldedHydrationSelects(db, type, tableName);
+					const booleanFieldsSelect = foldedBooleanFieldsSelect(db, type);
 
 					// LIMIT/OFFSET clause. SQLite only accepts OFFSET when a
 					// LIMIT is present, so a bare offset uses `LIMIT -1`
@@ -1352,7 +1396,7 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 							: sql`LIMIT -1 OFFSET ${offset}`;
 					}
 					result = await sql<Record<string, unknown>>`
-						SELECT *, ${termsSelect}, ${bylinesSelect}, ${bylinesExistSelect} FROM ${sql.ref(tableName)}
+						SELECT *, ${termsSelect}, ${bylinesSelect}, ${bylinesExistSelect}, ${booleanFieldsSelect} FROM ${sql.ref(tableName)}
 						WHERE deleted_at IS NULL
 						AND ${statusCondition}
 						${localeFilter}
@@ -1372,6 +1416,7 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 				// Map rows to entries
 				const i18nConfig = virtualConfig?.i18n;
 				const i18nEnabled = i18nConfig && i18nConfig.locales.length > 1;
+				const booleanFields = parseFoldedBooleanFields(rows[0]);
 				const entries = rows.map((row) => {
 					const slug = rowStr(row, "slug") || rowStr(row, "id");
 					const rowLocale = rowStr(row, "locale");
@@ -1380,7 +1425,7 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 						rowLocale !== "" &&
 						(rowLocale !== i18nConfig.defaultLocale || i18nConfig.prefixDefaultLocale);
 					const id = shouldPrefix ? `${rowLocale}/${slug}` : slug;
-					const data = mapRowToData(row);
+					const data = mapRowToData(row, booleanFields);
 					stashFolded(data, row);
 					return {
 						id,
@@ -1494,16 +1539,17 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 					bylinesExist: bylinesExistSelect,
 				} = foldedHydrationSelects(db, type, "c");
 				const seoSelect = foldedSeoSelect(db, type, "c");
+				const booleanFieldsSelect = foldedBooleanFieldsSelect(db, type);
 				const result = locale
 					? await sql<Record<string, unknown>>`
-							SELECT c.*, ${seoSelect}, ${termsSelect}, ${bylinesSelect}, ${bylinesExistSelect}
+							SELECT c.*, ${seoSelect}, ${termsSelect}, ${bylinesSelect}, ${bylinesExistSelect}, ${booleanFieldsSelect}
 							FROM ${sql.ref(tableName)} AS c
 							WHERE c.deleted_at IS NULL
 							AND ((c.slug = ${id} AND c.locale = ${locale}) OR c.id = ${id})
 							LIMIT 1
 						`.execute(db)
 					: await sql<Record<string, unknown>>`
-							SELECT c.*, ${seoSelect}, ${termsSelect}, ${bylinesSelect}, ${bylinesExistSelect}
+							SELECT c.*, ${seoSelect}, ${termsSelect}, ${bylinesSelect}, ${bylinesExistSelect}, ${booleanFieldsSelect}
 							FROM ${sql.ref(tableName)} AS c
 							WHERE c.deleted_at IS NULL
 							AND (c.slug = ${id} OR c.id = ${id})
@@ -1586,7 +1632,7 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 					}
 				}
 
-				const entryData = mapRowToData(row);
+				const entryData = mapRowToData(row, parseFoldedBooleanFields(row));
 				const entrySeo = extractSeo(row);
 				if (entrySeo) entryData.seo = entrySeo;
 				stashFolded(entryData, row);

--- a/packages/core/tests/unit/loader-boolean-fields.test.ts
+++ b/packages/core/tests/unit/loader-boolean-fields.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { handleContentCreate } from "../../src/api/index.js";
+import { emdashLoader } from "../../src/loader.js";
+import { runWithContext } from "../../src/request-context.js";
+import { SchemaRegistry } from "../../src/schema/registry.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../utils/test-db.js";
+
+describeEachDialect("Loader boolean field values", (dialect) => {
+	let ctx: DialectTestContext;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+		const registry = new SchemaRegistry(ctx.db);
+		await registry.createCollection({
+			slug: "feature",
+			label: "Features",
+			labelSingular: "Feature",
+		});
+		await registry.createField("feature", {
+			slug: "title",
+			label: "Title",
+			type: "string",
+		});
+		await registry.createField("feature", {
+			slug: "enabled",
+			label: "Enabled",
+			type: "boolean",
+		});
+		await registry.createField("feature", {
+			slug: "highlighted",
+			label: "Highlighted",
+			type: "boolean",
+		});
+		await registry.createField("feature", {
+			slug: "priority",
+			label: "Priority",
+			type: "integer",
+		});
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	async function createFeature(title: string, enabled: boolean, priority: number) {
+		const result = await handleContentCreate(ctx.db, "feature", {
+			data: { title, enabled, highlighted: null, priority },
+			status: "published",
+		});
+		if (!result.success) throw new Error("Failed to create feature");
+		return result.data!.item;
+	}
+
+	it("returns booleans from collection loads without coercing integer fields", async () => {
+		await createFeature("Enabled", true, 1);
+		await createFeature("Disabled", false, 0);
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ db: ctx.db }, () =>
+			loader.loadCollection!({ filter: { type: "feature" } }),
+		);
+		const enabled = result.entries.find((entry) => entry.data.title === "Enabled");
+		const disabled = result.entries.find((entry) => entry.data.title === "Disabled");
+
+		expect(enabled?.data.enabled).toBe(true);
+		expect(disabled?.data.enabled).toBe(false);
+		expect(enabled?.data.priority).toBe(1);
+		expect(disabled?.data.priority).toBe(0);
+		expect(enabled?.data.highlighted).toBeNull();
+	});
+
+	it("returns booleans from single-entry loads", async () => {
+		const feature = await createFeature("Enabled", true, 1);
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ db: ctx.db }, () =>
+			loader.loadEntry!({ filter: { type: "feature", id: feature.id } }),
+		);
+
+		expect(result).toBeDefined();
+		expect((result as { data: Record<string, unknown> }).data.enabled).toBe(true);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

`getEmDashCollection()` and `getEmDashEntry()` currently return SQLite-backed boolean fields as numeric `0` or `1`, even though generated TypeScript types declare those fields as `boolean`.

This change folds the collection's boolean field slugs into the existing content query and converts only those field values to `true` or `false`. Integer fields containing `0` or `1` remain numeric, nullable booleans remain `null`, and the loader adds no database round trip.

Regression tests cover collection and single-entry loading. Related to #651, which fixed the admin checkbox symptom but not the loader's runtime type mismatch.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable; this change adds no UI strings)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion (not applicable; this is a bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

No visual changes.

Validated with:

- `pnpm typecheck`
- `pnpm lint`
- 47 focused loader tests covering boolean fields, taxonomy pivots, wide collections, SEO, and folded hydration
