### PR TITLE
fix(core): let migration 017 finish after an interrupted run

### DIFF
--- a/.changeset/tough-pans-repeat.md
+++ b/.changeset/tough-pans-repeat.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes Cloudflare D1 sites that could never finish migrating after migration 017 was interrupted. Every retry failed with `table "_emdash_authorization_codes" already exists`; the migration now skips the statements that already ran.

--- a/packages/core/src/database/migrations/017_authorization_codes.ts
+++ b/packages/core/src/database/migrations/017_authorization_codes.ts
@@ -1,7 +1,6 @@
 import type { Kysely } from "kysely";
-import { sql } from "kysely";
 
-import { currentTimestamp } from "../dialect-helpers.js";
+import { columnExists, currentTimestamp } from "../dialect-helpers.js";
 
 /**
  * Authorization codes for OAuth 2.1 Authorization Code + PKCE flow.
@@ -10,10 +9,18 @@ import { currentTimestamp } from "../dialect-helpers.js";
  * via the standard OAuth authorization code grant.
  *
  * Also adds client_id tracking to oauth_tokens for per-client revocation.
+ *
+ * Every statement is guarded so the migration can restart after any one of
+ * them has committed. D1 commits each DDL statement on its own and the
+ * migrator records the migration only once `up` returns, so an interrupted
+ * run leaves the table created and the migration pending; an unguarded
+ * `CREATE TABLE` then fails on every retry and the database never finishes
+ * migrating.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
 	await db.schema
 		.createTable("_emdash_authorization_codes")
+		.ifNotExists()
 		.addColumn("code_hash", "text", (col) => col.primaryKey()) // SHA-256 hash of authorization code
 		.addColumn("client_id", "text", (col) => col.notNull()) // CIMD URL or opaque string
 		.addColumn("redirect_uri", "text", (col) => col.notNull()) // Must match exactly on exchange
@@ -31,15 +38,18 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 
 	await db.schema
 		.createIndex("idx_auth_codes_expires")
+		.ifNotExists()
 		.on("_emdash_authorization_codes")
 		.column("expires_at")
 		.execute();
 
 	// Track which client obtained a token (for per-client revocation)
-	await sql`ALTER TABLE _emdash_oauth_tokens ADD COLUMN client_id TEXT`.execute(db);
+	if (!(await columnExists(db, "_emdash_oauth_tokens", "client_id"))) {
+		await db.schema.alterTable("_emdash_oauth_tokens").addColumn("client_id", "text").execute();
+	}
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
-	await db.schema.dropTable("_emdash_authorization_codes").execute();
+	await db.schema.dropTable("_emdash_authorization_codes").ifExists().execute();
 	// SQLite doesn't support DROP COLUMN, but this is only for dev rollback
 }

--- a/packages/core/tests/unit/database/migrations/017_authorization_codes.test.ts
+++ b/packages/core/tests/unit/database/migrations/017_authorization_codes.test.ts
@@ -1,0 +1,125 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createDatabase } from "../../../../src/database/connection.js";
+import { up as up016 } from "../../../../src/database/migrations/016_api_tokens.js";
+import { down, up } from "../../../../src/database/migrations/017_authorization_codes.js";
+import type { Database } from "../../../../src/database/types.js";
+
+async function tableNames(db: Kysely<Database>): Promise<string[]> {
+	const tables = await db.introspection.getTables();
+	return tables.map((t) => t.name);
+}
+
+async function indexNames(db: Kysely<Database>): Promise<string[]> {
+	const indexes = await sql<{ name: string }>`
+		SELECT name FROM sqlite_master WHERE type = 'index'
+	`.execute(db);
+	return indexes.rows.map((r) => r.name);
+}
+
+async function columnNames(db: Kysely<Database>, table: string): Promise<string[]> {
+	const tables = await db.introspection.getTables();
+	return tables.find((t) => t.name === table)?.columns.map((c) => c.name) ?? [];
+}
+
+describe("017_authorization_codes migration", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = createDatabase({ url: ":memory:" });
+
+		// 017 has an FK to `users` (id) and adds a column to
+		// `_emdash_oauth_tokens`, which 016 creates.
+		await db.schema
+			.createTable("users")
+			.addColumn("id", "text", (col) => col.primaryKey())
+			.execute();
+		await up016(db);
+	});
+
+	afterEach(async () => {
+		await db.destroy();
+	});
+
+	it("creates the authorization codes table, its index, and the client_id column", async () => {
+		await up(db);
+
+		expect(await tableNames(db)).toContain("_emdash_authorization_codes");
+		expect(await indexNames(db)).toContain("idx_auth_codes_expires");
+		expect(await columnNames(db, "_emdash_oauth_tokens")).toContain("client_id");
+	});
+
+	it("reverts the authorization codes table", async () => {
+		await up(db);
+		await down(db);
+
+		expect(await tableNames(db)).not.toContain("_emdash_authorization_codes");
+	});
+
+	// D1 commits each DDL statement on its own and the migrator records 017 only
+	// once `up()` returns, so a cut-short run leaves it pending on its own output.
+	describe("re-run safety after a partially-applied migration", () => {
+		it("is a no-op when every statement has already run", async () => {
+			await up(db);
+
+			await expect(up(db)).resolves.not.toThrow();
+
+			expect(await tableNames(db)).toContain("_emdash_authorization_codes");
+			expect(await indexNames(db)).toContain("idx_auth_codes_expires");
+			expect(await columnNames(db, "_emdash_oauth_tokens")).toContain("client_id");
+		});
+
+		it("recovers when only the table was created before the crash", async () => {
+			// Running `up()` once and undoing the trailing statements leaves
+			// the table with the exact schema an interrupted run leaves.
+			await up(db);
+			await db.schema.dropIndex("idx_auth_codes_expires").execute();
+			await sql`ALTER TABLE _emdash_oauth_tokens DROP COLUMN client_id`.execute(db);
+
+			await expect(up(db)).resolves.not.toThrow();
+
+			expect(await tableNames(db)).toContain("_emdash_authorization_codes");
+			expect(await indexNames(db)).toContain("idx_auth_codes_expires");
+			expect(await columnNames(db, "_emdash_oauth_tokens")).toContain("client_id");
+
+			// `CREATE TABLE IF NOT EXISTS` is a no-op against an existing table
+			// even when the definitions differ, so the columns are checked too.
+			expect(await columnNames(db, "_emdash_authorization_codes")).toEqual(
+				expect.arrayContaining([
+					"code_hash",
+					"client_id",
+					"redirect_uri",
+					"user_id",
+					"scopes",
+					"code_challenge",
+					"code_challenge_method",
+					"resource",
+					"expires_at",
+					"created_at",
+				]),
+			);
+		});
+
+		it("recovers when the table and index were created before the crash", async () => {
+			await up(db);
+			await sql`ALTER TABLE _emdash_oauth_tokens DROP COLUMN client_id`.execute(db);
+
+			await expect(up(db)).resolves.not.toThrow();
+
+			expect(await columnNames(db, "_emdash_oauth_tokens")).toContain("client_id");
+		});
+
+		// The migrator clears the migration row only once `down()` returns, so a
+		// cut-short rollback leaves the table dropped and 017 still recorded.
+		it("recovers when the table was already dropped by an interrupted rollback", async () => {
+			await up(db);
+			await down(db);
+
+			await expect(down(db)).resolves.not.toThrow();
+
+			expect(await tableNames(db)).not.toContain("_emdash_authorization_codes");
+		});
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Lets a Cloudflare D1 database finish migrating after migration 017 was interrupted. D1 auto-commits each DDL statement and the migrator records a migration only after `up` returns, so a run cut short after the first statement leaves the authorization-codes table in place with 017 still pending; every later request replays it from the top and fails with `table "_emdash_authorization_codes" already exists`.

The migration now guards every statement the way 016 was hardened in #976: the table and index with `IF NOT EXISTS`, the client_id column with an existence check, the rollback's drop with `IF EXISTS`. The migrator clears the row only after `down` returns, so an interrupted rollback strands its own retry the same way, on a path reachable from the test suite rather than from a deploy. A correction migration cannot do any of this, because the migrator stops at the first failure and nothing after 017 runs until 017 completes. Databases that already ran 017 are unaffected. 25 of the 72 registered migrations fail the same replay on D1; that is a separate Discussion, not this fix.

Closes: N/A. Found while adding the real-D1 migration coverage for #1689.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (n/a: no admin UI change)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a: bug fix)
- [ ] I have included screenshots below if this PR changes the UI (n/a: no UI change)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5, Claude Fable 5.1

## Screenshots / test output

Not applicable. `pnpm vitest run tests/unit/database/migrations/017_authorization_codes.test.ts` in packages/core: 6 passed; against the migration on `main`, 4 failed — three with `table "_emdash_authorization_codes" already exists`, one with `no such table: _emdash_authorization_codes`.
