### PR TITLE
fix(core): join avatar media on the single-row byline finders

### DIFF
--- a/.changeset/byline-finder-avatar-join.md
+++ b/.changeset/byline-finder-avatar-join.md
@@ -1,0 +1,19 @@
+---
+"emdash": patch
+---
+
+Fixes byline profile pages having no way to render the byline's avatar ([#2613](https://github.com/emdash-cms/emdash/issues/2613)). `getByline`, `getBylineBySlug`, and the underlying single-row `BylineRepository` finders now resolve the avatar's media row in the same query, so `avatarStorageKey`, `avatarAlt`, `avatarBlurhash`, and `avatarDominantColor` are populated alongside `avatarMediaId`:
+
+```astro
+---
+import { getBylineBySlug } from "emdash";
+
+const byline = await getBylineBySlug(Astro.params.slug, { locale: Astro.currentLocale });
+const avatar = byline?.avatarStorageKey
+	? Astro.locals.emdash.getPublicMediaUrl(byline.avatarStorageKey)
+	: null;
+---
+{avatar && <img src={avatar} alt={byline.avatarAlt ?? byline.displayName} />}
+```
+
+Previously these fields were populated only when a byline was hydrated as a credit on a content entry, so a page keyed on the byline itself — `/authors/<slug>` and the like — held a bare media id with no public API to turn it into a URL. Nothing else changes: the lookup still costs one query (the avatar is a `LEFT JOIN`, not a second round trip), and `findMany` still skips the join, so byline list pages are unaffected.

--- a/packages/core/src/api/schemas/bylines.ts
+++ b/packages/core/src/api/schemas/bylines.ts
@@ -13,9 +13,9 @@ export const bylineSummarySchema = z
 		bio: z.string().nullable(),
 		avatarMediaId: z.string().nullable(),
 		/**
-		 * Avatar media storage key + alt, folded in by the media join during
-		 * content byline hydration. Null on the plain byline finders, which
-		 * don't join media.
+		 * Avatar media storage key + alt, folded in by the media join on the
+		 * content byline hydration path and the single-row byline finders.
+		 * Null on `findMany`, which doesn't join media.
 		 */
 		avatarStorageKey: z.string().nullish(),
 		avatarAlt: z.string().nullish(),

--- a/packages/core/src/database/repositories/byline.ts
+++ b/packages/core/src/database/repositories/byline.ts
@@ -30,9 +30,9 @@ type BylineRow = Selectable<BylineTable>;
 
 /**
  * A byline row optionally augmented with the avatar's media columns, folded in
- * by the `LEFT JOIN media` in the content-credit hydration queries. The plain
- * `selectAll()` finders produce rows without these keys, so they're optional
- * and `rowToByline` defaults them to null.
+ * by the `LEFT JOIN media` in the credit-hydration and single-row finder
+ * queries. `findMany` selects without the join, so the keys are optional and
+ * `rowToByline` defaults them to null.
  */
 type BylineRowWithAvatar = BylineRow & {
 	avatar_storage_key?: string | null;
@@ -298,7 +298,7 @@ export class BylineRepository {
 	 * same way `BylineRepository` doesn't resolve locale fallback for
 	 * the base byline lookup.
 	 */
-	private async withCustomFields(rows: BylineRow[]): Promise<BylineSummary[]> {
+	private async withCustomFields(rows: BylineRowWithAvatar[]): Promise<BylineSummary[]> {
 		const summaries = rows.map(rowToByline);
 		// Always populate `customFields = {}` (PR plan AC #6) — even when
 		// no fields are registered, every BylineSummary carries the empty
@@ -311,7 +311,9 @@ export class BylineRepository {
 		return summaries;
 	}
 
-	private async withCustomFieldsOne(row: BylineRow | undefined): Promise<BylineSummary | null> {
+	private async withCustomFieldsOne(
+		row: BylineRowWithAvatar | undefined,
+	): Promise<BylineSummary | null> {
 		if (!row) return null;
 		const [result] = await this.withCustomFields([row]);
 		return result ?? null;
@@ -501,12 +503,26 @@ export class BylineRepository {
 	// Reads
 	// ============================================
 
+	/**
+	 * Every byline column plus the avatar's media columns, folded in by the
+	 * same `LEFT JOIN media` the credit-hydration queries use. Only the
+	 * single-row finders select this; `findMany` stays a single-table scan.
+	 */
+	private selectBylineWithAvatar() {
+		return this.db
+			.selectFrom("_emdash_bylines as b")
+			.leftJoin("media as m", "m.id", "b.avatar_media_id")
+			.selectAll("b")
+			.select([
+				"m.storage_key as avatar_storage_key",
+				"m.alt as avatar_alt",
+				"m.blurhash as avatar_blurhash",
+				"m.dominant_color as avatar_dominant_color",
+			]);
+	}
+
 	async findById(id: string): Promise<BylineSummary | null> {
-		const row = await this.db
-			.selectFrom("_emdash_bylines")
-			.selectAll()
-			.where("id", "=", id)
-			.executeTakeFirst();
+		const row = await this.selectBylineWithAvatar().where("b.id", "=", id).executeTakeFirst();
 		return this.withCustomFieldsOne(row);
 	}
 
@@ -516,9 +532,9 @@ export class BylineRepository {
 	 * calls). Mirrors `TaxonomyRepository.findBySlug`.
 	 */
 	async findBySlug(slug: string, options?: { locale?: string }): Promise<BylineSummary | null> {
-		let query = this.db.selectFrom("_emdash_bylines").selectAll().where("slug", "=", slug);
-		if (options?.locale !== undefined) query = query.where("locale", "=", options.locale);
-		const row = await query.orderBy("locale", "asc").executeTakeFirst();
+		let query = this.selectBylineWithAvatar().where("b.slug", "=", slug);
+		if (options?.locale !== undefined) query = query.where("b.locale", "=", options.locale);
+		const row = await query.orderBy("b.locale", "asc").executeTakeFirst();
 		return this.withCustomFieldsOne(row);
 	}
 
@@ -529,9 +545,9 @@ export class BylineRepository {
 	 * the lowest-locale-code match.
 	 */
 	async findByUserId(userId: string, options?: { locale?: string }): Promise<BylineSummary | null> {
-		let query = this.db.selectFrom("_emdash_bylines").selectAll().where("user_id", "=", userId);
-		if (options?.locale !== undefined) query = query.where("locale", "=", options.locale);
-		const row = await query.orderBy("locale", "asc").executeTakeFirst();
+		let query = this.selectBylineWithAvatar().where("b.user_id", "=", userId);
+		if (options?.locale !== undefined) query = query.where("b.locale", "=", options.locale);
+		const row = await query.orderBy("b.locale", "asc").executeTakeFirst();
 		return this.withCustomFieldsOne(row);
 	}
 

--- a/packages/core/src/database/repositories/types.ts
+++ b/packages/core/src/database/repositories/types.ts
@@ -64,13 +64,14 @@ export interface BylineSummary {
 	avatarMediaId: string | null;
 	/**
 	 * The avatar media's storage key, folded in by a LEFT JOIN on the
-	 * `media` table during content byline hydration. Non-null only when the
-	 * byline has an avatar AND was loaded through the content-credit hydration
-	 * path (`getContentBylines` / `getContentBylinesMany`, i.e. the
-	 * `entry.data.bylines` populated by `getEmDashCollection` / `getEmDashEntry`).
-	 * The plain byline finders (`findById`, `findBySlug`, …) leave it null.
+	 * `media` table. Populated by the content-credit hydration path
+	 * (`getContentBylines` / `getContentBylinesMany`, i.e. the
+	 * `entry.data.bylines` populated by `getEmDashCollection` /
+	 * `getEmDashEntry`) and by the single-row finders (`findById`,
+	 * `findBySlug`, `findByUserId`, `findByUserIds`). `findMany` doesn't
+	 * join media, so it leaves this null.
 	 *
-	 * Lets list pages build a direct storage URL for an author avatar without a
+	 * Lets a page build a direct storage URL for an author avatar without a
 	 * per-byline `MediaRepository.findById`, avoiding an N+1 when many distinct
 	 * authors appear on one page.
 	 *
@@ -86,7 +87,7 @@ export interface BylineSummary {
 	 * same media join as `avatarStorageKey`. Lets a renderer paint a blurred
 	 * placeholder while the full avatar loads, with no extra media lookup.
 	 * Null when the byline has no avatar, the media row has no blurhash, or the
-	 * byline was loaded through a finder that doesn't join media.
+	 * byline came from `findMany`, which doesn't join media.
 	 */
 	avatarBlurhash?: string | null;
 	/**

--- a/packages/core/tests/unit/database/repositories/byline.test.ts
+++ b/packages/core/tests/unit/database/repositories/byline.test.ts
@@ -255,7 +255,7 @@ describe("BylineRepository", () => {
 		expect(resolved?.avatarDominantColor).toBe("#112233");
 	});
 
-	it("leaves avatar storage key null on the plain byline finders", async () => {
+	it("hydrates avatar media on the single-row byline finders", async () => {
 		await db
 			.insertInto("media")
 			.values({
@@ -264,19 +264,56 @@ describe("BylineRepository", () => {
 				mime_type: "image/png",
 				storage_key: "media-avatar-2.png",
 				status: "ready",
+				alt: "Finder avatar",
+				blurhash: "L6PZfSi_.AyE_3t7t7R**0o#DgR4",
+				dominant_color: "#445566",
+			})
+			.execute();
+		await db
+			.insertInto("users")
+			.values({
+				id: "user-finder",
+				email: "finder@example.com",
+				name: "Finder Avatar",
+				role: 30,
+				email_verified: 1,
 			})
 			.execute();
 		const created = await bylineRepo.create({
 			slug: "finder-avatar",
 			displayName: "Finder Avatar",
 			avatarMediaId: "media-avatar-2",
+			userId: "user-finder",
 		});
 
-		// findById/findBySlug don't join media — the field is null there, and
-		// callers should rely on the content-credit hydration path for it.
-		const byId = await bylineRepo.findById(created.id);
-		expect(byId?.avatarMediaId).toBe("media-avatar-2");
-		expect(byId?.avatarStorageKey).toBeNull();
+		// A byline profile page resolves exactly one byline and has no entry to
+		// hydrate credits through, so the by-id/by-slug/by-user finders join
+		// media themselves.
+		for (const found of [
+			await bylineRepo.findById(created.id),
+			await bylineRepo.findBySlug("finder-avatar"),
+			await bylineRepo.findByUserId("user-finder"),
+		]) {
+			expect(found?.avatarMediaId).toBe("media-avatar-2");
+			expect(found?.avatarStorageKey).toBe("media-avatar-2.png");
+			expect(found?.avatarAlt).toBe("Finder avatar");
+			expect(found?.avatarBlurhash).toBe("L6PZfSi_.AyE_3t7t7R**0o#DgR4");
+			expect(found?.avatarDominantColor).toBe("#445566");
+		}
+
+		// A byline with no avatar keeps nulls rather than undefined.
+		const bare = await bylineRepo.create({ slug: "no-avatar", displayName: "No Avatar" });
+		const foundBare = await bylineRepo.findById(bare.id);
+		expect(foundBare?.avatarStorageKey).toBeNull();
+		expect(foundBare?.avatarAlt).toBeNull();
+		expect(foundBare?.avatarBlurhash).toBeNull();
+		expect(foundBare?.avatarDominantColor).toBeNull();
+
+		// findMany stays a single-table scan — list pages pay no media join.
+		const listed = await bylineRepo.findMany();
+		const fromList = listed.items.find((b) => b.id === created.id);
+		expect(fromList?.avatarMediaId).toBe("media-avatar-2");
+		expect(fromList?.avatarStorageKey).toBeNull();
 	});
 
 	it("getContentBylinesMany handles more IDs than SQL_BATCH_SIZE", async () => {


### PR DESCRIPTION
## What does this PR do?

A site rendering a byline profile page (`/authors/<slug>`, `/creators/<slug>`, …) had no way to show the byline's avatar. `getByline` / `getBylineBySlug` — and the `BylineRepository` finders behind them — returned `avatarMediaId` but left `avatarStorageKey`, `avatarAlt`, `avatarBlurhash`, and `avatarDominantColor` null, and there is no public API that turns a media id into a URL (`getPublicMediaUrl` takes a storage key). So the avatar rendered everywhere a byline appeared as a credit on an entry, and nowhere on the page dedicated to that byline.

This is **option 2** from the issue, per @ascorbic's comment: always join on the single-row finders, leaving `findMany` alone.

- Adds a private `selectBylineWithAvatar()` base select — every byline column plus the avatar's media columns, folded in by the same `LEFT JOIN media` the credit-hydration queries (`getContentBylines` / `getContentBylinesMany` / `findByUserIds`) already use.
- `findById`, `findBySlug`, and `findByUserId` now build on it, so `getByline` / `getBylineBySlug` need no change — they pass the repository result straight through.
- `findMany` is untouched: byline list pages keep their single-table scan, and the join can't fan out per listed row.
- Updates the doc comments in `repositories/types.ts` and `api/schemas/bylines.ts` that described the old asymmetry.

A profile page can now do:

```astro
---
import { getBylineBySlug } from "emdash";

const byline = await getBylineBySlug(Astro.params.slug, { locale: Astro.currentLocale });
const avatar = byline?.avatarStorageKey
	? Astro.locals.emdash.getPublicMediaUrl(byline.avatarStorageKey)
	: null;
---
{avatar && <img src={avatar} alt={byline.avatarAlt ?? byline.displayName} />}
```

**Query cost is unchanged.** The avatar arrives as a `LEFT JOIN` on a lookup the page already issues, not a second round trip, so no logged-out route gains a query. No route in `scripts/query-counts.queries.*.json` calls these finders, so the snapshots are unaffected.

Closes #2613

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes — clean for this change. `pnpm lint:json` reports one diagnostic in `apps/release-service/src/ui/PublisherPage.tsx`; it reproduces on unmodified `main` and is unrelated to these files.
- [x] `pnpm test` passes — targeted: the full `packages/core` unit + integration suite (6145 passed, 5 skipped).
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — n/a, no admin UI strings change.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion — n/a, this is a bug fix against an existing issue.
- [x] I have included screenshots below if this PR changes the UI — n/a, no UI change.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Screenshots / test output

Not applicable — no UI change.

On the tests: the previous test pinned the old behaviour ("leaves avatar storage key null on the plain byline finders"). It is replaced with one asserting the new contract, written and run against unmodified source first, where it failed on `expected null to be 'media-avatar-2.png'`. It covers all three single-row finders, `null` (not `undefined`) for a byline with no avatar, and that `findMany` still leaves `avatarStorageKey` null.

```
 Test Files  511 passed | 1 skipped (512)
      Tests  6145 passed | 5 skipped (6150)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdmEcFqHNk8gU4yPfVoDBk
