### PR TITLE
fix(release-service): bind publication to current PDS

### DIFF
--- a/apps/release-service/src/publishing/create-only.ts
+++ b/apps/release-service/src/publishing/create-only.ts
@@ -2,12 +2,11 @@
 import type {} from "@atcute/atproto";
 import { Client, ok, type FetchHandlerObject } from "@atcute/client";
 import type { Blob } from "@atcute/lexicons/interfaces";
-import { isDid } from "@atcute/lexicons/syntax";
+import { isCid, isDid } from "@atcute/lexicons/syntax";
 import { NSID, type PackageRelease } from "@emdash-cms/registry-lexicons";
 
 const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
 const RKEY_PATTERN = /^[A-Za-z0-9._:~-]{1,512}$/;
-const CID_PATTERN = /^[A-Za-z0-9]+$/;
 
 export interface CreateReleaseInput {
 	publisherDid: string;
@@ -55,11 +54,7 @@ export async function createReleaseRecord(
 		}),
 	);
 	const expectedUri = `at://${input.publisherDid}/${NSID.packageRelease}/${input.rkey}`;
-	if (
-		result.uri !== expectedUri ||
-		typeof result.cid !== "string" ||
-		!CID_PATTERN.test(result.cid)
-	) {
+	if (result.uri !== expectedUri || typeof result.cid !== "string" || !isCid(result.cid)) {
 		throw new CreateReleaseError("CREATE_RESPONSE_INVALID");
 	}
 	return { uri: result.uri, cid: result.cid };

--- a/apps/release-service/src/publishing/workflow.ts
+++ b/apps/release-service/src/publishing/workflow.ts
@@ -35,6 +35,7 @@ import {
 	PublisherSnapshotError,
 	readPublisherVerificationSnapshot,
 	resolvePublicHostname,
+	resolvePublisherPds,
 } from "../verification/pds.js";
 import { verifyReleaseEvidence } from "../verification/staged-input.js";
 import { createReleaseRecord, uploadReleaseBlob } from "./create-only.js";
@@ -369,6 +370,22 @@ async function restorePublicationSession(env: PublicationWorkflowEnv, publisherD
 	}).restoreForPublication();
 }
 
+async function requireCurrentPublicationAudience(
+	publisher: DurableObjectStub<PublisherDurableObject>,
+	publisherDid: string,
+	restored: Awaited<ReturnType<typeof restorePublicationSession>>,
+): Promise<void> {
+	const token = await restored.session.getTokenInfo(false);
+	const currentPds = await resolvePublisherPds(publisherDid);
+	if (new URL(token.aud).href === currentPds) return;
+	await publisher.requireDelegationReauthorization(
+		publisherDid,
+		restored.delegationVersion,
+		"OAUTH_SESSION_INVALID",
+	);
+	throw new OAuthCustodyError("OAUTH_DELEGATION_UNAVAILABLE");
+}
+
 async function transition(
 	publisher: DurableObjectStub<PublisherDurableObject>,
 	input: Parameters<PublisherDurableObject["transitionIntent"]>[0],
@@ -499,6 +516,7 @@ async function uploadMaterializedArtifacts(
 				) {
 					throw new OAuthCustodyError("OAUTH_DELEGATION_UNAVAILABLE");
 				}
+				await requireCurrentPublicationAudience(publisher, publisherDid, restored);
 				const uploaded = await uploadReleaseBlob(
 					restored.session,
 					staged.bytes,
@@ -992,6 +1010,7 @@ export async function publishVerifiedIntent(
 						originalIntent.requestDigest,
 					);
 					if (!persistedRecord) return failBeforeWrite("MATERIALIZATION_UNAVAILABLE");
+					await requireCurrentPublicationAudience(publisher, publisherDid, restored);
 					const creatingPhase = await publisher.advancePublicationOperationPhase({
 						...completionBase,
 						phase: "creating",
@@ -999,20 +1018,36 @@ export async function publishVerifiedIntent(
 					});
 					if (!creatingPhase.ok) return failBeforeWrite(creatingPhase.code);
 					writeStarted = true;
+					await requireCurrentPublicationAudience(publisher, publisherDid, restored);
 					const created = await createReleaseRecord(restored.session, {
 						publisherDid,
 						rkey: `${originalIntent.packageSlug}:${originalIntent.version}`,
 						record: persistedRecord.record,
 					});
-					const completionDigest = await digest(["published", created.uri, created.cid]);
+					const authoritative = await findProofVerifiedRelease(
+						publisherDid,
+						originalIntent.packageSlug,
+						originalIntent.version,
+					);
+					const proof = reconcileReleaseRecord(
+						publisherDid,
+						originalIntent.packageSlug,
+						originalIntent.version,
+						persistedRecord.record,
+						authoritative,
+					);
+					if (proof.outcome !== "exact" || proof.uri !== created.uri || proof.cid !== created.cid) {
+						throw new Error("PUBLICATION_PROOF_MISMATCH");
+					}
+					const completionDigest = await digest(["published", proof.uri, proof.cid]);
 					const completed = await publisher.completePublicationOperation({
 						...completionBase,
 						completionDigest,
 						outcome: "published",
-						resultUri: created.uri,
-						resultCid: created.cid,
+						resultUri: proof.uri,
+						resultCid: proof.cid,
 					});
-					if (completed.ok) return { state: "published", uri: created.uri, cid: created.cid };
+					if (completed.ok) return { state: "published", uri: proof.uri, cid: proof.cid };
 					const ambiguous = await publisher.completePublicationOperation({
 						...completionBase,
 						completionDigest: await digest(["ambiguous", attempt, expectedEvidenceDigest]),
@@ -1023,7 +1058,7 @@ export async function publishVerifiedIntent(
 					if (ambiguous.ok) return { state: "reconciling" };
 					const latest = await publisher.getIntent(publisherDid, originalIntent.id);
 					return latest?.state === "published"
-						? { state: "published", uri: created.uri, cid: created.cid }
+						? { state: "published", uri: proof.uri, cid: proof.cid }
 						: { state: "reconciling" };
 				} catch (error) {
 					const errorCode = writeStarted

--- a/apps/release-service/src/publishing/workflow.ts
+++ b/apps/release-service/src/publishing/workflow.ts
@@ -36,6 +36,7 @@ import {
 	readPublisherVerificationSnapshot,
 	resolvePublicHostname,
 	resolvePublisherPds,
+	samePdsOrigin,
 } from "../verification/pds.js";
 import { verifyReleaseEvidence } from "../verification/staged-input.js";
 import { createReleaseRecord, uploadReleaseBlob } from "./create-only.js";
@@ -377,13 +378,13 @@ async function requireCurrentPublicationAudience(
 ): Promise<void> {
 	const token = await restored.session.getTokenInfo(false);
 	const currentPds = await resolvePublisherPds(publisherDid);
-	if (new URL(token.aud).href === currentPds) return;
+	if (samePdsOrigin(token.aud, currentPds)) return;
 	await publisher.requireDelegationReauthorization(
 		publisherDid,
 		restored.delegationVersion,
 		"OAUTH_SESSION_INVALID",
 	);
-	throw new OAuthCustodyError("OAUTH_DELEGATION_UNAVAILABLE");
+	throw new NonRetryableError("OAUTH_DELEGATION_UNAVAILABLE");
 }
 
 async function transition(

--- a/apps/release-service/src/verification/pds.ts
+++ b/apps/release-service/src/verification/pds.ts
@@ -273,6 +273,24 @@ function parseRecord(value: unknown): AuthoritativeRecord | null {
 	return { uri: value["uri"], cid: value["cid"], value: value["value"] };
 }
 
+export async function resolvePublisherPds(
+	publisherDid: string,
+	options: ReadPublisherSnapshotOptions = {},
+): Promise<string> {
+	if (!isDid(publisherDid)) throw new PublisherSnapshotError("PUBLISHER_IDENTITY_INVALID");
+	const fetchImplementation = options.fetch ?? globalThis.fetch;
+	let actor;
+	try {
+		actor = await (
+			options.actorResolver ?? createWorkerActorResolver(guardedIdentityFetch(fetchImplementation))
+		).resolve(publisherDid, { signal: AbortSignal.timeout(30_000), noCache: true });
+	} catch {
+		throw new PublisherSnapshotError("PUBLISHER_IDENTITY_INVALID");
+	}
+	if (actor.did !== publisherDid) throw new PublisherSnapshotError("PUBLISHER_IDENTITY_INVALID");
+	return actor.pds;
+}
+
 function guardedIdentityFetch(fetchImplementation: typeof fetch): typeof fetch {
 	return async (input, init) => {
 		const url = new URL(input instanceof Request ? input.url : input.toString());
@@ -422,18 +440,10 @@ export async function readPublisherVerificationSnapshot(
 		throw new PublisherSnapshotError("PUBLISHER_IDENTITY_INVALID");
 	}
 	const fetchImplementation = options.fetch ?? globalThis.fetch;
-	let actor;
-	try {
-		actor = await (
-			options.actorResolver ?? createWorkerActorResolver(guardedIdentityFetch(fetchImplementation))
-		).resolve(publisherDid, { signal: AbortSignal.timeout(30_000), noCache: true });
-	} catch {
-		throw new PublisherSnapshotError("PUBLISHER_IDENTITY_INVALID");
-	}
-	if (actor.did !== publisherDid) throw new PublisherSnapshotError("PUBLISHER_IDENTITY_INVALID");
+	const pds = await resolvePublisherPds(publisherDid, options);
 	const [profile, releases] = await Promise.all([
 		getProfile(publisherDid, packageSlug, fetchImplementation, options.didDocumentResolver),
-		listPackageReleases(actor.pds, publisherDid, packageSlug, fetchImplementation),
+		listPackageReleases(pds, publisherDid, packageSlug, fetchImplementation),
 	]);
 	const proposedRkey = `${packageSlug}:${version}`;
 	let baseline: AuthoritativeRecord | null = null;
@@ -469,16 +479,8 @@ export async function findAuthoritativeRelease(
 		throw new PublisherSnapshotError("PUBLISHER_IDENTITY_INVALID");
 	}
 	const fetchImplementation = options.fetch ?? globalThis.fetch;
-	let actor;
-	try {
-		actor = await (
-			options.actorResolver ?? createWorkerActorResolver(guardedIdentityFetch(fetchImplementation))
-		).resolve(publisherDid, { signal: AbortSignal.timeout(30_000), noCache: true });
-	} catch {
-		throw new PublisherSnapshotError("PUBLISHER_IDENTITY_INVALID");
-	}
-	if (actor.did !== publisherDid) throw new PublisherSnapshotError("PUBLISHER_IDENTITY_INVALID");
-	return getRelease(actor.pds, publisherDid, packageSlug, version, fetchImplementation);
+	const pds = await resolvePublisherPds(publisherDid, options);
+	return getRelease(pds, publisherDid, packageSlug, version, fetchImplementation);
 }
 
 export async function findProofVerifiedRelease(

--- a/apps/release-service/src/verification/pds.ts
+++ b/apps/release-service/src/verification/pds.ts
@@ -57,6 +57,10 @@ export class PublisherSnapshotError extends Error {
 	}
 }
 
+export function samePdsOrigin(left: string, right: string): boolean {
+	return new URL(left).origin === new URL(right).origin;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/apps/release-service/test/create-only.test.ts
+++ b/apps/release-service/test/create-only.test.ts
@@ -7,6 +7,26 @@ import releaseFixture from "../../../packages/registry-verification/fixtures/rec
 import { createReleaseRecord, uploadReleaseBlob } from "../src/publishing/create-only.js";
 
 describe("create-only release client", () => {
+	it("rejects a create receipt whose CID is not a valid CID", async () => {
+		const handle = vi.fn(async () =>
+			Response.json({
+				uri: `at://did:plc:publisher/${NSID.packageRelease}/gallery:1.2.3`,
+				cid: "bafyfakecid",
+			}),
+		);
+
+		await expect(
+			createReleaseRecord(
+				{ handle },
+				{
+					publisherDid: "did:plc:publisher",
+					rkey: "gallery:1.2.3",
+					record: structuredClone(releaseFixture) as PackageRelease.Main,
+				},
+			),
+		).rejects.toMatchObject({ code: "CREATE_RESPONSE_INVALID" });
+	});
+
 	it("calls only createRecord with validation enabled", async () => {
 		const handle = vi.fn(async (_pathname: string, _init: RequestInit) =>
 			Response.json({

--- a/apps/release-service/test/release-intent-workflow.test.ts
+++ b/apps/release-service/test/release-intent-workflow.test.ts
@@ -29,11 +29,14 @@ const PUBLISHER_DID = "did:web:publisher.example.com";
 const INTENT_ID = "01JABCDEFGHJKMNPQRSTVWXYZ0";
 const NOW = 1_800_000_000_000;
 const CREATED_URI = `at://${PUBLISHER_DID}/${NSID.packageRelease}/gallery:1.2.3`;
-const CREATED_CID = "bafyreigh2akiscaildc4mscz4uzpcbap5jxg26eecmrf6cmnvkzkjmoixe";
+const CREATED_CID = "bafyreihjpivdl5qdxouzqcstugdxujn55wjoivzhunem3wx6q7r5nz3fbe";
 const PACKAGE_BYTES = new Uint8Array([0x1f, 0x8b, 0x08, 0x00, 0x01]);
 const ARTIFACT_CHECKSUM = "bciqhazpl5w2ra742ngjezwxoy4p74p2eyiftnnhycsofanwmdrezity";
 const ARTIFACT_BLOB_CID = "bafkreidqmxv63niqp6ngtesm3lxmoh76h5cmeczwwt4bjhcqg3gbysmuj4";
 const DEFAULT_SIGNING_KEY = "zDnaeq9feE9D74uYD5jynoyyQPbhhWU2vStcmC8W1xQHG3fWe";
+const DEFAULT_PDS_URL = "https://pds.example.com";
+const FORMER_PDS_URL = "https://pds-a.example.com";
+const CURRENT_PDS_URL = "https://pds-b.example.com";
 
 function writeUint24LittleEndian(bytes: Uint8Array, offset: number, value: number): void {
 	bytes[offset] = value & 0xff;
@@ -148,7 +151,7 @@ async function createDpopKey(): Promise<StoredSession["dpopKey"]> {
 	return { kty: "EC", crv: "P-256", alg: "ES256", x: jwk.x, y: jwk.y, d: jwk.d };
 }
 
-async function storeDelegation() {
+async function storeDelegation(pdsUrl = DEFAULT_PDS_URL) {
 	const configuration = await loadConfiguration(TEST_BINDINGS);
 	const custody = createPublisherOAuthStores(
 		env.PUBLISHER_DO,
@@ -166,7 +169,7 @@ async function storeDelegation() {
 		tokenSet: {
 			iss: "https://authorization.example",
 			sub: PUBLISHER_DID,
-			aud: "https://pds.example.com",
+			aud: pdsUrl,
 			scope: configuration.oauth.releaseScope,
 			access_token: "access-token",
 			refresh_token: "refresh-token",
@@ -246,14 +249,22 @@ interface WorkflowNetworkOptions {
 	signingKey?: () => string;
 	onArtifactFetch?: () => Response | void | Promise<Response | void>;
 	onAuthorizationMetadata?: () => void | Promise<void>;
+	onAuthoritativeRead?: () => void;
+	onProofRead?: () => void;
 	onUploadBlob?: (request: Request) => Response | void | Promise<Response | void>;
 	onCreateRecord?: (request: Request) => Response | Promise<Response>;
+	pdsUrl?: () => string;
+	oauthPdsUrl?: string;
+	nominalCreateProof?: boolean;
 }
 
 function workflowNetwork(options: WorkflowNetworkOptions = {}) {
 	const profileProof = options.profileProof ?? PROFILE_PROOF;
+	let nominalCreateVisible = false;
 	return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
 		const url = new URL(input instanceof Request ? input.url : input.toString());
+		const pdsUrl = options.pdsUrl?.() ?? DEFAULT_PDS_URL;
+		const oauthPdsUrl = options.oauthPdsUrl ?? pdsUrl;
 		if (url.hostname === "cloudflare-dns.com") {
 			return Response.json({
 				Status: 0,
@@ -268,21 +279,26 @@ function workflowNetwork(options: WorkflowNetworkOptions = {}) {
 						id: `${PUBLISHER_DID}#atproto`,
 						type: "Multikey",
 						controller: PUBLISHER_DID,
-						publicKeyMultibase: options.signingKey?.() ?? DEFAULT_SIGNING_KEY,
+						publicKeyMultibase:
+							options.signingKey?.() ??
+							(nominalCreateVisible ? publicationProofs.signingKey : DEFAULT_SIGNING_KEY),
 					},
 				],
 				service: [
 					{
 						id: "#atproto_pds",
 						type: "AtprotoPersonalDataServer",
-						serviceEndpoint: "https://pds.example.com",
+						serviceEndpoint: pdsUrl,
 					},
 				],
 			});
 		}
-		if (url.hostname === "pds.example.com" && url.pathname === "/xrpc/com.atproto.sync.getRecord") {
+		if (url.origin === pdsUrl && url.pathname === "/xrpc/com.atproto.sync.getRecord") {
 			if (url.searchParams.get("collection") === NSID.packageRelease) {
-				const proof = options.authoritativeProof?.() ?? null;
+				options.onProofRead?.();
+				const proof =
+					options.authoritativeProof?.() ??
+					(nominalCreateVisible ? proofBytes(publicationProofs.exactProof) : null);
 				return proof
 					? new Response(proof, {
 							headers: { "content-type": "application/vnd.ipld.car" },
@@ -294,12 +310,9 @@ function workflowNetwork(options: WorkflowNetworkOptions = {}) {
 				{ headers: { "content-type": "application/vnd.ipld.car" } },
 			);
 		}
-		if (
-			url.hostname === "pds.example.com" &&
-			url.pathname === "/.well-known/oauth-protected-resource"
-		) {
+		if (url.origin === oauthPdsUrl && url.pathname === "/.well-known/oauth-protected-resource") {
 			return Response.json({
-				resource: "https://pds.example.com",
+				resource: oauthPdsUrl,
 				authorization_servers: ["https://authorization.example"],
 			});
 		}
@@ -333,10 +346,7 @@ function workflowNetwork(options: WorkflowNetworkOptions = {}) {
 				headers: { "content-type": artifactSource.mimeType },
 			});
 		}
-		if (
-			url.hostname === "pds.example.com" &&
-			url.pathname === "/xrpc/com.atproto.repo.uploadBlob"
-		) {
+		if (url.origin === oauthPdsUrl && url.pathname === "/xrpc/com.atproto.repo.uploadBlob") {
 			const request = input instanceof Request ? input : new Request(url, init);
 			const response = await options.onUploadBlob?.(request);
 			if (response) return response;
@@ -349,27 +359,27 @@ function workflowNetwork(options: WorkflowNetworkOptions = {}) {
 				},
 			});
 		}
-		if (url.hostname === "pds.example.com" && url.pathname === "/xrpc/com.atproto.repo.getRecord") {
+		if (url.origin === pdsUrl && url.pathname === "/xrpc/com.atproto.repo.getRecord") {
 			const collection = url.searchParams.get("collection");
 			if (collection === NSID.packageRelease) {
+				options.onAuthoritativeRead?.();
 				expect(url.searchParams.get("rkey")).toBe("gallery:1.2.3");
-				return options.authoritativeProof?.()
+				return options.authoritativeProof?.() || nominalCreateVisible
 					? Response.json({ uri: CREATED_URI, cid: CREATED_CID, value: {} })
 					: Response.json({ error: "RecordNotFound" }, { status: 400 });
 			}
 		}
-		if (
-			url.hostname === "pds.example.com" &&
-			url.pathname === "/xrpc/com.atproto.repo.listRecords"
-		) {
+		if (url.origin === pdsUrl && url.pathname === "/xrpc/com.atproto.repo.listRecords") {
 			return Response.json({ records: options.listedReleases?.() ?? [] });
 		}
-		if (
-			url.hostname === "pds.example.com" &&
-			url.pathname === "/xrpc/com.atproto.repo.createRecord"
-		) {
+		if (url.origin === oauthPdsUrl && url.pathname === "/xrpc/com.atproto.repo.createRecord") {
 			const request = input instanceof Request ? input : new Request(url, init);
-			if (options.onCreateRecord) return options.onCreateRecord(request);
+			if (options.onCreateRecord) {
+				const response = await options.onCreateRecord(request);
+				if (response.ok && options.nominalCreateProof !== false) nominalCreateVisible = true;
+				return response;
+			}
+			nominalCreateVisible = true;
 			return Response.json({
 				uri: CREATED_URI,
 				cid: CREATED_CID,
@@ -382,6 +392,7 @@ function workflowNetwork(options: WorkflowNetworkOptions = {}) {
 async function createVerifyingIntent(
 	transitionToVerifying = true,
 	releaseInputJson = JSON.stringify({ release: releaseRecord() }),
+	pdsUrl = DEFAULT_PDS_URL,
 ) {
 	const publisher = env.PUBLISHER_DO.getByName(PUBLISHER_DID);
 	await publisher.putWorkloadPolicy({
@@ -412,7 +423,7 @@ async function createVerifyingIntent(
 		expiresAt: NOW + 60_000,
 		now: NOW + 1,
 	});
-	await storeDelegation();
+	await storeDelegation(pdsUrl);
 	if (!transitionToVerifying) return;
 	await publisher.transitionIntent({
 		publisherDid: PUBLISHER_DID,
@@ -496,7 +507,20 @@ describe("ReleaseIntentWorkflow", () => {
 	});
 
 	it("persists every verification stage and publishes a valid non-escalating intent", async () => {
-		vi.stubGlobal("fetch", workflowNetwork());
+		let createAttempts = 0;
+		let proofReads = 0;
+		vi.stubGlobal(
+			"fetch",
+			workflowNetwork({
+				onCreateRecord: () => {
+					createAttempts += 1;
+					return Response.json({ uri: CREATED_URI, cid: CREATED_CID });
+				},
+				onProofRead: () => {
+					proofReads += 1;
+				},
+			}),
+		);
 		await createVerifyingIntent();
 		await using introspector = await introspectWorkflowInstance(
 			env.RELEASE_INTENT_WORKFLOW,
@@ -526,6 +550,146 @@ describe("ReleaseIntentWorkflow", () => {
 			{ name: "policy-decision" },
 			{ name: "final-verification" },
 		]);
+		expect(createAttempts).toBe(1);
+		expect(proofReads).toBe(1);
+	});
+
+	it("requires reauthorization instead of writing after a PDS migration", async () => {
+		let migrated = false;
+		let uploadAttempts = 0;
+		let createAttempts = 0;
+		vi.stubGlobal(
+			"fetch",
+			workflowNetwork({
+				pdsUrl: () => (migrated ? CURRENT_PDS_URL : FORMER_PDS_URL),
+				oauthPdsUrl: FORMER_PDS_URL,
+				onAuthorizationMetadata: () => {
+					migrated = true;
+				},
+				onUploadBlob: () => {
+					uploadAttempts += 1;
+					return Response.json({
+						blob: {
+							$type: "blob",
+							ref: { $link: ARTIFACT_BLOB_CID },
+							mimeType: "application/gzip",
+							size: PACKAGE_BYTES.byteLength,
+						},
+					});
+				},
+				onCreateRecord: () => {
+					createAttempts += 1;
+					return Response.json({ uri: CREATED_URI, cid: "bafyfakecid" });
+				},
+			}),
+		);
+		await createVerifyingIntent(true, undefined, FORMER_PDS_URL);
+		await using introspector = await introspectWorkflowInstance(
+			env.RELEASE_INTENT_WORKFLOW,
+			INTENT_ID,
+		);
+		await env.RELEASE_INTENT_WORKFLOW.create({
+			id: INTENT_ID,
+			params: { publisherDid: PUBLISHER_DID, intentId: INTENT_ID },
+		});
+		await introspector.waitForStatus("complete");
+
+		await expect(introspector.getOutput()).resolves.toEqual({
+			intentId: INTENT_ID,
+			state: "failed",
+			reasonCode: "OAUTH_DELEGATION_UNAVAILABLE",
+		});
+		expect(uploadAttempts).toBe(0);
+		expect(createAttempts).toBe(0);
+		await expect(
+			env.PUBLISHER_DO.getByName(PUBLISHER_DID).getDelegation(PUBLISHER_DID),
+		).resolves.toMatchObject({ status: "reauthorization_required" });
+	});
+
+	it("rechecks the PDS audience after uploads before creating the release", async () => {
+		let migrated = false;
+		let uploadAttempts = 0;
+		let createAttempts = 0;
+		vi.stubGlobal(
+			"fetch",
+			workflowNetwork({
+				pdsUrl: () => (migrated ? CURRENT_PDS_URL : FORMER_PDS_URL),
+				oauthPdsUrl: FORMER_PDS_URL,
+				onUploadBlob: () => {
+					uploadAttempts += 1;
+					migrated = true;
+					return Response.json({
+						blob: {
+							$type: "blob",
+							ref: { $link: ARTIFACT_BLOB_CID },
+							mimeType: "application/gzip",
+							size: PACKAGE_BYTES.byteLength,
+						},
+					});
+				},
+				onCreateRecord: () => {
+					createAttempts += 1;
+					return Response.json({ uri: CREATED_URI, cid: "bafyfakecid" });
+				},
+			}),
+		);
+		await createVerifyingIntent(true, undefined, FORMER_PDS_URL);
+		await using introspector = await introspectWorkflowInstance(
+			env.RELEASE_INTENT_WORKFLOW,
+			INTENT_ID,
+		);
+		await env.RELEASE_INTENT_WORKFLOW.create({
+			id: INTENT_ID,
+			params: { publisherDid: PUBLISHER_DID, intentId: INTENT_ID },
+		});
+		await introspector.waitForStatus("complete");
+
+		await expect(introspector.getOutput()).resolves.toEqual({
+			intentId: INTENT_ID,
+			state: "failed",
+			reasonCode: "OAUTH_DELEGATION_UNAVAILABLE",
+		});
+		expect(uploadAttempts).toBe(1);
+		expect(createAttempts).toBe(0);
+		await expect(
+			env.PUBLISHER_DO.getByName(PUBLISHER_DID).getDelegation(PUBLISHER_DID),
+		).resolves.toMatchObject({ status: "reauthorization_required" });
+	});
+
+	it("does not publish a nominal create receipt when the authoritative record is absent", async () => {
+		let createAttempts = 0;
+		let authoritativeReads = 0;
+		vi.stubGlobal(
+			"fetch",
+			workflowNetwork({
+				nominalCreateProof: false,
+				onCreateRecord: () => {
+					createAttempts += 1;
+					return Response.json({ uri: CREATED_URI, cid: CREATED_CID });
+				},
+				onAuthoritativeRead: () => {
+					authoritativeReads += 1;
+				},
+			}),
+		);
+		await createVerifyingIntent();
+		await using introspector = await introspectWorkflowInstance(
+			env.RELEASE_INTENT_WORKFLOW,
+			INTENT_ID,
+		);
+		await env.RELEASE_INTENT_WORKFLOW.create({
+			id: INTENT_ID,
+			params: { publisherDid: PUBLISHER_DID, intentId: INTENT_ID },
+		});
+		await introspector.waitForStatus("complete");
+
+		await expect(introspector.getOutput()).resolves.toEqual({
+			intentId: INTENT_ID,
+			state: "failed",
+			reasonCode: "PDS_RETRY_EXHAUSTED",
+		});
+		expect(createAttempts).toBe(3);
+		expect(authoritativeReads).toBeGreaterThanOrEqual(3);
 	});
 
 	it("publishes private workflow uploads and promotes only verified provenance", async () => {

--- a/apps/release-service/test/verification-pds.test.ts
+++ b/apps/release-service/test/verification-pds.test.ts
@@ -7,6 +7,7 @@ import {
 	findAuthoritativeRelease,
 	PublisherSnapshotError,
 	readPublisherVerificationSnapshot,
+	samePdsOrigin,
 } from "../src/verification/pds.js";
 
 const PUBLISHER_DID = "did:plc:publisher";
@@ -118,6 +119,13 @@ function releaseFetch(record: ReturnType<typeof release> | null, options: { erro
 			: Response.json({ error: options.error ?? "RecordNotFound" }, { status: 400 });
 	};
 }
+
+describe("PDS origin identity", () => {
+	it("treats canonical URL variants as the same resource server", () => {
+		expect(samePdsOrigin("https://pds.example.com", "https://PDS.EXAMPLE.COM:443/")).toBe(true);
+		expect(samePdsOrigin("https://pds.example.com", "https://pds.example.com:8443/")).toBe(false);
+	});
+});
 
 describe("publisher verification snapshot", () => {
 	it("uses a signed repository proof instead of an unverified profile response", async () => {


### PR DESCRIPTION
## What does this PR do?

Prevents delegated publication from writing to or trusting a stale PDS after a publisher migrates their DID.

Before each blob or record write, the release service now resolves the publisher DID without cache and compares the current PDS with the restored OAuth token audience. A mismatch marks the delegation as requiring reauthorization and stops the write. A nominal `createRecord` success is no longer terminal on its receipt alone: the service proof-reads the current repository and requires the URI, CID, and canonical release record to match before marking the intent published. Receipt CID parsing now uses the AT Protocol CID validator.

The existing deterministic ambiguous-write reconciliation remains the recovery path when a create response cannot be proven.

Closes # N/A — independently validated security audit finding.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). N/A: no admin UI or user-visible strings changed; no `messages.po` files are included.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package). N/A: `@emdash-cms/release-service` is private and no published package changed.
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... N/A: this is a security bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

No visual changes.

- `pnpm lint:json | jq '.diagnostics | length'` — `0`
- `pnpm typecheck` — passed
- `pnpm --dir apps/release-service typecheck` — passed
- Publication/PDS regression suite — 47 tests passed
- Contention-affected Worker files rerun serially — 65 tests passed
- `pnpm --dir apps/release-service build` — passed

The full release-service Worker run completed 432 tests with 423 passing. Nine tests timed out under file-parallel execution after shared `reset()` calls deleted other files' Durable Objects (`deleteAllDurableObjects` / missing table errors). All four affected files passed when rerun serially; the focused publication suite also passed independently.
