### PR TITLE
fix: group Archives widget posts when publishedAt is a Date

### DIFF
--- a/.changeset/archives-published-at-dates.md
+++ b/.changeset/archives-published-at-dates.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the Archives widget so monthly and yearly lists include posts whose `publishedAt` value is a `Date` object instead of rendering an empty list.

--- a/packages/core/src/components/widgets/Archives.astro
+++ b/packages/core/src/components/widgets/Archives.astro
@@ -1,5 +1,6 @@
 ---
 import { getEmDashCollection } from "../../query.js";
+import { groupEntriesByPublishedAt } from "../../widgets/archives.js";
 
 interface Props {
 	type?: "monthly" | "yearly";
@@ -8,47 +9,11 @@ interface Props {
 
 const { type = "monthly", limit = 12 } = Astro.props;
 
-// Get all posts to build archives
 const { entries: posts } = await getEmDashCollection("posts", {
 	orderBy: { published_at: "desc" },
 });
 
-// Group posts by date
-const archives = new Map<string, { label: string; count: number; url: string }>();
-
-for (const post of posts) {
-	const publishedAt = post.data.publishedAt;
-	if (typeof publishedAt !== "string") continue;
-
-	const date = new Date(publishedAt);
-	let key: string;
-	let label: string;
-	let url: string;
-
-	if (type === "yearly") {
-		const year = date.getFullYear();
-		key = `${year}`;
-		label = `${year}`;
-		url = `/archives/${year}`;
-	} else {
-		const year = date.getFullYear();
-		const month = date.getMonth() + 1;
-		key = `${year}-${month.toString().padStart(2, "0")}`;
-		label = date.toLocaleDateString("en-US", {
-			year: "numeric",
-			month: "long",
-		});
-		url = `/archives/${year}/${month.toString().padStart(2, "0")}`;
-	}
-
-	if (!archives.has(key)) {
-		archives.set(key, { label, count: 0, url });
-	}
-	archives.get(key)!.count++;
-}
-
-// Convert to array and limit
-const archiveList = [...archives.values()].slice(0, limit);
+const archiveList = groupEntriesByPublishedAt(posts, { type, limit });
 ---
 
 <ul class="widget-archives">

--- a/packages/core/src/widgets/archives.ts
+++ b/packages/core/src/widgets/archives.ts
@@ -20,8 +20,8 @@ function toPublishedDate(value: unknown): Date | null {
 /**
  * Group collection entries by published date for the Archives widget.
  *
- * `getEmDashCollection()` returns `publishedAt` as a `Date`. The widget used
- * to skip every non-string value, so the list was always empty.
+ * Accepts `Date` objects, ISO strings, and numeric timestamps; `getEmDashCollection()`
+ * returns `publishedAt` as a `Date`.
  */
 export function groupEntriesByPublishedAt(
 	entries: Array<{ data: { publishedAt?: unknown } }>,

--- a/packages/core/src/widgets/archives.ts
+++ b/packages/core/src/widgets/archives.ts
@@ -1,0 +1,67 @@
+export type ArchiveGroupType = "monthly" | "yearly";
+
+export interface ArchiveGroup {
+	label: string;
+	count: number;
+	url: string;
+}
+
+function toPublishedDate(value: unknown): Date | null {
+	if (value instanceof Date) {
+		return Number.isNaN(value.getTime()) ? null : value;
+	}
+	if (typeof value === "string" || typeof value === "number") {
+		const date = new Date(value);
+		return Number.isNaN(date.getTime()) ? null : date;
+	}
+	return null;
+}
+
+/**
+ * Group collection entries by published date for the Archives widget.
+ *
+ * `getEmDashCollection()` returns `publishedAt` as a `Date`. The widget used
+ * to skip every non-string value, so the list was always empty.
+ */
+export function groupEntriesByPublishedAt(
+	entries: Array<{ data: { publishedAt?: unknown } }>,
+	options: { type?: ArchiveGroupType; limit?: number } = {},
+): ArchiveGroup[] {
+	const type = options.type ?? "monthly";
+	const limit = options.limit ?? 12;
+	const archives = new Map<string, ArchiveGroup>();
+
+	for (const entry of entries) {
+		const date = toPublishedDate(entry.data.publishedAt);
+		if (!date) continue;
+
+		let key: string;
+		let label: string;
+		let url: string;
+
+		if (type === "yearly") {
+			const year = date.getFullYear();
+			key = `${year}`;
+			label = `${year}`;
+			url = `/archives/${year}`;
+		} else {
+			const year = date.getFullYear();
+			const month = date.getMonth() + 1;
+			key = `${year}-${month.toString().padStart(2, "0")}`;
+			label = date.toLocaleDateString("en-US", {
+				year: "numeric",
+				month: "long",
+			});
+			url = `/archives/${year}/${month.toString().padStart(2, "0")}`;
+		}
+
+		const existing = archives.get(key);
+		if (existing) {
+			existing.count++;
+		} else {
+			archives.set(key, { label, count: 1, url });
+		}
+	}
+
+	return [...archives.values()].slice(0, limit);
+}

--- a/packages/core/tests/unit/widgets/archives.test.ts
+++ b/packages/core/tests/unit/widgets/archives.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { groupEntriesByPublishedAt } from "../../../src/widgets/archives.js";
+
+function entry(publishedAt: unknown) {
+	return { data: { publishedAt } };
+}
+
+describe("groupEntriesByPublishedAt", () => {
+	it("groups Date publishedAt values by month instead of skipping them", () => {
+		const groups = groupEntriesByPublishedAt(
+			[entry(new Date(2026, 2, 15)), entry(new Date(2026, 2, 20)), entry(new Date(2026, 1, 1))],
+			{ type: "monthly" },
+		);
+
+		expect(groups).toEqual([
+			{
+				label: "March 2026",
+				count: 2,
+				url: "/archives/2026/03",
+			},
+			{
+				label: "February 2026",
+				count: 1,
+				url: "/archives/2026/02",
+			},
+		]);
+	});
+
+	it("still accepts ISO date strings", () => {
+		const groups = groupEntriesByPublishedAt([entry("2026-07-04T12:00:00.000Z")], {
+			type: "monthly",
+		});
+
+		expect(groups).toHaveLength(1);
+		expect(groups[0]?.count).toBe(1);
+		expect(groups[0]?.url).toMatch(/^\/archives\/\d{4}\/\d{2}$/);
+	});
+
+	it("groups by year when type is yearly", () => {
+		const groups = groupEntriesByPublishedAt(
+			[entry(new Date(2025, 11, 1)), entry(new Date(2026, 0, 1)), entry(new Date(2026, 6, 1))],
+			{ type: "yearly" },
+		);
+
+		expect(groups).toEqual([
+			{ label: "2025", count: 1, url: "/archives/2025" },
+			{ label: "2026", count: 2, url: "/archives/2026" },
+		]);
+	});
+
+	it("skips missing and invalid publishedAt values", () => {
+		const groups = groupEntriesByPublishedAt(
+			[
+				entry(null),
+				entry(undefined),
+				entry(""),
+				entry("not-a-date"),
+				entry(new Date(Number.NaN)),
+				entry(new Date(2026, 4, 1)),
+			],
+			{ type: "monthly" },
+		);
+
+		expect(groups).toEqual([
+			{
+				label: "May 2026",
+				count: 1,
+				url: "/archives/2026/05",
+			},
+		]);
+	});
+
+	it("respects the limit", () => {
+		const groups = groupEntriesByPublishedAt(
+			[entry(new Date(2026, 0, 1)), entry(new Date(2026, 1, 1)), entry(new Date(2026, 2, 1))],
+			{ type: "monthly", limit: 2 },
+		);
+
+		expect(groups).toHaveLength(2);
+		expect(groups.map((group) => group.url)).toEqual(["/archives/2026/01", "/archives/2026/02"]);
+	});
+});

--- a/packages/core/tests/unit/widgets/archives.test.ts
+++ b/packages/core/tests/unit/widgets/archives.test.ts
@@ -39,13 +39,13 @@ describe("groupEntriesByPublishedAt", () => {
 
 	it("groups by year when type is yearly", () => {
 		const groups = groupEntriesByPublishedAt(
-			[entry(new Date(2025, 11, 1)), entry(new Date(2026, 0, 1)), entry(new Date(2026, 6, 1))],
+			[entry(new Date(2026, 6, 1)), entry(new Date(2026, 0, 1)), entry(new Date(2025, 11, 1))],
 			{ type: "yearly" },
 		);
 
 		expect(groups).toEqual([
-			{ label: "2025", count: 1, url: "/archives/2025" },
 			{ label: "2026", count: 2, url: "/archives/2026" },
+			{ label: "2025", count: 1, url: "/archives/2025" },
 		]);
 	});
 


### PR DESCRIPTION
## What does this PR do?

The Archives widget skipped every post whose `publishedAt` was not a string. `getEmDashCollection()` returns that field as a `Date`, so the widget rendered an empty list on every site.

Grouping now accepts `Date` and string values, and only skips missing or invalid dates. Monthly and yearly counts are covered by unit tests.

Closes #2838

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor Grok 4.6

## Screenshots / test output

Not a visual restyle. The widget markup is unchanged; it was empty because every `Date` was skipped.

Targeted tests:

```
pnpm --filter emdash exec vitest run tests/unit/widgets/archives.test.ts
Test Files  1 passed (1)
Tests  5 passed (5)
```

`pnpm lint:quick` reported 0 diagnostics. Full `pnpm typecheck` / `pnpm lint` were not run against a complete workspace build in this environment (missing package `dist/` types until `pnpm build`).

Made with [Cursor](https://cursor.com)
