### PR TITLE
fix(release-service): revoke stale workload intents

### DIFF
--- a/apps/release-service/src/intents/routes.ts
+++ b/apps/release-service/src/intents/routes.ts
@@ -297,6 +297,28 @@ export async function handleSubmitReleaseIntent(
 			if (replay.requestDigest !== requestDigest) {
 				throw new ApiError("IDEMPOTENCY_CONFLICT", 409, "Idempotency key conflicts with prior use");
 			}
+		}
+		const admission = await env.SERVICE_CONTROL_DO.getByName(
+			SERVICE_CONTROL_OBJECT_NAME,
+		).getAdmissionDecision(publisherDid);
+		if (!admission.allowed) {
+			throw new ApiError(
+				admission.code === "PUBLISHER_SUSPENDED" ? "PUBLISHER_SUSPENDED" : "SERVICE_PAUSED",
+				503,
+				admission.code === "PUBLISHER_SUSPENDED"
+					? "Publisher is suspended"
+					: "Release admission is paused",
+			);
+		}
+		const policy = await publisher.getWorkloadPolicy(publisherDid, release.package);
+		if (
+			!policy ||
+			!evaluateWorkloadPolicy(identity, policy).ok ||
+			(replay !== null && replay.intent.workloadPolicyVersion !== policy.stateVersion)
+		) {
+			throw new ApiError("WORKLOAD_NOT_ALLOWED", 403, "Workload is not authorized");
+		}
+		if (replay) {
 			const started = await (dependencies.startWorkflow ?? startReleaseIntentWorkflow)(
 				env.RELEASE_INTENT_WORKFLOW,
 				env.PUBLISHER_DO,
@@ -314,22 +336,6 @@ export async function handleSubmitReleaseIntent(
 				},
 				requestId,
 			);
-		}
-		const admission = await env.SERVICE_CONTROL_DO.getByName(
-			SERVICE_CONTROL_OBJECT_NAME,
-		).getAdmissionDecision(publisherDid);
-		if (!admission.allowed) {
-			throw new ApiError(
-				admission.code === "PUBLISHER_SUSPENDED" ? "PUBLISHER_SUSPENDED" : "SERVICE_PAUSED",
-				503,
-				admission.code === "PUBLISHER_SUSPENDED"
-					? "Publisher is suspended"
-					: "Release admission is paused",
-			);
-		}
-		const policy = await publisher.getWorkloadPolicy(publisherDid, release.package);
-		if (!policy || !evaluateWorkloadPolicy(identity, policy).ok) {
-			throw new ApiError("WORKLOAD_NOT_ALLOWED", 403, "Workload is not authorized");
 		}
 		const workloadRateKey = await digest([
 			"intent-rate-limit",

--- a/apps/release-service/src/publisher-do/publication-operation.ts
+++ b/apps/release-service/src/publisher-do/publication-operation.ts
@@ -1,5 +1,9 @@
 import { base64url } from "jose";
 
+import { evaluateWorkloadPolicy } from "../workload/policy.js";
+import type { VerifiedWorkloadIdentity } from "../workload/types.js";
+import { WorkloadPolicyStore } from "./workload-policy.js";
+
 const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
 const ULID_PATTERN = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
@@ -43,8 +47,15 @@ export type AdvancePublicationOperationPhaseResult =
 			code:
 				| "MATERIALIZATION_UNAVAILABLE"
 				| "PUBLICATION_CAS_REQUIRED"
-				| "PUBLICATION_PHASE_CONFLICT";
+				| "PUBLICATION_PHASE_CONFLICT"
+				| "WORKLOAD_POLICY_UNAVAILABLE";
 	  };
+
+export interface PublicationWorkloadAuthorization {
+	identity: VerifiedWorkloadIdentity;
+	identityDigest: string;
+	identityJson: string;
+}
 
 export type BeginPublicationOperationResult =
 	| { ok: true; lease: PublicationOperationLease; replayed: boolean }
@@ -101,6 +112,10 @@ interface IntentRow {
 	[key: string]: string | number | ArrayBuffer | null;
 	state: string;
 	state_generation: number;
+	package_slug: string;
+	workload_policy_version: number;
+	workload_identity_digest: string;
+	workload_identity_json: string;
 }
 
 export class PublicationOperationError extends Error {
@@ -133,7 +148,12 @@ function hashesEqual(left: string, right: string): boolean {
 function readIntent(storage: DurableObjectStorage, intentId: string): IntentRow | null {
 	return (
 		storage.sql
-			.exec<IntentRow>("SELECT state, state_generation FROM intents WHERE id = ?", intentId)
+			.exec<IntentRow>(
+				`SELECT state, state_generation, package_slug, workload_policy_version,
+				        workload_identity_digest, workload_identity_json
+				 FROM intents WHERE id = ?`,
+				intentId,
+			)
 			.toArray()[0] ?? null
 	);
 }
@@ -335,6 +355,7 @@ export class PublicationOperationStore {
 
 	async advancePhase(
 		input: AdvancePublicationOperationPhaseInput,
+		authorization: PublicationWorkloadAuthorization | null = null,
 	): Promise<AdvancePublicationOperationPhaseResult> {
 		const now = input.now ?? Date.now();
 		if (
@@ -411,6 +432,19 @@ export class PublicationOperationStore {
 				materialization.record_digest !== input.materializationDigest
 			) {
 				return { ok: false, code: "MATERIALIZATION_UNAVAILABLE" } as const;
+			}
+			if (input.phase === "creating") {
+				const policy = new WorkloadPolicyStore(this.#storage).get(intent.package_slug);
+				if (
+					!authorization ||
+					authorization.identityJson !== intent.workload_identity_json ||
+					authorization.identityDigest !== intent.workload_identity_digest ||
+					!policy ||
+					policy.stateVersion !== intent.workload_policy_version ||
+					!evaluateWorkloadPolicy(authorization.identity, policy).ok
+				) {
+					return { ok: false, code: "WORKLOAD_POLICY_UNAVAILABLE" } as const;
+				}
 			}
 			this.#storage.sql.exec(
 				`UPDATE publication_operations SET phase = ?, materialization_digest = ?

--- a/apps/release-service/src/publisher-do/publisher-do.ts
+++ b/apps/release-service/src/publisher-do/publisher-do.ts
@@ -1,10 +1,13 @@
 import { DurableObject } from "cloudflare:workers";
 
+import { invalidateApprovalChallenges } from "../approvals/invalidation.js";
 import type {
 	EncryptionRecordPage,
 	EncryptionRecordReplacement,
 } from "../operations/encryption-records.js";
 import { MAX_ENCRYPTION_RECORD_PAGE } from "../operations/encryption-records.js";
+import { digestWorkloadIdentity } from "../workload/policy.js";
+import { parseStoredWorkloadIdentity } from "../workload/types.js";
 import {
 	initializeIntentStateSchema,
 	IntentStateStore,
@@ -736,9 +739,33 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		});
 	}
 
-	putWorkloadPolicy(input: PutWorkloadPolicyInput): PutWorkloadPolicyResult {
+	async putWorkloadPolicy(input: PutWorkloadPolicyInput): Promise<PutWorkloadPolicyResult> {
 		this.#assertPublisherDid(input.publisherDid);
-		return this.#workloadPolicies.put(input);
+		const result = this.#workloadPolicies.put(input);
+		if (!result.ok) return result;
+		const invalidations = await Promise.allSettled(
+			result.invalidatedApprovalChallenges.map((invalidation) =>
+				invalidateApprovalChallenges(
+					this.env.APPROVER_DO,
+					invalidation.approverDids,
+					invalidation.intentId,
+					"WORKLOAD_CHANGED",
+					input.now ?? Date.now(),
+				),
+			),
+		);
+		for (const invalidation of invalidations) {
+			if (invalidation.status === "rejected") {
+				console.error(
+					JSON.stringify({
+						event: "workload_approval_invalidation_failed",
+						publisherDid: input.publisherDid,
+						name: invalidation.reason instanceof Error ? invalidation.reason.name : "UnknownError",
+					}),
+				);
+			}
+		}
+		return { ok: true, policy: result.policy };
 	}
 
 	getWorkloadPolicy(publisherDid: string, packageSlug: string): StoredWorkloadPolicy | null {
@@ -806,12 +833,12 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		return this.#workflowConnections.listPending(limit, now);
 	}
 
-	confirmWorkflowConnection(
+	async confirmWorkflowConnection(
 		publisherDid: string,
 		requestId: string,
 		refScope: WorkflowConnectionRefScope,
 		now = Date.now(),
-	): ConfirmWorkflowConnectionResult {
+	): Promise<ConfirmWorkflowConnectionResult> {
 		this.#assertPublisherDid(publisherDid);
 		const prepared = this.#workflowConnections.prepareConfirmation(requestId, now);
 		if (!prepared.ok) return prepared;
@@ -829,7 +856,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 				? { ok: true, request: prepared.request, policy, replayed: true }
 				: { ok: false, code: "WORKFLOW_CONNECTION_CONFLICT" };
 		}
-		const result = this.#workloadPolicies.put({
+		const result = await this.putWorkloadPolicy({
 			publisherDid,
 			...expectedPolicy,
 			expectedVersion,
@@ -960,7 +987,17 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		input: AdvancePublicationOperationPhaseInput,
 	): Promise<AdvancePublicationOperationPhaseResult> {
 		this.#assertPublisherDid(input.publisherDid);
-		const result = await this.#publicationOperations.advancePhase(input);
+		const intent = input.phase === "creating" ? this.#intents.get(input.intentId) : null;
+		const identity = intent ? parseStoredWorkloadIdentity(intent.workloadIdentityJson) : null;
+		const authorization =
+			intent && identity
+				? {
+						identity,
+						identityDigest: await digestWorkloadIdentity(identity),
+						identityJson: intent.workloadIdentityJson,
+					}
+				: null;
+		const result = await this.#publicationOperations.advancePhase(input, authorization);
 		await this.#scheduleNextAlarm(input.now ?? Date.now());
 		return result;
 	}

--- a/apps/release-service/src/publisher-do/workload-policy.ts
+++ b/apps/release-service/src/publisher-do/workload-policy.ts
@@ -41,6 +41,19 @@ export type PutWorkloadPolicyResult =
 	| { ok: true; policy: StoredWorkloadPolicy }
 	| { ok: false; code: "WORKLOAD_POLICY_CAS_REQUIRED" };
 
+export interface InvalidatedApprovalChallenges {
+	intentId: string;
+	approverDids: readonly string[];
+}
+
+export type WorkloadPolicyStoreResult =
+	| {
+			ok: true;
+			policy: StoredWorkloadPolicy;
+			invalidatedApprovalChallenges: readonly InvalidatedApprovalChallenges[];
+	  }
+	| { ok: false; code: "WORKLOAD_POLICY_CAS_REQUIRED" };
+
 interface WorkloadPolicyRow {
 	[key: string]: string | number | ArrayBuffer | null;
 	package_slug: string;
@@ -55,6 +68,18 @@ interface WorkloadPolicyRow {
 	authorized_by: string;
 	created_at: number;
 	updated_at: number;
+}
+
+interface InvalidatedIntentRow {
+	[key: string]: string | number | ArrayBuffer | null;
+	id: string;
+	state: string;
+	state_generation: number;
+	state_data_json: string;
+	workload_identity_digest: string;
+	operation_generation: number | null;
+	operation_phase: string | null;
+	operation_status: string | null;
 }
 
 export class WorkloadPolicyError extends Error {
@@ -104,6 +129,29 @@ function validEnvironment(value: string): boolean {
 		if (codePoint <= 31 || codePoint === 127) return false;
 	}
 	return true;
+}
+
+function approvalChallengeInvalidation(
+	row: InvalidatedIntentRow,
+): InvalidatedApprovalChallenges | null {
+	if (row.state !== "awaiting_approval") return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(row.state_data_json);
+	} catch {
+		return null;
+	}
+	if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+	const approverDids = Reflect.get(parsed, "approverDids");
+	if (
+		!Array.isArray(approverDids) ||
+		approverDids.length > MAX_POLICY_VALUES ||
+		new Set(approverDids).size !== approverDids.length ||
+		approverDids.some((value) => typeof value !== "string" || !DID_PATTERN.test(value))
+	) {
+		return null;
+	}
+	return { intentId: row.id, approverDids };
 }
 
 export function validRefRule(value: string): boolean {
@@ -197,7 +245,7 @@ export class WorkloadPolicyStore {
 		this.#storage = storage;
 	}
 
-	put(input: PutWorkloadPolicyInput): PutWorkloadPolicyResult {
+	put(input: PutWorkloadPolicyInput): WorkloadPolicyStoreResult {
 		const now = input.now ?? Date.now();
 		if (typeof input.repository !== "string" || typeof input.workflowRef !== "string") {
 			throw new WorkloadPolicyError();
@@ -271,8 +319,113 @@ export class WorkloadPolicyStore {
 				input.packageSlug,
 				now,
 			);
-			return { ok: true, policy: this.get(input.packageSlug)! } as const;
+			const invalidatedApprovalChallenges = this.#invalidatePreWriteIntents(
+				input.publisherDid,
+				input.packageSlug,
+				stateVersion,
+				now,
+			);
+			return {
+				ok: true,
+				policy: this.get(input.packageSlug)!,
+				invalidatedApprovalChallenges,
+			} as const;
 		});
+	}
+
+	#invalidatePreWriteIntents(
+		publisherDid: string,
+		packageSlug: string,
+		policyVersion: number,
+		now: number,
+	): readonly InvalidatedApprovalChallenges[] {
+		const rows = this.#storage.sql
+			.exec<InvalidatedIntentRow>(
+				`SELECT intents.id, intents.state, intents.state_generation,
+				        intents.state_data_json, intents.workload_identity_digest,
+				        publication_operations.generation AS operation_generation,
+				        publication_operations.phase AS operation_phase,
+				        publication_operations.status AS operation_status
+				 FROM intents
+				 LEFT JOIN publication_operations ON publication_operations.intent_id = intents.id
+				 WHERE intents.package_slug = ?
+				   AND intents.workload_policy_version <> ?
+				   AND intents.state IN (
+				     'received', 'verifying', 'verified', 'awaiting_approval', 'ready', 'publishing'
+				   )`,
+				packageSlug,
+				policyVersion,
+			)
+			.toArray();
+		const invalidatedApprovalChallenges: InvalidatedApprovalChallenges[] = [];
+		for (const row of rows) {
+			if (
+				row.state === "publishing" &&
+				row.operation_status === "active" &&
+				row.operation_phase === "creating"
+			) {
+				continue;
+			}
+			const approvalInvalidation = approvalChallengeInvalidation(row);
+			if (approvalInvalidation) invalidatedApprovalChallenges.push(approvalInvalidation);
+			const nextGeneration = row.state_generation + 1;
+			const stateDataJson = '{"reasonCode":"WORKLOAD_POLICY_CHANGED"}';
+			this.#storage.sql.exec(
+				`UPDATE intents SET state = 'invalid', state_generation = ?,
+				        state_data_json = ?, updated_at = ? WHERE id = ?`,
+				nextGeneration,
+				stateDataJson,
+				now,
+				row.id,
+			);
+			this.#storage.sql.exec(
+				`INSERT INTO intent_transitions (
+					intent_id, sequence, from_state, to_state, state_generation,
+					transition_digest, actor_realm, actor_identity, reason_code,
+					state_data_json, created_at
+				) VALUES (?, ?, ?, 'invalid', ?, ?, 'publisher', ?,
+				          'WORKLOAD_POLICY_CHANGED', ?, ?)`,
+				row.id,
+				nextGeneration,
+				row.state,
+				nextGeneration,
+				row.workload_identity_digest,
+				publisherDid,
+				stateDataJson,
+				now,
+			);
+			this.#storage.sql.exec("DELETE FROM release_reservations WHERE intent_id = ?", row.id);
+			if (
+				row.state === "publishing" &&
+				row.operation_status === "active" &&
+				row.operation_generation !== null
+			) {
+				this.#storage.sql.exec(
+					`UPDATE publication_operations SET status = 'completed',
+					        completion_digest = token_hash, outcome = 'failed',
+					        reason_code = 'WORKLOAD_POLICY_CHANGED', completed_at = ?
+					 WHERE intent_id = ? AND generation = ? AND status = 'active'`,
+					now,
+					row.id,
+					row.operation_generation,
+				);
+				this.#storage.sql.exec(
+					"DELETE FROM deadlines WHERE kind = 'publication-operation' AND subject_id = ?",
+					row.id,
+				);
+			}
+			this.#storage.sql.exec(
+				`INSERT INTO audit_events (
+					event_type, actor_realm, actor_identity, subject,
+					reason_code, public_payload, created_at
+				) VALUES ('intent-invalidated', 'publisher', ?, ?,
+				          'WORKLOAD_POLICY_CHANGED', '{}', ?)`,
+				publisherDid,
+				row.id,
+				now,
+			);
+		}
+		return invalidatedApprovalChallenges;
 	}
 
 	get(packageSlug: string): StoredWorkloadPolicy | null {

--- a/apps/release-service/src/workload/types.ts
+++ b/apps/release-service/src/workload/types.ts
@@ -42,3 +42,163 @@ export interface VerifiedWorkloadIdentity {
 	issuedAt: number;
 	expiresAt: number;
 }
+
+const DECIMAL_ID_PATTERN = /^[1-9][0-9]*$/;
+const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const LOGIN_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$/;
+const ACTOR_PATTERN = /^(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})|[A-Za-z0-9-]{1,39}\[bot\])$/;
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const REF_PATTERN = /^refs\/[A-Za-z0-9._/-]{1,507}$/;
+const WORKFLOW_REF_PATTERN =
+	/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/\.github\/workflows\/[A-Za-z0-9_./-]+\.ya?ml@refs\/[A-Za-z0-9._/-]+$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+	const keys = Object.keys(value);
+	return keys.length === expected.length && keys.every((key) => expected.includes(key));
+}
+
+export function parseStoredWorkloadIdentity(value: string): VerifiedWorkloadIdentity | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		return null;
+	}
+	if (
+		!isRecord(parsed) ||
+		!hasExactKeys(parsed, [
+			"issuer",
+			"subject",
+			"tokenId",
+			"repository",
+			"workflow",
+			"run",
+			"issuedAt",
+			"expiresAt",
+		]) ||
+		parsed.issuer !== "github-actions" ||
+		typeof parsed.subject !== "string" ||
+		parsed.subject.length === 0 ||
+		parsed.subject.length > 2048 ||
+		typeof parsed.tokenId !== "string" ||
+		parsed.tokenId.length === 0 ||
+		parsed.tokenId.length > 255 ||
+		!isRecord(parsed.repository) ||
+		!hasExactKeys(parsed.repository, ["name", "id", "owner", "ownerId", "visibility"]) ||
+		!isRecord(parsed.workflow) ||
+		!hasExactKeys(parsed.workflow, ["ref", "sha", "jobRef", "jobSha"]) ||
+		!isRecord(parsed.run) ||
+		!hasExactKeys(parsed.run, [
+			"id",
+			"attempt",
+			"actor",
+			"actorId",
+			"eventName",
+			"ref",
+			"refType",
+			"commitSha",
+			"environment",
+			"runnerEnvironment",
+		])
+	) {
+		return null;
+	}
+	const repository = parsed.repository;
+	const workflow = parsed.workflow;
+	const run = parsed.run;
+	if (
+		typeof repository.name !== "string" ||
+		!REPOSITORY_PATTERN.test(repository.name) ||
+		repository.name !== repository.name.toLowerCase() ||
+		typeof repository.id !== "string" ||
+		!DECIMAL_ID_PATTERN.test(repository.id) ||
+		typeof repository.owner !== "string" ||
+		!LOGIN_PATTERN.test(repository.owner) ||
+		repository.owner !== repository.owner.toLowerCase() ||
+		typeof repository.ownerId !== "string" ||
+		!DECIMAL_ID_PATTERN.test(repository.ownerId) ||
+		(repository.visibility !== "public" &&
+			repository.visibility !== "private" &&
+			repository.visibility !== "internal") ||
+		typeof workflow.ref !== "string" ||
+		workflow.ref.length > 1024 ||
+		!WORKFLOW_REF_PATTERN.test(workflow.ref) ||
+		typeof workflow.sha !== "string" ||
+		!SHA_PATTERN.test(workflow.sha) ||
+		(workflow.jobRef !== null &&
+			(typeof workflow.jobRef !== "string" ||
+				workflow.jobRef.length > 1024 ||
+				!WORKFLOW_REF_PATTERN.test(workflow.jobRef))) ||
+		(workflow.jobSha !== null &&
+			(typeof workflow.jobSha !== "string" || !SHA_PATTERN.test(workflow.jobSha))) ||
+		(workflow.jobRef === null) !== (workflow.jobSha === null) ||
+		typeof run.id !== "string" ||
+		!DECIMAL_ID_PATTERN.test(run.id) ||
+		typeof run.attempt !== "number" ||
+		!Number.isSafeInteger(run.attempt) ||
+		run.attempt < 1 ||
+		typeof run.actor !== "string" ||
+		!ACTOR_PATTERN.test(run.actor) ||
+		typeof run.actorId !== "string" ||
+		!DECIMAL_ID_PATTERN.test(run.actorId) ||
+		typeof run.eventName !== "string" ||
+		run.eventName.length === 0 ||
+		run.eventName.length > 128 ||
+		typeof run.ref !== "string" ||
+		!REF_PATTERN.test(run.ref) ||
+		(run.refType !== "branch" && run.refType !== "tag") ||
+		typeof run.commitSha !== "string" ||
+		!SHA_PATTERN.test(run.commitSha) ||
+		(run.environment !== null &&
+			(typeof run.environment !== "string" ||
+				run.environment.length === 0 ||
+				run.environment.length > 255)) ||
+		(run.runnerEnvironment !== "github-hosted" && run.runnerEnvironment !== "self-hosted") ||
+		typeof parsed.issuedAt !== "number" ||
+		!Number.isSafeInteger(parsed.issuedAt) ||
+		typeof parsed.expiresAt !== "number" ||
+		!Number.isSafeInteger(parsed.expiresAt) ||
+		parsed.issuedAt > parsed.expiresAt ||
+		repository.name.split("/", 1)[0] !== repository.owner ||
+		!workflow.ref.toLowerCase().startsWith(`${repository.name}/.github/workflows/`)
+	) {
+		return null;
+	}
+	const identity: VerifiedWorkloadIdentity = {
+		issuer: "github-actions",
+		subject: parsed.subject,
+		tokenId: parsed.tokenId,
+		repository: {
+			name: repository.name,
+			id: repository.id,
+			owner: repository.owner,
+			ownerId: repository.ownerId,
+			visibility: repository.visibility,
+		},
+		workflow: {
+			ref: workflow.ref,
+			sha: workflow.sha,
+			jobRef: workflow.jobRef,
+			jobSha: workflow.jobSha,
+		},
+		run: {
+			id: run.id,
+			attempt: run.attempt,
+			actor: run.actor,
+			actorId: run.actorId,
+			eventName: run.eventName,
+			ref: run.ref,
+			refType: run.refType,
+			commitSha: run.commitSha,
+			environment: run.environment,
+			runnerEnvironment: run.runnerEnvironment,
+		},
+		issuedAt: parsed.issuedAt,
+		expiresAt: parsed.expiresAt,
+	};
+	return JSON.stringify(identity) === value ? identity : null;
+}

--- a/apps/release-service/test/intent-routes.test.ts
+++ b/apps/release-service/test/intent-routes.test.ts
@@ -293,10 +293,18 @@ describe("release intent API", () => {
 		).resolves.toEqual({ count: 0 });
 	});
 
-	it("submits asynchronously, replays with a fresh matching token, and never stores the token", async () => {
+	it("rejects a failed-start replay after the workload is disabled and never stores the token", async () => {
 		await putPolicy();
 		const configuration = await loadConfiguration(TEST_BINDINGS);
 		const firstToken = await token();
+		let workflowStarts = 0;
+		const dependencies = {
+			...submitDependencies,
+			startWorkflow: async () => {
+				workflowStarts += 1;
+				return { ok: false, code: "WORKFLOW_UNAVAILABLE" } as const;
+			},
+		};
 		const body = {
 			publisherDid: PUBLISHER_DID,
 			packageSlug: "gallery",
@@ -311,11 +319,11 @@ describe("release intent API", () => {
 			}),
 			"request-1",
 			configuration,
-			submitDependencies,
+			dependencies,
 		);
-		expect(first.status).toBe(202);
+		expect(first.status).toBe(503);
 		expect(await first.json()).toMatchObject({
-			data: { intent: { id: INTENT_ID, state: "received" }, replayed: false },
+			error: { code: "WORKFLOW_UNAVAILABLE" },
 		});
 		await env.PUBLISHER_DO.getByName(PUBLISHER_DID).putWorkloadPolicy({
 			publisherDid: PUBLISHER_DID,
@@ -340,18 +348,22 @@ describe("release intent API", () => {
 			}),
 			"request-2",
 			configuration,
-			submitDependencies,
+			dependencies,
 		);
-		expect(replay.status).toBe(200);
+		expect(replay.status).toBe(403);
 		expect(await replay.json()).toMatchObject({
-			data: { intent: { id: INTENT_ID }, replayed: true },
+			error: { code: "WORKLOAD_NOT_ALLOWED" },
 		});
+		expect(workflowStarts).toBe(1);
 
 		const stored = await env.PUBLISHER_DO.getByName(PUBLISHER_DID).getIntent(
 			PUBLISHER_DID,
 			INTENT_ID,
 		);
-		expect(stored).not.toBeNull();
+		expect(stored).toMatchObject({
+			state: "invalid",
+			stateDataJson: '{"reasonCode":"WORKLOAD_POLICY_CHANGED"}',
+		});
 		expect(JSON.stringify(stored)).not.toContain(firstToken);
 		expect(JSON.stringify(stored)).not.toContain(secondToken);
 	});

--- a/apps/release-service/test/publication-operation.test.ts
+++ b/apps/release-service/test/publication-operation.test.ts
@@ -3,6 +3,8 @@ import { env } from "cloudflare:workers";
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { IntentState, PutWorkloadPolicyInput } from "../src/publisher-do/publisher-do.js";
+import { digestWorkloadIdentity } from "../src/workload/policy.js";
+import type { VerifiedWorkloadIdentity } from "../src/workload/types.js";
 
 const DID = "did:plc:publisher";
 const INTENT_ID = "01JABCDEFGHJKMNPQRSTVWXYZ0";
@@ -13,6 +15,38 @@ const ATTEMPT_TOKEN = "T".repeat(43);
 const CHECKSUM = "bciqb43wwlv35mnso5lwvu5c3uxcjqwxcw4an3boxz57qe667fffdh7a";
 const BLOB_CID = "bafkreia6n3lf256wgzhov3k2orn2lreyllrloag5qxl467ycpppsssrt7q";
 const SOURCE_URL = "https://example.com/gallery.tar.gz";
+const WORKLOAD_IDENTITY: VerifiedWorkloadIdentity = {
+	issuer: "github-actions",
+	subject: "repo:emdash-cms/gallery:ref:refs/heads/main",
+	tokenId: "release-token-100",
+	repository: {
+		name: "emdash-cms/gallery",
+		id: "123",
+		owner: "emdash-cms",
+		ownerId: "456",
+		visibility: "public",
+	},
+	workflow: {
+		ref: "emdash-cms/gallery/.github/workflows/release.yml@refs/heads/main",
+		sha: "a".repeat(40),
+		jobRef: null,
+		jobSha: null,
+	},
+	run: {
+		id: "100",
+		attempt: 1,
+		actor: "release-bot",
+		actorId: "200",
+		eventName: "workflow_dispatch",
+		ref: "refs/heads/main",
+		refType: "branch",
+		commitSha: "b".repeat(40),
+		environment: null,
+		runnerEnvironment: "github-hosted",
+	},
+	issuedAt: 1_800_000_000,
+	expiresAt: 1_800_000_300,
+};
 
 function sourceRelease() {
 	return {
@@ -76,11 +110,11 @@ async function preparePublishing() {
 		packageSlug: "gallery",
 		version: "1.2.3",
 		workloadPolicyVersion: 1,
-		workloadIdentityDigest: "A".repeat(43),
+		workloadIdentityDigest: await digestWorkloadIdentity(WORKLOAD_IDENTITY),
 		workloadIdempotencyDigest: "I".repeat(43),
 		idempotencyKey: "github-run-100-attempt-1",
 		requestDigest: "B".repeat(43),
-		workloadIdentityJson: '{"issuer":"github-actions"}',
+		workloadIdentityJson: JSON.stringify(WORKLOAD_IDENTITY),
 		releaseInputJson: JSON.stringify({ release: sourceRelease() }),
 		expiresAt: NOW + 60_000,
 		now: NOW + 1,
@@ -302,6 +336,126 @@ describe("publisher publication operations", () => {
 		await expect(
 			stub.advancePublicationOperationPhase({ ...input, phase: "creating", now: NOW + 12 }),
 		).resolves.toMatchObject({ ok: true, phase: "creating", replayed: false });
+	});
+
+	it.each([
+		["disabled", { active: false }],
+		["narrowed", { allowedRefs: ["refs/tags/*"] }],
+	] as const)(
+		"invalidates a pre-write operation when its workload is %s",
+		async (_name, change) => {
+			const stub = await preparePublishing();
+			const started = await beginPublicationOperation(stub, 5_000, NOW + 10);
+			expect(started.ok).toBe(true);
+			if (!started.ok) return;
+			const materializationDigest = await materialize(stub);
+			const phaseInput = {
+				publisherDid: DID,
+				intentId: INTENT_ID,
+				generation: started.lease.generation,
+				token: started.lease.token,
+				expectedIntentGeneration: started.lease.expectedIntentGeneration,
+				materializationDigest,
+			};
+			await stub.advancePublicationOperationPhase({
+				...phaseInput,
+				phase: "materialized",
+				now: NOW + 11,
+			});
+
+			await stub.putWorkloadPolicy({
+				...policy(),
+				...change,
+				expectedVersion: 1,
+				now: NOW + 12,
+			});
+
+			await expect(stub.getIntent(DID, INTENT_ID)).resolves.toMatchObject({
+				state: "invalid",
+				stateGeneration: 6,
+				stateDataJson: '{"reasonCode":"WORKLOAD_POLICY_CHANGED"}',
+			});
+			await expect(
+				stub.advancePublicationOperationPhase({
+					...phaseInput,
+					phase: "creating",
+					now: NOW + 13,
+				}),
+			).resolves.toEqual({ ok: false, code: "PUBLICATION_CAS_REQUIRED" });
+		},
+	);
+
+	it.each([
+		["inactive version", "UPDATE workload_policies SET active = 0, state_version = 2"],
+		["narrowed current rules", `UPDATE workload_policies SET allowed_refs = '["refs/tags/*"]'`],
+		[
+			"canonical stored identity",
+			`UPDATE intents SET workload_identity_json = '{"issuer":"github-actions"}'`,
+		],
+	] as const)("rechecks the %s at the atomic creating gate", async (_name, policyUpdate) => {
+		const stub = await preparePublishing();
+		const started = await beginPublicationOperation(stub, 5_000, NOW + 10);
+		expect(started.ok).toBe(true);
+		if (!started.ok) return;
+		const materializationDigest = await materialize(stub);
+		const phaseInput = {
+			publisherDid: DID,
+			intentId: INTENT_ID,
+			generation: started.lease.generation,
+			token: started.lease.token,
+			expectedIntentGeneration: started.lease.expectedIntentGeneration,
+			materializationDigest,
+		};
+		await stub.advancePublicationOperationPhase({
+			...phaseInput,
+			phase: "materialized",
+			now: NOW + 11,
+		});
+		await runInDurableObject(stub, (_instance, state) => {
+			state.storage.sql.exec(policyUpdate);
+		});
+
+		await expect(
+			stub.advancePublicationOperationPhase({
+				...phaseInput,
+				phase: "creating",
+				now: NOW + 12,
+			}),
+		).resolves.toEqual({ ok: false, code: "WORKLOAD_POLICY_UNAVAILABLE" });
+	});
+
+	it("preserves reconciliation after the creating boundary wins the ordering race", async () => {
+		const stub = await preparePublishing();
+		const started = await beginPublicationOperation(stub, 5_000, NOW + 10);
+		expect(started.ok).toBe(true);
+		if (!started.ok) return;
+		await advanceToCreating(stub, started.lease);
+
+		await stub.putWorkloadPolicy({
+			...policy(),
+			active: false,
+			expectedVersion: 1,
+			now: NOW + 11,
+		});
+
+		await expect(stub.getIntent(DID, INTENT_ID)).resolves.toMatchObject({
+			state: "publishing",
+			stateGeneration: 5,
+		});
+		await expect(
+			stub.completePublicationOperation({
+				publisherDid: DID,
+				intentId: INTENT_ID,
+				generation: started.lease.generation,
+				token: started.lease.token,
+				expectedIntentGeneration: started.lease.expectedIntentGeneration,
+				completionDigest: "Z".repeat(43),
+				outcome: "ambiguous",
+				resultUri: null,
+				resultCid: null,
+				now: NOW + 12,
+			}),
+		).resolves.toMatchObject({ ok: true, state: "reconciling" });
 	});
 
 	it("completes a confirmed write atomically and replays the exact completion", async () => {

--- a/apps/release-service/test/publisher-intent-state.test.ts
+++ b/apps/release-service/test/publisher-intent-state.test.ts
@@ -2,6 +2,11 @@ import { reset, runDurableObjectAlarm, runInDurableObject } from "cloudflare:tes
 import { env } from "cloudflare:workers";
 import { afterEach, describe, expect, it } from "vitest";
 
+import {
+	decodeAwaitingApprovalState,
+	encodeAwaitingApprovalState,
+	type ApprovalEvidence,
+} from "../src/approvals/digest.js";
 import type {
 	CreateIntentInput,
 	IntentState,
@@ -13,6 +18,8 @@ const DID = "did:plc:publisher";
 const INTENT_1 = "01JABCDEFGHJKMNPQRSTVWXYZ0";
 const INTENT_2 = "01JABCDEFGHJKMNPQRSTVWXYZ1";
 const NOW = 1_800_000_000_000;
+const APPROVER_DID = "did:plc:approver";
+const APPROVAL_CHALLENGE = "C".repeat(43);
 
 function publisher() {
 	return env.PUBLISHER_DO.getByName(DID);
@@ -250,6 +257,67 @@ describe("publisher release intents", () => {
 			ok: false,
 			code: "WORKLOAD_POLICY_UNAVAILABLE",
 		});
+	});
+
+	it("invalidates outstanding approval challenges when a workload policy changes", async () => {
+		const stub = publisher();
+		await stub.putWorkloadPolicy(policy());
+		await stub.createIntent(intent());
+		await stub.transitionIntent(transition("received", 1, "verifying"));
+		await stub.transitionIntent(transition("verifying", 2, "verified"));
+		const evidence: ApprovalEvidence = {
+			intentId: INTENT_1,
+			publisherDid: DID,
+			packageSlug: "gallery",
+			version: "1.2.3",
+			verificationGeneration: 4,
+			workloadIdentityDigest: "A".repeat(43),
+			releaseInputDigest: "B".repeat(43),
+			profileCid: "bafyprofile",
+			baselineReleaseCid: null,
+			artifactChecksum: "sha256:artifact",
+			provenanceChecksum: "sha256:provenance",
+			declaredAccessDiffDigest: "D".repeat(43),
+			verificationDigest: "E".repeat(43),
+		};
+		const approvalState = await encodeAwaitingApprovalState(evidence, [APPROVER_DID]);
+		const approval = await decodeAwaitingApprovalState(approvalState);
+		await stub.transitionIntent(
+			transition("verified", 3, "awaiting_approval", {
+				reasonCode: "APPROVAL_REQUIRED",
+				stateDataJson: approvalState,
+			}),
+		);
+		await env.APPROVER_DO.getByName(APPROVER_DID).createChallenge(APPROVER_DID, {
+			challengeHash: APPROVAL_CHALLENGE,
+			kind: "approval",
+			intentId: INTENT_1,
+			publisherDid: DID,
+			approvalDigest: approval.approvalEvidenceDigest,
+			context: "approval-context",
+			expiresAt: NOW + 60_000,
+			now: NOW + 4,
+		});
+
+		await stub.putWorkloadPolicy({
+			...policy(),
+			active: false,
+			expectedVersion: 1,
+			now: NOW + 5,
+		});
+
+		await expect(stub.getIntent(DID, INTENT_1)).resolves.toMatchObject({
+			state: "invalid",
+			stateDataJson: '{"reasonCode":"WORKLOAD_POLICY_CHANGED"}',
+		});
+		await expect(
+			env.APPROVER_DO.getByName(APPROVER_DID).consumeChallenge(
+				APPROVER_DID,
+				APPROVAL_CHALLENGE,
+				"approval",
+				NOW + 6,
+			),
+		).resolves.toEqual({ ok: false, code: "CHALLENGE_CONSUMED" });
 	});
 
 	it("enforces explicit generation-guarded transitions and idempotent replay", async () => {

--- a/apps/release-service/test/release-intent-workflow.test.ts
+++ b/apps/release-service/test/release-intent-workflow.test.ts
@@ -22,6 +22,8 @@ import {
 	restartReleaseIntentWorkflow,
 	startReleaseIntentWorkflow,
 } from "../src/workflows/start.js";
+import { digestWorkloadIdentity } from "../src/workload/policy.js";
+import type { VerifiedWorkloadIdentity } from "../src/workload/types.js";
 import { ASSERTION_KEY_2, TEST_BINDINGS } from "./fixtures/oauth.js";
 import publicationProofs from "./fixtures/publication-proofs.json";
 
@@ -34,6 +36,38 @@ const PACKAGE_BYTES = new Uint8Array([0x1f, 0x8b, 0x08, 0x00, 0x01]);
 const ARTIFACT_CHECKSUM = "bciqhazpl5w2ra742ngjezwxoy4p74p2eyiftnnhycsofanwmdrezity";
 const ARTIFACT_BLOB_CID = "bafkreidqmxv63niqp6ngtesm3lxmoh76h5cmeczwwt4bjhcqg3gbysmuj4";
 const DEFAULT_SIGNING_KEY = "zDnaeq9feE9D74uYD5jynoyyQPbhhWU2vStcmC8W1xQHG3fWe";
+const WORKLOAD_IDENTITY: VerifiedWorkloadIdentity = {
+	issuer: "github-actions",
+	subject: "repo:example/gallery:ref:refs/heads/main",
+	tokenId: "release-token-100",
+	repository: {
+		name: "example/gallery",
+		id: "123456789",
+		owner: "example",
+		ownerId: "987654321",
+		visibility: "public",
+	},
+	workflow: {
+		ref: "example/gallery/.github/workflows/release.yml@refs/heads/main",
+		sha: "a".repeat(40),
+		jobRef: null,
+		jobSha: null,
+	},
+	run: {
+		id: "100",
+		attempt: 1,
+		actor: "release-bot",
+		actorId: "200",
+		eventName: "workflow_dispatch",
+		ref: "refs/heads/main",
+		refType: "branch",
+		commitSha: "b".repeat(40),
+		environment: null,
+		runnerEnvironment: "github-hosted",
+	},
+	issuedAt: 1_800_000_000,
+	expiresAt: 1_800_000_300,
+};
 
 function writeUint24LittleEndian(bytes: Uint8Array, offset: number, value: number): void {
 	bytes[offset] = value & 0xff;
@@ -403,11 +437,11 @@ async function createVerifyingIntent(
 		packageSlug: "gallery",
 		version: "1.2.3",
 		workloadPolicyVersion: 1,
-		workloadIdentityDigest: "A".repeat(43),
+		workloadIdentityDigest: await digestWorkloadIdentity(WORKLOAD_IDENTITY),
 		workloadIdempotencyDigest: "I".repeat(43),
 		idempotencyKey: "github-run-100-attempt-1",
 		requestDigest: "B".repeat(43),
-		workloadIdentityJson: JSON.stringify({ issuer: "github-actions", runId: "100" }),
+		workloadIdentityJson: JSON.stringify(WORKLOAD_IDENTITY),
 		releaseInputJson,
 		expiresAt: NOW + 60_000,
 		now: NOW + 1,

--- a/apps/release-service/test/workload-policy.test.ts
+++ b/apps/release-service/test/workload-policy.test.ts
@@ -74,13 +74,13 @@ describe("publisher workload policies", () => {
 			},
 		});
 		await runInDurableObject(publisher(), async (instance) => {
-			expect(() =>
+			await expect(
 				instance.putWorkloadPolicy(
 					input({
 						workflowRef: "EmDash-CMS/Gallery/.github/workflows/*.yml@refs/tags/*",
 					}),
 				),
-			).toThrowError(expect.objectContaining({ code: "WORKLOAD_POLICY_INVALID" }));
+			).rejects.toEqual(expect.objectContaining({ code: "WORKLOAD_POLICY_INVALID" }));
 		});
 	});
 
@@ -156,24 +156,24 @@ describe("publisher workload policies", () => {
 	it("rejects invalid workflow ownership, duplicate restrictions, and publisher mismatch", async () => {
 		const stub = publisher();
 		await runInDurableObject(stub, async (instance) => {
-			expect(() =>
+			await expect(
 				instance.putWorkloadPolicy({
 					...input(),
 					// @ts-expect-error - exercises an untyped RPC payload
 					repository: 42,
 				}),
-			).toThrowError(expect.objectContaining({ code: "WORKLOAD_POLICY_INVALID" }));
-			expect(() =>
+			).rejects.toEqual(expect.objectContaining({ code: "WORKLOAD_POLICY_INVALID" }));
+			await expect(
 				instance.putWorkloadPolicy(
 					input({
 						workflowRef: "attacker/repo/.github/workflows/release.yml@refs/heads/main",
 					}),
 				),
-			).toThrowError(expect.objectContaining({ code: "WORKLOAD_POLICY_INVALID" }));
-			expect(() =>
+			).rejects.toEqual(expect.objectContaining({ code: "WORKLOAD_POLICY_INVALID" }));
+			await expect(
 				instance.putWorkloadPolicy(input({ allowedRefs: ["refs/heads/main", "refs/heads/main"] })),
-			).toThrowError(expect.objectContaining({ code: "WORKLOAD_POLICY_INVALID" }));
-			expect(() => instance.putWorkloadPolicy(input({ publisherDid: OTHER_DID }))).toThrowError(
+			).rejects.toEqual(expect.objectContaining({ code: "WORKLOAD_POLICY_INVALID" }));
+			await expect(instance.putWorkloadPolicy(input({ publisherDid: OTHER_DID }))).rejects.toEqual(
 				expect.objectContaining({ code: "PUBLISHER_DID_MISMATCH" }),
 			);
 		});


### PR DESCRIPTION
## What does this PR do?

Fixes the independently validated delegated-release finding where disabling or narrowing a workload policy did not revoke intents admitted under an older policy version.

The Publisher Durable Object now invalidates affected pre-write intents in the same SQLite transaction as the policy version change, releases their reservations, closes active pre-create publication operations, and invalidates outstanding approver challenges. The transition from `materialized` to `creating` also atomically rechecks the active policy version and rules against a canonically parsed and re-hashed stored OIDC identity. Operations already in `creating` or reconciliation remain untouched so ambiguous writes can still converge safely.

Idempotent submission replays now pass current service admission and workload-policy checks before a Workflow can be started again.

Related issue/discussion: N/A — independently validated security audit finding.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — security bug fix, not a feature.

Changeset: N/A — `apps/release-service` is private and no published package changes.

i18n: N/A — no admin UI or user-visible strings changed.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

No visual changes.

- Required pre-edit JSON lint baseline: `0`
- `pnpm --filter @emdash-cms/release-service build`
- `pnpm lint:json | jq '.diagnostics | length'` → `0`
- `pnpm --filter @emdash-cms/release-service typecheck`
- Focused revocation regressions: 41/41
- Complete release-service Workerd suite: 435/435
- Encryption-v2 suite: 1/1
- Release-service UI suite: 13/13
