### PR TITLE
test: define core UX acceptance journeys

### DIFF
--- a/acceptance/journeys/00-publish-first-update.md
+++ b/acceptance/journeys/00-publish-first-update.md
@@ -1,0 +1,55 @@
+---
+id: publish-first-update
+site: editorial-small
+target: node
+status: ready
+requires: []
+---
+
+# Publish the first update
+
+This calibration journey confirms that the tester can complete the main publishing workflow using the existing scaffold.
+
+## Bootstrap requirements
+
+Use the seeded `editorial-small` profile and its authenticated Admin. Start from the admin dashboard with the first-login welcome experience intact.
+
+## Tester brief
+
+### Persona
+
+You own a small publication and are using EmDash for the first time. You need to publish a short studio announcement.
+
+### Goal
+
+Publish a new post titled **September studio update**. Confirm that visitors can read it when you are finished.
+
+### Starting knowledge
+
+You know the announcement belongs with the site's posts. You have not been shown where posts are created or how EmDash distinguishes saved work from published work.
+
+### Supplied material
+
+Use this summary:
+
+> A short update on what the studio is building this autumn.
+
+Use this body:
+
+> We are opening the workshop for community projects throughout September.
+
+## Coordinator checks
+
+- Exactly one post has the title `September studio update`.
+- The post is published.
+- Its excerpt and body match the supplied text.
+- It has a non-empty slug.
+- Its public URL returns a successful response containing the supplied body.
+
+## Areas to observe
+
+- Does the welcome experience help the tester begin or obstruct the task?
+- Can the tester discover where to create a post?
+- Can the tester distinguish saving from publishing?
+- Does the interface communicate when the post becomes public?
+- Can the tester find a way to confirm what visitors see?

--- a/acceptance/journeys/01-update-live-article-safely.md
+++ b/acceptance/journeys/01-update-live-article-safely.md
@@ -1,0 +1,54 @@
+---
+id: update-live-article-safely
+site: editorial-team
+target: node
+status: needs-profile
+requires:
+  - Author session
+  - Published owned article without pending changes
+  - Draft preview support
+---
+
+# Update a live article safely
+
+This journey tests whether the editor communicates the relationship between saved work, pending changes, previews, and the public version.
+
+## Bootstrap requirements
+
+Provide an Author who owns the published article **Autumn opening hours**. The article must have no pending changes and must support drafts, revisions, and preview. Capture its public content and revision state before dispatch.
+
+## Tester brief
+
+### Persona
+
+You are a staff writer. You have used other publishing systems but have not used EmDash before.
+
+### Goal
+
+Update the opening paragraph of **Autumn opening hours**. Check how the change will look to visitors before making it public, and keep the current article available until you are satisfied.
+
+### Starting knowledge
+
+The article is currently visible to visitors and must not disappear while you work.
+
+### Supplied material
+
+Replace the opening paragraph with:
+
+> From 1 October, the studio will open Tuesday through Sunday from 10am until 6pm.
+
+## Coordinator checks
+
+- The article remains published throughout the run.
+- The final public article contains the replacement paragraph.
+- No pending draft remains after publication.
+- Fields outside the opening paragraph are unchanged.
+- No other entry changes.
+- The revision history records the update without losing earlier revisions.
+
+## Areas to observe
+
+- Can the tester tell whether an edit is saved but not yet public?
+- Are autosave, Save, Preview, Live View, and Publish understood as distinct actions or states?
+- Can the tester inspect the draft without risking the live article?
+- Does the tester know when visitors can see the replacement?

--- a/acceptance/journeys/02-review-colleague-draft.md
+++ b/acceptance/journeys/02-review-colleague-draft.md
@@ -1,0 +1,56 @@
+---
+id: review-colleague-draft
+site: editorial-team
+target: node
+status: needs-profile
+requires:
+  - Editor session
+  - Contributor-owned draft among a populated content list
+  - Localized bylines and News taxonomy term
+---
+
+# Review a colleague's draft
+
+This journey tests retrieval, ownership, public credits, taxonomy assignment, and publication as one editorial task.
+
+## Bootstrap requirements
+
+Provide an Editor and a populated posts collection containing a Contributor-owned draft titled **Community garden opens Saturday**. The draft must have an incorrect summary, an existing writer byline, and no category. Provide an English byline named **Alex Morgan** and an English **News** category.
+
+## Tester brief
+
+### Persona
+
+You are the managing editor of a publication with several writers and a busy content calendar.
+
+### Goal
+
+Prepare **Community garden opens Saturday** for publication. Replace its summary, categorize it as News, credit Alex Morgan as Photographer after the existing writer credit, and publish it.
+
+### Starting knowledge
+
+The draft was created by a colleague. Their ownership of the entry must not change.
+
+### Supplied material
+
+Use this summary:
+
+> Volunteers will welcome neighbours to the new community garden this Saturday morning.
+
+## Coordinator checks
+
+- The originally supplied draft is published.
+- Its owner is unchanged.
+- Its excerpt matches the supplied text.
+- The News term is assigned.
+- Alex Morgan follows the existing writer in the public byline order with the role label `Photographer`.
+- Its public URL returns a successful response containing the supplied summary.
+- Other drafts remain unchanged.
+
+## Areas to observe
+
+- Can the tester find the correct draft without knowing its route?
+- Do search, filters, status, and ownership provide enough context?
+- Is ownership distinguishable from public byline credit?
+- Can the tester understand and control byline order?
+- Does the interface provide confidence that the correct entry was published?

--- a/acceptance/journeys/03-invite-right-collaborator.md
+++ b/acceptance/journeys/03-invite-right-collaborator.md
@@ -1,0 +1,48 @@
+---
+id: invite-right-collaborator
+site: editorial-team
+target: node
+status: needs-profile
+requires:
+  - Admin session
+  - No existing user or invitation for priya@example.com
+  - Email delivery disabled
+---
+
+# Invite the right collaborator
+
+This journey tests whether role descriptions and invitation feedback let an administrator grant the intended access without being told an EmDash role name.
+
+## Bootstrap requirements
+
+Provide an Admin on a configured team site. Ensure that `priya@example.com` has no user or outstanding invitation and that no email provider is configured, so a successful invitation returns the manual sharing flow.
+
+## Tester brief
+
+### Persona
+
+You own a small publication and manage access for its contributors. You understand what each person should be allowed to do, but you do not know EmDash's role names.
+
+### Goal
+
+Invite Priya Shah at `priya@example.com`. Priya should be able to create, edit, and publish her own posts. She must not be able to edit other writers' posts or change site settings.
+
+Obtain whatever Priya needs to complete registration.
+
+### Starting knowledge
+
+No email delivery service has been connected to this site.
+
+## Coordinator checks
+
+- A valid invitation exists for `priya@example.com`.
+- The invitation grants role level 30.
+- No user account or duplicate invitation is created.
+- The tester records the generated invite link for manual sharing without exposing it beyond the acceptance report.
+
+## Areas to observe
+
+- Can the tester discover where collaborators are invited?
+- Do the available role names and descriptions support the correct access decision?
+- Is the difference between creating an invitation and sending email clear?
+- Does the fallback explain how to complete the invitation safely?

--- a/acceptance/journeys/04-publish-arabic-translation.md
+++ b/acceptance/journeys/04-publish-arabic-translation.md
@@ -1,0 +1,57 @@
+---
+id: publish-arabic-translation
+site: multilingual-editorial
+target: node
+status: needs-profile
+requires:
+  - Arabic Editor session
+  - Published English source without an Arabic translation
+  - Arabic content, taxonomy, and menu locales
+---
+
+# Publish an Arabic translation
+
+This journey tests content locale, admin language, translation relationships, right-to-left interaction, and independent publication state together.
+
+## Bootstrap requirements
+
+Provide an Editor whose admin language is Arabic. The English article **Visitor information** must be published with no Arabic translation. Configure English and Arabic content locales, localized navigation, and localized taxonomy definitions. Capture the English entry and its public response before dispatch.
+
+## Tester brief
+
+### Persona
+
+You are an Arabic-speaking localization editor responsible for publishing translated visitor information.
+
+### Goal
+
+Publish the supplied Arabic translation of **Visitor information** using the slug `معلومات-الزوار`. Keep the English article unchanged and publicly available.
+
+### Starting knowledge
+
+The English article is complete. You need to create its Arabic counterpart rather than replace the English content.
+
+### Supplied material
+
+Use this title:
+
+> معلومات الزوار
+
+Use this body:
+
+> يفتح المركز أبوابه من الثلاثاء إلى الأحد، من الساعة العاشرة صباحًا حتى السادسة مساءً.
+
+## Coordinator checks
+
+- The English and Arabic entries share one translation group.
+- The Arabic entry uses locale `ar`, the supplied title, body, and slug, and is published.
+- The English entry's data, slug, and publication state are unchanged.
+- Both locale-specific public URLs return successful responses with the expected language.
+
+## Areas to observe
+
+- Can the tester distinguish admin language from content locale?
+- Is the current content locale continuously visible and understandable?
+- Can the tester create a related translation rather than an unrelated entry?
+- Is per-locale publication clear?
+- Does the workflow remain usable and visually coherent in a right-to-left interface?

--- a/acceptance/journeys/05-recover-accidental-edit.md
+++ b/acceptance/journeys/05-recover-accidental-edit.md
@@ -1,0 +1,54 @@
+---
+id: recover-accidental-edit
+site: editorial-team
+target: node
+status: needs-profile
+requires:
+  - Editor session
+  - Published article with revision history and incorrect current copy
+  - Draft preview support
+---
+
+# Recover an accidental edit
+
+This journey tests whether revision history supports a safe recovery without obscuring the resulting draft and publication state.
+
+## Bootstrap requirements
+
+Provide an Editor and a published article titled **Annual report**. Its current public opening paragraph must contain known incorrect copy. Revision history must contain an earlier version beginning with the supplied sentence. Enable drafts, revisions, and preview. Capture the public response and complete revision list before dispatch.
+
+## Tester brief
+
+### Persona
+
+You are the managing editor responding to a report that an article was accidentally replaced with outdated copy.
+
+### Goal
+
+Recover the version of **Annual report** whose opening sentence matches the supplied text. Check the recovered result before making it public, and keep the article available throughout the task.
+
+### Starting knowledge
+
+The correct version existed previously. The current public article must not be taken offline while you recover it.
+
+### Supplied material
+
+The correct version begins:
+
+> This year's programme supported 48 community-led projects across the region.
+
+## Coordinator checks
+
+- The article remains published throughout the run.
+- The final public article begins with the supplied sentence.
+- Restoring the selected revision creates a new revision rather than deleting or rewriting history.
+- No earlier revision is lost.
+- No unrelated entry changes.
+
+## Areas to observe
+
+- Can the tester discover revision history from the editing workflow?
+- Do revision timestamps and previews provide enough information to choose safely?
+- Is the effect of Restore clear before confirmation?
+- Can the tester distinguish a restored draft from the public version?
+- Does the tester know when the recovered copy becomes public?

--- a/acceptance/journeys/_template.md
+++ b/acceptance/journeys/_template.md
@@ -1,11 +1,20 @@
 ---
+id: journey-id
 site: editorial-small
 target: node
+status: ready
+requires: []
 ---
 
 # Journey title
 
 The coordinator sends only the `Tester brief` section to the tester. Keep setup details and success checks outside that section.
+
+Set `status` to `needs-profile` until the selected site profile provides every item in `requires`.
+
+## Bootstrap requirements
+
+Describe the starting data, authenticated role, locale, and feature configuration the profile must provide. Keep this section empty only when the named profile already provides the required state.
 
 ## Tester brief
 

--- a/skills/ux-acceptance-coordinator/SKILL.md
+++ b/skills/ux-acceptance-coordinator/SKILL.md
@@ -9,16 +9,17 @@ Run a goal-driven browser journey with a tester that has no repository context. 
 
 ## Prepare the run
 
-1. Read the selected journey in `acceptance/journeys/` and its site profile in `acceptance/sites/`.
-2. Read `acceptance/tester/SKILL.md`. This file is the tester's portable instruction payload; it is deliberately outside the repository's discoverable `skills/` directory.
-3. Choose the journey's target. Use Node unless the journey or change under test requires the Cloudflare runtime.
-4. Start one disposable site:
+1. Read the selected journey in `acceptance/journeys/`.
+2. Check the journey's `status` and `requires` frontmatter. If its status is `needs-profile`, report the missing bootstrap requirements and stop. Do not substitute a simpler profile or relax the journey.
+3. Read its site profile in `acceptance/sites/` and the portable tester instructions in `acceptance/tester/SKILL.md`.
+4. Choose the journey's target. Use Node unless the journey or change under test requires the Cloudflare runtime.
+5. Start one disposable site:
 
    ```console
    pnpm ux:site:start -- --target node --profile editorial-small
    ```
 
-5. Keep the run ID, start URL, and run-data path from the command output. Never send the run-data file or API token to the tester.
+6. Keep the run ID, start URL, and run-data path from the command output. Never send the run-data file or API token to the tester.
 
 ## Isolate the tester
 


### PR DESCRIPTION
## What does this PR do?

Defines the first six goal-driven UX acceptance journeys for the EmDash admin:

- publishing a first update;
- updating a live article safely;
- reviewing a colleague's draft;
- inviting a collaborator with the right access;
- publishing an Arabic translation;
- recovering an accidental edit from revision history.

Each journey separates the tester brief from bootstrap requirements, coordinator-only checks, and areas to observe. The existing `editorial-small` profile can run the calibration journey. The other five are marked `needs-profile` until role-specific and multilingual fixtures provide their declared requirements; the coordinator now refuses to substitute a simpler profile for them.

This is the second layer of stack #2856 and is based on #2854. Merge #2854 first.

No linked issue.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

The i18n, changeset, and Discussion items are not applicable because this PR changes only internal test specifications and coordinator instructions. It adds no admin UI strings or published-package behavior.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Validated on commit `89de11960`:

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- Prettier validation for every journey and the coordinator skill
- Skill validation for `ux-acceptance-coordinator`
- Structural check: six unique journey IDs, one `ready` journey, five `needs-profile` journeys, and all required private/public sections present

No browser run was performed because this layer defines journey specifications; #2854 verifies the site lifecycle and browser handoff they depend on.
