### PR TITLE
Fix media source identity across editor workflows

### DIFF
--- a/.changeset/preserve-media-source-identity.md
+++ b/.changeset/preserve-media-source-identity.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": patch
+"emdash": patch
+---
+
+Fixes image fields and Portable Text editors so they preserve direct image URLs and external provider identities, allowing selected images to continue rendering after saving or replacement.

--- a/packages/admin/src/components/ImageFieldRenderer.tsx
+++ b/packages/admin/src/components/ImageFieldRenderer.tsx
@@ -14,7 +14,7 @@ import { Image as ImageIcon, ImageBroken, ImageSquare, X } from "@phosphor-icons
 import * as React from "react";
 
 import type { MediaItem } from "../lib/api";
-import { getMediaObjectPosition, metaString } from "../lib/media-utils";
+import { canonicalMediaProviderId, getMediaObjectPosition, metaString } from "../lib/media-utils";
 import { FieldHelpLabel } from "./FieldHelpLabel.js";
 import { MediaPickerModal } from "./MediaPickerModal";
 
@@ -88,14 +88,17 @@ export function ImageFieldRenderer({
 	}, [displayUrl]);
 
 	const handleSelect = (item: MediaItem) => {
-		const isLocalProvider = !item.provider || item.provider === "local";
+		const provider = canonicalMediaProviderId(item.provider);
+		const isLocalProvider = provider === "local";
+		const isDirectUrl = provider === "external";
 
 		onChange({
 			id: item.id,
-			provider: item.provider || "local",
-			// Local media derives URLs from meta.storageKey at display time — no src needed
-			// External providers cache a preview URL for admin display
-			previewUrl: isLocalProvider ? undefined : item.url,
+			provider,
+			// Local media derives its URL from storageKey. Direct URLs persist src,
+			// while external providers cache a preview URL for the admin.
+			src: isDirectUrl ? item.url : undefined,
+			previewUrl: !isLocalProvider && !isDirectUrl ? item.url : undefined,
 			alt: item.alt || "",
 			width: item.width,
 			height: item.height,

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -113,6 +113,7 @@ import * as React from "react";
 
 import type { MediaItem } from "../lib/api";
 import type { Section } from "../lib/api";
+import { canonicalMediaProviderId } from "../lib/media-utils.js";
 import {
 	UnsupportedPortableTextMarksError,
 	assertPortableTextMarksSupported,
@@ -181,7 +182,7 @@ interface PortableTextTextBlock {
 interface PortableTextImageBlock {
 	_type: "image";
 	_key: string;
-	asset: { _ref: string; url?: string; meta?: Record<string, unknown> };
+	asset: { _ref: string; url?: string; provider?: string; meta?: Record<string, unknown> };
 	alt?: string;
 	caption?: string;
 	width?: number;
@@ -1014,6 +1015,7 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 					title: imageBlock.caption || "",
 					caption: imageBlock.caption || "",
 					mediaId: imageBlock.asset._ref,
+					provider: canonicalMediaProviderId(imageBlock.asset.provider),
 					width: imageBlock.width,
 					height: imageBlock.height,
 					blurhash,
@@ -3198,7 +3200,7 @@ export function PortableTextEditor({
 					src: item.url,
 					alt: item.alt || item.filename,
 					mediaId: item.id,
-					provider: item.provider || "local",
+					provider: canonicalMediaProviderId(item.provider),
 					width: item.width,
 					height: item.height,
 					blurhash: item.blurhash,

--- a/packages/admin/src/components/editor/ImageDetailPanel.tsx
+++ b/packages/admin/src/components/editor/ImageDetailPanel.tsx
@@ -20,6 +20,7 @@ import * as React from "react";
 
 import type { MediaItem } from "../../lib/api";
 import { useStableCallback } from "../../lib/hooks";
+import { canonicalMediaProviderId } from "../../lib/media-utils.js";
 import { ConfirmDialog } from "../ConfirmDialog";
 import { MediaPickerModal } from "../MediaPickerModal";
 
@@ -29,6 +30,7 @@ export interface ImageAttributes {
 	title?: string;
 	caption?: string;
 	mediaId?: string;
+	provider?: string;
 	/** Original image width */
 	width?: number;
 	/** Original image height */
@@ -117,6 +119,7 @@ export function ImageDetailPanel({
 			src: item.url,
 			alt: item.alt || item.filename,
 			mediaId: item.id,
+			provider: canonicalMediaProviderId(item.provider),
 			width: item.width,
 			height: item.height,
 			blurhash: item.blurhash,

--- a/packages/admin/src/components/editor/ImageNode.tsx
+++ b/packages/admin/src/components/editor/ImageNode.tsx
@@ -96,6 +96,7 @@ function ImageNodeView({
 		title: node.attrs.title,
 		caption: node.attrs.caption,
 		mediaId: node.attrs.mediaId,
+		provider: node.attrs.provider,
 		width: node.attrs.width,
 		height: node.attrs.height,
 		blurhash: node.attrs.blurhash,

--- a/packages/admin/src/lib/media-utils.ts
+++ b/packages/admin/src/lib/media-utils.ts
@@ -1,5 +1,10 @@
 import type { MediaItem, MediaProviderItem } from "./api/media.js";
 
+export function canonicalMediaProviderId(provider: string | undefined): string {
+	if (!provider) return "local";
+	return provider === "external-url" ? "external" : provider;
+}
+
 export interface MediaFocalPoint {
 	focalX: number;
 	focalY: number;

--- a/packages/admin/tests/components/ImageDetailPanel.test.tsx
+++ b/packages/admin/tests/components/ImageDetailPanel.test.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ImageDetailPanel } from "../../src/components/editor/ImageDetailPanel.js";
+import type { MediaItem } from "../../src/lib/api/media.js";
+import { render } from "../utils/render.js";
+
+const replacements: Record<string, MediaItem> = {
+	"Choose local image": {
+		id: "local-image",
+		filename: "local.jpg",
+		mimeType: "image/jpeg",
+		url: "/_emdash/api/media/file/local.jpg",
+		storageKey: "local.jpg",
+		size: 100,
+		createdAt: "2026-08-16T00:00:00.000Z",
+	},
+	"Choose provider image": {
+		id: "provider-image",
+		filename: "provider.jpg",
+		mimeType: "image/jpeg",
+		url: "https://media.example/provider.jpg",
+		provider: "cloudflare-images",
+		size: 100,
+		createdAt: "2026-08-16T00:00:00.000Z",
+	},
+};
+
+vi.mock("../../src/components/MediaPickerModal.js", () => ({
+	MediaPickerModal: ({ open, onSelect }: { open: boolean; onSelect: (item: MediaItem) => void }) =>
+		open ? (
+			<>
+				{Object.entries(replacements).map(([label, item]) => (
+					<button key={label} type="button" onClick={() => onSelect(item)}>
+						{label}
+					</button>
+				))}
+			</>
+		) : null,
+}));
+
+describe("ImageDetailPanel replacement", () => {
+	it.each([
+		{ action: "Choose local image", expectedProvider: "local" },
+		{ action: "Choose provider image", expectedProvider: "cloudflare-images" },
+	])("uses the replacement provider for $action", async ({ action, expectedProvider }) => {
+		const onReplace = vi.fn();
+		const screen = await render(
+			<ImageDetailPanel
+				attributes={{
+					src: "https://media.example/old.jpg",
+					provider: "old-provider",
+					mediaId: "old-image",
+				}}
+				onUpdate={vi.fn()}
+				onReplace={onReplace}
+				onDelete={vi.fn()}
+				onClose={vi.fn()}
+				inline
+			/>,
+		);
+
+		await screen.getByRole("button", { name: "Replace Image" }).click();
+		await screen.getByRole("button", { name: action }).click();
+
+		expect(onReplace).toHaveBeenCalledWith(expect.objectContaining({ provider: expectedProvider }));
+	});
+});

--- a/packages/admin/tests/components/ImageFieldRenderer.test.tsx
+++ b/packages/admin/tests/components/ImageFieldRenderer.test.tsx
@@ -7,28 +7,48 @@ import { render } from "../utils/render.tsx";
 vi.mock("../../src/components/MediaPickerModal", () => ({
 	MediaPickerModal: ({ open, onSelect }: { open: boolean; onSelect: (item: unknown) => void }) =>
 		open ? (
-			<button
-				type="button"
-				onClick={() =>
-					onSelect({
-						id: "replacement-image",
-						filename: "replacement.webp",
-						mimeType: "image/webp",
-						url: "/media/replacement.webp",
-						storageKey: "replacement.webp",
-						provider: "local",
-						size: 31_744,
-						width: 1600,
-						height: 800,
-						focalX: 0.2,
-						focalY: 0.8,
-						alt: "Replacement image",
-						createdAt: "2026-07-23T12:00:00.000Z",
-					})
-				}
-			>
-				Choose replacement
-			</button>
+			<>
+				<button
+					type="button"
+					onClick={() =>
+						onSelect({
+							id: "replacement-image",
+							filename: "replacement.webp",
+							mimeType: "image/webp",
+							url: "/media/replacement.webp",
+							storageKey: "replacement.webp",
+							provider: "local",
+							size: 31_744,
+							width: 1600,
+							height: 800,
+							focalX: 0.2,
+							focalY: 0.8,
+							alt: "Replacement image",
+							createdAt: "2026-07-23T12:00:00.000Z",
+						})
+					}
+				>
+					Choose replacement
+				</button>
+				<button
+					type="button"
+					onClick={() =>
+						onSelect({
+							id: "",
+							filename: "external.jpg",
+							mimeType: "image/jpeg",
+							url: "https://media.example/external.jpg",
+							provider: "external-url",
+							size: 0,
+							width: 1200,
+							height: 800,
+							createdAt: "2026-07-23T12:00:00.000Z",
+						})
+					}
+				>
+					Choose external URL
+				</button>
+			</>
 		) : null,
 }));
 
@@ -130,6 +150,30 @@ describe("ImageFieldRenderer", () => {
 				focalY: 0.8,
 			}),
 		);
+	});
+
+	it("stores an external URL as a renderable direct media value", async () => {
+		const onChange = vi.fn();
+		const screen = await render(
+			<ImageFieldRenderer
+				label="Featured image"
+				value={selectedImage}
+				onChange={onChange}
+				variant="featured"
+			/>,
+		);
+
+		await screen.getByRole("button", { name: "Replace" }).click();
+		await screen.getByRole("button", { name: "Choose external URL" }).click();
+
+		expect(onChange).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: "",
+				provider: "external",
+				src: "https://media.example/external.jpg",
+			}),
+		);
+		expect(onChange.mock.calls[0]?.[0].previewUrl).toBeUndefined();
 	});
 
 	it("removes the featured image immediately", async () => {

--- a/packages/admin/tests/editor/image-lqip.test.ts
+++ b/packages/admin/tests/editor/image-lqip.test.ts
@@ -17,7 +17,7 @@ import {
 type ImagePMNode = { type: string; attrs?: Record<string, unknown> };
 type ImagePTBlock = {
 	_type: string;
-	asset?: { meta?: { blurhash?: string; dominantColor?: string } };
+	asset?: { provider?: string; meta?: { blurhash?: string; dominantColor?: string } };
 	blurhash?: string;
 	dominantColor?: string;
 };
@@ -78,4 +78,47 @@ describe("admin editor image LQIP round-trip", () => {
 		expect(restored.dominantColor).toBe("#112233");
 		expect(restored.asset?.meta?.blurhash).toBeUndefined();
 	});
+
+	it.each([
+		{
+			name: "configured provider",
+			provider: "cloudflare-images",
+			expectedNodeProvider: "cloudflare-images",
+			expectedStoredProvider: "cloudflare-images",
+		},
+		{
+			name: "legacy external URL provider",
+			provider: "external-url",
+			expectedNodeProvider: "external",
+			expectedStoredProvider: "external",
+		},
+		{
+			name: "local provider",
+			provider: "local",
+			expectedNodeProvider: "local",
+			expectedStoredProvider: undefined,
+		},
+	])(
+		"preserves a $name through PT → PM → PT",
+		({ provider, expectedNodeProvider, expectedStoredProvider }) => {
+			const block = {
+				_type: "image" as const,
+				_key: "provider-image",
+				asset: {
+					_ref: "provider-image-id",
+					url: "https://media.example/provider-image.jpg",
+					provider,
+				},
+				alt: "Provider image",
+			};
+
+			// eslint-disable-next-line typescript/no-unsafe-type-assertion -- test fixture
+			const pm = portableTextToProsemirror([block as never]);
+			const node = pm.content?.[0] as ImagePMNode;
+			expect(node.attrs?.provider).toBe(expectedNodeProvider);
+
+			const restored = prosemirrorToPortableText({ type: "doc", content: pm.content });
+			expect((restored[0] as ImagePTBlock).asset?.provider).toBe(expectedStoredProvider);
+		},
+	);
 });

--- a/packages/admin/tests/editor/image-selection.test.tsx
+++ b/packages/admin/tests/editor/image-selection.test.tsx
@@ -2,23 +2,35 @@ import { screen } from "@testing-library/react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import * as React from "react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { ImageExtension } from "../../src/components/editor/ImageNode.js";
 import { render } from "../utils/render.js";
 
-function TestEditor() {
+function TestEditor({ onSidebarOpen }: { onSidebarOpen?: (panel: unknown) => void } = {}) {
 	const editor = useEditor({
 		extensions: [StarterKit, ImageExtension],
 		content: {
 			type: "doc",
 			content: [
 				{ type: "paragraph", content: [{ type: "text", text: "Before" }] },
-				{ type: "image", attrs: { src: "/img.jpg", alt: "Example" } },
+				{
+					type: "image",
+					attrs: { src: "/img.jpg", alt: "Example", provider: "cloudflare-images" },
+				},
 			],
 		},
 		immediatelyRender: true,
 	});
+	React.useEffect(() => {
+		if (!editor || !onSidebarOpen) return;
+		const storage = (editor.storage as unknown as Record<string, Record<string, unknown>>).image;
+		if (!storage) return;
+		storage.onOpenBlockSidebar = onSidebarOpen;
+		return () => {
+			storage.onOpenBlockSidebar = null;
+		};
+	}, [editor, onSidebarOpen]);
 
 	if (!editor) return null;
 	return <EditorContent editor={editor} />;
@@ -58,5 +70,19 @@ describe("Editor image selection", () => {
 
 		const settings = await screen.findByRole("button", { name: "Image settings" });
 		expect(getComputedStyle(settings.parentElement!).opacity).toBe("1");
+	});
+
+	it("passes the image provider to the settings sidebar", async () => {
+		const onSidebarOpen = vi.fn();
+		void render(<TestEditor onSidebarOpen={onSidebarOpen} />);
+		const image = await screen.findByRole("img", { name: "Example" });
+
+		pressWithPointerDrift(image);
+		(await screen.findByRole("button", { name: "Image settings" })).click();
+
+		await vi.waitFor(() => expect(onSidebarOpen).toHaveBeenCalledOnce());
+		expect(onSidebarOpen.mock.calls[0]?.[0]).toMatchObject({
+			attrs: { provider: "cloudflare-images" },
+		});
 	});
 });

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -42,6 +42,22 @@ vi.mock("../../src/components/MediaPickerModal", () => ({
 				>
 					Choose test image
 				</button>
+				<button
+					type="button"
+					onClick={() =>
+						onSelect({
+							id: "",
+							filename: "remote.jpg",
+							mimeType: "image/jpeg",
+							url: "https://media.example/remote.jpg",
+							provider: "external-url",
+							size: 0,
+							createdAt: "2026-08-16T00:00:00.000Z",
+						})
+					}
+				>
+					Choose external image
+				</button>
 				<button type="button" onClick={() => onOpenChange(false)}>
 					Cancel image picker
 				</button>
@@ -426,6 +442,23 @@ describe("Block insertion", () => {
 				alt: "Architecture diagram",
 				mediaId: "image-1",
 				provider: "local",
+			});
+		});
+	});
+
+	it("stores a canonical provider when inserting an external URL", async () => {
+		const { screen, editor } = await renderEditor();
+		editor.commands.focus("end");
+
+		getToolbarButton(screen, "Insert Image").element().click();
+		await screen.getByRole("button", { name: "Choose external image" }).click();
+
+		await vi.waitFor(() => {
+			const image = editor.getJSON().content?.find((node) => node.type === "image");
+			expect(image?.attrs).toMatchObject({
+				src: "https://media.example/remote.jpg",
+				mediaId: "",
+				provider: "external",
 			});
 		});
 	});

--- a/packages/core/src/components/EmDashImage.astro
+++ b/packages/core/src/components/EmDashImage.astro
@@ -21,6 +21,7 @@ import type { HTMLAttributes } from "astro/types";
 import { Image as AstroImage, getImage } from "astro:assets";
 import type { ImageEmbed } from "../media/types.js";
 import { getMediaProvider } from "../media/provider-loader.js";
+import { normalizeLegacyExternalMediaValue } from "../media/normalize.js";
 import { buildRenderMediaUrl } from "../media/url.js";
 import {
 	buildResponsiveImage,
@@ -67,7 +68,7 @@ function normalizeImage(
 	if (typeof img === "string") {
 		return { id: "", src: img };
 	}
-	return img;
+	return normalizeLegacyExternalMediaValue(img);
 }
 
 /**

--- a/packages/core/src/components/EmDashMedia.astro
+++ b/packages/core/src/components/EmDashMedia.astro
@@ -20,6 +20,7 @@ import type { MediaValue } from "../fields/types.js";
 import type { EmbedResult, EmbedOptions } from "../media/types.js";
 import type { HTMLAttributes } from "astro/types";
 import { getMediaProvider } from "../media/provider-loader.js";
+import { normalizeLegacyExternalMediaValue } from "../media/normalize.js";
 
 interface Props extends Omit<HTMLAttributes<"img" | "video" | "audio">, "src" | "width" | "height"> {
 	/** Media value from content field */
@@ -42,7 +43,7 @@ function normalizeValue(val: MediaValue | string | undefined | null): MediaValue
 	if (typeof val === "string") {
 		return { id: "", src: val, provider: "local" };
 	}
-	return val;
+	return normalizeLegacyExternalMediaValue(val);
 }
 
 const media = normalizeValue(value);

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -2225,6 +2225,7 @@ export function InlinePortableTextEditor({
 					src,
 					alt: item.alt || item.filename || "",
 					mediaId: item.id,
+					provider: item.provider || "local",
 					width: item.width,
 					height: item.height,
 					blurhash: item.blurhash,

--- a/packages/core/src/media/normalize.ts
+++ b/packages/core/src/media/normalize.ts
@@ -15,6 +15,16 @@ import type { MediaProvider, MediaProviderItem, MediaValue } from "./types.js";
 export const INTERNAL_MEDIA_PREFIX = "/_emdash/api/media/file/";
 const URL_PATTERN = /^https?:\/\//;
 
+export function normalizeLegacyExternalMediaValue(value: MediaValue): MediaValue {
+	if (value.provider !== "external-url") return value;
+	const src = value.src ?? value.previewUrl;
+	return {
+		...value,
+		provider: "external",
+		...(src === undefined ? {} : { src }),
+	};
+}
+
 /**
  * Normalize a media field value into a consistent MediaValue shape.
  *
@@ -41,16 +51,17 @@ export async function normalizeMediaValue(
 	// Must have at least an id to be a valid media value
 	if (!("id" in value) && !("src" in value)) return null;
 
-	const provider = (typeof value.provider === "string" ? value.provider : undefined) || "local";
-	const id = typeof value.id === "string" ? value.id : "";
+	const parsed = normalizeLegacyExternalMediaValue(recordToMediaValue(value));
+	const provider = parsed.provider || "local";
+	const id = parsed.id;
 
 	// External URLs — return as-is, no server-side dimension detection
 	if (provider === "external") {
-		return recordToMediaValue(value);
+		return parsed;
 	}
 
 	// Build the base value from the input
-	const result: MediaValue = { ...recordToMediaValue(value), provider };
+	const result: MediaValue = { ...parsed, provider };
 
 	// For local media, strip `src` — it's derived at display time from storageKey
 	if (provider === "local") {

--- a/packages/core/tests/repro/image-render.render.test.ts
+++ b/packages/core/tests/repro/image-render.render.test.ts
@@ -8,6 +8,7 @@ import { experimental_AstroContainer as AstroContainer } from "astro/container";
 import { describe, expect, test } from "vitest";
 
 import EmDashImage from "../../src/components/EmDashImage.astro";
+import EmDashMedia from "../../src/components/EmDashMedia.astro";
 import Image from "../../src/components/Image.astro";
 import OverrideImage from "./OverrideImage.astro";
 
@@ -72,6 +73,11 @@ async function renderImage(
 async function renderEmDashImage(props: Record<string, unknown>) {
 	const c = await AstroContainer.create();
 	return c.renderToString(EmDashImage, { props, locals });
+}
+
+async function renderEmDashMedia(props: Record<string, unknown>) {
+	const c = await AstroContainer.create();
+	return c.renderToString(EmDashMedia, { props, locals });
 }
 
 describe("faithful render of migrated image node", () => {
@@ -237,6 +243,33 @@ describe("faithful render of migrated image node", () => {
 		expect(attr(tag, "width")).toBe("640");
 		expect(attr(tag, "height")).toBe("360");
 		expect(attr(tag, "class")).toContain("emdash-image-media");
+	});
+
+	test.each([
+		{
+			name: "canonical direct URL",
+			value: {
+				id: "",
+				provider: "external",
+				src: "https://media.example/canonical.jpg",
+			},
+			expectedSrc: "https://media.example/canonical.jpg",
+		},
+		{
+			name: "legacy external URL",
+			value: {
+				id: "",
+				provider: "external-url",
+				previewUrl: "https://media.example/legacy.jpg",
+			},
+			expectedSrc: "https://media.example/legacy.jpg",
+		},
+	])("public media components render a $name value", async ({ value: mediaValue, expectedSrc }) => {
+		const imageHtml = await renderEmDashImage({ image: mediaValue, alt: "Remote image" });
+		const mediaHtml = await renderEmDashMedia({ value: mediaValue, alt: "Remote image" });
+
+		expect(attr(imgTag(imageHtml), "src")).toBe(expectedSrc);
+		expect(attr(imgTag(mediaHtml), "src")).toBe(expectedSrc);
 	});
 
 	test("public EmDashImage uses Astro Image for same-origin local media", async () => {

--- a/packages/core/tests/unit/components/inline-portable-text-media-picker.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-media-picker.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { InlinePortableTextEditor } from "../../../src/components/InlinePortableTextEditor.js";
+
+const actGlobal = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+describe("inline Portable Text media picker", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeEach(() => {
+		actGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement("div");
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(async () => {
+		await act(async () => root.unmount());
+		container.remove();
+		delete actGlobal.IS_REACT_ACT_ENVIRONMENT;
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it("saves the configured provider for an inserted image", async () => {
+		const requests: Array<{ url: string; init?: RequestInit }> = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+				const url =
+					typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+				requests.push({ url, init });
+				if (url === "/_emdash/api/media/providers") {
+					return Response.json({
+						data: {
+							items: [
+								{
+									id: "cloudflare-images",
+									name: "Cloudflare Images",
+									capabilities: { browse: true, search: true, upload: true, delete: true },
+								},
+							],
+						},
+					});
+				}
+				if (url.startsWith("/_emdash/api/media/providers/cloudflare-images?")) {
+					return Response.json({
+						data: {
+							items: [
+								{
+									id: "provider-image",
+									filename: "provider.jpg",
+									mimeType: "image/jpeg",
+									previewUrl: "https://media.example/provider.jpg",
+									width: 1200,
+									height: 800,
+								},
+							],
+						},
+					});
+				}
+				if (url.startsWith("/_emdash/api/media?")) {
+					return Response.json({ data: { items: [] } });
+				}
+				if (url === "/_emdash/api/content/posts/post-1") {
+					return new Response(null, { status: 204 });
+				}
+				throw new Error(`Unexpected request: ${url}`);
+			}),
+		);
+
+		await act(async () => {
+			root.render(
+				React.createElement(InlinePortableTextEditor, {
+					value: [],
+					collection: "posts",
+					entryId: "post-1",
+					field: "body",
+				}),
+			);
+		});
+		await vi.waitFor(() => expect(container.querySelector(".emdash-inline-editor")).not.toBeNull());
+
+		await act(async () => document.dispatchEvent(new CustomEvent("emdash:open-media-picker")));
+		const providerTab = await vi.waitFor(() => {
+			const button = [...document.querySelectorAll("button")].find(
+				(candidate) => candidate.textContent === "Cloudflare Images",
+			);
+			expect(button).not.toBeUndefined();
+			return button!;
+		});
+		await act(async () => providerTab.click());
+
+		const providerImage = await vi.waitFor(() => {
+			const button = document.querySelector<HTMLButtonElement>('button[aria-label="provider.jpg"]');
+			expect(button).not.toBeNull();
+			return button!;
+		});
+		await act(async () => providerImage.click());
+		const insert = [
+			...document.querySelectorAll<HTMLButtonElement>(".emdash-media-picker button"),
+		].find((button) => button.textContent === "Insert");
+		expect(insert).not.toBeUndefined();
+		await act(async () => insert!.click());
+
+		const saved = await vi.waitFor(() => {
+			const request = requests.find(
+				(candidate) => candidate.url === "/_emdash/api/content/posts/post-1",
+			);
+			expect(request).not.toBeUndefined();
+			return request!;
+		});
+		const requestBody = saved.init?.body;
+		expect(typeof requestBody).toBe("string");
+		if (typeof requestBody !== "string") throw new TypeError("Expected a string request body");
+		const body = JSON.parse(requestBody) as {
+			data: { body: Array<{ asset: { provider?: string } }> };
+		};
+		expect(saved.init?.method).toBe("PUT");
+		expect(body.data.body[0]?.asset.provider).toBe("cloudflare-images");
+	});
+});

--- a/packages/core/tests/unit/media/normalize.test.ts
+++ b/packages/core/tests/unit/media/normalize.test.ts
@@ -46,6 +46,48 @@ describe("normalizeMediaValue", () => {
 		});
 	});
 
+	it.each([
+		{
+			name: "prefers src when both URLs exist",
+			value: {
+				src: "https://media.example/source.jpg",
+				previewUrl: "https://media.example/preview.jpg",
+			},
+			expectedSrc: "https://media.example/source.jpg",
+		},
+		{
+			name: "promotes previewUrl when src is missing",
+			value: { previewUrl: "https://media.example/preview.jpg" },
+			expectedSrc: "https://media.example/preview.jpg",
+		},
+		{
+			name: "does not invent a missing URL",
+			value: {},
+			expectedSrc: undefined,
+		},
+	])("canonicalizes legacy external URL media and $name", async ({ value, expectedSrc }) => {
+		const providerLookup = vi.fn();
+		const result = await normalizeMediaValue(
+			{
+				id: "",
+				provider: "external-url",
+				filename: "legacy.jpg",
+				mimeType: "image/jpeg",
+				...value,
+			},
+			providerLookup,
+		);
+
+		expect(result).toMatchObject({
+			id: "",
+			provider: "external",
+			filename: "legacy.jpg",
+			mimeType: "image/jpeg",
+		});
+		expect(result?.src).toBe(expectedSrc);
+		expect(providerLookup).not.toHaveBeenCalled();
+	});
+
 	it("converts bare local media ID to full local MediaValue when provider resolves it", async () => {
 		const providerItem: MediaProviderItem = {
 			id: "01KRZKN0BK219P9HBMPYYGYRHY",


### PR DESCRIPTION
## What does this PR do?

Preserves direct image URLs and external media provider identities across image fields, the admin Portable Text editor, image replacement, and visual editing.

Previously, URL-backed image fields could persist only an admin preview URL, leaving public renderers with no source. Portable Text editing could also drop or retain the wrong provider. This layer keeps the public picker contract unchanged, normalizes legacy values without a migration, and adds regression coverage for each path.

Closes: N/A

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

No user-visible strings were added. This is a bug fix, so a feature Discussion is not applicable.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex with GPT-5.6 Sol

## Screenshots / test output

No visual changes.

- Full admin suite: 140 files, 1,773 tests passed.
- Full core suite: 510 files passed, 2 skipped; 6,180 tests passed, 9 skipped.
- `pnpm build`, `pnpm typecheck`, `pnpm lint`, and `pnpm format` passed.
- Focused admin, core unit, and Astro rendering regressions passed.
- Changeset validation and `git diff --check` passed.