### PR TITLE
docs: require screenshots for interface changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,6 +42,15 @@ body:
       required: true
 
   - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If this issue refers to the interface, attach at least one screenshot showing the problem. Include useful alt text. Otherwise, enter "Not applicable."
+      placeholder: Drag or paste screenshots here, or enter "Not applicable."
+    validations:
+      required: true
+
+  - type: textarea
     id: logs
     attributes:
       label: Logs / error output

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,6 +28,7 @@ Closes #
 - [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
 - [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
 - [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
+- [ ] I have included screenshots below if this PR changes the UI
 
 ## AI-generated code disclosure
 
@@ -37,4 +38,4 @@ Closes #
 
 ## Screenshots / test output
 
-<!-- Optional. Include if the change is visual or if you want to show test results. -->
+<!-- Screenshots are required for every UI change. Show the rendered result and include before-and-after images when the result alone is not enough. Use descriptive alt text. For non-UI changes, write "Not applicable"; test output remains optional. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,21 @@ A changeset is user-facing documentation that lands verbatim in a package CHANGE
 
 When opening a PR with `gh`/the API, copy `.github/PULL_REQUEST_TEMPLATE.md` into the body and fill every section -- the GitHub UI injects it automatically but the CLI does not, and PRs missing it are auto-closed. Check the AI-generated code disclosure box and name the model. Tick checklist items only for what you actually verified; for test-only/docs/CI PRs, note why changeset/i18n/Discussion items are n/a.
 
+Issues that refer to the interface must include a screenshot that shows the reported state. PRs that change the UI must include screenshots of the rendered result; include before-and-after images when the change is not clear from the result alone. Keep the behavior described in text and give every image useful alt text.
+
+Agents can attach local images with GitHub CLI 2.99.0 or later. The `--attach` flag is repeatable on `gh issue create|edit|comment` and `gh pr create|edit|comment`. For example:
+
+```bash
+gh issue create --body-file /tmp/emdash-issue.md \
+	--attach './interface-error.png#The settings screen showing the validation error'
+
+gh pr create --body-file /tmp/emdash-pr.md \
+	--attach './before.png#Settings screen before the change' \
+	--attach './after.png#Settings screen after the change'
+```
+
+To place an image at a specific point in the body, add `![descriptive alt text](./after.png)` to the body file and pass `--attach ./after.png`; `gh` replaces the local path with the uploaded asset URL. An attachment that is not referenced in the body is appended. Image uploads require repository write access. See [CONTRIBUTING.md § Interface screenshots](CONTRIBUTING.md#interface-screenshots).
+
 ## Architecture
 
 EmDash is an Astro-native CMS on Cloudflare (D1 + R2 + Workers) or Node + SQLite.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ gh pr create --body-file /tmp/emdash-pr.md \
 	--attach './after.png#Settings screen after the change'
 ```
 
-To place an image at a specific point in the body, add `![descriptive alt text](./after.png)` to the body file and pass `--attach ./after.png`; `gh` replaces the local path with the uploaded asset URL. An attachment that is not referenced in the body is appended. Image uploads require repository write access. See [CONTRIBUTING.md § Interface screenshots](CONTRIBUTING.md#interface-screenshots).
+To place an image at a specific point in the body, add `![descriptive alt text](./after.png)` to the body file and pass `--attach ./after.png`; `gh` replaces the local path with the uploaded asset URL. An attachment that is not referenced in the body is appended. CLI `--attach` uploads require repository write access. See [CONTRIBUTING.md § Interface screenshots](CONTRIBUTING.md#interface-screenshots).
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,12 +153,29 @@ AI-assisted contributions are welcome and held to the same quality bar as any ot
 - AI-generated PRs must pass CI, follow project patterns, and include tests.
 - Check the PR template's AI disclosure box and name the model/tool (e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6). This isn't punitive -- it helps reviewers focus on edge cases that AI tools tend to miss and run the review pass with a different model family.
 
+### Interface screenshots
+
+An issue that refers to the interface must include a screenshot showing the reported state. A PR that changes the UI must include screenshots of the rendered result. Include before-and-after images when the result alone does not make the change clear. Describe the behavior in text as well, and use alt text that identifies the screen and relevant state.
+
+In the GitHub web interface, drag or paste the images into the issue or PR body. From GitHub CLI 2.99.0 or later, use the repeatable `--attach` flag with issue and PR create, edit, or comment commands. Image uploads require write access to the repository.
+
+The following command attaches two screenshots to a PR body:
+
+```bash
+gh pr create --body-file /tmp/emdash-pr.md \
+	--attach './before.png#Settings screen before the change' \
+	--attach './after.png#Settings screen after the change'
+```
+
+If the body contains `![Settings screen after the change](./after.png)`, pass `--attach ./after.png` to upload the image and replace the local path in place. GitHub appends attached files that are not referenced in the body. See [Attaching files with GitHub CLI](https://docs.github.com/en/github-cli/github-cli/attaching-files-with-github-cli) for the supported formats and size limits.
+
 ### PR rules
 
 - Branch from `main`.
 - Fill out the PR template completely. **PRs with an empty or missing template will be closed automatically.** The template is loaded by the GitHub UI; if you create a PR via API/CLI, copy `.github/PULL_REQUEST_TEMPLATE.md` into the body.
 - `pnpm typecheck` and `pnpm lint` must pass before pushing.
 - Run relevant tests.
+- Include screenshots for every UI change.
 - Commit messages describe _why_, not just _what_.
 
 ## Changesets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ AI-assisted contributions are welcome and held to the same quality bar as any ot
 
 An issue that refers to the interface must include a screenshot showing the reported state. A PR that changes the UI must include screenshots of the rendered result. Include before-and-after images when the result alone does not make the change clear. Describe the behavior in text as well, and use alt text that identifies the screen and relevant state.
 
-In the GitHub web interface, drag or paste the images into the issue or PR body. From GitHub CLI 2.99.0 or later, use the repeatable `--attach` flag with issue and PR create, edit, or comment commands. Image uploads require write access to the repository.
+In the GitHub web interface, drag or paste the images into the issue or PR body. From GitHub CLI 2.99.0 or later, use the repeatable `--attach` flag with issue and PR create, edit, or comment commands. CLI `--attach` uploads require write access to the repository; web interface uploads do not.
 
 The following command attaches two screenshots to a PR body:
 

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -134,7 +134,8 @@ Useful details to ask for on bug reports:
 - Relevant collection schema, field config, or plugin config.
 - Exact steps to reproduce from a fresh project when possible.
 - Expected behavior and actual behavior.
-- Error logs, screenshots, or network response details.
+- Error logs or network response details.
+- A screenshot for every report that refers to the interface.
 
 Do not ask for everything by default. Ask for the smallest missing piece that would unblock the next person.
 
@@ -149,7 +150,7 @@ For issues, priority is often the best thing a human triager can add — it's a 
 
 Use priority labels when you have enough context to make a reasonable call. If you are unsure, leave priority unset and explain what information would help judge impact.
 
-For bugs, a confirmed reproduction is the most useful evidence for priority. If you reproduce something, leave the exact environment and steps you used. Where the bug is visual or interactive — admin UI glitches, editor behavior, layout problems — a screenshot or short screen recording is extra useful: it shows exactly what you saw, and often settles "works for me" threads instantly. You can drag media straight into a GitHub comment.
+For bugs, a confirmed reproduction is the most useful evidence for priority. If you reproduce something, leave the exact environment and steps you used. A report that refers to the interface must include a screenshot showing the reported state. If it is missing, ask the author to add one. A short screen recording can supplement the screenshot when the bug depends on an interaction. You can drag or paste media into a GitHub comment, or attach a local file with `gh issue comment --attach './screenshot.png#Description of the reported state'` when using GitHub CLI 2.99.0 or later.
 
 ### The Investigation Bot and `bot:*` Labels
 
@@ -222,6 +223,7 @@ The bot does code-level review and is good at it, but it's not perfect. The most
 - For bug fixes, is there a test that would fail without the fix?
 - For user-facing package behavior changes, is there a changeset, and is it well written? (See [Checking Changesets](#checking-changesets).)
 - For admin UI changes, are user-facing strings localized and does the layout use RTL-safe classes?
+- For UI changes, does the PR include screenshots of the rendered result?
 - For feature/refactor/performance PRs, has a maintainer approved the idea — a linked Discussion labeled `Approved for PR`, or approval in a PR or issue comment?
 - Are unrelated files changed, such as generated translation catalogs in a non-translation PR?
 - Is the AI disclosure filled in, and has a human author understood and tested the change? (See [AI-Assisted Contributions](#ai-assisted-contributions).)


### PR DESCRIPTION
## What does this PR do?

Requires screenshots for issues that refer to the interface and PRs that change the UI.

Documents how agents and contributors can upload local screenshots with GitHub CLI 2.99.0 or later, including repeatable `--attach` flags, alt text, in-body placement, and repository write-access requirements. Updates the PR template, bug-report form, and triage checklist so the requirement appears where reports and reviews are created.

Related issue: Not applicable.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (not applicable; this PR changes documentation and GitHub templates only)
- [ ] `pnpm format` has been run (changed files pass a targeted Prettier check)
- [ ] I have added/updated tests for my changes (not applicable; there is no executable behavior)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable; there are no admin UI changes)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (not applicable; no published package changes)
- [ ] New features link to an approved Discussion (not applicable; this is contributor-policy documentation)
- [ ] I have included screenshots below if this PR changes the UI (not applicable; this PR does not change the UI)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex (GPT-5)

## Screenshots / test output

Not applicable: this PR does not change the UI.

Verified with:

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint:quick`
- `pnpm lint:json` — 0 diagnostics
- `pnpm --dir docs build`
- `pnpm exec prettier --check AGENTS.md CONTRIBUTING.md TRIAGE.md .github/PULL_REQUEST_TEMPLATE.md .github/ISSUE_TEMPLATE/bug_report.yml`
- YAML parse of `.github/ISSUE_TEMPLATE/bug_report.yml`
- `git diff --check`
