### PR TITLE
fix(core): preserve publish date when unpublishing

### DIFF
--- a/.changeset/calm-drafts-remember.md
+++ b/.changeset/calm-drafts-remember.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes unpublishing content resetting its publication date. Previously published drafts keep their date visible and editable in the admin, and republishing them without a date override reuses it.

--- a/docs/src/content/docs/guides/preview.mdx
+++ b/docs/src/content/docs/guides/preview.mdx
@@ -315,7 +315,7 @@ if (!entry) {
           {entry.data.publishedAt.toLocaleDateString()}
         </time>
       )}
-      {isPreview && entry.data.status !== "published" && (
+      {isPreview && entry.data.status === "draft" && (
         <span class="draft-indicator">Draft</span>
       )}
     </header>

--- a/docs/src/content/docs/guides/preview.mdx
+++ b/docs/src/content/docs/guides/preview.mdx
@@ -315,7 +315,7 @@ if (!entry) {
           {entry.data.publishedAt.toLocaleDateString()}
         </time>
       )}
-      {isPreview && !entry.data.publishedAt && (
+      {isPreview && entry.data.status !== "published" && (
         <span class="draft-indicator">Draft</span>
       )}
     </header>

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -180,7 +180,7 @@ The `data` object contains all content fields plus system fields:
 - `status` - "draft" | "published" | "archived"
 - `createdAt` - ISO timestamp
 - `updatedAt` - ISO timestamp
-- `publishedAt` - ISO timestamp or null
+- `publishedAt` - Publication timestamp or null; retained when content is unpublished
 - Plus all custom fields defined in your collection schema
 
 ## Preview system

--- a/docs/src/content/docs/reference/mcp-server.mdx
+++ b/docs/src/content/docs/reference/mcp-server.mdx
@@ -186,12 +186,13 @@ Permanently and irreversibly delete a trashed content item. The item must be in 
 
 #### `content_publish`
 
-Publish a content item, making it live on the site. Creates a published revision from the current draft. Further edits create a new draft without affecting the live version until re-published.
+Publish a content item, making it live on the site. Creates a published revision from the current draft. Further edits create a new draft without affecting the live version until re-published. Re-publishing without `publishedAt` reuses the retained publication date.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `collection` | `string` | Yes | Collection slug |
 | `id` | `string` | Yes | Content item ID or slug |
+| `publishedAt` | `string` | No | ISO 8601 publication date. Setting it requires `content:publish_any`. |
 
 **Scope:** `content:write`
 

--- a/docs/src/content/docs/reference/mcp-server.mdx
+++ b/docs/src/content/docs/reference/mcp-server.mdx
@@ -197,7 +197,7 @@ Publish a content item, making it live on the site. Creates a published revision
 
 #### `content_unpublish`
 
-Revert a published item to draft status. It will no longer be visible on the live site but its content is preserved.
+Revert a published item to draft status. It will no longer be visible on the live site, but its content and publication date are preserved.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |

--- a/packages/admin/tests/components/ContentSettingsPanel.test.tsx
+++ b/packages/admin/tests/components/ContentSettingsPanel.test.tsx
@@ -624,6 +624,30 @@ describe("ContentSettingsPanel", () => {
 		}
 	});
 
+	it("lets editors update a retained publish date while content is unpublished", async () => {
+		const onPublishedAtChange = vi.fn();
+		const screen = await render(
+			<ContentSettingsPanel
+				{...makePanelProps({
+					item: makeItem({
+						status: "draft",
+						publishedAt: "2025-01-15T10:30:00.000Z",
+						liveRevisionId: null,
+					}),
+					isLive: false,
+					onPublishedAtChange,
+				})}
+			/>,
+		);
+
+		const input = screen.getByLabelText("Publish date");
+		await expect.element(input).toHaveValue("2025-01-15T10:30");
+		await input.fill("2020-06-01T08:45");
+		await screen.getByRole("button", { name: "Update publish date" }).click();
+
+		expect(onPublishedAtChange).toHaveBeenCalledWith("2020-06-01T08:45:00.000Z");
+	});
+
 	it("does not expose publish-date editing below the editor role", async () => {
 		const screen = await render(
 			<ContentSettingsPanel

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -2042,8 +2042,8 @@ export class ContentRepository {
 	/**
 	 * Unpublish content
 	 *
-	 * Removes live pointer but preserves draft. If no draft exists,
-	 * creates one from the live version so the content isn't lost.
+	 * Removes live pointer but preserves the draft and publication date. If no
+	 * draft exists, creates one from the live version so the content isn't lost.
 	 */
 	async unpublish(
 		type: string,
@@ -2082,7 +2082,6 @@ export class ContentRepository {
 				SET live_revision_id = NULL,
 					draft_revision_id = ${draftRevisionId},
 					status = 'draft',
-					published_at = NULL,
 					updated_at = ${now},
 					version = version + 1
 				WHERE id = ${id}

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -1313,7 +1313,7 @@ export function createMcpServer(
 			title: "Unpublish Content",
 			description:
 				"Unpublish a content item, reverting it to draft status. It will no " +
-				"longer be visible on the live site but its content is preserved.",
+				"longer be visible on the live site, but its content and publication date are preserved.",
 			inputSchema: z.object({
 				collection: z.string().describe("Collection slug"),
 				id: z.string().describe("Content item ID or slug"),

--- a/packages/core/tests/integration/mcp/lifecycle.test.ts
+++ b/packages/core/tests/integration/mcp/lifecycle.test.ts
@@ -99,6 +99,7 @@ describe("MCP content_unpublish — publishedAt preservation", () => {
 	});
 
 	it("re-publish after unpublish keeps the original publishedAt timestamp", async () => {
+		const publishedAt = "2020-01-01T00:00:00.000Z";
 		const created = await harness.client.callTool({
 			name: "content_create",
 			arguments: { collection: "post", data: { title: "T" } },
@@ -107,10 +108,10 @@ describe("MCP content_unpublish — publishedAt preservation", () => {
 
 		const firstPub = await harness.client.callTool({
 			name: "content_publish",
-			arguments: { collection: "post", id },
+			arguments: { collection: "post", id, publishedAt },
 		});
 		const firstTs = extractJson<{ item: { publishedAt: string } }>(firstPub).item.publishedAt;
-		expect(firstTs).toBeTruthy();
+		expect(firstTs).toBe(publishedAt);
 
 		await harness.client.callTool({
 			name: "content_unpublish",
@@ -122,8 +123,7 @@ describe("MCP content_unpublish — publishedAt preservation", () => {
 			arguments: { collection: "post", id },
 		});
 		const secondTs = extractJson<{ item: { publishedAt: string } }>(secondPub).item.publishedAt;
-		expect(secondTs).toBeTruthy();
-		expect(secondTs).toBe(firstTs);
+		expect(secondTs).toBe(publishedAt);
 	});
 });
 

--- a/packages/core/tests/integration/mcp/lifecycle.test.ts
+++ b/packages/core/tests/integration/mcp/lifecycle.test.ts
@@ -127,11 +127,7 @@ describe("MCP content_unpublish — publishedAt preservation", () => {
 	});
 });
 
-// ---------------------------------------------------------------------------
-// Bug #11: schema_create_collection supports default
-// ---------------------------------------------------------------------------
-
-describe("MCP schema_create_collection — supports default (bug #11)", () => {
+describe("MCP schema_create_collection — supports default", () => {
 	let db: Kysely<Database>;
 	let harness: McpHarness;
 
@@ -153,7 +149,6 @@ describe("MCP schema_create_collection — supports default (bug #11)", () => {
 		expect(result.isError, extractText(result)).toBeFalsy();
 		const created = extractJson<{ supports: string[] }>(result);
 
-		// Bug #11: today this is [] or null. After fix: ['drafts', 'revisions'].
 		expect(created.supports).toEqual(expect.arrayContaining(["drafts", "revisions"]));
 	});
 
@@ -182,8 +177,6 @@ describe("MCP schema_create_collection — supports default (bug #11)", () => {
 	});
 
 	it("default-supports collection accepts publish/unpublish/revision flows immediately", async () => {
-		// Default supports should include drafts + revisions, so the standard
-		// publish/unpublish lifecycle should work without further config.
 		await harness.client.callTool({
 			name: "schema_create_collection",
 			arguments: { slug: "story", label: "Stories" },
@@ -200,7 +193,6 @@ describe("MCP schema_create_collection — supports default (bug #11)", () => {
 		expect(created.isError, extractText(created)).toBeFalsy();
 		const id = extractJson<{ item: { id: string } }>(created).item.id;
 
-		// Update should create a draft revision (only meaningful if 'revisions' is in supports)
 		await harness.client.callTool({
 			name: "content_update",
 			arguments: { collection: "story", id, data: { title: "Updated" } },
@@ -210,8 +202,6 @@ describe("MCP schema_create_collection — supports default (bug #11)", () => {
 			name: "revision_list",
 			arguments: { collection: "story", id },
 		});
-		// If supports doesn't include 'revisions', revision_list returns empty
-		// or fails. After fix: revisions exist.
 		expect(revs.isError, extractText(revs)).toBeFalsy();
 		const items = extractJson<{ items: unknown[] }>(revs).items;
 		expect(items.length).toBeGreaterThan(0);

--- a/packages/core/tests/integration/mcp/lifecycle.test.ts
+++ b/packages/core/tests/integration/mcp/lifecycle.test.ts
@@ -3,9 +3,9 @@
  *
  * Covers two contracts that callers rely on:
  *
- * - `content_unpublish` clears `published_at` so a missing/null timestamp
- *   unambiguously means the item is not currently live. Re-publishing
- *   assigns a fresh timestamp.
+ * - `content_unpublish` preserves `published_at` as the editorial publication
+ *   date. Publication state comes from the status and revision pointers, and
+ *   re-publishing without an override keeps the same timestamp.
  * - `schema_create_collection` applies its documented default of
  *   `['drafts', 'revisions']` for `supports` when the caller omits it.
  *   Explicit `[]` is preserved as an opt-out.
@@ -30,11 +30,7 @@ import {
 
 const ADMIN_ID = "user_admin";
 
-// ---------------------------------------------------------------------------
-// Bug #10: unpublish publishedAt
-// ---------------------------------------------------------------------------
-
-describe("MCP content_unpublish — publishedAt clearing (bug #10)", () => {
+describe("MCP content_unpublish — publishedAt preservation", () => {
 	let db: Kysely<Database>;
 	let harness: McpHarness;
 
@@ -48,7 +44,7 @@ describe("MCP content_unpublish — publishedAt clearing (bug #10)", () => {
 		await teardownTestDatabase(db);
 	});
 
-	it("unpublish clears publishedAt so 'currently live' is unambiguous", async () => {
+	it("unpublish preserves publishedAt", async () => {
 		const created = await harness.client.callTool({
 			name: "content_create",
 			arguments: { collection: "post", data: { title: "Will publish" } },
@@ -60,10 +56,9 @@ describe("MCP content_unpublish — publishedAt clearing (bug #10)", () => {
 			name: "content_publish",
 			arguments: { collection: "post", id },
 		});
-		const publishedItem = extractJson<{ item: { publishedAt: string | null } }>(published);
-		expect(publishedItem.item.publishedAt).toBeTruthy();
+		const publishedAt = extractJson<{ item: { publishedAt: string } }>(published).item.publishedAt;
+		expect(publishedAt).toBeTruthy();
 
-		// Unpublish — should clear publishedAt
 		const unpublished = await harness.client.callTool({
 			name: "content_unpublish",
 			arguments: { collection: "post", id },
@@ -73,20 +68,20 @@ describe("MCP content_unpublish — publishedAt clearing (bug #10)", () => {
 		}>(unpublished);
 
 		expect(unpubItem.item.status).toBe("draft");
-		// Bug #10: today, publishedAt is still the old timestamp.
-		expect(unpubItem.item.publishedAt).toBeNull();
+		expect(unpubItem.item.publishedAt).toBe(publishedAt);
 	});
 
-	it("content_get after unpublish reflects null publishedAt and status=draft", async () => {
+	it("content_get after unpublish returns the retained publishedAt and draft status", async () => {
 		const created = await harness.client.callTool({
 			name: "content_create",
 			arguments: { collection: "post", data: { title: "T" } },
 		});
 		const id = extractJson<{ item: { id: string } }>(created).item.id;
-		await harness.client.callTool({
+		const published = await harness.client.callTool({
 			name: "content_publish",
 			arguments: { collection: "post", id },
 		});
+		const publishedAt = extractJson<{ item: { publishedAt: string } }>(published).item.publishedAt;
 		await harness.client.callTool({
 			name: "content_unpublish",
 			arguments: { collection: "post", id },
@@ -100,10 +95,10 @@ describe("MCP content_unpublish — publishedAt clearing (bug #10)", () => {
 			item: { publishedAt: string | null; status: string };
 		}>(got);
 		expect(gotItem.item.status).toBe("draft");
-		expect(gotItem.item.publishedAt).toBeNull();
+		expect(gotItem.item.publishedAt).toBe(publishedAt);
 	});
 
-	it("re-publish after unpublish gets a fresh publishedAt timestamp", async () => {
+	it("re-publish after unpublish keeps the original publishedAt timestamp", async () => {
 		const created = await harness.client.callTool({
 			name: "content_create",
 			arguments: { collection: "post", data: { title: "T" } },
@@ -122,17 +117,13 @@ describe("MCP content_unpublish — publishedAt clearing (bug #10)", () => {
 			arguments: { collection: "post", id },
 		});
 
-		// Wait briefly so the new timestamp is distinguishable
-		await new Promise((r) => setTimeout(r, 5));
-
 		const secondPub = await harness.client.callTool({
 			name: "content_publish",
 			arguments: { collection: "post", id },
 		});
 		const secondTs = extractJson<{ item: { publishedAt: string } }>(secondPub).item.publishedAt;
 		expect(secondTs).toBeTruthy();
-		// Should be a new timestamp, not the old one.
-		expect(secondTs).not.toBe(firstTs);
+		expect(secondTs).toBe(firstTs);
 	});
 });
 

--- a/packages/core/tests/unit/loader-revision-preview.test.ts
+++ b/packages/core/tests/unit/loader-revision-preview.test.ts
@@ -94,6 +94,28 @@ describe("Loader revision preview", () => {
 		expect(data.updatedAt).toBeInstanceOf(Date);
 	});
 
+	it("excludes unpublished posts with retained publication dates from public collection loads", async () => {
+		const unpublished = await createPublishedPost("Unpublished");
+		const visible = await createPublishedPost("Visible");
+		const contentRepo = new ContentRepository(db);
+		await contentRepo.publish("post", unpublished.id, "2020-01-01T00:00:00.000Z");
+		await contentRepo.unpublish("post", unpublished.id);
+		await contentRepo.publish("post", visible.id, "2021-01-01T00:00:00.000Z");
+
+		const retained = await contentRepo.findById("post", unpublished.id);
+		expect(retained).toMatchObject({
+			status: "draft",
+			publishedAt: "2020-01-01T00:00:00.000Z",
+		});
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({ filter: { type: "post" } }),
+		);
+
+		expect(result.entries.map((entry) => entry.data.title)).toEqual(["Visible"]);
+	});
+
 	it("should use revision content fields while preserving system date types", async () => {
 		const post = await createPublishedPost("Original Title");
 


### PR DESCRIPTION
## What does this PR do?

Preserves a content item's publication date when it is unpublished. Publication state continues to come from the content status and revision pointers, while a previously published draft keeps its date visible and editable in the admin. Republishing without a date override reuses the retained date.

Updates the API and MCP references to document the retained date. The preview guide now checks content status instead of treating a missing publication date as draft state.

Closes: N/A

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (N/A: no admin strings changed.)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: N/A — bug fix
- [x] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

After unpublishing, the item has Draft status while its original Publish date remains visible and editable.

![Draft post retaining its editable publish date](https://github.com/user-attachments/assets/2f36208c-1c7d-4a65-8488-e1bc56f2efc6)

Verified with:

- `pnpm lint:json | jq '.diagnostics | length'` — 0 diagnostics
- `pnpm typecheck`
- `pnpm --filter emdash exec vitest run tests/integration/mcp/lifecycle.test.ts` — 7 tests passed
- `pnpm --filter @emdash-cms/admin exec vitest run tests/components/ContentSettingsPanel.test.tsx` — 37 tests passed
- `pnpm --dir docs build`
- Browser journey: publish, unpublish, retain and edit the date as a draft, then republish with the edited date
