### PR TITLE
test(e2e): stabilize playground smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,13 +230,15 @@ jobs:
   test-e2e-rollup:
     name: E2E Tests
     if: always()
-    needs: [test-e2e]
+    needs: [test-e2e, test-e2e-cloudflare, test-e2e-playground]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check E2E shard results
+      - name: Check E2E results
         run: |
-          if [ "${{ needs.test-e2e.result }}" != "success" ]; then
+          if [ "${{ needs.test-e2e.result }}" != "success" ] ||
+             [ "${{ needs.test-e2e-cloudflare.result }}" != "success" ] ||
+             [ "${{ needs.test-e2e-playground.result }}" != "success" ]; then
             echo "E2E tests failed or were cancelled"
             exit 1
           fi
@@ -278,6 +280,38 @@ jobs:
             test-results/
           retention-days: 7
 
+  test-e2e-playground:
+    name: Playground E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run --filter "@emdash-cms/playground^..." build
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('pnpm-lock.yaml') }}
+      - run: pnpm exec playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - run: pnpm run test:e2e:playground
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: playwright-report-playground
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+
   test-e2e-cloudflare:
     name: E2E Cloudflare (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
@@ -311,8 +345,6 @@ jobs:
       - run: pnpm exec playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
           EMDASH_E2E_TARGET: cloudflare
-      - run: pnpm run test:e2e:playground
-        if: matrix.shardIndex == 1
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,9 +307,7 @@ jobs:
         if: failure()
         with:
           name: playwright-report-playground
-          path: |
-            playwright-report/
-            test-results/
+          path: test-results/
           retention-days: 7
 
   test-e2e-cloudflare:

--- a/e2e/playground/media-ready.spec.ts
+++ b/e2e/playground/media-ready.spec.ts
@@ -18,7 +18,7 @@ async function openFreshPlayground(page: Page): Promise<void> {
 		dialog.getByRole("button", { name: "Get Started" }).click(),
 	);
 	await page.goto("/playground");
-	await page.waitForURL(ADMIN_URL_PATTERN, { timeout: 120_000 });
+	await page.waitForURL(ADMIN_URL_PATTERN, { timeout: 240_000 });
 	await expect(page.getByRole("link", { name: "Media", exact: true })).toBeVisible({
 		timeout: 60_000,
 	});

--- a/e2e/playground/playwright.config.ts
+++ b/e2e/playground/playwright.config.ts
@@ -5,7 +5,8 @@ export default defineConfig({
 	testMatch: "media-ready.spec.ts",
 	fullyParallel: false,
 	workers: 1,
-	timeout: 240_000,
+	retries: process.env.CI ? 1 : 0,
+	timeout: 360_000,
 	use: {
 		baseURL: "http://localhost:4450",
 		trace: "retain-on-failure",

--- a/e2e/playground/playwright.config.ts
+++ b/e2e/playground/playwright.config.ts
@@ -5,10 +5,10 @@ export default defineConfig({
 	testMatch: "media-ready.spec.ts",
 	fullyParallel: false,
 	workers: 1,
-	timeout: 120_000,
+	timeout: 240_000,
 	use: {
 		baseURL: "http://localhost:4450",
-		trace: "on-first-retry",
+		trace: "retain-on-failure",
 		screenshot: "only-on-failure",
 		...devices["Desktop Chrome"],
 	},

--- a/e2e/playground/playwright.config.ts
+++ b/e2e/playground/playwright.config.ts
@@ -1,12 +1,16 @@
+import { fileURLToPath } from "node:url";
+
 import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
 	testDir: ".",
 	testMatch: "media-ready.spec.ts",
+	outputDir: fileURLToPath(new URL("../../test-results", import.meta.url)),
 	fullyParallel: false,
 	workers: 1,
 	retries: process.env.CI ? 1 : 0,
 	timeout: 360_000,
+	expect: { timeout: 60_000 },
 	use: {
 		baseURL: "http://localhost:4450",
 		trace: "retain-on-failure",


### PR DESCRIPTION
## What does this PR do?

Stabilizes the workerd-backed Playground smoke after repeated CI runs exhausted its 120-second initialization deadline. The retained trace from this PR confirmed that `POST /_playground/init` was still pending when the navigation timeout fired.

- Gives initialization a 240-second budget and the complete smoke a 360-second budget.
- Retains traces on failures and retries one transient failure in CI with a fresh browser session.
- Allows data-backed admin assertions up to 60 seconds to finish loading on slower CI runners.
- Pins Playwright output to the repo-root `test-results/` directory consumed by the artifact upload.
- Runs the Playground smoke in a dedicated CI job rather than after the long Cloudflare shard 1 workload.
- Includes Node, Cloudflare, and Playground results in the required `E2E Tests` roll-up.

Failure evidence: [run 33536074249](https://github.com/emdash-cms/emdash/actions/runs/33536074249/job/99950586571) and [run 33511649004](https://github.com/emdash-cms/emdash/actions/runs/33511649004/job/99873171257).

Related issue: none.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Targeted tests for this change pass
- [x] Formatting passes for the changed files with Prettier
- [x] I have updated the existing Playground E2E test configuration and CI coverage
- [x] User-visible strings are wrapped for translation (not applicable: no user-visible strings changed)
- [x] I have added and reviewed a changeset (not applicable: no published package changed)
- [x] New features link to an approved Discussion (not applicable: test and CI stabilization only)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

No screenshots: this changes test orchestration only.

- `pnpm build`
- `pnpm run --filter "@emdash-cms/playground^..." build`
- Current Playground E2E config repeated across three fresh sessions: 3 passed
- Controlled failure retained its trace under repo-root `test-results/`
- `pnpm typecheck`
- `pnpm lint`
- Workflow YAML parsing, Prettier, and `git diff --check`
