### PR TITLE
ci: shard core tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,15 @@ jobs:
             echo "No changesets added since origin/main; skipping validation."
           fi
 
-  test:
-    name: Tests
+  test-shards:
+    name: Test Shard (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     services:
       postgres:
         image: postgres:17
@@ -124,12 +129,32 @@ jobs:
       # leave them unbuilt and their tests would fail to resolve workspace
       # links to dist/.
       - run: pnpm run --filter emdash... --filter "@emdash-cms/aggregator" --filter "@emdash-cms/labeler" --filter "@emdash-cms/plugin-cli" --filter "@emdash-cms/registry-*" --filter "@emdash-cms/plugin-types" build
-      - run: pnpm test:unit
+      - run: pnpm --filter emdash exec vitest run --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        env:
+          EMDASH_TEST_PG: postgres://postgres:test@localhost:5432/emdash_test
+      - name: Test other packages
+        if: matrix.shardIndex == 1
+        run: pnpm run --filter @emdash-cms/aggregator --filter @emdash-cms/auth --filter @emdash-cms/blocks --filter @emdash-cms/gutenberg-to-portable-text --filter @emdash-cms/labeler --filter @emdash-cms/marketplace --filter @emdash-cms/plugin-cli --filter @emdash-cms/plugin-forms --filter @emdash-cms/plugin-types --filter @emdash-cms/registry-client --filter @emdash-cms/registry-lexicons --filter @emdash-cms/registry-moderation test
         env:
           EMDASH_TEST_PG: postgres://postgres:test@localhost:5432/emdash_test
       # Render tests use the Astro Vite plugin (vitest.repro.config.ts);
       # they can't run under the plain-node config in test:unit.
-      - run: pnpm --filter emdash exec vitest run --config vitest.repro.config.ts
+      - if: matrix.shardIndex == 1
+        run: pnpm --filter emdash exec vitest run --config vitest.repro.config.ts
+
+  test:
+    name: Tests
+    if: always()
+    needs: [test-shards]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check test shard results
+        run: |
+          if [ "${{ needs.test-shards.result }}" != "success" ]; then
+            echo "Tests failed or were cancelled"
+            exit 1
+          fi
 
   test-smoke:
     name: Smoke Tests


### PR DESCRIPTION
## What does this PR do?

Runs the 512-file core Vitest suite across four GitHub Actions runners instead of one, while running the smaller workspace-package and Astro render suites once on shard 1.

A recent successful [Tests job](https://github.com/emdash-cms/emdash/actions/runs/33503499858/job/99851090341) spent 8m31s in `pnpm test:unit`; the core suite accounted for 7m48s of that step. The four shards contain exactly 128 core test files each and should reduce execution wall time from roughly 11 minutes to roughly 5 minutes, including setup and build time.

The final roll-up job keeps the existing `CI / Tests` required-check name stable.

Related issue: none.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Targeted tests for this change pass
- [x] Formatting passes for the changed workflow with `pnpm exec prettier --check .github/workflows/ci.yml`
- [x] I have added/updated tests for my changes (not applicable: this only changes CI orchestration; every resulting test command was exercised)
- [x] User-visible strings are wrapped for translation (not applicable: no user-visible strings)
- [x] I have added and reviewed a changeset (not applicable: no published package changed)
- [x] New features link to an approved Discussion (not applicable: CI-only change)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

No screenshots: this is a CI-only change.

- `pnpm typecheck`
- `pnpm lint`
- All four `vitest run --shard=N/4` core shards: 512 files total
- All 12 non-core package test suites
- Astro render suite: 8 files / 45 tests
- Workflow YAML parsing and Prettier check
