### PR TITLE
docs: document the single-taxonomy endpoints

### DIFF
--- a/.changeset/taxonomy-get-locale-description.md
+++ b/.changeset/taxonomy-get-locale-description.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the OpenAPI description for `GET /_emdash/api/taxonomies/{name}`, which said that omitting `locale` returns the lowest-locale definition. The endpoint returns the configured default locale's definition and only falls back to the lowest locale code when the default locale has none. Behavior is unchanged; only the generated API description was wrong.

--- a/docs/src/content/docs/reference/rest-api.mdx
+++ b/docs/src/content/docs/reference/rest-api.mdx
@@ -1380,6 +1380,51 @@ Content-Type: application/json
 GET /_emdash/api/taxonomies
 ```
 
+### Get Taxonomy
+
+```http
+GET /_emdash/api/taxonomies/:name
+```
+
+A taxonomy has one definition per locale. `locale` selects which one to return.
+Omit it and EmDash returns the definition for the site's default locale, falling
+back to the lowest locale code when the default locale has no definition. The
+endpoint requires `taxonomies:read`.
+
+#### Parameters
+
+| Parameter | Type     | Description                      |
+| --------- | -------- | -------------------------------- |
+| `name`    | `string` | Taxonomy name (path)             |
+| `locale`  | `string` | Locale of the definition (query) |
+
+#### Response
+
+```json
+{
+  "success": true,
+  "data": {
+    "taxonomy": {
+      "id": "01HXK5MZSN...",
+      "name": "genre",
+      "label": "Genres",
+      "labelSingular": "Genre",
+      "hierarchical": true,
+      "collections": ["books", "movies"],
+      "locale": "en",
+      "translationGroup": "01HXK5MZSN..."
+    }
+  }
+}
+```
+
+`collections` lists only the collections that still exist. A collection that was
+deleted after being added to the taxonomy is filtered out of the response but
+kept in storage, so re-creating the collection restores the link.
+
+Every locale of a taxonomy shares one `translationGroup`. An untranslated
+taxonomy has its own `id` there, as above.
+
 ### Create Taxonomy
 
 ```http
@@ -1394,6 +1439,93 @@ Content-Type: application/json
   "collections": ["books", "movies"]
 }
 ```
+
+### Update Taxonomy
+
+```http
+PUT /_emdash/api/taxonomies/:name
+Content-Type: application/json
+
+{
+  "label": "Categories",
+  "labelSingular": "Category",
+  "hierarchical": true,
+  "collections": ["books"]
+}
+```
+
+Every field is optional and an omitted field keeps its stored value. Send
+`"labelSingular": null` to clear it. Naming a collection that does not exist
+returns `VALIDATION_ERROR` and writes nothing. The response is the updated
+definition, in the same shape as [Get Taxonomy](#get-taxonomy). The endpoint
+requires `taxonomies:manage`.
+
+The request writes a single locale's definition, selected by `locale`. Pass it
+explicitly on a translated taxonomy: without it, the write lands on the
+definition with the lowest locale code. Addressing a locale that has no
+definition returns `NOT_FOUND` — unlike [Get Taxonomy](#get-taxonomy), this
+endpoint never falls back to another locale's row.
+
+Do not send `name` or `locale` in the body. Both identify the definition being
+written rather than a value to change, so the body rejects them with
+`VALIDATION_ERROR` instead of ignoring them. A taxonomy cannot be renamed,
+because its terms are keyed on `name`.
+
+### Delete Taxonomy
+
+```http
+DELETE /_emdash/api/taxonomies/:name
+```
+
+Deletes the taxonomy in every locale: each locale's definition, every term under
+that name, and every assignment of those terms to content. Content entries
+themselves are not deleted; they lose the term assignments.
+
+There is no `locale` parameter, and EmDash does not refuse the request when the
+taxonomy still has terms. The endpoint requires `taxonomies:manage`.
+
+<Aside type="caution">
+	This endpoint deletes immediately and EmDash cannot restore the terms or their content
+	assignments afterwards. Back up the database before deleting a taxonomy in production.
+</Aside>
+
+#### Response
+
+```json
+{
+  "success": true,
+  "data": { "deleted": true }
+}
+```
+
+### List Taxonomy Translations
+
+```http
+GET /_emdash/api/taxonomies/:name/translations
+```
+
+Lists every locale that the taxonomy definition has been translated into. Any
+locale of the taxonomy returns the same list, so `locale` only chooses which
+definition resolves the group. The endpoint requires `taxonomies:read`.
+
+#### Response
+
+```json
+{
+  "success": true,
+  "data": {
+    "translationGroup": "01HXK5MZSN...",
+    "translations": [
+      { "id": "01HXK5MZSN...", "name": "genre", "label": "Genres", "locale": "en" },
+      { "id": "01HXK6P2QT...", "name": "genre", "label": "Géneros", "locale": "es" }
+    ]
+  }
+}
+```
+
+To add a locale, post to [Create Taxonomy](#create-taxonomy) with the same
+`name`, the new `locale`, and `translationOf` set to a definition `id` from this
+list.
 
 ### List Terms
 

--- a/packages/core/src/api/handlers/taxonomies.ts
+++ b/packages/core/src/api/handlers/taxonomies.ts
@@ -304,8 +304,8 @@ export async function handleTaxonomyList(
 /**
  * Get a single taxonomy definition by name.
  *
- * Definitions are per-locale, so `locale` picks which one; without it the
- * lowest-locale match wins (same rule as `handleMenuGet`).
+ * Definitions are per-locale, so `locale` picks which one. Without it the
+ * configured default locale wins, then the lowest locale code.
  */
 export async function handleTaxonomyGet(
 	db: Kysely<Database>,

--- a/packages/core/src/api/openapi/document.ts
+++ b/packages/core/src/api/openapi/document.ts
@@ -1648,7 +1648,7 @@ const taxonomyPaths = {
 			operationId: "getTaxonomy",
 			summary: "Get a taxonomy definition",
 			description:
-				"Definitions are per-locale; `locale` picks one, and without it the lowest-locale match is returned.",
+				"Definitions are per-locale; `locale` picks one. Without it the configured default locale is returned, falling back to the lowest locale code.",
 			tags: ["Taxonomies"],
 			requestParams: {
 				path: z.object({ name: z.string().meta({ description: "Taxonomy name" }) }),


### PR DESCRIPTION
## What does this PR do?

[#2431](https://github.com/emdash-cms/emdash/pull/2431) added single-taxonomy CRUD and exposed the definition translations route, but the REST API reference still documented only `GET /_emdash/api/taxonomies` and `POST /_emdash/api/taxonomies`. This documents the four endpoints that shipped.

New sections in `docs/src/content/docs/reference/rest-api.mdx`, ordered to match the existing Menu Endpoints section (List, Get, Create, Update, Delete):

| Section                     | Endpoint                                      |
| --------------------------- | --------------------------------------------- |
| Get Taxonomy                | `GET /_emdash/api/taxonomies/:name`           |
| Update Taxonomy             | `PUT /_emdash/api/taxonomies/:name`           |
| Delete Taxonomy             | `DELETE /_emdash/api/taxonomies/:name`        |
| List Taxonomy Translations  | `GET /_emdash/api/taxonomies/:name/translations` |

Documentation only — no source, schema, or behavior change.

### What the prose covers

The locale rules are the part a caller gets wrong, so each endpoint states its own:

- **`GET`** resolves the requested locale, then the site's default locale, then the lowest locale code.
- **`PUT`** writes exactly one locale's definition row and never falls back — addressing an untranslated locale returns `NOT_FOUND`. Omitting `locale` writes the definition with the *lowest locale code*, which is not necessarily the default locale, so the page tells callers to pass it explicitly on a translated taxonomy.
- **`DELETE`** takes no `locale`: it removes every locale's definition, every term under that name, and those terms' content assignments. Content entries survive and lose the assignments. A caution `<Aside>` states that this is not recoverable.

Also documented, because each is observable in a response and not inferable from the request: `name` and `locale` are rejected in the `PUT` body rather than ignored (the schema is `.strict()`), `collections` is filtered to collections that still exist while storage keeps the reference, and `translationGroup` is the row's own `id` for an untranslated taxonomy.

Each endpoint names its permission (`taxonomies:read` / `taxonomies:manage`), matching how the newer sections of this page document permissions.

### Verification of the documented claims

Response shapes were read off `handleTaxonomyGet` / `handleTaxonomyUpdate` / `handleTaxonomyDelete` / `handleTaxonomyDefTranslations` and the assertions in `packages/core/tests/unit/taxonomies/taxonomy-crud.test.ts`.

Two locale claims were not covered by an existing test, so rather than ship them as inferences from `requireTaxonomyDef`'s `orderBy`, I confirmed them with a throwaway test (created a taxonomy in `en`, a `de` translation, then updated with no `locale`, with `defaultLocale: "en"`):

- The unscoped `PUT` wrote the `de` row and left `en` untouched, confirming lowest-locale-code rather than default-locale targeting.
- The unscoped `GET` resolved `en`, confirming default-locale-first.

The scratch file was deleted; the diff is one `.mdx` file.

One deliberate deviation from the style guide: headings use Title Case (`Get Taxonomy`), because every one of the ~90 endpoint headings on this page does. Sentence case here would make the Taxonomy section inconsistent with the page around it.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes — full workspace clean
- [x] `pnpm lint` passes — `pnpm lint:json` reports one diagnostic, in `apps/release-service/src/ui/PublisherPage.tsx`, which is pre-existing on `main` (from #2848) and untouched by this PR
- [x] `pnpm test` passes (or targeted tests for my change) — targeted check for a docs-only change: `pnpm --dir docs build` succeeds and the rendered page was inspected (see below). No test files changed
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a, prose only; the behavior this documents is already covered by `taxonomy-crud.test.ts`
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — n/a, no admin UI in this PR
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package) — n/a, `docs` is not a published package and no published package changed
- [ ] New features link to an approved Discussion — n/a, documents endpoints already merged in #2431
- [ ] I have included screenshots below if this PR changes the UI — n/a, no UI change

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Screenshots / test output

Not applicable — no UI change.

`pnpm --dir docs build` completes and the rendered page was checked for the things MDX can silently get wrong:

```
$ grep -o 'id="[a-z-]*taxonom[a-z-]*"' docs/dist/client/reference/rest-api/index.html | sort -u
id="create-taxonomy"
id="delete-taxonomy"
id="get-taxonomy"
id="list-taxonomy-definitions"
id="list-taxonomy-translations"
id="taxonomy-endpoints"
id="update-taxonomy"
```

Both in-page links resolve to ids that exist on the page (`#get-taxonomy`, `#create-taxonomy`), and the caution `<Aside>` renders as `starlight-aside--caution` rather than leaking as literal MDX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPYtGeiq7T5j3Ky8SXzrJy

---

## Review response (5edeb830)

Both follow-up notes are fixed in this PR rather than deferred — they are the same stale claim as the page this PR adds, and leaving them would ship a reference page that contradicts the served spec.

**1. OpenAPI description — fixed.** `packages/core/src/api/openapi/document.ts` now reads "Definitions are per-locale; `locale` picks one. Without it the configured default locale is returned, falling back to the lowest locale code."

**2. `handleTaxonomyGet` comment — fixed, with one correction beyond the note.** The comment said "without it the lowest-locale match wins (same rule as `handleMenuGet`)". Both halves were wrong, not just the first: `handleMenuGet` resolves through `MenuRepository.findByName`, which orders by `locale asc` and takes `matches[0]` with no default-locale preference, so menus genuinely do return the lowest-locale match. Taxonomies stopped matching that rule when `requireTaxonomyDefWithFallback` began preferring the configured default. Amending only the first clause would have left a false cross-reference, so the parenthetical is dropped.

I grepped every `lowest-locale` / `lowest locale` claim in the repo. The remaining ones (`handleMenuGet`, `TaxonomyRepository.findByName`, the byline, relation, and content repositories, and the WXR importer) describe paths that really are lowest-locale-only and are left alone.

### Changeset added

This PR now touches a published package, so it carries a `patch` changeset for the OpenAPI text. The judgment call is worth flagging: the code comment alone would not warrant one, but the OpenAPI description is served to users as part of the spec, and without a changeset the correction would not reach them until some unrelated change triggered a release. Happy to drop it if you would rather not spend a patch release on description text.

No behavior changed in either file.

### Re-verified after the change

- `pnpm typecheck` — clean, full workspace
- `pnpm lint:json` — still the one pre-existing `apps/release-service` diagnostic, unchanged
- `pnpm format` — run
- Full `packages/core` suite: **6264 passed, 9 skipped, 518 files**
- `pnpm --dir docs build` succeeds

The OpenAPI tests (`tests/unit/api/openapi.test.ts`, `tests/integration/openapi/`) and `taxonomy-crud.test.ts` pass together: 65 tests. No test asserted the old description text, so nothing was changed to make a test pass.
