### PR TITLE
test(core): run core migrations and queries against real D1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,25 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter emdash exec vitest run --config vitest.integration.config.ts
 
+  test-workerd:
+    name: D1 Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # The suite imports the Cloudflare package, which resolves `emdash`
+      # through its published entry points rather than source.
+      - run: pnpm run --filter emdash... build
+      - run: pnpm --filter emdash exec vitest run --config vitest.workerd.config.ts
+
   test-browser:
     name: Browser Tests
     runs-on: ubuntu-latest

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -211,7 +211,7 @@ export interface MigrationOptions {
 	raceWaitMs?: number;
 }
 
-function createMigrator(db: Kysely<Database>, options?: MigrationOptions): Migrator {
+export function createMigrator(db: Kysely<Database>, options?: MigrationOptions): Migrator {
 	return new Migrator({
 		db,
 		provider: new StaticMigrationProvider(),

--- a/packages/core/tests/unit/database/migrations/036_i18n_menus_and_taxonomies.test.ts
+++ b/packages/core/tests/unit/database/migrations/036_i18n_menus_and_taxonomies.test.ts
@@ -7,6 +7,7 @@ import { createDatabase } from "../../../../src/database/connection.js";
 import { down, up } from "../../../../src/database/migrations/036_i18n_menus_and_taxonomies.js";
 import type { Database } from "../../../../src/database/types.js";
 import { setI18nConfig } from "../../../../src/i18n/config.js";
+import { seedPreI18nSchema } from "../../../utils/pre-i18n-schema.js";
 
 /**
  * Build a Kysely instance backed by better-sqlite3 with foreign keys ON and
@@ -31,106 +32,12 @@ function createD1LikeDatabase(): Kysely<Database> {
 	return new KyselyCtor<Database>({ dialect });
 }
 
-/**
- * Seed the four pre-i18n tables that migration 036 widens, plus the support
- * tables it reads (`_emdash_collections`, `ec_posts`). Mirrors the schema
- * shape immediately before this migration runs in production.
- */
-async function seedPreMigrationSchema(db: Kysely<Database>): Promise<void> {
-	await sql`
-		CREATE TABLE _emdash_menus (
-			id TEXT PRIMARY KEY,
-			name TEXT NOT NULL UNIQUE,
-			label TEXT NOT NULL,
-			created_at TEXT DEFAULT (datetime('now')),
-			updated_at TEXT DEFAULT (datetime('now'))
-		)
-	`.execute(db);
-
-	await sql`
-		CREATE TABLE _emdash_menu_items (
-			id TEXT PRIMARY KEY,
-			menu_id TEXT NOT NULL,
-			parent_id TEXT,
-			sort_order INTEGER NOT NULL DEFAULT 0,
-			type TEXT NOT NULL,
-			reference_collection TEXT,
-			reference_id TEXT,
-			custom_url TEXT,
-			label TEXT NOT NULL,
-			title_attr TEXT,
-			target TEXT,
-			css_classes TEXT,
-			created_at TEXT DEFAULT (datetime('now')),
-			CONSTRAINT menu_items_menu_fk FOREIGN KEY (menu_id)
-				REFERENCES _emdash_menus(id) ON DELETE CASCADE,
-			CONSTRAINT menu_items_parent_fk FOREIGN KEY (parent_id)
-				REFERENCES _emdash_menu_items(id) ON DELETE CASCADE
-		)
-	`.execute(db);
-
-	await sql`CREATE INDEX idx_menu_items_menu ON _emdash_menu_items(menu_id, sort_order)`.execute(
-		db,
-	);
-	await sql`CREATE INDEX idx_menu_items_parent ON _emdash_menu_items(parent_id)`.execute(db);
-
-	await sql`
-		CREATE TABLE taxonomies (
-			id TEXT PRIMARY KEY,
-			name TEXT NOT NULL,
-			slug TEXT NOT NULL,
-			label TEXT NOT NULL,
-			parent_id TEXT,
-			data TEXT,
-			UNIQUE(name, slug),
-			FOREIGN KEY (parent_id) REFERENCES taxonomies(id) ON DELETE SET NULL
-		)
-	`.execute(db);
-
-	await sql`
-		CREATE TABLE _emdash_taxonomy_defs (
-			id TEXT PRIMARY KEY,
-			name TEXT NOT NULL UNIQUE,
-			label TEXT NOT NULL,
-			label_singular TEXT,
-			hierarchical INTEGER DEFAULT 0,
-			collections TEXT,
-			created_at TEXT DEFAULT (datetime('now'))
-		)
-	`.execute(db);
-
-	await sql`
-		CREATE TABLE content_taxonomies (
-			collection TEXT NOT NULL,
-			entry_id TEXT NOT NULL,
-			taxonomy_id TEXT NOT NULL,
-			PRIMARY KEY (collection, entry_id, taxonomy_id),
-			FOREIGN KEY (taxonomy_id) REFERENCES taxonomies(id) ON DELETE CASCADE
-		)
-	`.execute(db);
-
-	await sql`
-		CREATE TABLE _emdash_collections (
-			slug TEXT PRIMARY KEY
-		)
-	`.execute(db);
-
-	// translation_group is added to ec_* by migration 019; 036 reads it during remap.
-	await sql`
-		CREATE TABLE ec_posts (
-			id TEXT PRIMARY KEY,
-			locale TEXT NOT NULL DEFAULT 'en',
-			translation_group TEXT
-		)
-	`.execute(db);
-}
-
 describe("036_i18n_menus_and_taxonomies migration", () => {
 	let db: Kysely<Database>;
 
 	beforeEach(async () => {
 		db = createDatabase({ url: ":memory:" });
-		await seedPreMigrationSchema(db);
+		await seedPreI18nSchema(db);
 	});
 
 	afterEach(async () => {
@@ -191,7 +98,7 @@ describe("036_i18n_menus_and_taxonomies migration", () => {
 			// the FK already gone and the index still missing.
 			await db.destroy();
 			db = createDatabase({ url: ":memory:" });
-			await seedPreMigrationSchema(db);
+			await seedPreI18nSchema(db);
 			await sql`DROP TABLE content_taxonomies`.execute(db);
 			await sql`
 				CREATE TABLE content_taxonomies (
@@ -314,7 +221,7 @@ describe("036_i18n_menus_and_taxonomies migration", () => {
 			// enforcement.
 			await db.destroy();
 			db = createD1LikeDatabase();
-			await seedPreMigrationSchema(db);
+			await seedPreI18nSchema(db);
 			await sql`INSERT INTO taxonomies (id, name, slug, label) VALUES ('news', 'category', 'news', 'News')`.execute(
 				db,
 			);
@@ -338,7 +245,7 @@ describe("036_i18n_menus_and_taxonomies migration", () => {
 			// that mimics D1's locked-on FK enforcement.
 			await db.destroy();
 			db = createD1LikeDatabase();
-			await seedPreMigrationSchema(db);
+			await seedPreI18nSchema(db);
 			await sql`INSERT INTO taxonomies (id, name, slug, label) VALUES ('news', 'category', 'news', 'News')`.execute(
 				db,
 			);
@@ -363,7 +270,7 @@ describe("036_i18n_menus_and_taxonomies migration", () => {
 			// first to physically strip both FKs.
 			await db.destroy();
 			db = createD1LikeDatabase();
-			await seedPreMigrationSchema(db);
+			await seedPreI18nSchema(db);
 			await sql`INSERT INTO _emdash_menus (id, name, label) VALUES ('main', 'main', 'Main')`.execute(
 				db,
 			);
@@ -397,7 +304,7 @@ describe("036_i18n_menus_and_taxonomies migration", () => {
 			// re-trigger the same cascade on D1.
 			await db.destroy();
 			db = createD1LikeDatabase();
-			await seedPreMigrationSchema(db);
+			await seedPreI18nSchema(db);
 
 			await up(db);
 
@@ -565,7 +472,7 @@ describe("036_i18n_menus_and_taxonomies migration", () => {
 			// removed the FK that would otherwise wipe child rows.
 			await db.destroy();
 			db = createD1LikeDatabase();
-			await seedPreMigrationSchema(db);
+			await seedPreI18nSchema(db);
 			await sql`INSERT INTO _emdash_menus (id, name, label) VALUES ('main', 'main', 'Main')`.execute(
 				db,
 			);

--- a/packages/core/tests/utils/pre-i18n-schema.ts
+++ b/packages/core/tests/utils/pre-i18n-schema.ts
@@ -1,0 +1,97 @@
+import { type Kysely, sql } from "kysely";
+
+import type { Database } from "../../src/database/types.js";
+
+/**
+ * Seed the four pre-i18n tables that migration 036 widens, plus the support
+ * tables it reads (`_emdash_collections`, `ec_posts`). Mirrors the schema
+ * shape immediately before this migration runs in production.
+ */
+export async function seedPreI18nSchema(db: Kysely<Database>): Promise<void> {
+	await sql`
+		CREATE TABLE _emdash_menus (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL UNIQUE,
+			label TEXT NOT NULL,
+			created_at TEXT DEFAULT (datetime('now')),
+			updated_at TEXT DEFAULT (datetime('now'))
+		)
+	`.execute(db);
+
+	await sql`
+		CREATE TABLE _emdash_menu_items (
+			id TEXT PRIMARY KEY,
+			menu_id TEXT NOT NULL,
+			parent_id TEXT,
+			sort_order INTEGER NOT NULL DEFAULT 0,
+			type TEXT NOT NULL,
+			reference_collection TEXT,
+			reference_id TEXT,
+			custom_url TEXT,
+			label TEXT NOT NULL,
+			title_attr TEXT,
+			target TEXT,
+			css_classes TEXT,
+			created_at TEXT DEFAULT (datetime('now')),
+			CONSTRAINT menu_items_menu_fk FOREIGN KEY (menu_id)
+				REFERENCES _emdash_menus(id) ON DELETE CASCADE,
+			CONSTRAINT menu_items_parent_fk FOREIGN KEY (parent_id)
+				REFERENCES _emdash_menu_items(id) ON DELETE CASCADE
+		)
+	`.execute(db);
+
+	await sql`CREATE INDEX idx_menu_items_menu ON _emdash_menu_items(menu_id, sort_order)`.execute(
+		db,
+	);
+	await sql`CREATE INDEX idx_menu_items_parent ON _emdash_menu_items(parent_id)`.execute(db);
+
+	await sql`
+		CREATE TABLE taxonomies (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			slug TEXT NOT NULL,
+			label TEXT NOT NULL,
+			parent_id TEXT,
+			data TEXT,
+			UNIQUE(name, slug),
+			FOREIGN KEY (parent_id) REFERENCES taxonomies(id) ON DELETE SET NULL
+		)
+	`.execute(db);
+
+	await sql`
+		CREATE TABLE _emdash_taxonomy_defs (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL UNIQUE,
+			label TEXT NOT NULL,
+			label_singular TEXT,
+			hierarchical INTEGER DEFAULT 0,
+			collections TEXT,
+			created_at TEXT DEFAULT (datetime('now'))
+		)
+	`.execute(db);
+
+	await sql`
+		CREATE TABLE content_taxonomies (
+			collection TEXT NOT NULL,
+			entry_id TEXT NOT NULL,
+			taxonomy_id TEXT NOT NULL,
+			PRIMARY KEY (collection, entry_id, taxonomy_id),
+			FOREIGN KEY (taxonomy_id) REFERENCES taxonomies(id) ON DELETE CASCADE
+		)
+	`.execute(db);
+
+	await sql`
+		CREATE TABLE _emdash_collections (
+			slug TEXT PRIMARY KEY
+		)
+	`.execute(db);
+
+	// translation_group is added to ec_* by migration 019; 036 reads it during remap.
+	await sql`
+		CREATE TABLE ec_posts (
+			id TEXT PRIMARY KEY,
+			locale TEXT NOT NULL DEFAULT 'en',
+			translation_group TEXT
+		)
+	`.execute(db);
+}

--- a/packages/core/tests/workerd/d1-schema.ts
+++ b/packages/core/tests/workerd/d1-schema.ts
@@ -1,0 +1,97 @@
+import { type Kysely, sql } from "kysely";
+
+import type { Database } from "../../src/database/types.js";
+
+/**
+ * Names that may be interpolated into raw SQL here.
+ *
+ * The core tables start with an underscore, which `validateIdentifier()` from
+ * `database/validate.ts` rejects, so this is a local widening of that pattern
+ * rather than a call to it. The names come from `sqlite_master`, but AGENTS.md
+ * asks for a check before any identifier reaches `sql.raw`.
+ */
+const SAFE_OBJECT_NAME = /^[a-z_][a-z0-9_]*$/;
+
+function safeName(name: string): string {
+	if (!SAFE_OBJECT_NAME.test(name)) {
+		throw new Error(`resetD1Schema refuses to interpolate the object name: ${name}`);
+	}
+	return name;
+}
+
+/**
+ * Drop every object in the D1 database so the next test starts empty.
+ *
+ * The pool's D1 binding keeps its contents for the whole test file, and D1
+ * enforces foreign keys with no way to suspend them, so tables are dropped
+ * children first.
+ */
+export async function resetD1Schema(db: Kysely<Database>): Promise<void> {
+	for (const type of ["view", "trigger"] as const) {
+		const objects = await sql<{ name: string }>`
+			SELECT name FROM sqlite_master WHERE type = ${type} AND name NOT LIKE 'sqlite_%'
+		`.execute(db);
+		for (const { name } of objects.rows) {
+			await sql.raw(`DROP ${type.toUpperCase()} IF EXISTS "${safeName(name)}"`).execute(db);
+		}
+	}
+
+	for (const name of await dropOrder(db)) {
+		await sql.raw(`DROP TABLE IF EXISTS "${safeName(name)}"`).execute(db);
+	}
+
+	const left = await listTables(db);
+	if (left.length > 0) {
+		throw new Error(`resetD1Schema left tables behind: ${left.join(", ")}`);
+	}
+}
+
+/**
+ * Order the tables so each one is dropped before the tables it points at.
+ * Self-references are ignored; a reference cycle is reported, not spun on.
+ */
+async function dropOrder(db: Kysely<Database>): Promise<string[]> {
+	const parents = new Map<string, Set<string>>();
+	for (const table of await listTables(db)) {
+		const rows = await sql<{ table: string }>`PRAGMA foreign_key_list(${sql.ref(table)})`.execute(
+			db,
+		);
+		parents.set(table, new Set(rows.rows.map((row) => row.table).filter((name) => name !== table)));
+	}
+
+	const ordered: string[] = [];
+	while (parents.size > 0) {
+		const referenced = new Set([...parents.values()].flatMap((set) => [...set]));
+		const free = [...parents.keys()].filter((table) => !referenced.has(table));
+		if (free.length === 0) {
+			throw new Error(`resetD1Schema found a foreign-key cycle: ${[...parents.keys()].join(", ")}`);
+		}
+		for (const table of free) parents.delete(table);
+		ordered.push(...free);
+	}
+	return ordered;
+}
+
+/** User table names currently in the database, in no particular order. */
+export async function listTables(db: Kysely<Database>): Promise<string[]> {
+	const rows = await sql<{ name: string }>`
+		SELECT name FROM sqlite_master
+		WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_cf_%'
+	`.execute(db);
+	return rows.rows.map((row) => row.name);
+}
+
+/** Index names declared on a table, excluding the ones SQLite creates itself. */
+export async function listIndexes(db: Kysely<Database>, table: string): Promise<string[]> {
+	const rows = await sql<{ name: string }>`
+		SELECT name FROM sqlite_master
+		WHERE type = 'index' AND tbl_name = ${table} AND name NOT LIKE 'sqlite_%'
+	`.execute(db);
+	return rows.rows.map((row) => row.name).toSorted();
+}
+
+/** Column names of a table in declaration order. */
+export async function listColumns(db: Kysely<Database>, table: string): Promise<string[]> {
+	const rows = await sql<{ name: string }>`PRAGMA table_info(${sql.ref(table)})`.execute(db);
+	return rows.rows.map((row) => row.name);
+}

--- a/packages/core/tests/workerd/loader-wide-collection-d1.test.ts
+++ b/packages/core/tests/workerd/loader-wide-collection-d1.test.ts
@@ -1,0 +1,139 @@
+import { env } from "cloudflare:test";
+import { Kysely, sql } from "kysely";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { RawBindingD1Dialect } from "../../../cloudflare/src/db/d1-dialect.js";
+import { handleContentCreate } from "../../src/api/index.js";
+import { runMigrations } from "../../src/database/migrations/runner.js";
+import { SeoRepository } from "../../src/database/repositories/seo.js";
+import type { Database } from "../../src/database/types.js";
+import { emdashLoader } from "../../src/loader.js";
+import { runWithContext } from "../../src/request-context.js";
+import { SchemaRegistry } from "../../src/schema/registry.js";
+import { listColumns, resetD1Schema } from "./d1-schema.js";
+
+declare module "cloudflare:test" {
+	interface ProvidedEnv {
+		DB: D1Database;
+	}
+}
+
+/**
+ * The loader's entry read at the widest collection D1 can still return.
+ *
+ * D1 caps a result set at 100 columns. `loadEntry` selects `c.*` plus the
+ * folded hydration columns, so 96 table columns is the widest collection that
+ * still leaves them room under the cap.
+ */
+const COLLECTION = "wide_d1";
+/** Takes `ec_wide_d1` to LOADABLE_TABLE_WIDTH alongside `title`. */
+const USER_FIELD_COUNT = 80;
+/** 15 system columns plus `title` plus USER_FIELD_COUNT. */
+const LOADABLE_TABLE_WIDTH = 96;
+
+let db: Kysely<Database>;
+let seoRepo: SeoRepository;
+
+beforeAll(async () => {
+	db = new Kysely<Database>({ dialect: new RawBindingD1Dialect({ database: env.DB }) });
+	await resetD1Schema(db);
+	await runMigrations(db);
+
+	const registry = new SchemaRegistry(db);
+	await registry.createCollection({
+		slug: COLLECTION,
+		label: "Wide D1",
+		labelSingular: "Wide D1 Entry",
+	});
+	await registry.createField(COLLECTION, { slug: "title", label: "Title", type: "string" });
+	for (let i = 1; i <= USER_FIELD_COUNT; i++) {
+		await registry.createField(COLLECTION, {
+			slug: `field_${i}`,
+			label: `Field ${i}`,
+			type: "string",
+		});
+	}
+	await db
+		.updateTable("_emdash_collections")
+		.set({ has_seo: 1 })
+		.where("slug", "=", COLLECTION)
+		.execute();
+
+	seoRepo = new SeoRepository(db);
+});
+
+afterAll(async () => {
+	await db.destroy();
+});
+
+function load(idOrSlug: string) {
+	const loader = emdashLoader();
+	return runWithContext({ db, editMode: false }, () =>
+		loader.loadEntry!({ filter: { type: COLLECTION, id: idOrSlug } }),
+	);
+}
+
+async function createEntry(title: string): Promise<{ id: string; slug: string }> {
+	const data: Record<string, string> = { title };
+	for (let i = 1; i <= USER_FIELD_COUNT; i++) data[`field_${i}`] = `value-${i}`;
+	const result = await handleContentCreate(db, COLLECTION, { data, status: "published" });
+	if (!result.success) throw new Error(`Failed to create entry: ${JSON.stringify(result)}`);
+	const item = result.data!.item;
+	return { id: item.id, slug: item.slug! };
+}
+
+describe("loader on a wide collection on D1", () => {
+	it("builds the collection at the loadable width", async () => {
+		expect(await listColumns(db, `ec_${COLLECTION}`)).toHaveLength(LOADABLE_TABLE_WIDTH);
+	});
+
+	it("rejects five flat columns on top of c.* at this width", async () => {
+		// Five alias columns on top of `c.*` ask D1 for 101 columns here, and
+		// D1 refuses the statement rather than truncating it.
+		await expect(
+			sql
+				.raw(
+					`SELECT c.*, s.seo_no_index, s.seo_canonical, s.seo_title, s.seo_description, s.seo_image
+					 FROM ec_${COLLECTION} c
+					 LEFT JOIN _emdash_seo s ON s.collection = '${COLLECTION}' AND s.content_id = c.id`,
+				)
+				.execute(db),
+		).rejects.toThrow(/too many columns in result set/);
+	});
+
+	it("loads an entry at the loadable width", async () => {
+		const { slug } = await createEntry("Wide Entry");
+
+		const loaded = await load(slug);
+
+		const data = (loaded as { data: Record<string, unknown> }).data;
+		expect(data.title).toBe("Wide Entry");
+		expect(data.field_1).toBe("value-1");
+		expect(data.field_80).toBe("value-80");
+	});
+
+	it("still attaches data.seo at the loadable width", async () => {
+		const { id, slug } = await createEntry("Wide With SEO");
+		await seoRepo.upsert(COLLECTION, id, {
+			noIndex: true,
+			canonical: "https://example.com/wide",
+			title: "Wide SEO Title",
+		});
+
+		const loaded = await load(slug);
+
+		const seo = (loaded as { data: Record<string, unknown> }).data.seo as Record<string, unknown>;
+		expect(seo).toBeDefined();
+		expect(seo.noIndex).toBe(true);
+		expect(seo.canonical).toBe("https://example.com/wide");
+		expect(seo.title).toBe("Wide SEO Title");
+	});
+
+	it("omits data.seo at the loadable width when no SEO row exists", async () => {
+		const { slug } = await createEntry("No SEO");
+
+		const loaded = await load(slug);
+
+		expect((loaded as { data: Record<string, unknown> }).data.seo).toBeUndefined();
+	});
+});

--- a/packages/core/tests/workerd/migrations-d1.test.ts
+++ b/packages/core/tests/workerd/migrations-d1.test.ts
@@ -1,0 +1,209 @@
+import { env } from "cloudflare:test";
+import { Kysely, sql } from "kysely";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { RawBindingD1Dialect } from "../../../cloudflare/src/db/d1-dialect.js";
+import { up as up016 } from "../../src/database/migrations/016_api_tokens.js";
+import { up as up036 } from "../../src/database/migrations/036_i18n_menus_and_taxonomies.js";
+import {
+	MIGRATION_COUNT,
+	MIGRATION_NAMES,
+	createMigrator,
+	getExactMigrationStatus,
+	runMigrations,
+} from "../../src/database/migrations/runner.js";
+import type { Database } from "../../src/database/types.js";
+import { seedPreI18nSchema } from "../utils/pre-i18n-schema.js";
+import { listColumns, listIndexes, listTables, resetD1Schema } from "./d1-schema.js";
+
+declare module "cloudflare:test" {
+	interface ProvidedEnv {
+		DB: D1Database;
+	}
+}
+
+let db: Kysely<Database>;
+
+beforeAll(() => {
+	db = new Kysely<Database>({ dialect: new RawBindingD1Dialect({ database: env.DB }) });
+});
+
+beforeEach(async () => {
+	await resetD1Schema(db);
+});
+
+afterAll(async () => {
+	await db.destroy();
+});
+
+describe("core migrations on D1", () => {
+	it("applies every registered migration to an empty database", async () => {
+		const { applied } = await runMigrations(db);
+
+		expect(applied).toEqual([...MIGRATION_NAMES]);
+		const status = await getExactMigrationStatus(db);
+		expect(status.pending).toEqual([]);
+		expect(status.unknownApplied).toEqual([]);
+		expect(status.knownApplied).toHaveLength(MIGRATION_COUNT);
+	});
+
+	it("applies nothing on a second run", async () => {
+		await runMigrations(db);
+
+		const { applied } = await runMigrations(db);
+
+		expect(applied).toEqual([]);
+		const rows = await db.selectFrom("_emdash_migrations").selectAll().execute();
+		expect(rows).toHaveLength(MIGRATION_COUNT);
+	});
+});
+
+describe("retry after a partial run on D1", () => {
+	// D1 auto-commits each DDL statement, so a run that dies partway leaves
+	// the schema changed and the bookkeeping row missing. The next request
+	// reruns the migration against its own output, and an unguarded CREATE
+	// there fails on every boot from then on.
+	async function migrateThrough(name: string): Promise<void> {
+		const { error } = await createMigrator(db).migrateTo(name);
+		if (error) throw error;
+	}
+
+	it("finishes 016 after a run that stopped after its first statement", async () => {
+		await migrateThrough("015_indexes");
+		await up016(db);
+		await sql`DROP INDEX idx_api_tokens_user_id`.execute(db);
+		await sql`DROP INDEX idx_api_tokens_token_hash`.execute(db);
+		await sql`DROP TABLE _emdash_device_codes`.execute(db);
+		await sql`DROP TABLE _emdash_oauth_tokens`.execute(db);
+
+		const { applied } = await runMigrations(db);
+
+		expect(applied).toEqual(MIGRATION_NAMES.slice(MIGRATION_NAMES.indexOf("016_api_tokens")));
+		expect(await listTables(db)).toEqual(
+			expect.arrayContaining([
+				"_emdash_api_tokens",
+				"_emdash_oauth_tokens",
+				"_emdash_device_codes",
+			]),
+		);
+		expect(await listIndexes(db, "_emdash_api_tokens")).toEqual([
+			"idx_api_tokens_token_hash",
+			"idx_api_tokens_user_id",
+		]);
+		expect((await getExactMigrationStatus(db)).pending).toEqual([]);
+	});
+
+	it("records 016 after a run that stopped before its bookkeeping row", async () => {
+		await migrateThrough("015_indexes");
+		await up016(db);
+
+		const { applied } = await runMigrations(db);
+
+		expect(applied[0]).toBe("016_api_tokens");
+		expect((await getExactMigrationStatus(db)).pending).toEqual([]);
+	});
+});
+
+describe("036 taxonomy rebuild on D1", () => {
+	it("keeps content_taxonomies rows the FK cascade would take", async () => {
+		// D1 enforces foreign keys and ignores `PRAGMA foreign_keys = OFF`,
+		// so dropping `taxonomies` during the rebuild cascades into
+		// `content_taxonomies` unless the FK is physically removed first.
+		await seedPreI18nSchema(db);
+		await sql`PRAGMA foreign_keys = OFF`.execute(db);
+		const pragma = await sql<{ foreign_keys: number }>`PRAGMA foreign_keys`.execute(db);
+		expect(pragma.rows[0]?.foreign_keys).toBe(1);
+
+		await sql`INSERT INTO taxonomies (id, name, slug, label) VALUES ('news', 'category', 'news', 'News')`.execute(
+			db,
+		);
+		await sql`INSERT INTO content_taxonomies (collection, entry_id, taxonomy_id) VALUES ('posts', 'p1', 'news')`.execute(
+			db,
+		);
+
+		await up036(db);
+
+		const rows = await sql<{ entry_id: string }>`
+			SELECT entry_id FROM content_taxonomies
+		`.execute(db);
+		expect(rows.rows).toEqual([{ entry_id: "p1" }]);
+	});
+
+	it("keeps menu items the menus rebuild would cascade away", async () => {
+		await seedPreI18nSchema(db);
+		await sql`INSERT INTO _emdash_menus (id, name, label) VALUES ('main', 'main', 'Main')`.execute(
+			db,
+		);
+		await sql`
+			INSERT INTO _emdash_menu_items (id, menu_id, type, label)
+			VALUES ('item-1', 'main', 'custom', 'Home')
+		`.execute(db);
+
+		await up036(db);
+
+		const rows = await sql<{ id: string }>`SELECT id FROM _emdash_menu_items`.execute(db);
+		expect(rows.rows).toEqual([{ id: "item-1" }]);
+	});
+
+	it("restores idx_content_taxonomies_term when a first run stopped after the drop", async () => {
+		// A first run that committed the content_taxonomies rebuild and died
+		// before the index recreate leaves the table with no FK and no index;
+		// the retry finds nothing to strip and must still recreate the index.
+		await seedPreI18nSchema(db);
+		await sql`DROP TABLE content_taxonomies`.execute(db);
+		await sql`
+			CREATE TABLE content_taxonomies (
+				collection TEXT NOT NULL,
+				entry_id TEXT NOT NULL,
+				taxonomy_id TEXT NOT NULL,
+				PRIMARY KEY (collection, entry_id, taxonomy_id)
+			)
+		`.execute(db);
+
+		await up036(db);
+
+		expect(await listIndexes(db, "content_taxonomies")).toContain("idx_content_taxonomies_term");
+	});
+});
+
+describe("040 byline rebuild on D1", () => {
+	it("renames the staged table back when 040 stopped between drop and rename", async () => {
+		// 040 drops `_emdash_content_bylines` and renames the staged copy in
+		// two auto-committed statements. When only the drop lands, a rerun
+		// finds no FKs to strip and skips the rebuild, leaving the credits in
+		// `_emdash_content_bylines_new`; 071 repairs that state.
+		await runMigrations(db);
+		await sql`
+			INSERT INTO _emdash_content_bylines (collection_slug, content_id, byline_id, sort_order)
+			VALUES ('posts', 'p1', 'b1', 0)
+		`.execute(db);
+		await sql`ALTER TABLE _emdash_content_bylines RENAME TO _emdash_content_bylines_new`.execute(
+			db,
+		);
+		const trailing = MIGRATION_NAMES.slice(
+			MIGRATION_NAMES.indexOf("071_restore_content_bylines_table"),
+		);
+		await db.deleteFrom("_emdash_migrations").where("name", "in", trailing).execute();
+
+		await runMigrations(db);
+
+		expect(await listTables(db)).toContain("_emdash_content_bylines");
+		expect(await listTables(db)).not.toContain("_emdash_content_bylines_new");
+		expect(await listIndexes(db, "_emdash_content_bylines")).toEqual([
+			"idx_content_bylines_byline",
+			"idx_content_bylines_content",
+		]);
+		const credits = await sql<{ content_id: string }>`
+			SELECT content_id FROM _emdash_content_bylines
+		`.execute(db);
+		expect(credits.rows).toEqual([{ content_id: "p1" }]);
+	});
+
+	it("carries the i18n columns 040 adds to the bylines table", async () => {
+		await runMigrations(db);
+
+		const columns = await listColumns(db, "_emdash_bylines");
+		expect(columns).toContain("locale");
+		expect(columns).toContain("translation_group");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Runs the core migration chain and the loader's entry read against a real D1 database in CI, so a regression that only D1 produces fails a check instead of a deploy. D1 enforces foreign keys and ignores `PRAGMA foreign_keys = OFF`, auto-commits each DDL statement, and caps tables and result sets at 100 columns. The unit tests simulate the first two on SQLite; its cap is 2000 columns, so the third has no cover that can fail.

The cases go into the workerd pool `packages/core` already has, which never ran in CI: a full run and a no-op second run, the 036 and 040 rebuilds, a retry after 016 stopped partway with no bookkeeping row, and the entry read at the widest collection that fits D1's result-set cap. `test:workerd` becomes a CI job. The live-D1 suite stays the opt-in smoke test, unchanged. `D1 Tests` stays a check of its own rather than joining the `Tests` rollup: branch protection can require a stable-named job directly, as it does Smoke Tests and Browser Tests. Whether a new suite gates every merge from its first run is that call. The retry cases cover 016 and 036, which guard their statements for a rerun; 25 others fail the same replay today and are a separate discussion.

Closes #1689

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (n/a: no admin UI change)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package) (n/a: tests and CI; the one source edit exports an existing function unchanged)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a: tests, for an issue on the 1.0 milestone)
- [ ] I have included screenshots below if this PR changes the UI (n/a: no UI change)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5, Claude Fable 5.1

## Screenshots / test output

Not applicable. `pnpm --filter emdash exec vitest run --config vitest.workerd.config.ts`: 7 files, 26 tests passed. With the `IF NOT EXISTS` guard removed from 016's first statement, both retry cases fail with `table "_emdash_api_tokens" already exists`.
