### PR TITLE
fix(release-service): coordinate package publication

### DIFF
--- a/apps/release-service/src/control-do/service-control-do.ts
+++ b/apps/release-service/src/control-do/service-control-do.ts
@@ -11,6 +11,8 @@ const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$/;
 const DIGEST_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 const REASON_CODE_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
 const INTENT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const PACKAGE_SLUG_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+const CID_PATTERN = /^[A-Za-z0-9]{8,256}$/;
 const PERMIT_ID_PATTERN = /^[A-Za-z0-9_-]{22}$/;
 const PERMIT_TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 const MAX_KEY_VERSION = 2_147_483_647;
@@ -123,6 +125,9 @@ export interface PublicationPermit {
 	token: string;
 	publisherDid: string;
 	intentId: string;
+	packageSlug: string;
+	profileCid: string;
+	baselineCid: string | null;
 	modeEpoch: number;
 	encryptionKeyVersion: number;
 	expiresAt: number;
@@ -135,11 +140,25 @@ export type IssuePublicationPermitResult =
 			code: "ENCRYPTION_KEY_INACTIVE" | "PUBLICATION_PAUSED" | "PUBLISHER_SUSPENDED";
 	  };
 
+export interface IssuePublicationPermitInput {
+	publisherDid: string;
+	intentId: string;
+	packageSlug: string;
+	profileCid: string;
+	baselineCid: string | null;
+	ttlMs: number;
+	encryptionKeyVersion: number;
+	now?: number;
+}
+
 export interface ConsumePublicationPermitInput {
 	id: string;
 	token: string;
 	publisherDid: string;
 	intentId: string;
+	packageSlug: string;
+	profileCid: string;
+	baselineCid: string | null;
 	now?: number;
 }
 
@@ -220,6 +239,9 @@ interface PublicationPermitRow {
 	token_hash: string;
 	publisher_did: string;
 	intent_id: string;
+	package_slug: string | null;
+	profile_cid: string | null;
+	baseline_cid: string | null;
 	mode_epoch: number;
 	encryption_key_version: number;
 	expires_at: number;
@@ -430,6 +452,9 @@ export class ServiceControlDurableObject extends DurableObject<Env> {
 				token_hash TEXT NOT NULL,
 				publisher_did TEXT NOT NULL,
 				intent_id TEXT NOT NULL,
+				package_slug TEXT NOT NULL,
+				profile_cid TEXT NOT NULL,
+				baseline_cid TEXT,
 				mode_epoch INTEGER NOT NULL CHECK (mode_epoch >= 1),
 				encryption_key_version INTEGER NOT NULL CHECK (encryption_key_version >= 1),
 				expires_at INTEGER NOT NULL,
@@ -450,6 +475,21 @@ export class ServiceControlDurableObject extends DurableObject<Env> {
 				created_at INTEGER NOT NULL
 			);
 		`);
+		const permitColumns = new Set(
+			this.ctx.storage.sql
+				.exec<{ name: string }>("PRAGMA table_info(publication_permits)")
+				.toArray()
+				.map((column) => column.name),
+		);
+		if (!permitColumns.has("package_slug")) {
+			this.ctx.storage.sql.exec("ALTER TABLE publication_permits ADD COLUMN package_slug TEXT");
+		}
+		if (!permitColumns.has("profile_cid")) {
+			this.ctx.storage.sql.exec("ALTER TABLE publication_permits ADD COLUMN profile_cid TEXT");
+		}
+		if (!permitColumns.has("baseline_cid")) {
+			this.ctx.storage.sql.exec("ALTER TABLE publication_permits ADD COLUMN baseline_cid TEXT");
+		}
 	}
 
 	#assertObjectName(): void {
@@ -1090,22 +1130,22 @@ export class ServiceControlDurableObject extends DurableObject<Env> {
 	}
 
 	async issuePublicationPermit(
-		publisherDid: string,
-		intentId: string,
-		ttlMs: number,
-		encryptionKeyVersion: number,
-		now = Date.now(),
+		input: IssuePublicationPermitInput,
 	): Promise<IssuePublicationPermitResult> {
 		this.#assertObjectName();
+		const now = input.now ?? Date.now();
 		if (
-			!DID_PATTERN.test(publisherDid) ||
-			!INTENT_ID_PATTERN.test(intentId) ||
-			!Number.isSafeInteger(ttlMs) ||
-			ttlMs < 1 ||
-			ttlMs > MAX_PERMIT_TTL_MS ||
-			!validKeyVersion(encryptionKeyVersion) ||
+			!DID_PATTERN.test(input.publisherDid) ||
+			!INTENT_ID_PATTERN.test(input.intentId) ||
+			!PACKAGE_SLUG_PATTERN.test(input.packageSlug) ||
+			!CID_PATTERN.test(input.profileCid) ||
+			(input.baselineCid !== null && !CID_PATTERN.test(input.baselineCid)) ||
+			!Number.isSafeInteger(input.ttlMs) ||
+			input.ttlMs < 1 ||
+			input.ttlMs > MAX_PERMIT_TTL_MS ||
+			!validKeyVersion(input.encryptionKeyVersion) ||
 			!validTimestamp(now) ||
-			now > Number.MAX_SAFE_INTEGER - ttlMs
+			now > Number.MAX_SAFE_INTEGER - input.ttlMs
 		) {
 			throw new ServiceControlError("CONTROL_INPUT_INVALID");
 		}
@@ -1117,24 +1157,27 @@ export class ServiceControlDurableObject extends DurableObject<Env> {
 			if (state.mode === "publication-paused") {
 				return { ok: false, code: "PUBLICATION_PAUSED" } as const;
 			}
-			if (this.#readActiveEncryptionKey().version !== encryptionKeyVersion) {
+			if (this.#readActiveEncryptionKey().version !== input.encryptionKeyVersion) {
 				return { ok: false, code: "ENCRYPTION_KEY_INACTIVE" } as const;
 			}
-			if (this.#readPublisherControl(publisherDid).status === "suspended") {
+			if (this.#readPublisherControl(input.publisherDid).status === "suspended") {
 				return { ok: false, code: "PUBLISHER_SUSPENDED" } as const;
 			}
-			const expiresAt = now + ttlMs;
+			const expiresAt = now + input.ttlMs;
 			this.ctx.storage.sql.exec(
 				`INSERT INTO publication_permits (
-					id, token_hash, publisher_did, intent_id, mode_epoch, encryption_key_version,
-					expires_at, consumed_at, created_at
-				) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
+					id, token_hash, publisher_did, intent_id, package_slug, profile_cid,
+					baseline_cid, mode_epoch, encryption_key_version, expires_at, consumed_at, created_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
 				id,
 				tokenHash,
-				publisherDid,
-				intentId,
+				input.publisherDid,
+				input.intentId,
+				input.packageSlug,
+				input.profileCid,
+				input.baselineCid,
 				state.epoch,
-				encryptionKeyVersion,
+				input.encryptionKeyVersion,
 				expiresAt,
 				now,
 			);
@@ -1143,7 +1186,7 @@ export class ServiceControlDurableObject extends DurableObject<Env> {
 				"system",
 				"release-service",
 				null,
-				`${publisherDid}:${intentId}`,
+				`${input.publisherDid}:${input.packageSlug}:${input.intentId}`,
 				null,
 				now,
 			);
@@ -1152,10 +1195,13 @@ export class ServiceControlDurableObject extends DurableObject<Env> {
 				permit: {
 					id,
 					token,
-					publisherDid,
-					intentId,
+					publisherDid: input.publisherDid,
+					intentId: input.intentId,
+					packageSlug: input.packageSlug,
+					profileCid: input.profileCid,
+					baselineCid: input.baselineCid,
 					modeEpoch: state.epoch,
-					encryptionKeyVersion,
+					encryptionKeyVersion: input.encryptionKeyVersion,
 					expiresAt,
 				},
 			} as const;
@@ -1174,6 +1220,9 @@ export class ServiceControlDurableObject extends DurableObject<Env> {
 			!PERMIT_TOKEN_PATTERN.test(input.token) ||
 			!DID_PATTERN.test(input.publisherDid) ||
 			!INTENT_ID_PATTERN.test(input.intentId) ||
+			!PACKAGE_SLUG_PATTERN.test(input.packageSlug) ||
+			!CID_PATTERN.test(input.profileCid) ||
+			(input.baselineCid !== null && !CID_PATTERN.test(input.baselineCid)) ||
 			!validTimestamp(now)
 		) {
 			throw new ServiceControlError("CONTROL_INPUT_INVALID");
@@ -1182,7 +1231,8 @@ export class ServiceControlDurableObject extends DurableObject<Env> {
 		return this.ctx.storage.transactionSync(() => {
 			const permit = this.ctx.storage.sql
 				.exec<PublicationPermitRow>(
-					`SELECT token_hash, publisher_did, intent_id, mode_epoch,
+					`SELECT token_hash, publisher_did, intent_id, package_slug, profile_cid,
+					        baseline_cid, mode_epoch,
 					        encryption_key_version, expires_at, consumed_at
 					 FROM publication_permits WHERE id = ?`,
 					input.id,
@@ -1192,6 +1242,9 @@ export class ServiceControlDurableObject extends DurableObject<Env> {
 			if (
 				permit.publisher_did !== input.publisherDid ||
 				permit.intent_id !== input.intentId ||
+				permit.package_slug !== input.packageSlug ||
+				permit.profile_cid !== input.profileCid ||
+				permit.baseline_cid !== input.baselineCid ||
 				!hashesEqual(permit.token_hash, tokenHash)
 			) {
 				return { ok: false, code: "PERMIT_INVALID" } as const;
@@ -1223,7 +1276,7 @@ export class ServiceControlDurableObject extends DurableObject<Env> {
 				"system",
 				"release-service",
 				null,
-				`${input.publisherDid}:${input.intentId}`,
+				`${input.publisherDid}:${input.packageSlug}:${input.intentId}`,
 				null,
 				now,
 			);

--- a/apps/release-service/src/publisher-do/publication-coordination.ts
+++ b/apps/release-service/src/publisher-do/publication-coordination.ts
@@ -1,0 +1,351 @@
+import { base64url } from "jose";
+
+const DID_PATTERN = /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/;
+const ULID_PATTERN = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const PACKAGE_SLUG_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const MAX_LEASE_MS = 5 * 60_000;
+
+export interface PublicationCoordinationLease {
+	packageSlug: string;
+	intentId: string;
+	generation: number;
+	token: string;
+	expiresAt: number;
+}
+
+export type AcquirePublicationCoordinationResult =
+	| { ok: true; lease: PublicationCoordinationLease; replayed: boolean }
+	| { ok: false; code: "PUBLICATION_COORDINATION_BUSY"; retryAt: number };
+
+export interface RenewPublicationCoordinationInput {
+	publisherDid: string;
+	packageSlug: string;
+	intentId: string;
+	generation: number;
+	token: string;
+	leaseMs: number;
+	now?: number;
+}
+
+export type RenewPublicationCoordinationResult =
+	| { ok: true; lease: PublicationCoordinationLease }
+	| { ok: false; code: "PUBLICATION_COORDINATION_REQUIRED" };
+
+export interface ReleasePublicationCoordinationInput {
+	publisherDid: string;
+	packageSlug: string;
+	intentId: string;
+	generation: number;
+	token: string;
+	now?: number;
+}
+
+export type ReleasePublicationCoordinationResult =
+	| { ok: true; replayed: boolean }
+	| { ok: false; code: "PUBLICATION_COORDINATION_REQUIRED" };
+
+interface CoordinationRow {
+	[key: string]: string | number | ArrayBuffer | null;
+	intent_id: string;
+	generation: number;
+	token_hash: string;
+	expires_at: number;
+}
+
+export class PublicationCoordinationError extends Error {
+	readonly code = "PUBLICATION_COORDINATION_INVALID";
+
+	constructor() {
+		super("PUBLICATION_COORDINATION_INVALID");
+		this.name = "PublicationCoordinationError";
+	}
+}
+
+async function hashToken(token: string): Promise<string> {
+	return base64url.encode(
+		new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token))),
+	);
+}
+
+function hashesEqual(left: string, right: string): boolean {
+	try {
+		const leftBytes = base64url.decode(left);
+		const rightBytes = base64url.decode(right);
+		return (
+			leftBytes.length === rightBytes.length && crypto.subtle.timingSafeEqual(leftBytes, rightBytes)
+		);
+	} catch {
+		return false;
+	}
+}
+
+function validLeaseInput(
+	publisherDid: string,
+	packageSlug: string,
+	intentId: string,
+	leaseMs: number,
+	token: string,
+	now: number,
+): boolean {
+	return (
+		DID_PATTERN.test(publisherDid) &&
+		PACKAGE_SLUG_PATTERN.test(packageSlug) &&
+		ULID_PATTERN.test(intentId) &&
+		Number.isSafeInteger(leaseMs) &&
+		leaseMs >= 1 &&
+		leaseMs <= MAX_LEASE_MS &&
+		TOKEN_PATTERN.test(token) &&
+		Number.isSafeInteger(now) &&
+		now >= 0 &&
+		now <= Number.MAX_SAFE_INTEGER - leaseMs
+	);
+}
+
+function validLeaseIdentity(
+	publisherDid: string,
+	packageSlug: string,
+	intentId: string,
+	generation: number,
+	token: string,
+	now: number,
+): boolean {
+	return (
+		DID_PATTERN.test(publisherDid) &&
+		PACKAGE_SLUG_PATTERN.test(packageSlug) &&
+		ULID_PATTERN.test(intentId) &&
+		Number.isSafeInteger(generation) &&
+		generation >= 1 &&
+		TOKEN_PATTERN.test(token) &&
+		Number.isSafeInteger(now) &&
+		now >= 0
+	);
+}
+
+export function initializePublicationCoordinationSchema(storage: DurableObjectStorage): void {
+	storage.sql.exec(`
+		CREATE TABLE IF NOT EXISTS publication_coordinations (
+			package_slug TEXT PRIMARY KEY,
+			intent_id TEXT NOT NULL,
+			generation INTEGER NOT NULL CHECK (generation >= 1),
+			token_hash TEXT NOT NULL,
+			expires_at INTEGER NOT NULL,
+			acquired_at INTEGER NOT NULL,
+			renewed_at INTEGER NOT NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_publication_coordinations_expiry
+			ON publication_coordinations(expires_at);
+	`);
+}
+
+export class PublicationCoordinationStore {
+	constructor(private readonly storage: DurableObjectStorage) {}
+
+	async acquire(
+		publisherDid: string,
+		packageSlug: string,
+		intentId: string,
+		leaseMs: number,
+		token: string,
+		now = Date.now(),
+	): Promise<AcquirePublicationCoordinationResult> {
+		if (!validLeaseInput(publisherDid, packageSlug, intentId, leaseMs, token, now)) {
+			throw new PublicationCoordinationError();
+		}
+		const tokenHash = await hashToken(token);
+		return this.storage.transactionSync(() => {
+			const current = this.storage.sql
+				.exec<CoordinationRow>(
+					`SELECT intent_id, generation, token_hash, expires_at
+					 FROM publication_coordinations WHERE package_slug = ?`,
+					packageSlug,
+				)
+				.toArray()[0];
+			if (
+				current &&
+				current.expires_at > now &&
+				current.intent_id === intentId &&
+				hashesEqual(current.token_hash, tokenHash)
+			) {
+				return {
+					ok: true,
+					lease: {
+						packageSlug,
+						intentId,
+						generation: current.generation,
+						token,
+						expiresAt: current.expires_at,
+					},
+					replayed: true,
+				} as const;
+			}
+			if (current && current.expires_at > now && current.intent_id !== intentId) {
+				return {
+					ok: false,
+					code: "PUBLICATION_COORDINATION_BUSY",
+					retryAt: current.expires_at,
+				} as const;
+			}
+			const generation = (current?.generation ?? 0) + 1;
+			const expiresAt = now + leaseMs;
+			this.storage.sql.exec(
+				`INSERT INTO publication_coordinations (
+					package_slug, intent_id, generation, token_hash, expires_at, acquired_at, renewed_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT(package_slug) DO UPDATE SET
+					intent_id = excluded.intent_id,
+					generation = excluded.generation,
+					token_hash = excluded.token_hash,
+					expires_at = excluded.expires_at,
+					acquired_at = excluded.acquired_at,
+					renewed_at = excluded.renewed_at`,
+				packageSlug,
+				intentId,
+				generation,
+				tokenHash,
+				expiresAt,
+				now,
+				now,
+			);
+			this.storage.sql.exec(
+				`INSERT INTO audit_events (
+					event_type, actor_realm, actor_identity, subject,
+					reason_code, public_payload, created_at
+				) VALUES ('publication-coordination-acquired', 'system',
+				          'release-service', ?, NULL, '{}', ?)`,
+				`${packageSlug}:${intentId}`,
+				now,
+			);
+			return {
+				ok: true,
+				lease: { packageSlug, intentId, generation, token, expiresAt },
+				replayed: false,
+			} as const;
+		});
+	}
+
+	async renew(
+		input: RenewPublicationCoordinationInput,
+	): Promise<RenewPublicationCoordinationResult> {
+		const now = input.now ?? Date.now();
+		if (
+			!validLeaseInput(
+				input.publisherDid,
+				input.packageSlug,
+				input.intentId,
+				input.leaseMs,
+				input.token,
+				now,
+			) ||
+			!Number.isSafeInteger(input.generation) ||
+			input.generation < 1
+		) {
+			throw new PublicationCoordinationError();
+		}
+		const tokenHash = await hashToken(input.token);
+		return this.storage.transactionSync(() => {
+			const current = this.storage.sql
+				.exec<CoordinationRow>(
+					`SELECT intent_id, generation, token_hash, expires_at
+					 FROM publication_coordinations WHERE package_slug = ?`,
+					input.packageSlug,
+				)
+				.toArray()[0];
+			if (
+				!current ||
+				current.intent_id !== input.intentId ||
+				current.generation !== input.generation ||
+				!hashesEqual(current.token_hash, tokenHash) ||
+				current.expires_at <= now
+			) {
+				return { ok: false, code: "PUBLICATION_COORDINATION_REQUIRED" } as const;
+			}
+			const expiresAt = now + input.leaseMs;
+			this.storage.sql.exec(
+				`UPDATE publication_coordinations SET expires_at = ?, renewed_at = ?
+				 WHERE package_slug = ?`,
+				expiresAt,
+				now,
+				input.packageSlug,
+			);
+			return {
+				ok: true,
+				lease: {
+					packageSlug: input.packageSlug,
+					intentId: input.intentId,
+					generation: input.generation,
+					token: input.token,
+					expiresAt,
+				},
+			} as const;
+		});
+	}
+
+	async release(
+		input: ReleasePublicationCoordinationInput,
+	): Promise<ReleasePublicationCoordinationResult> {
+		const now = input.now ?? Date.now();
+		if (
+			!validLeaseIdentity(
+				input.publisherDid,
+				input.packageSlug,
+				input.intentId,
+				input.generation,
+				input.token,
+				now,
+			)
+		) {
+			throw new PublicationCoordinationError();
+		}
+		const tokenHash = await hashToken(input.token);
+		return this.storage.transactionSync(() => {
+			const current = this.storage.sql
+				.exec<CoordinationRow>(
+					`SELECT intent_id, generation, token_hash, expires_at
+					 FROM publication_coordinations WHERE package_slug = ?`,
+					input.packageSlug,
+				)
+				.toArray()[0];
+			if (!current) return { ok: true, replayed: true } as const;
+			if (
+				current.intent_id !== input.intentId ||
+				current.generation !== input.generation ||
+				!hashesEqual(current.token_hash, tokenHash)
+			) {
+				return { ok: false, code: "PUBLICATION_COORDINATION_REQUIRED" } as const;
+			}
+			this.storage.sql.exec(
+				"DELETE FROM publication_coordinations WHERE package_slug = ?",
+				input.packageSlug,
+			);
+			this.storage.sql.exec(
+				`INSERT INTO audit_events (
+					event_type, actor_realm, actor_identity, subject,
+					reason_code, public_payload, created_at
+				) VALUES ('publication-coordination-released', 'system',
+				          'release-service', ?, NULL, '{}', ?)`,
+				`${input.packageSlug}:${input.intentId}`,
+				now,
+			);
+			return { ok: true, replayed: false } as const;
+		});
+	}
+
+	recoverExpired(now = Date.now()): number {
+		if (!Number.isSafeInteger(now) || now < 0) throw new PublicationCoordinationError();
+		return this.storage.sql
+			.exec(
+				"DELETE FROM publication_coordinations WHERE expires_at <= ? RETURNING package_slug",
+				now,
+			)
+			.toArray().length;
+	}
+
+	nextDeadline(): number | null {
+		return this.storage.sql
+			.exec<{ expires_at: number | null }>(
+				"SELECT MIN(expires_at) AS expires_at FROM publication_coordinations",
+			)
+			.one().expires_at;
+	}
+}

--- a/apps/release-service/src/publisher-do/publisher-do.ts
+++ b/apps/release-service/src/publisher-do/publisher-do.ts
@@ -23,6 +23,15 @@ import {
 	type ApplyPublisherRestorePageResult,
 } from "./operations-restore.js";
 import {
+	initializePublicationCoordinationSchema,
+	PublicationCoordinationStore,
+	type AcquirePublicationCoordinationResult,
+	type ReleasePublicationCoordinationInput,
+	type ReleasePublicationCoordinationResult,
+	type RenewPublicationCoordinationInput,
+	type RenewPublicationCoordinationResult,
+} from "./publication-coordination.js";
+import {
 	initializePublicationMaterializationSchema,
 	PublicationMaterializationStore,
 	type CompletePublicationMaterializationInput,
@@ -86,6 +95,14 @@ export type {
 	TransitionIntentInput,
 	TransitionIntentResult,
 } from "./intent-state.js";
+export type {
+	AcquirePublicationCoordinationResult,
+	PublicationCoordinationLease,
+	ReleasePublicationCoordinationInput,
+	ReleasePublicationCoordinationResult,
+	RenewPublicationCoordinationInput,
+	RenewPublicationCoordinationResult,
+} from "./publication-coordination.js";
 export type {
 	CompletePublicationMaterializationInput,
 	PublicationArtifactSlot,
@@ -536,6 +553,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 	readonly #objectName: string | undefined;
 	readonly #workloadPolicies: WorkloadPolicyStore;
 	readonly #intents: IntentStateStore;
+	readonly #publicationCoordinations: PublicationCoordinationStore;
 	readonly #publicationMaterializations: PublicationMaterializationStore;
 	readonly #publicationOperations: PublicationOperationStore;
 	readonly #verificationSteps: VerificationStepStore;
@@ -548,6 +566,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		this.#objectName = ctx.id.name;
 		this.#workloadPolicies = new WorkloadPolicyStore(ctx.storage);
 		this.#intents = new IntentStateStore(ctx.storage);
+		this.#publicationCoordinations = new PublicationCoordinationStore(ctx.storage);
 		this.#publicationMaterializations = new PublicationMaterializationStore(ctx.storage);
 		this.#publicationOperations = new PublicationOperationStore(ctx.storage);
 		this.#verificationSteps = new VerificationStepStore(ctx.storage);
@@ -635,6 +654,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		`);
 		initializeWorkloadPolicySchema(this.ctx.storage);
 		initializeIntentStateSchema(this.ctx.storage);
+		initializePublicationCoordinationSchema(this.ctx.storage);
 		initializePublicationMaterializationSchema(this.ctx.storage);
 		initializePublicationOperationSchema(this.ctx.storage);
 		initializeVerificationStepSchema(this.ctx.storage);
@@ -944,6 +964,45 @@ export class PublisherDurableObject extends DurableObject<Env> {
 			now,
 		);
 		await this.#scheduleNextAlarm(now);
+		return result;
+	}
+
+	async acquirePublicationCoordination(
+		publisherDid: string,
+		packageSlug: string,
+		intentId: string,
+		leaseMs: number,
+		token: string,
+		now = Date.now(),
+	): Promise<AcquirePublicationCoordinationResult> {
+		this.#assertPublisherDid(publisherDid);
+		const result = await this.#publicationCoordinations.acquire(
+			publisherDid,
+			packageSlug,
+			intentId,
+			leaseMs,
+			token,
+			now,
+		);
+		await this.#scheduleNextAlarm(now);
+		return result;
+	}
+
+	async renewPublicationCoordination(
+		input: RenewPublicationCoordinationInput,
+	): Promise<RenewPublicationCoordinationResult> {
+		this.#assertPublisherDid(input.publisherDid);
+		const result = await this.#publicationCoordinations.renew(input);
+		await this.#scheduleNextAlarm(input.now ?? Date.now());
+		return result;
+	}
+
+	async releasePublicationCoordination(
+		input: ReleasePublicationCoordinationInput,
+	): Promise<ReleasePublicationCoordinationResult> {
+		this.#assertPublisherDid(input.publisherDid);
+		const result = await this.#publicationCoordinations.release(input);
+		await this.#scheduleNextAlarm(input.now ?? Date.now());
 		return result;
 	}
 
@@ -1441,6 +1500,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 			this.ctx.storage.sql.exec("DELETE FROM release_reservations");
 			this.ctx.storage.sql.exec("DELETE FROM intent_idempotency");
 			this.ctx.storage.sql.exec("DELETE FROM publication_operations");
+			this.ctx.storage.sql.exec("DELETE FROM publication_coordinations");
 			this.ctx.storage.sql.exec("DELETE FROM deadlines");
 			this.ctx.storage.sql.exec("DELETE FROM intents");
 			this.ctx.storage.sql.exec("DELETE FROM workload_policies");
@@ -2010,6 +2070,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 		const candidates = this.ctx.storage.sql
 			.exec<{
 				operation_deadline: number | null;
+				coordination_deadline: number | null;
 				oauth_expiry: number | null;
 				session_expiry: number | null;
 				idempotency_expiry: number | null;
@@ -2019,6 +2080,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 			}>(
 				`SELECT
 					(SELECT MIN(scheduled_at) FROM deadlines) AS operation_deadline,
+					(SELECT MIN(expires_at) FROM publication_coordinations) AS coordination_deadline,
 					(SELECT MIN(expires_at) FROM oauth_states) AS oauth_expiry,
 					(SELECT MIN(expires_at) FROM publisher_sessions) AS session_expiry,
 					(SELECT MIN(expires_at) FROM intent_idempotency) AS idempotency_expiry,
@@ -2044,6 +2106,7 @@ export class PublisherDurableObject extends DurableObject<Env> {
 
 	override async alarm(): Promise<void> {
 		const now = Date.now();
+		this.#publicationCoordinations.recoverExpired(now);
 		this.#publicationOperations.recoverExpired(now);
 		const publisherDid = this.#objectName;
 		if (publisherDid !== undefined) {

--- a/apps/release-service/src/publishing/workflow.ts
+++ b/apps/release-service/src/publishing/workflow.ts
@@ -20,6 +20,7 @@ import { writeOperationsMetric } from "../observability/metrics.js";
 import type {
 	IntentState,
 	PublicationArtifactSlot,
+	PublicationCoordinationLease,
 	PublicationOperationLease,
 	PublisherDurableObject,
 	StoredIntent,
@@ -28,6 +29,7 @@ import type {
 import {
 	evaluateVerifiedRelease,
 	normalizeVerifierReport,
+	parseNormalizedVerifierReport,
 	prepareVerifierInput,
 } from "../verification/evaluate.js";
 import {
@@ -61,8 +63,10 @@ import {
 } from "./workload-staging.js";
 
 const PUBLICATION_PERMIT_TTL_MS = 30_000;
+const PUBLICATION_COORDINATION_LEASE_MS = 5 * 60_000;
 const PUBLICATION_OPERATION_LEASE_MS = 5 * 60_000;
 const MAX_PUBLICATION_ATTEMPTS = 3;
+const MAX_COORDINATION_WAITS = 3;
 const FINAL_VERIFICATION_STEP_CONFIG = {
 	retries: { limit: 3, delay: "1 second", backoff: "exponential" },
 	timeout: "2 minutes",
@@ -119,6 +123,10 @@ type OperationBeginSummary =
 	| { ok: true; lease: PublicationOperationLease; replayed: boolean }
 	| { ok: false; code: string };
 
+type CoordinationAcquireSummary =
+	| { ok: true; lease: PublicationCoordinationLease }
+	| { ok: false; code: "PUBLICATION_COORDINATION_BUSY"; retryAt: number };
+
 type OperationPhaseSummary =
 	| { ok: true; phase: "creating" | "materialized"; materializationDigest: string }
 	| { ok: false; code: string };
@@ -134,7 +142,11 @@ interface MaterializedSummary {
 }
 
 type FinalVerificationResult =
-	| { ok: true; verificationDigest: string }
+	| {
+			ok: true;
+			verificationDigest: string;
+			verifierJson: string;
+	  }
 	| { ok: false; reasonCode: string; terminalState: "conflict" | "invalid" };
 
 const PUBLISHER_SNAPSHOT_ERROR_CODES: readonly PublisherSnapshotError["code"][] = [
@@ -203,6 +215,61 @@ function randomCredential(): AttemptCredential {
 		attemptKey: base64url.encode(crypto.getRandomValues(new Uint8Array(32))),
 		token: base64url.encode(crypto.getRandomValues(new Uint8Array(32))),
 	};
+}
+
+export async function acquirePublicationCoordination(
+	step: WorkflowStep,
+	publisher: DurableObjectStub<PublisherDurableObject>,
+	publisherDid: string,
+	intent: StoredIntent,
+	attempt: number | "recovery",
+): Promise<PublicationCoordinationLease | null> {
+	const credential = await step.do<AttemptCredential>(
+		`publication-coordination-credential-${attempt}`,
+		async () => randomCredential(),
+	);
+	for (let wait = 1; wait <= MAX_COORDINATION_WAITS; wait += 1) {
+		const result = await step.do<CoordinationAcquireSummary>(
+			`publication-coordinate-${attempt}-${wait}`,
+			async () => {
+				const acquired = await publisher.acquirePublicationCoordination(
+					publisherDid,
+					intent.packageSlug,
+					intent.id,
+					PUBLICATION_COORDINATION_LEASE_MS,
+					credential.token,
+				);
+				return acquired.ok
+					? { ok: true, lease: acquired.lease }
+					: { ok: false, code: acquired.code, retryAt: acquired.retryAt };
+			},
+		);
+		if (result.ok) return result.lease;
+		await step.sleepUntil(
+			`publication-coordinate-wait-${attempt}-${wait}`,
+			Math.max(Date.now() + 1, result.retryAt),
+		);
+	}
+	return null;
+}
+
+export async function releasePublicationCoordination(
+	step: WorkflowStep,
+	publisher: DurableObjectStub<PublisherDurableObject>,
+	publisherDid: string,
+	lease: PublicationCoordinationLease,
+	stepName: string,
+): Promise<void> {
+	await step.do(stepName, async () => {
+		await publisher.releasePublicationCoordination({
+			publisherDid,
+			packageSlug: lease.packageSlug,
+			intentId: lease.intentId,
+			generation: lease.generation,
+			token: lease.token,
+		});
+		return true;
+	});
 }
 
 export function releaseFromIntent(intent: StoredIntent): DelegatedReleaseSourceRecord | null {
@@ -625,6 +692,20 @@ export async function publishVerifiedIntent(
 	const expectedEvidenceDigest = await computeApprovalEvidenceDigest(approvalEvidence);
 
 	for (let attempt = 1; attempt <= MAX_PUBLICATION_ATTEMPTS; attempt += 1) {
+		const coordination = await acquirePublicationCoordination(
+			step,
+			publisher,
+			publisherDid,
+			originalIntent,
+			attempt,
+		);
+		if (!coordination) {
+			return {
+				intentId: originalIntent.id,
+				state: "ready",
+				reasonCode: "PUBLICATION_COORDINATION_BUSY",
+			};
+		}
 		let finalVerification: FinalVerificationResult;
 		try {
 			finalVerification = await step.do<FinalVerificationResult>(
@@ -647,6 +728,9 @@ export async function publishVerifiedIntent(
 							verifier: env.RELEASE_VERIFIER,
 						}),
 					);
+					if (!verifier.success) {
+						return { ok: false, reasonCode: verifier.error.code, terminalState: "invalid" };
+					}
 					const evaluation = await evaluateVerifiedRelease(
 						publisherDid,
 						originalIntent,
@@ -679,6 +763,7 @@ export async function publishVerifiedIntent(
 						? {
 								ok: true,
 								verificationDigest: evaluation.value.approvalEvidence.verificationDigest,
+								verifierJson: JSON.stringify(verifier),
 							}
 						: { ok: false, reasonCode: stored.code, terminalState: "invalid" };
 				},
@@ -693,6 +778,13 @@ export async function publishVerifiedIntent(
 			};
 		}
 		if (!finalVerification.ok) {
+			await releasePublicationCoordination(
+				step,
+				publisher,
+				publisherDid,
+				coordination,
+				`publication-coordinate-final-release-${attempt}`,
+			);
 			const current = await step.do(`final-invalid-state-${attempt}`, () =>
 				currentState(publisher, publisherDid, originalIntent.id),
 			);
@@ -741,6 +833,7 @@ export async function publishVerifiedIntent(
 			if (current?.state === "published") {
 				return { state: "published", uri: "", cid: "" };
 			}
+			if (current?.state === "expired") return { state: "expired" };
 			if (current?.state === "reconciling") return { state: "reconciling" };
 			if (!current || (current.state !== "ready" && current.state !== "publishing")) {
 				return { state: "failed", reasonCode: "INTENT_NOT_READY" };
@@ -758,7 +851,11 @@ export async function publishVerifiedIntent(
 					reasonCode: "INTENT_EXPIRED",
 					stateDataJson: JSON.stringify({ reasonCode: "INTENT_EXPIRED" }),
 				});
-				return expired.ok ? { state: "expired" } : { state: "failed", reasonCode: expired.code };
+				if (expired.ok) return { state: "expired" };
+				const latest = await publisher.getIntent(publisherDid, originalIntent.id);
+				return latest?.state === "expired"
+					? { state: "expired" }
+					: { state: "failed", reasonCode: expired.code };
 			}
 			const staged = await step.do<MaterializationStageResult>(
 				"publication-stage",
@@ -960,12 +1057,46 @@ export async function publishVerifiedIntent(
 					) {
 						return failBeforeWrite("OAUTH_DELEGATION_UNAVAILABLE");
 					}
-					const permit = await control.issuePublicationPermit(
+					const snapshot = await readPublisherVerificationSnapshot(
 						publisherDid,
-						originalIntent.id,
-						PUBLICATION_PERMIT_TTL_MS,
-						serviceConfiguration.encryption.currentKeyVersion,
+						originalIntent.packageSlug,
+						originalIntent.version,
 					);
+					const verifier = parseNormalizedVerifierReport(finalVerification.verifierJson);
+					if (!verifier?.success) return failBeforeWrite("FINAL_INPUT_INVALID");
+					const evaluation = await evaluateVerifiedRelease(
+						publisherDid,
+						originalIntent,
+						snapshot,
+						verifier,
+					);
+					if (
+						!evaluation.success ||
+						(await computeApprovalEvidenceDigest(evaluation.value.approvalEvidence)) !==
+							expectedEvidenceDigest
+					) {
+						return failBeforeWrite(
+							evaluation.success ? "FINAL_VERIFICATION_CHANGED" : evaluation.reasonCode,
+						);
+					}
+					const renewed = await publisher.renewPublicationCoordination({
+						publisherDid,
+						packageSlug: coordination.packageSlug,
+						intentId: coordination.intentId,
+						generation: coordination.generation,
+						token: coordination.token,
+						leaseMs: PUBLICATION_COORDINATION_LEASE_MS,
+					});
+					if (!renewed.ok) return failBeforeWrite(renewed.code, true);
+					const permit = await control.issuePublicationPermit({
+						publisherDid,
+						intentId: originalIntent.id,
+						packageSlug: originalIntent.packageSlug,
+						profileCid: snapshot.profile.cid,
+						baselineCid: snapshot.baseline?.cid ?? null,
+						ttlMs: PUBLICATION_PERMIT_TTL_MS,
+						encryptionKeyVersion: serviceConfiguration.encryption.currentKeyVersion,
+					});
 					if (!permit.ok) {
 						return failBeforeWrite(permit.code, isRetryablePublicationBlock(permit.code));
 					}
@@ -974,6 +1105,9 @@ export async function publishVerifiedIntent(
 						token: permit.permit.token,
 						publisherDid,
 						intentId: originalIntent.id,
+						packageSlug: originalIntent.packageSlug,
+						profileCid: snapshot.profile.cid,
+						baselineCid: snapshot.baseline?.cid ?? null,
 					});
 					if (!consumed.ok) {
 						return failBeforeWrite(consumed.code, isRetryablePublicationBlock(consumed.code));
@@ -1073,6 +1207,15 @@ export async function publishVerifiedIntent(
 				}
 			});
 		})();
+		if (attemptResult.state !== "reconciling") {
+			await releasePublicationCoordination(
+				step,
+				publisher,
+				publisherDid,
+				coordination,
+				`publication-coordinate-release-${attempt}`,
+			);
+		}
 		if (attemptResult.state === "published") {
 			return { intentId: originalIntent.id, state: "published", reasonCode: null };
 		}
@@ -1142,6 +1285,13 @@ export async function publishVerifiedIntent(
 		});
 		const current = await step.do(`reconciliation-state-${attempt}`, () =>
 			currentState(publisher, publisherDid, originalIntent.id),
+		);
+		await releasePublicationCoordination(
+			step,
+			publisher,
+			publisherDid,
+			coordination,
+			`publication-coordinate-reconciliation-release-${attempt}`,
 		);
 		if (current?.state === "published") {
 			return { intentId: originalIntent.id, state: "published", reasonCode: null };

--- a/apps/release-service/src/workflows/release-intent.ts
+++ b/apps/release-service/src/workflows/release-intent.ts
@@ -13,7 +13,12 @@ import type {
 	TransitionIntentInput,
 } from "../publisher-do/publisher-do.js";
 import { reconcileReleaseRecord } from "../publishing/reconcile.js";
-import { publishVerifiedIntent, readPersistedMaterializedRelease } from "../publishing/workflow.js";
+import {
+	acquirePublicationCoordination,
+	publishVerifiedIntent,
+	readPersistedMaterializedRelease,
+	releasePublicationCoordination,
+} from "../publishing/workflow.js";
 import {
 	evaluateVerifiedRelease,
 	normalizeVerifierReport,
@@ -290,6 +295,20 @@ export class ReleaseIntentWorkflow extends WorkflowEntrypoint<
 				stateGeneration: decision.approvalEvidence.verificationGeneration - 2,
 			};
 			if (intent.state === "reconciling") {
+				const coordination = await acquirePublicationCoordination(
+					step,
+					publisher,
+					params.publisherDid,
+					intent,
+					"recovery",
+				);
+				if (!coordination) {
+					return {
+						intentId: params.intentId,
+						state: "ready",
+						reasonCode: "PUBLICATION_COORDINATION_BUSY",
+					};
+				}
 				const reconciliation = await step.do("recovery-reconciliation", async () => {
 					const materialized = await readPersistedMaterializedRelease(
 						publisher,
@@ -336,6 +355,13 @@ export class ReleaseIntentWorkflow extends WorkflowEntrypoint<
 						}),
 					);
 					if (!published.ok) throw new NonRetryableError(published.code);
+					await releasePublicationCoordination(
+						step,
+						publisher,
+						params.publisherDid,
+						coordination,
+						"recovery-coordinate-release-published",
+					);
 					return { intentId: params.intentId, state: "published", reasonCode: null };
 				}
 				if (reconciliation.outcome === "conflict") {
@@ -354,6 +380,13 @@ export class ReleaseIntentWorkflow extends WorkflowEntrypoint<
 						}),
 					);
 					if (!conflict.ok) throw new NonRetryableError(conflict.code);
+					await releasePublicationCoordination(
+						step,
+						publisher,
+						params.publisherDid,
+						coordination,
+						"recovery-coordinate-release-conflict",
+					);
 					return {
 						intentId: params.intentId,
 						state: "conflict",
@@ -375,6 +408,13 @@ export class ReleaseIntentWorkflow extends WorkflowEntrypoint<
 					}),
 				);
 				if (!ready.ok) throw new NonRetryableError(ready.code);
+				await releasePublicationCoordination(
+					step,
+					publisher,
+					params.publisherDid,
+					coordination,
+					"recovery-coordinate-release-absent",
+				);
 			}
 			return await publishVerifiedIntent(
 				this.env,

--- a/apps/release-service/test/publisher-publication-coordination.test.ts
+++ b/apps/release-service/test/publisher-publication-coordination.test.ts
@@ -1,0 +1,153 @@
+import { reset, runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { afterEach, describe, expect, it } from "vitest";
+
+const PUBLISHER_DID = "did:plc:publisher";
+const FIRST_INTENT = "01JABCDEFGHJKMNPQRSTVWXYZ0";
+const SECOND_INTENT = "01JABCDEFGHJKMNPQRSTVWXYZ1";
+const FIRST_TOKEN = "A".repeat(43);
+const SECOND_TOKEN = "B".repeat(43);
+const NOW = 1_800_000_000_000;
+
+function publisher() {
+	return env.PUBLISHER_DO.getByName(PUBLISHER_DID);
+}
+
+afterEach(async () => {
+	await reset();
+});
+
+describe("publisher publication coordination", () => {
+	it("serializes one package while allowing another package to proceed", async () => {
+		const stub = publisher();
+		const first = await stub.acquirePublicationCoordination(
+			PUBLISHER_DID,
+			"gallery",
+			FIRST_INTENT,
+			1_000,
+			FIRST_TOKEN,
+			NOW,
+		);
+		expect(first).toMatchObject({ ok: true, replayed: false });
+		if (!first.ok) return;
+
+		await expect(
+			stub.acquirePublicationCoordination(
+				PUBLISHER_DID,
+				"gallery",
+				SECOND_INTENT,
+				1_000,
+				SECOND_TOKEN,
+				NOW + 1,
+			),
+		).resolves.toEqual({
+			ok: false,
+			code: "PUBLICATION_COORDINATION_BUSY",
+			retryAt: NOW + 1_000,
+		});
+		await expect(
+			stub.acquirePublicationCoordination(
+				PUBLISHER_DID,
+				"forms",
+				SECOND_INTENT,
+				1_000,
+				SECOND_TOKEN,
+				NOW + 1,
+			),
+		).resolves.toMatchObject({ ok: true });
+		await expect(
+			stub.acquirePublicationCoordination(
+				PUBLISHER_DID,
+				"gallery",
+				FIRST_INTENT,
+				1_000,
+				FIRST_TOKEN,
+				NOW + 2,
+			),
+		).resolves.toEqual({ ...first, replayed: true });
+	});
+
+	it("renews, releases, and fences stale lease holders", async () => {
+		const stub = publisher();
+		const acquired = await stub.acquirePublicationCoordination(
+			PUBLISHER_DID,
+			"gallery",
+			FIRST_INTENT,
+			1_000,
+			FIRST_TOKEN,
+			NOW,
+		);
+		if (!acquired.ok) throw new Error("Expected publication coordination");
+		const identity = {
+			publisherDid: PUBLISHER_DID,
+			packageSlug: "gallery",
+			intentId: FIRST_INTENT,
+			generation: acquired.lease.generation,
+			token: acquired.lease.token,
+		};
+
+		await expect(
+			stub.renewPublicationCoordination({ ...identity, leaseMs: 2_000, now: NOW + 500 }),
+		).resolves.toMatchObject({ ok: true, lease: { expiresAt: NOW + 2_500 } });
+		await expect(
+			stub.releasePublicationCoordination({ ...identity, generation: 99, now: NOW + 501 }),
+		).resolves.toEqual({ ok: false, code: "PUBLICATION_COORDINATION_REQUIRED" });
+		await expect(
+			stub.releasePublicationCoordination({ ...identity, now: NOW + 502 }),
+		).resolves.toEqual({ ok: true, replayed: false });
+		await expect(
+			stub.acquirePublicationCoordination(
+				PUBLISHER_DID,
+				"gallery",
+				SECOND_INTENT,
+				1_000,
+				SECOND_TOKEN,
+				NOW + 503,
+			),
+		).resolves.toMatchObject({ ok: true });
+	});
+
+	it("expires abandoned leases and never persists their bearer token", async () => {
+		const stub = publisher();
+		const oldNow = Date.now() - 1_000;
+		const acquired = await stub.acquirePublicationCoordination(
+			PUBLISHER_DID,
+			"gallery",
+			FIRST_INTENT,
+			1,
+			FIRST_TOKEN,
+			oldNow,
+		);
+		if (!acquired.ok) throw new Error("Expected publication coordination");
+		const stored = await runInDurableObject(stub, (_instance, state) =>
+			state.storage.sql
+				.exec<{ token_hash: string }>(
+					"SELECT token_hash FROM publication_coordinations WHERE package_slug = 'gallery'",
+				)
+				.one(),
+		);
+		expect(stored.token_hash).not.toBe(FIRST_TOKEN);
+		await expect(
+			stub.renewPublicationCoordination({
+				publisherDid: PUBLISHER_DID,
+				packageSlug: "gallery",
+				intentId: FIRST_INTENT,
+				generation: acquired.lease.generation,
+				token: FIRST_TOKEN,
+				leaseMs: 1_000,
+				now: Date.now(),
+			}),
+		).resolves.toEqual({ ok: false, code: "PUBLICATION_COORDINATION_REQUIRED" });
+
+		await runDurableObjectAlarm(stub);
+		await expect(
+			stub.acquirePublicationCoordination(
+				PUBLISHER_DID,
+				"gallery",
+				SECOND_INTENT,
+				1_000,
+				SECOND_TOKEN,
+			),
+		).resolves.toMatchObject({ ok: true, replayed: false });
+	});
+});

--- a/apps/release-service/test/release-intent-workflow.test.ts
+++ b/apps/release-service/test/release-intent-workflow.test.ts
@@ -115,6 +115,9 @@ const PROFILE_PROOF =
 	"OqJlcm9vdHOB2CpYJQABcRIgDvmOi+nZTPwAHpDNlC2y2J7fUQ1ApZKJRa48jp934NBndmVyc2lvbgHdAQFxEiAO+Y6L6dlM/AAekM2ULbLYnt9RDUClkolFrjyOn3fg0KZjZGlkeB1kaWQ6d2ViOnB1Ymxpc2hlci5leGFtcGxlLmNvbWNyZXZtM211NXFhZHRwazIybWNzaWdYQKq7vfiaEIAWBU/mBxVb+dRselfs/o/vLWgXiiWtBrrBIT9LTKTG8Ylh5LuryHBu1Xx0m0Zu/FeAL7dzSrbBs9tkZGF0YdgqWCUAAXESICPWWGKAvX12s+8YBNB6iLwFl8YMr6smSZpFoaG8aBsnZHByZXb2Z3ZlcnNpb24DkwEBcRIgI9ZYYoC9fXaz7xgE0HqIvAWXxgyvqyZJmkWhobxoGyeiYWWBpGFrWDJjb20uZW1kYXNoY21zLmV4cGVyaW1lbnRhbC5wYWNrYWdlLnByb2ZpbGUvZ2FsbGVyeWFwAGF09mF22CpYJQABcRIg75HAxLI29zFxT2IAMP+6xED3Uxy3mslLTuujJkBV1nphbPbQAwFxEiDvkcDEsjb3MXFPYgAw/7rEQPdTHLeayUtO66MmQFXWeqhiaWR4VWF0Oi8vZGlkOndlYjpwdWJsaXNoZXIuZXhhbXBsZS5jb20vY29tLmVtZGFzaGNtcy5leHBlcmltZW50YWwucGFja2FnZS5wcm9maWxlL2dhbGxlcnlkbmFtZWdHYWxsZXJ5ZHR5cGVtZW1kYXNoLXBsdWdpbmUkdHlwZXgqY29tLmVtZGFzaGNtcy5leHBlcmltZW50YWwucGFja2FnZS5wcm9maWxlZ2F1dGhvcnOBoWRuYW1lcUV4YW1wbGUgUHVibGlzaGVyZ2xpY2Vuc2VjTUlUaHNlY3VyaXR5gaFlZW1haWx0c2VjdXJpdHlAZXhhbXBsZS5jb21qZXh0ZW5zaW9uc6F4M2NvbS5lbWRhc2hjbXMuZXhwZXJpbWVudGFsLnBhY2thZ2UucHJvZmlsZUV4dGVuc2lvbqJlJHR5cGV4M2NvbS5lbWRhc2hjbXMuZXhwZXJpbWVudGFsLnBhY2thZ2UucHJvZmlsZUV4dGVuc2lvbmpyZXBvc2l0b3J5eCJodHRwczovL2dpdGh1Yi5jb20vZXhhbXBsZS9nYWxsZXJ5";
 const APPROVAL_PROFILE_PROOF =
 	"OqJlcm9vdHOB2CpYJQABcRIgt4Be/ylpOhy2o33XFr7JATwH2VmFRzL6VB4p2I0MSzVndmVyc2lvbgHdAQFxEiC3gF7/KWk6HLajfdcWvskBPAfZWYVHMvpUHinYjQxLNaZjZGlkeB1kaWQ6d2ViOnB1Ymxpc2hlci5leGFtcGxlLmNvbWNyZXZtM211NXFhZHR6Y2sybWNzaWdYQBg2vVFiuGjkb1Q9TukMNZFbFZ/xXo5d8a6UZnGNnq/FIGQMPMH+RiEl+yhSvATZ9KnIQ2ujZ5q5qkjKyu5t6XhkZGF0YdgqWCUAAXESIGduRlvZ/Lua96nilhYmPVcpLg+ZjEa4kIialhQmHwB0ZHByZXb2Z3ZlcnNpb24DkwEBcRIgZ25GW9n8u5r3qeKWFiY9VykuD5mMRriQiJqWFCYfAHSiYWWBpGFrWDJjb20uZW1kYXNoY21zLmV4cGVyaW1lbnRhbC5wYWNrYWdlLnByb2ZpbGUvZ2FsbGVyeWFwAGF09mF22CpYJQABcRIgrKiSWBl9zSDvo1PXTnK3qUZGccnZeweHtjm0xemh2J5hbPaPBAFxEiCsqJJYGX3NIO+jU9dOcrepRkZxydl7B4e2ObTF6aHYnqhiaWR4VWF0Oi8vZGlkOndlYjpwdWJsaXNoZXIuZXhhbXBsZS5jb20vY29tLmVtZGFzaGNtcy5leHBlcmltZW50YWwucGFja2FnZS5wcm9maWxlL2dhbGxlcnlkbmFtZWdHYWxsZXJ5ZHR5cGVtZW1kYXNoLXBsdWdpbmUkdHlwZXgqY29tLmVtZGFzaGNtcy5leHBlcmltZW50YWwucGFja2FnZS5wcm9maWxlZ2F1dGhvcnOBoWRuYW1lcUV4YW1wbGUgUHVibGlzaGVyZ2xpY2Vuc2VjTUlUaHNlY3VyaXR5gaFlZW1haWx0c2VjdXJpdHlAZXhhbXBsZS5jb21qZXh0ZW5zaW9uc6F4M2NvbS5lbWRhc2hjbXMuZXhwZXJpbWVudGFsLnBhY2thZ2UucHJvZmlsZUV4dGVuc2lvbqNlJHR5cGV4M2NvbS5lbWRhc2hjbXMuZXhwZXJpbWVudGFsLnBhY2thZ2UucHJvZmlsZUV4dGVuc2lvbmpyZXBvc2l0b3J5eCJodHRwczovL2dpdGh1Yi5jb20vZXhhbXBsZS9nYWxsZXJ5bXJlbGVhc2VQb2xpY3miaWFwcHJvdmVyc4FwZGlkOnBsYzphcHByb3Zlcmxjb25maXJtYXRpb25mYWx3YXlz";
+const ESCALATION_ONLY_PROFILE_PROOF =
+	"OqJlcm9vdHOB2CpYJQABcRIg9qJp06k9Bpe+jLKRiea83D3qgyuWI1PLK7ZIuHEC+z9ndmVyc2lvbgHdAQFxEiD2omnTqT0Gl76MspGJ5rzcPeqDK5YjU8srtki4cQL7P6ZjZGlkeB1kaWQ6d2ViOnB1Ymxpc2hlci5leGFtcGxlLmNvbWNyZXZtM211amt6dHZwamMyeGNzaWdYQCWWVx/ubT52wRrIeUXNKyG88VYq3qksj4dMdk1V+fmAeR9K1vt3fK1vmpfvG2eVBWEmfNkxExHnHal22FDev6JkZGF0YdgqWCUAAXESINF8ERKM5sXJ8zAdcMaArpcVuqgGvseuNQmec5MYvHnQZHByZXb2Z3ZlcnNpb24DkwEBcRIg0XwREozmxcnzMB1wxoCulxW6qAa+x641CZ5zkxi8edCiYWWBpGFrWDJjb20uZW1kYXNoY21zLmV4cGVyaW1lbnRhbC5wYWNrYWdlLnByb2ZpbGUvZ2FsbGVyeWFwAGF09mF22CpYJQABcRIgN+KakpY3MooEiEzdUFA1gQ7vaaorJdv7QEQF4jxZ9t9hbPaYBAFxEiA34pqSljcyigSITN1QUDWBDu9pqisl2/tARAXiPFn236hiaWR4VWF0Oi8vZGlkOndlYjpwdWJsaXNoZXIuZXhhbXBsZS5jb20vY29tLmVtZGFzaGNtcy5leHBlcmltZW50YWwucGFja2FnZS5wcm9maWxlL2dhbGxlcnlkbmFtZWdHYWxsZXJ5ZHR5cGVtZW1kYXNoLXBsdWdpbmUkdHlwZXgqY29tLmVtZGFzaGNtcy5leHBlcmltZW50YWwucGFja2FnZS5wcm9maWxlZ2F1dGhvcnOBoWRuYW1lcUV4YW1wbGUgUHVibGlzaGVyZ2xpY2Vuc2VjTUlUaHNlY3VyaXR5gaFlZW1haWx0c2VjdXJpdHlAZXhhbXBsZS5jb21qZXh0ZW5zaW9uc6F4M2NvbS5lbWRhc2hjbXMuZXhwZXJpbWVudGFsLnBhY2thZ2UucHJvZmlsZUV4dGVuc2lvbqNlJHR5cGV4M2NvbS5lbWRhc2hjbXMuZXhwZXJpbWVudGFsLnBhY2thZ2UucHJvZmlsZUV4dGVuc2lvbmpyZXBvc2l0b3J5eCJodHRwczovL2dpdGh1Yi5jb20vZXhhbXBsZS9nYWxsZXJ5bXJlbGVhc2VQb2xpY3miaWFwcHJvdmVyc4FwZGlkOnBsYzphcHByb3Zlcmxjb25maXJtYXRpb25vZXNjYWxhdGlvbi1vbmx5";
+const ESCALATION_ONLY_SIGNING_KEY = "zDnaekRBnvWmwwGibpSzPHpH1rvvZZXB6APVS4tHEccxMBEDc";
 const PROVENANCE = {
 	predicateType: "https://slsa.dev/provenance/v1",
 	url: "https://github.com/example/gallery/attestation.sigstore.json",
@@ -186,6 +189,19 @@ function releaseRecord() {
 	release.artifacts.package.checksum = ARTIFACT_CHECKSUM;
 	release.extensions[NSID.packageReleaseExtension]!.provenance = PROVENANCE;
 	return release;
+}
+
+const NETWORK_ACCESS = { network: { request: {} } } as const;
+
+function baselineRelease(version: string, declaredAccess: Record<string, unknown>) {
+	const value = releaseRecord();
+	value.version = version;
+	value.extensions[NSID.packageReleaseExtension]!.declaredAccess = declaredAccess;
+	return {
+		uri: `at://${PUBLISHER_DID}/${NSID.packageRelease}/gallery:${version}`,
+		cid: `bafygallery${version.replaceAll(".", "")}`,
+		value,
+	};
 }
 
 async function fullReleaseRecord() {
@@ -930,6 +946,65 @@ describe("ReleaseIntentWorkflow", () => {
 		await expect(
 			env.PUBLISHER_DO.getByName(PUBLISHER_DID).getIntent(PUBLISHER_DID, INTENT_ID),
 		).resolves.toMatchObject({ state: "invalid" });
+	}, 15_000);
+
+	it("does not reintroduce access after a capability-removing release changes the baseline", async () => {
+		let baseline = baselineRelease("1.0.0", NETWORK_ACCESS);
+		let createAttempts = 0;
+		let removalPublished = false;
+		const release = releaseRecord();
+		release.artifacts.package.url =
+			"https://github.com/example/gallery/releases/download/v1.2.3/gallery.tar.gz?declaredAccess=network";
+		release.extensions[NSID.packageReleaseExtension]!.declaredAccess = NETWORK_ACCESS;
+		vi.stubGlobal(
+			"fetch",
+			workflowNetwork({
+				profileProof: ESCALATION_ONLY_PROFILE_PROOF,
+				signingKey: () => ESCALATION_ONLY_SIGNING_KEY,
+				listedReleases: () => [baseline],
+				onAuthorizationMetadata: () => {
+					baseline = baselineRelease("1.1.0", {});
+					removalPublished = true;
+				},
+				onCreateRecord: () => {
+					createAttempts += 1;
+					return Response.json({ uri: CREATED_URI, cid: CREATED_CID });
+				},
+			}),
+		);
+		await createVerifyingIntent(true, JSON.stringify({ release }));
+		await using introspector = await introspectWorkflowInstance(
+			env.RELEASE_INTENT_WORKFLOW,
+			INTENT_ID,
+		);
+		await env.RELEASE_INTENT_WORKFLOW.create({
+			id: INTENT_ID,
+			params: { publisherDid: PUBLISHER_DID, intentId: INTENT_ID },
+		});
+		await introspector.waitForStatus("complete");
+
+		const publisher = env.PUBLISHER_DO.getByName(PUBLISHER_DID);
+		const decision = await publisher.getVerificationStep(
+			PUBLISHER_DID,
+			INTENT_ID,
+			"policy-decision",
+		);
+		expect(JSON.parse(decision?.resultJson ?? "null")).toMatchObject({
+			requiresApproval: false,
+			approvalEvidence: { baselineReleaseCid: "bafygallery100" },
+		});
+		expect(
+			(await publisher.listIntentTransitions(PUBLISHER_DID, INTENT_ID)).map(
+				(transition) => transition.toState,
+			),
+		).not.toContain("awaiting_approval");
+		expect(removalPublished).toBe(true);
+		expect(createAttempts).toBe(0);
+		await expect(introspector.getOutput()).resolves.toEqual({
+			intentId: INTENT_ID,
+			state: "failed",
+			reasonCode: "FINAL_VERIFICATION_CHANGED",
+		});
 	}, 15_000);
 
 	it("uses a fresh permit and publication generation after each confirmed absence", async () => {

--- a/apps/release-service/test/service-control-do.test.ts
+++ b/apps/release-service/test/service-control-do.test.ts
@@ -6,11 +6,15 @@ import type { AccessActor } from "../src/access/auth.js";
 import {
 	SERVICE_CONTROL_OBJECT_NAME,
 	type ActivateEncryptionKeyInput,
+	type IssuePublicationPermitInput,
 	type SetServiceModeInput,
 } from "../src/control-do/service-control-do.js";
 
 const DID = "did:plc:publisher";
 const INTENT_ID = "intent-01JABCDEFGHJKMNPQRSTVWXYZ";
+const PACKAGE_SLUG = "gallery";
+const PROFILE_CID = "bafyprofile";
+const BASELINE_CID = "bafybaseline";
 const NOW = 1_800_000_000_000;
 const VIEWER = {
 	realm: "access",
@@ -49,6 +53,22 @@ function activationInput(
 		requestDigest: "K".repeat(43),
 		version: 2,
 		now: NOW + 1,
+		...overrides,
+	};
+}
+
+function permitInput(
+	overrides: Partial<IssuePublicationPermitInput> = {},
+): IssuePublicationPermitInput {
+	return {
+		publisherDid: DID,
+		intentId: INTENT_ID,
+		packageSlug: PACKAGE_SLUG,
+		profileCid: PROFILE_CID,
+		baselineCid: BASELINE_CID,
+		ttlMs: 5_000,
+		encryptionKeyVersion: 1,
+		now: NOW,
 		...overrides,
 	};
 }
@@ -222,7 +242,7 @@ describe("ServiceControlDurableObject", () => {
 			mode: "admission-paused",
 			code: "ADMISSION_PAUSED",
 		});
-		const admittedPermit = await stub.issuePublicationPermit(DID, INTENT_ID, 5_000, 1, NOW + 1);
+		const admittedPermit = await stub.issuePublicationPermit(permitInput({ now: NOW + 1 }));
 		expect(admittedPermit).toMatchObject({ ok: true, permit: { modeEpoch: 2 } });
 
 		await stub.setServiceMode(
@@ -238,7 +258,7 @@ describe("ServiceControlDurableObject", () => {
 			mode: "publication-paused",
 			code: null,
 		});
-		await expect(stub.issuePublicationPermit(DID, INTENT_ID, 5_000, 1, NOW + 3)).resolves.toEqual({
+		await expect(stub.issuePublicationPermit(permitInput({ now: NOW + 3 }))).resolves.toEqual({
 			ok: false,
 			code: "PUBLICATION_PAUSED",
 		});
@@ -246,14 +266,23 @@ describe("ServiceControlDurableObject", () => {
 
 	it("issues a bound permit that can be consumed exactly once", async () => {
 		const stub = control();
-		await expect(stub.issuePublicationPermit(DID, INTENT_ID, 5_000, 2, NOW)).resolves.toEqual({
+		await expect(
+			stub.issuePublicationPermit(permitInput({ encryptionKeyVersion: 2 })),
+		).resolves.toEqual({
 			ok: false,
 			code: "ENCRYPTION_KEY_INACTIVE",
 		});
-		const issued = await stub.issuePublicationPermit(DID, INTENT_ID, 5_000, 1, NOW);
+		const issued = await stub.issuePublicationPermit(permitInput());
 		expect(issued.ok).toBe(true);
 		if (!issued.ok) return;
 
+		await expect(
+			stub.consumePublicationPermit({
+				...issued.permit,
+				baselineCid: "bafydifferent",
+				now: NOW + 1,
+			}),
+		).resolves.toEqual({ ok: false, code: "PERMIT_INVALID" });
 		await expect(
 			stub.consumePublicationPermit({
 				...issued.permit,
@@ -277,7 +306,7 @@ describe("ServiceControlDurableObject", () => {
 
 	it("invalidates a cached permit when the service mode epoch changes", async () => {
 		const stub = control();
-		const issued = await stub.issuePublicationPermit(DID, INTENT_ID, 5_000, 1, NOW);
+		const issued = await stub.issuePublicationPermit(permitInput());
 		expect(issued.ok).toBe(true);
 		if (!issued.ok) return;
 		await stub.setServiceMode(
@@ -291,7 +320,7 @@ describe("ServiceControlDurableObject", () => {
 
 	it("suspends publisher admission and invalidates outstanding permits", async () => {
 		const stub = control();
-		const issued = await stub.issuePublicationPermit(DID, INTENT_ID, 5_000, 1, NOW);
+		const issued = await stub.issuePublicationPermit(permitInput());
 		expect(issued.ok).toBe(true);
 		if (!issued.ok) return;
 
@@ -313,7 +342,9 @@ describe("ServiceControlDurableObject", () => {
 			allowed: false,
 			code: "PUBLISHER_SUSPENDED",
 		});
-		await expect(stub.issuePublicationPermit(DID, "intent-2", 5_000, 1, NOW + 2)).resolves.toEqual({
+		await expect(
+			stub.issuePublicationPermit(permitInput({ intentId: "intent-2", now: NOW + 2 })),
+		).resolves.toEqual({
 			ok: false,
 			code: "PUBLISHER_SUSPENDED",
 		});
@@ -324,7 +355,7 @@ describe("ServiceControlDurableObject", () => {
 
 	it("never persists a plaintext permit token", async () => {
 		const stub = control();
-		const issued = await stub.issuePublicationPermit(DID, INTENT_ID, 5_000, 1, NOW);
+		const issued = await stub.issuePublicationPermit(permitInput());
 		expect(issued.ok).toBe(true);
 		if (!issued.ok) return;
 
@@ -346,7 +377,7 @@ describe("ServiceControlDurableObject", () => {
 	it("cleans expired permits and operator idempotency with its alarm", async () => {
 		const stub = control();
 		const oldNow = Date.now() - 24 * 60 * 60_000 - 1_000;
-		await stub.issuePublicationPermit(DID, INTENT_ID, 1, 1, oldNow);
+		await stub.issuePublicationPermit(permitInput({ ttlMs: 1, now: oldNow }));
 		await stub.setServiceMode(
 			modeInput({
 				mode: "admission-paused",

--- a/apps/release-service/vitest.config.ts
+++ b/apps/release-service/vitest.config.ts
@@ -34,7 +34,10 @@ export default defineConfig({
 												manifest: {
 													id: input.artifact.packageSlug,
 													version: input.artifact.version,
-													declaredAccess: {},
+													declaredAccess:
+														new URL(input.artifact.url).searchParams.get("declaredAccess") === "network"
+															? { network: { request: {} } }
+															: {},
 												},
 												bundle: { backendBytes: 100, adminBytes: null },
 											},


### PR DESCRIPTION
## What does this PR do?

Fixes a high-severity delegated-release race where a release could retain a no-approval decision while a concurrent release removed, then made it reintroduce, a capability before create.

- Adds durable publisher/package-scoped publication coordination with fenced leases, expiry alarms, same-intent workflow takeover, and deterministic release.
- Re-reads the signed publisher profile and current release baseline while holding coordination, then recomputes the complete evidence and access decision immediately before create.
- Binds the one-shot publication permit to the package, profile CID, and baseline release CID, invalidating unbound permits from older deployments.
- Keeps ambiguous-write reconciliation under the same package coordination and reacquires it safely after workflow resumption.

Related: delegated-release security audit finding “Concurrent baseline change bypasses passkey approval.”

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. N/A: this changes no admin UI strings or catalogs.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package). N/A: only the private release-service app changes.
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... N/A: this is a security bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 (Codex)

## Screenshots / test output

No visual changes.

- `pnpm typecheck` — passed
- `pnpm lint` — passed with zero diagnostics
- `pnpm --filter @emdash-cms/release-service typecheck` — passed
- `pnpm --filter @emdash-cms/release-service exec vitest run --maxWorkers=1` — 49 files / 432 tests passed
- `pnpm --filter @emdash-cms/release-service test:encryption-v2` — 1 test passed
- `pnpm --filter @emdash-cms/release-service test:ui` — 4 files / 13 tests passed
- Release-service production build — passed

The default parallel Worker run was locally nondeterministic in Miniflare: concurrent test-file resets produced `Application called deleteAllDurableObjects()` / `no such table` failures. Each reported test passed in isolation, and the complete serial Worker run above passed.
