### PR TITLE
fix(core): keep the media-usage cleanup scan bounded when the lease is lost

### DIFF
--- a/.changeset/bounded-media-usage-gc-scan.md
+++ b/.changeset/bounded-media-usage-gc-scan.md
@@ -2,4 +2,4 @@
 "emdash": patch
 ---
 
-Fixes the scheduled media-usage cleanup so a tick that no longer holds the cleanup lease stops immediately instead of scanning the whole occurrence table. On large sites the guarded scan previously read every occurrence in the sweep window — hundreds of thousands of rows on a table its `LIMIT` was meant to keep at a few hundred — and returned nothing. Sites on Cloudflare D1 will see the corresponding rows-read spikes disappear from cron ticks.
+Fixes scheduled media-usage cleanup reading far more rows than its batch size on large sites. A cleanup run that had lost its lease scanned the whole occurrence table before returning nothing, so cron ticks could spike into the hundreds of thousands of rows read. Sites on Cloudflare D1 will see those spikes disappear.

--- a/.changeset/bounded-media-usage-gc-scan.md
+++ b/.changeset/bounded-media-usage-gc-scan.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the scheduled media-usage cleanup so a tick that no longer holds the cleanup lease stops immediately instead of scanning the whole occurrence table. On large sites the guarded scan previously read every occurrence in the sweep window — hundreds of thousands of rows on a table its `LIMIT` was meant to keep at a few hundred — and returned nothing. Sites on Cloudflare D1 will see the corresponding rows-read spikes disappear from cron ticks.

--- a/packages/core/src/database/repositories/media-usage.ts
+++ b/packages/core/src/database/repositories/media-usage.ts
@@ -1807,6 +1807,8 @@ export class MediaUsageRepository {
 		limit: number;
 		cleanupLease?: MediaUsageCleanupLease;
 	}): Promise<MediaUsageCleanupCandidate[]> {
+		if (input.cleanupLease && !(await this.holdsCleanupLease(input.cleanupLease))) return [];
+
 		let query = this.db
 			.selectFrom("_emdash_media_usage as u")
 			.leftJoin("_emdash_media_usage_sources as s", "s.source_key", "u.source_key")
@@ -1828,9 +1830,6 @@ export class MediaUsageRepository {
 			.orderBy("u.created_at", "asc")
 			.orderBy("u.id", "asc")
 			.limit(Math.max(0, Math.floor(input.limit)));
-		if (input.cleanupLease) {
-			query = query.where(this.activeCleanupLeaseExpression(input.cleanupLease));
-		}
 
 		if (input.cursor) {
 			query = query.where((eb) =>
@@ -1929,8 +1928,9 @@ export class MediaUsageRepository {
 			);
 		}
 		if (!canIssueCleanupStatement(options.canIssueStatement)) return 0;
+		if (options.cleanupLease && !(await this.holdsCleanupLease(options.cleanupLease))) return 0;
 
-		let query = this.db
+		const rows = await this.db
 			.selectFrom("_emdash_media_usage as u")
 			.leftJoin("_emdash_media_usage_sources as s", (join) =>
 				join.onRef("s.source_key", "=", "u.source_key"),
@@ -1946,11 +1946,8 @@ export class MediaUsageRepository {
 			.where(this.noActiveGenerationWriteExpression("u"))
 			.orderBy("u.created_at", "asc")
 			.orderBy("u.id", "asc")
-			.limit(batchLimit);
-		if (options.cleanupLease) {
-			query = query.where(this.activeCleanupLeaseExpression(options.cleanupLease));
-		}
-		const rows = await query.execute();
+			.limit(batchLimit)
+			.execute();
 
 		return this.deleteOrphanCandidateIds(
 			rows.map((row) => row.id),
@@ -1976,8 +1973,9 @@ export class MediaUsageRepository {
 			);
 		}
 		if (!canIssueCleanupStatement(options.canIssueStatement)) return 0;
+		if (options.cleanupLease && !(await this.holdsCleanupLease(options.cleanupLease))) return 0;
 
-		let query = this.db
+		const rows = await this.db
 			.selectFrom("_emdash_media_usage as u")
 			.innerJoin("_emdash_media_usage_sources as s", (join) =>
 				join.onRef("s.source_key", "=", "u.source_key"),
@@ -1994,11 +1992,8 @@ export class MediaUsageRepository {
 			.where(this.noActiveGenerationWriteExpression("u"))
 			.orderBy("u.created_at", "asc")
 			.orderBy("u.id", "asc")
-			.limit(batchLimit);
-		if (options.cleanupLease) {
-			query = query.where(this.activeCleanupLeaseExpression(options.cleanupLease));
-		}
-		const rows = await query.execute();
+			.limit(batchLimit)
+			.execute();
 
 		return this.deleteStaleCandidateIds(
 			rows.map((row) => row.id),
@@ -2024,8 +2019,9 @@ export class MediaUsageRepository {
 			);
 		}
 		if (!canIssueCleanupStatement(options.canIssueStatement)) return 0;
+		if (options.cleanupLease && !(await this.holdsCleanupLease(options.cleanupLease))) return 0;
 
-		let query = this.db
+		const rows = await this.db
 			.selectFrom("_emdash_media_usage as u")
 			.innerJoin("_emdash_media_usage_sources as s", (join) =>
 				join.onRef("s.source_key", "=", "u.source_key"),
@@ -2042,11 +2038,8 @@ export class MediaUsageRepository {
 			.where(this.noActiveGenerationWriteExpression("u"))
 			.orderBy("u.created_at", "asc")
 			.orderBy("u.id", "asc")
-			.limit(batchLimit);
-		if (options.cleanupLease) {
-			query = query.where(this.activeCleanupLeaseExpression(options.cleanupLease));
-		}
-		const rows = await query.execute();
+			.limit(batchLimit)
+			.execute();
 
 		return this.deleteAbandonedCandidateIds(
 			rows.map((row) => row.id),
@@ -2063,15 +2056,15 @@ export class MediaUsageRepository {
 	): Promise<number> {
 		const batchLimit = Math.floor(limit);
 		if (batchLimit <= 0 || !canIssueCleanupStatement(canIssueStatement)) return 0;
-		let query = this.db
+		if (cleanupLease && !(await this.holdsCleanupLease(cleanupLease))) return 0;
+		const rows = await this.db
 			.selectFrom("_emdash_media_usage_generation_writes")
 			.select("lease_token")
 			.where(this.generationWriteLeaseHasExpired("expires_at"))
 			.orderBy("expires_at", "asc")
 			.orderBy("lease_token", "asc")
-			.limit(batchLimit);
-		if (cleanupLease) query = query.where(this.activeCleanupLeaseExpression(cleanupLease));
-		const rows = await query.execute();
+			.limit(batchLimit)
+			.execute();
 		if (rows.length === 0 || !canIssueCleanupStatement(canIssueStatement)) return 0;
 		let deleteQuery = this.db
 			.deleteFrom("_emdash_media_usage_generation_writes")
@@ -2904,6 +2897,26 @@ export class MediaUsageRepository {
 					AND writer.generation = ${generation}
 					AND ${this.generationWriteLeaseExpiryIsInFuture("writer.expires_at")}
 			)`;
+	}
+
+	/**
+	 * Reads the lease row on its own so a lost lease can short-circuit a sweep.
+	 *
+	 * As a row-level `EXISTS` inside a `LIMIT`ed scan this predicate is constant
+	 * across every candidate row: when it is false the limit is unreachable and
+	 * the scan reads the whole `created_at` range before returning nothing.
+	 * Mutating statements still carry {@link activeCleanupLeaseExpression},
+	 * which is what actually fences a displaced owner.
+	 */
+	private async holdsCleanupLease(cleanupLease: MediaUsageCleanupLease): Promise<boolean> {
+		let query = this.db
+			.selectFrom("_emdash_media_usage_cleanup")
+			.select("task_key")
+			.where("task_key", "=", "projection_gc")
+			.where("lease_token", "=", cleanupLease.leaseToken)
+			.where(this.cleanupLeaseExpiryIsInFuture("_emdash_media_usage_cleanup.lease_expires_at"));
+		if (isPostgres(this.db)) query = query.forUpdate();
+		return (await query.executeTakeFirst()) !== undefined;
 	}
 
 	private activeCleanupLeaseExpression(cleanupLease: MediaUsageCleanupLease) {

--- a/packages/core/src/database/repositories/media-usage.ts
+++ b/packages/core/src/database/repositories/media-usage.ts
@@ -1801,13 +1801,20 @@ export class MediaUsageRepository {
 		};
 	}
 
+	/**
+	 * Scans for reclaimable occurrences, or resolves to `null` when the sweep was
+	 * never issued because the lease is gone or the tick is out of budget. An
+	 * empty array means the scan ran and found nothing, which lets the caller
+	 * retire the sweep window; `null` must leave the cursor where it was.
+	 */
 	async findMediaUsageCleanupCandidates(input: {
 		cutoff: string;
 		cursor: MediaUsageCleanupCursor | null;
 		limit: number;
 		cleanupLease?: MediaUsageCleanupLease;
-	}): Promise<MediaUsageCleanupCandidate[]> {
-		if (input.cleanupLease && !(await this.holdsCleanupLease(input.cleanupLease))) return [];
+		canIssueStatement?: () => boolean;
+	}): Promise<MediaUsageCleanupCandidate[] | null> {
+		if (!(await this.admitCleanupScan(input.cleanupLease, input.canIssueStatement))) return null;
 
 		let query = this.db
 			.selectFrom("_emdash_media_usage as u")
@@ -1927,8 +1934,7 @@ export class MediaUsageRepository {
 				options.canIssueStatement,
 			);
 		}
-		if (!canIssueCleanupStatement(options.canIssueStatement)) return 0;
-		if (options.cleanupLease && !(await this.holdsCleanupLease(options.cleanupLease))) return 0;
+		if (!(await this.admitCleanupScan(options.cleanupLease, options.canIssueStatement))) return 0;
 
 		const rows = await this.db
 			.selectFrom("_emdash_media_usage as u")
@@ -1972,8 +1978,7 @@ export class MediaUsageRepository {
 				options.canIssueStatement,
 			);
 		}
-		if (!canIssueCleanupStatement(options.canIssueStatement)) return 0;
-		if (options.cleanupLease && !(await this.holdsCleanupLease(options.cleanupLease))) return 0;
+		if (!(await this.admitCleanupScan(options.cleanupLease, options.canIssueStatement))) return 0;
 
 		const rows = await this.db
 			.selectFrom("_emdash_media_usage as u")
@@ -2018,8 +2023,7 @@ export class MediaUsageRepository {
 				options.canIssueStatement,
 			);
 		}
-		if (!canIssueCleanupStatement(options.canIssueStatement)) return 0;
-		if (options.cleanupLease && !(await this.holdsCleanupLease(options.cleanupLease))) return 0;
+		if (!(await this.admitCleanupScan(options.cleanupLease, options.canIssueStatement))) return 0;
 
 		const rows = await this.db
 			.selectFrom("_emdash_media_usage as u")
@@ -2055,8 +2059,8 @@ export class MediaUsageRepository {
 		canIssueStatement?: () => boolean,
 	): Promise<number> {
 		const batchLimit = Math.floor(limit);
-		if (batchLimit <= 0 || !canIssueCleanupStatement(canIssueStatement)) return 0;
-		if (cleanupLease && !(await this.holdsCleanupLease(cleanupLease))) return 0;
+		if (batchLimit <= 0) return 0;
+		if (!(await this.admitCleanupScan(cleanupLease, canIssueStatement))) return 0;
 		const rows = await this.db
 			.selectFrom("_emdash_media_usage_generation_writes")
 			.select("lease_token")
@@ -2897,6 +2901,23 @@ export class MediaUsageRepository {
 					AND writer.generation = ${generation}
 					AND ${this.generationWriteLeaseExpiryIsInFuture("writer.expires_at")}
 			)`;
+	}
+
+	/**
+	 * Gates a bounded cleanup scan on the lease and the tick's statement budget.
+	 *
+	 * The budget is re-read after the lease row because that read is itself a
+	 * statement: an isolate suspended across it can resume with the budget spent.
+	 */
+	private async admitCleanupScan(
+		cleanupLease: MediaUsageCleanupLease | undefined,
+		canIssueStatement: (() => boolean) | undefined,
+	): Promise<boolean> {
+		if (!canIssueCleanupStatement(canIssueStatement)) return false;
+		if (!cleanupLease) return true;
+		return (
+			(await this.holdsCleanupLease(cleanupLease)) && canIssueCleanupStatement(canIssueStatement)
+		);
 	}
 
 	/**

--- a/packages/core/src/media/usage/cleanup.ts
+++ b/packages/core/src/media/usage/cleanup.ts
@@ -81,14 +81,15 @@ export async function cleanupMediaUsage(db: Kysely<Database>): Promise<MediaUsag
 			);
 		}
 
-		if (canIssueStatement()) {
-			const cutoff = claim.scanBeforeAt;
-			const candidates = await repo.findMediaUsageCleanupCandidates({
-				cutoff,
-				cursor: claim.cursor,
-				limit: MEDIA_USAGE_CLEANUP_CANDIDATE_LIMIT,
-				cleanupLease: cleanupLease(leaseToken),
-			});
+		const cutoff = claim.scanBeforeAt;
+		const candidates = await repo.findMediaUsageCleanupCandidates({
+			cutoff,
+			cursor: claim.cursor,
+			limit: MEDIA_USAGE_CLEANUP_CANDIDATE_LIMIT,
+			cleanupLease: cleanupLease(leaseToken),
+			canIssueStatement,
+		});
+		if (candidates) {
 			candidateRows = candidates.length;
 			scanHasMore = candidates.length === MEDIA_USAGE_CLEANUP_CANDIDATE_LIMIT;
 

--- a/packages/core/tests/integration/database/media-usage-cleanup-plan.test.ts
+++ b/packages/core/tests/integration/database/media-usage-cleanup-plan.test.ts
@@ -17,7 +17,7 @@ interface CapturedQuery {
 	parameters: readonly unknown[];
 }
 
-const MAX_CLEANUP_STATEMENTS_PER_TICK = 14;
+const MAX_CLEANUP_STATEMENTS_PER_TICK = 16;
 const MAX_BIND_PARAMETERS_PER_CLEANUP_STATEMENT = 52;
 const MAX_CLEANUP_ADMISSION_TIME_MS = 5_000;
 

--- a/packages/core/tests/integration/database/media-usage-cleanup-plan.test.ts
+++ b/packages/core/tests/integration/database/media-usage-cleanup-plan.test.ts
@@ -1,5 +1,16 @@
 import Database from "better-sqlite3";
-import { Kysely, SqliteDialect, sql } from "kysely";
+import {
+	CompiledQuery,
+	Kysely,
+	SqliteDialect,
+	sql,
+	type KyselyPlugin,
+	type PluginTransformQueryArgs,
+	type PluginTransformResultArgs,
+	type QueryResult,
+	type RootOperationNode,
+	type UnknownRow,
+} from "kysely";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
 import { runMigrations } from "../../../src/database/migrations/runner.js";
@@ -515,6 +526,22 @@ async function insertOccurrence(
 		.execute();
 }
 
+/** Compiles every statement a repository call issues, so a plan test can EXPLAIN the real query. */
+class CompiledQueryRecorder implements KyselyPlugin {
+	readonly queries: CompiledQuery[] = [];
+
+	constructor(private readonly target: Kysely<DatabaseSchema>) {}
+
+	transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
+		this.queries.push(this.target.getExecutor().compileQuery(args.node, args.queryId));
+		return args.node;
+	}
+
+	async transformResult(args: PluginTransformResultArgs): Promise<QueryResult<UnknownRow>> {
+		return args.result;
+	}
+}
+
 function explain(query: CapturedQuery): string {
 	const rows = sqlite.prepare(`EXPLAIN QUERY PLAN ${query.sql}`).all(...query.parameters) as {
 		detail: string;
@@ -553,40 +580,19 @@ it.skipIf(!hasPgTestDatabase)("uses the cleanup scan index in PostgreSQL", async
 		}
 
 		await sql`ANALYZE _emdash_media_usage`.execute(context.db);
-		await context.db
-			.updateTable("_emdash_media_usage_cleanup")
-			.set({
-				lease_token: "plan-cleanup-lease",
-				lease_expires_at: "2100-01-01T00:00:00.000Z",
-			})
-			.where("task_key", "=", "projection_gc")
-			.execute();
-		const result = await sql<{ "QUERY PLAN": string }>`
-			EXPLAIN (COSTS OFF)
-			SELECT
-				u.id,
-				u.source_key,
-				u.generation,
-				u.created_at,
-				s.current_generation,
-				s.indexed_at,
-				writer.expires_at AS write_lease_expires_at
-			FROM _emdash_media_usage AS u
-			LEFT JOIN _emdash_media_usage_sources AS s ON s.source_key = u.source_key
-			LEFT JOIN _emdash_media_usage_generation_writes AS writer
-				ON writer.source_key = u.source_key AND writer.generation = u.generation
-			WHERE u.created_at < ${now.toISOString()}
-				AND EXISTS (
-					SELECT 1
-					FROM _emdash_media_usage_cleanup AS cleanup
-					WHERE cleanup.task_key = 'projection_gc'
-						AND cleanup.lease_token = 'plan-cleanup-lease'
-						AND cleanup.lease_expires_at::timestamptz > clock_timestamp()
-					FOR UPDATE
-				)
-			ORDER BY u.created_at ASC, u.id ASC
-			LIMIT 250
-		`.execute(context.db);
+		const recorder = new CompiledQueryRecorder(context.db);
+		await new MediaUsageRepository(context.db.withPlugin(recorder)).findMediaUsageCleanupCandidates(
+			{
+				cutoff: now.toISOString(),
+				cursor: null,
+				limit: MEDIA_USAGE_CLEANUP_CANDIDATE_LIMIT,
+			},
+		);
+		const scan = recorder.queries.at(-1);
+		if (!scan) throw new Error("the candidate scan issued no statement");
+		const result = await context.db.executeQuery<{ "QUERY PLAN": string }>(
+			CompiledQuery.raw(`EXPLAIN (COSTS OFF) ${scan.sql}`, [...scan.parameters]),
+		);
 		const plan = result.rows.map((row) => row["QUERY PLAN"]).join("\n");
 
 		expect(plan).toMatch(/Index(?: Only)? Scan using idx__emdash_media_usage_cleanup_scan/);

--- a/packages/core/tests/integration/database/media-usage-cleanup.test.ts
+++ b/packages/core/tests/integration/database/media-usage-cleanup.test.ts
@@ -1,4 +1,14 @@
-import { sql, type Kysely, type Transaction } from "kysely";
+import {
+	sql,
+	type Kysely,
+	type KyselyPlugin,
+	type PluginTransformQueryArgs,
+	type PluginTransformResultArgs,
+	type QueryResult,
+	type RootOperationNode,
+	type Transaction,
+	type UnknownRow,
+} from "kysely";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
 import { runSystemCleanup } from "../../../src/cleanup.js";
@@ -9,6 +19,7 @@ import {
 	MEDIA_USAGE_CLEANUP_CANDIDATE_LIMIT,
 	MEDIA_USAGE_CLEANUP_DELETE_LIMIT,
 	MEDIA_USAGE_CLEANUP_INTERVAL_MS,
+	MEDIA_USAGE_CLEANUP_WRITE_LEASE_DELETE_LIMIT,
 } from "../../../src/media/usage/cleanup.js";
 import {
 	describeEachDialect,
@@ -18,6 +29,36 @@ import {
 } from "../../utils/test-db.js";
 
 const MAX_CLEANUP_ADMISSION_TIME_MS = 5_000;
+
+/** Records every table a statement reads through its FROM or JOIN clauses. */
+class ReadTableRecorder implements KyselyPlugin {
+	readonly tables = new Set<string>();
+
+	transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
+		collectTableNames(args.node, this.tables);
+		return args.node;
+	}
+
+	async transformResult(args: PluginTransformResultArgs): Promise<QueryResult<UnknownRow>> {
+		return args.result;
+	}
+}
+
+function collectTableNames(node: unknown, into: Set<string>): void {
+	if (Array.isArray(node)) {
+		for (const item of node) collectTableNames(item, into);
+		return;
+	}
+	if (node === null || typeof node !== "object") return;
+	const table = (node as { kind?: string; table?: { identifier?: { name?: unknown } } }).table;
+	if (
+		(node as { kind?: string }).kind === "TableNode" &&
+		typeof table?.identifier?.name === "string"
+	) {
+		into.add(table.identifier.name);
+	}
+	for (const value of Object.values(node)) collectTableNames(value, into);
+}
 
 describeEachDialect("scheduled media usage cleanup", (dialect) => {
 	let ctx: DialectTestContext;
@@ -926,6 +967,70 @@ describeEachDialect("scheduled media usage cleanup", (dialect) => {
 			.where("source_key", "=", stale.sourceKey)
 			.executeTakeFirst();
 		expect(Number(promotion.numUpdatedRows ?? 0)).toBe(0);
+	});
+
+	it("reads only the lease row when its cleanup lease is lost", async () => {
+		const stale = await repo.replaceSource(contentSource("entry-fenced-scan"), [
+			occurrence("media-stale"),
+		]);
+		await repo.replaceSource(contentSource("entry-fenced-scan"), [occurrence("media-current")]);
+		await db
+			.updateTable("_emdash_media_usage")
+			.set({ created_at: "2026-02-01T19:00:00.000Z" })
+			.where("generation", "=", stale.currentGeneration)
+			.execute();
+		expect(
+			await repo.claimMediaUsageCleanup({
+				leaseToken: "fenced-scan-owner",
+				leaseDurationSeconds: 5 * 60,
+				nextEligibleDelaySeconds: 60,
+				sweepSafetyWindowSeconds: 60 * 60,
+			}),
+		).not.toBeNull();
+
+		const cutoff = "2100-01-01T00:00:00.000Z";
+		const scanArgs = {
+			cutoff,
+			cursor: null,
+			limit: MEDIA_USAGE_CLEANUP_CANDIDATE_LIMIT,
+		};
+		expect(
+			await repo.findMediaUsageCleanupCandidates({
+				...scanArgs,
+				cleanupLease: { leaseToken: "fenced-scan-owner" },
+			}),
+		).not.toHaveLength(0);
+
+		const readTables = new ReadTableRecorder();
+		const fenced = new MediaUsageRepository(db.withPlugin(readTables));
+		const lostLease = { leaseToken: "displaced-owner" };
+
+		expect(
+			await fenced.findMediaUsageCleanupCandidates({ ...scanArgs, cleanupLease: lostLease }),
+		).toEqual([]);
+		expect(
+			await fenced.deleteOrphanOccurrencesOlderThan(cutoff, MEDIA_USAGE_CLEANUP_DELETE_LIMIT, {
+				cleanupLease: lostLease,
+			}),
+		).toBe(0);
+		expect(
+			await fenced.deleteStaleGenerationsOlderThan(cutoff, MEDIA_USAGE_CLEANUP_DELETE_LIMIT, {
+				cleanupLease: lostLease,
+			}),
+		).toBe(0);
+		expect(
+			await fenced.deleteAbandonedGenerationsOlderThan(cutoff, MEDIA_USAGE_CLEANUP_DELETE_LIMIT, {
+				cleanupLease: lostLease,
+			}),
+		).toBe(0);
+		expect(
+			await fenced.deleteExpiredGenerationWriteLeases(
+				MEDIA_USAGE_CLEANUP_WRITE_LEASE_DELETE_LIMIT,
+				lostLease,
+			),
+		).toBe(0);
+
+		expect([...readTables.tables]).toEqual(["_emdash_media_usage_cleanup"]);
 	});
 
 	it("stops deletion when a newer cleanup owner takes the lease", async () => {

--- a/packages/core/tests/integration/database/media-usage-cleanup.test.ts
+++ b/packages/core/tests/integration/database/media-usage-cleanup.test.ts
@@ -44,6 +44,22 @@ class ReadTableRecorder implements KyselyPlugin {
 	}
 }
 
+/** Spends the whole statement budget while the cleanup lease row is being read. */
+class SuspendOnCleanupLeaseRead implements KyselyPlugin {
+	transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
+		const tables = new Set<string>();
+		collectTableNames(args.node, tables);
+		if (tables.has("_emdash_media_usage_cleanup")) {
+			vi.advanceTimersByTime(MAX_CLEANUP_ADMISSION_TIME_MS);
+		}
+		return args.node;
+	}
+
+	async transformResult(args: PluginTransformResultArgs): Promise<QueryResult<UnknownRow>> {
+		return args.result;
+	}
+}
+
 function collectTableNames(node: unknown, into: Set<string>): void {
 	if (Array.isArray(node)) {
 		for (const item of node) collectTableNames(item, into);
@@ -1007,7 +1023,7 @@ describeEachDialect("scheduled media usage cleanup", (dialect) => {
 
 		expect(
 			await fenced.findMediaUsageCleanupCandidates({ ...scanArgs, cleanupLease: lostLease }),
-		).toEqual([]);
+		).toBeNull();
 		expect(
 			await fenced.deleteOrphanOccurrencesOlderThan(cutoff, MEDIA_USAGE_CLEANUP_DELETE_LIMIT, {
 				cleanupLease: lostLease,
@@ -1030,6 +1046,45 @@ describeEachDialect("scheduled media usage cleanup", (dialect) => {
 			),
 		).toBe(0);
 
+		expect([...readTables.tables]).toEqual(["_emdash_media_usage_cleanup"]);
+	});
+
+	it("does not issue its scan when the budget expires during the lease read", async () => {
+		const stale = await repo.replaceSource(contentSource("entry-lease-read-budget"), [
+			occurrence("media-stale"),
+		]);
+		await repo.replaceSource(contentSource("entry-lease-read-budget"), [
+			occurrence("media-current"),
+		]);
+		await db
+			.updateTable("_emdash_media_usage")
+			.set({ created_at: "2026-02-01T19:00:00.000Z" })
+			.where("generation", "=", stale.currentGeneration)
+			.execute();
+		expect(
+			await repo.claimMediaUsageCleanup({
+				leaseToken: "lease-read-budget-owner",
+				leaseDurationSeconds: 5 * 60,
+				nextEligibleDelaySeconds: 60,
+				sweepSafetyWindowSeconds: 60 * 60,
+			}),
+		).not.toBeNull();
+
+		const readTables = new ReadTableRecorder();
+		const startedMs = Date.now();
+		const suspended = new MediaUsageRepository(
+			db.withPlugin(readTables).withPlugin(new SuspendOnCleanupLeaseRead()),
+		);
+
+		expect(
+			await suspended.findMediaUsageCleanupCandidates({
+				cutoff: "2100-01-01T00:00:00.000Z",
+				cursor: null,
+				limit: MEDIA_USAGE_CLEANUP_CANDIDATE_LIMIT,
+				cleanupLease: { leaseToken: "lease-read-budget-owner" },
+				canIssueStatement: () => Date.now() - startedMs < MAX_CLEANUP_ADMISSION_TIME_MS,
+			}),
+		).toBeNull();
 		expect([...readTables.tables]).toEqual(["_emdash_media_usage_cleanup"]);
 	});
 


### PR DESCRIPTION
## What does this PR do?

The media-usage cleanup lane folds its lease check into the `WHERE` of the candidate scan as `EXISTS (SELECT 1 FROM _emdash_media_usage_cleanup ...)`. That predicate is uncorrelated — true for every candidate row or false for every candidate row. Inside a `LIMIT`ed keyset scan a false guard means no row can ever satisfy the predicate, the limit is never reached, and the scan walks the entire `created_at` range through all three joins before returning nothing. On the reporter's 166,110-row `_emdash_media_usage` table that is 496,341 rows read versus 751 for the identical scan with the lease held, and the cost scales with table size, so it grows on exactly the installations that need the GC most.

This PR verifies the lease in its own statement and drops the `EXISTS` from every lease-gated scan:

- `findMediaUsageCleanupCandidates`
- the fallback scans in `deleteOrphanOccurrencesOlderThan`, `deleteStaleGenerationsOlderThan`, `deleteAbandonedGenerationsOlderThan`
- `deleteExpiredGenerationWriteLeases`

The mutating statements keep `activeCleanupLeaseExpression()` unchanged. They are what actually fences a displaced owner, and their `id IN (...)` / `lease_token IN (...)` bound means a constant-false guard costs an indexed probe per batch, not a table scan. On PostgreSQL the new check takes the same `FOR UPDATE` row lock the in-statement guard did, so the lane's lock ordering against source writes is unchanged.

Closes #2844

### Two things reviewers should weigh

1. **`MAX_CLEANUP_STATEMENTS_PER_TICK` moves from 14 to 16.** The check is one single-row read at each of the two scan sites a full tick reaches. That is a deliberate budget increase — two indexed single-row reads per cron tick in exchange for removing the cliff. The alternative that holds the budget at 14 is to drop the lease consultation from the scans entirely: the claim already proves the lease at tick start, the 5s time budget stops a suspended tick, and the mutations re-check. A fenced tick would then still burn one *bounded* (~750-row) scan, which is what the issue asked to avoid, so this PR follows the issue's suggested fix. Happy to switch if you prefer the flat budget.
2. **The check lives in the repository, per call, not only in `cleanupMediaUsage`.** That costs the second statement but means a future caller cannot reintroduce the pattern by forgetting the gate.

The issue's closing note — that this shape is worth avoiding wherever it appears, not only in this lane — is not addressed here. That looks like a separate audit rather than a drive-by.

### Updates from review

- The candidate scan resolves to `MediaUsageCleanupCandidate[] | null`. `[]` means the scan ran and found nothing, which retires the sweep window and clears the cursor; `null` means it was never issued and the caller leaves the cursor alone. Previously a fenced tick returned `[]` and relied on `completeMediaUsageCleanup` being lease-fenced to reject the resulting `sweepComplete: true`.
- Both gates now go through one `admitCleanupScan` helper — budget, lease row, budget again — shared by the candidate scan and the four bounded delete scans. The lease read is a statement, so a tick suspended across it could resume with its 5s budget spent and still issue the scan.
- The PostgreSQL plan test no longer hand-writes the scan SQL (which still carried the removed `EXISTS`). It compiles the statement the repository actually issues and `EXPLAIN`s that, so the two cannot drift again.

`MAX_CLEANUP_STATEMENTS_PER_TICK` is unchanged at 16 — no new statements.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — n/a, no admin UI strings
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Screenshots / test output

New regression test in `media-usage-cleanup.test.ts`. It fails on `main`, where the fenced scan reads all three data tables:

```
AssertionError: expected [ '_emdash_media_usage', …(6) ] to deeply equal [ '_emdash_media_usage_cleanup' ]

- Expected
+ Received

  [
-   "_emdash_media_usage_cleanup",
+   "_emdash_media_usage",
+   "_emdash_media_usage_sources",
+   "s",
+   "u",
+   "_emdash_media_usage_generation_writes",
+   "writer",
+   "cleanup",
  ]
```

With the fix, both cleanup suites pass on SQLite and on a real PostgreSQL 17, so the dialect-specific lock-ordering tests actually executed:

```
$ EMDASH_TEST_PG=... vitest run tests/integration/database/media-usage-cleanup.test.ts \
    tests/integration/database/media-usage-cleanup-plan.test.ts

 Test Files  2 passed (2)
      Tests  58 passed (58)
```

`tests/integration/database` and `tests/unit/database` are green on both dialects apart from two 5s vitest timeouts under parallel load (`media-usage-projection-admission-measurement` and the PostgreSQL plan test); both pass in isolation in ~2s and neither is related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvCS2j4PWyCjtZX4pWLzT5

