### PR TITLE
fix(core): index scheduled sweep on (deleted_at, scheduled_at)

### DIFF
--- a/.changeset/scheduled-sweep-index.md
+++ b/.changeset/scheduled-sweep-index.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes scheduled publishing so its recurring check no longer reads every content entry on each run. Sites running the scheduler on a frequent cron trigger, as the Cloudflare deployment guide recommends, previously saw database reads grow with the size of their content library rather than with the amount of scheduled work — a cost that is directly billable on D1 and was paid even when nothing was scheduled. Existing sites pick up the fix when migrations run on upgrade; no configuration or code changes are needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@ Test representative upgrades from existing data, retry after partial completion,
 
 ## Indexes
 
-Every content table gets indexes on: `status`, `slug`, `created_at`, `deleted_at`, `scheduled_at` (partial, `WHERE scheduled_at IS NOT NULL`), `live_revision_id`, `draft_revision_id`, `author_id`, `primary_byline_id`, `updated_at`, `locale`, `translation_group`. Foreign key columns always get an index.
+Every content table gets indexes on: `status`, `slug`, `created_at`, `deleted_at`, `(deleted_at, scheduled_at)` (partial, `WHERE scheduled_at IS NOT NULL`), `live_revision_id`, `draft_revision_id`, `author_id`, `primary_byline_id`, `updated_at`, `locale`, `translation_group`. Foreign key columns always get an index.
 
 Naming: `idx_{table}_{column}` for single-column, `idx_{table}_{purpose}` for multi-column.
 

--- a/packages/core/src/database/migrations/074_content_deleted_scheduled_index.ts
+++ b/packages/core/src/database/migrations/074_content_deleted_scheduled_index.ts
@@ -1,0 +1,60 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+
+import { listTablesLike } from "../dialect-helpers.js";
+
+/**
+ * Migration: replace the single-column partial `scheduled_at` index on content
+ * tables with a `(deleted_at, scheduled_at)` composite.
+ *
+ * The scheduled-publishing sweep reads `scheduled_at IS NOT NULL AND
+ * scheduled_at <= ? AND deleted_at IS NULL` ordered by `scheduled_at`. A
+ * stats-blind planner cannot seek the `scheduled_at`-only partial index and
+ * satisfy `deleted_at IS NULL` too, so it takes the `deleted_at=?` equality on
+ * whichever `deleted_at`-leading composite it finds first, reads every live row
+ * in the table, and sorts the result in a temp b-tree. The sweep runs per
+ * collection on every scheduler tick, so a site with no scheduled content still
+ * pays its entire content size in reads every tick.
+ *
+ * Leading with `deleted_at` lets the same index serve the equality and then walk
+ * `scheduled_at` in order, which satisfies the range and the ORDER BY together.
+ * The partial `WHERE scheduled_at IS NOT NULL` clause is kept so the index stays
+ * proportional to scheduled content rather than to the table. D1 never has
+ * `sqlite_stat1`, so the index shape is the only lever.
+ *
+ * Forward-only and idempotent (`IF NOT EXISTS`).
+ *
+ * The short `del_sched` suffix keeps the name inside Postgres's 63-byte
+ * identifier limit for long collection slugs. Keep it identical to the name in
+ * `schema/registry.ts`.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+	const tableNames = await listTablesLike(db, "ec_%");
+
+	for (const tableName of tableNames) {
+		// D1 DDL is non-transactional: create the replacement before dropping the
+		// old index so an interrupted migration always leaves a scheduled_at index
+		// in place.
+		await sql`
+			CREATE INDEX IF NOT EXISTS ${sql.ref(`idx_${tableName}_del_sched`)}
+			ON ${sql.ref(tableName)} (deleted_at, scheduled_at)
+			WHERE scheduled_at IS NOT NULL
+		`.execute(db);
+
+		await sql`DROP INDEX IF EXISTS ${sql.ref(`idx_${tableName}_scheduled`)}`.execute(db);
+	}
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	const tableNames = await listTablesLike(db, "ec_%");
+
+	for (const tableName of tableNames) {
+		await sql`
+			CREATE INDEX IF NOT EXISTS ${sql.ref(`idx_${tableName}_scheduled`)}
+			ON ${sql.ref(tableName)} (scheduled_at)
+			WHERE scheduled_at IS NOT NULL
+		`.execute(db);
+
+		await sql`DROP INDEX IF EXISTS ${sql.ref(`idx_${tableName}_del_sched`)}`.execute(db);
+	}
+}

--- a/packages/core/src/database/migrations/074_content_deleted_scheduled_index.ts
+++ b/packages/core/src/database/migrations/074_content_deleted_scheduled_index.ts
@@ -7,20 +7,15 @@ import { listTablesLike } from "../dialect-helpers.js";
  * Migration: replace the single-column partial `scheduled_at` index on content
  * tables with a `(deleted_at, scheduled_at)` composite.
  *
- * The scheduled-publishing sweep reads `scheduled_at IS NOT NULL AND
- * scheduled_at <= ? AND deleted_at IS NULL` ordered by `scheduled_at`. A
- * stats-blind planner cannot seek the `scheduled_at`-only partial index and
- * satisfy `deleted_at IS NULL` too, so it takes the `deleted_at=?` equality on
- * whichever `deleted_at`-leading composite it finds first, reads every live row
- * in the table, and sorts the result in a temp b-tree. The sweep runs per
- * collection on every scheduler tick, so a site with no scheduled content still
- * pays its entire content size in reads every tick.
+ * The scheduled-publishing sweep filters `scheduled_at` by range and
+ * `deleted_at IS NULL`, ordered by `scheduled_at`. A `scheduled_at`-only index
+ * cannot satisfy the soft-delete term, so a stats-blind planner seeks a
+ * `deleted_at`-leading composite instead and reads every live row. Leading with
+ * `deleted_at` lets one index serve the equality, the range, and the ORDER BY.
+ * D1 never has `sqlite_stat1`, so the index shape is the only lever.
  *
- * Leading with `deleted_at` lets the same index serve the equality and then walk
- * `scheduled_at` in order, which satisfies the range and the ORDER BY together.
- * The partial `WHERE scheduled_at IS NOT NULL` clause is kept so the index stays
- * proportional to scheduled content rather than to the table. D1 never has
- * `sqlite_stat1`, so the index shape is the only lever.
+ * The partial predicate from migration 030 is kept so the index stays
+ * proportional to scheduled content rather than to the table.
  *
  * Forward-only and idempotent (`IF NOT EXISTS`).
  *

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -76,6 +76,7 @@ import * as m070 from "./070_collection_routable.js";
 import * as m071 from "./071_restore_content_bylines_table.js";
 import * as m072 from "./072_media_folders.js";
 import * as m073 from "./073_media_focal_point.js";
+import * as m074 from "./074_content_deleted_scheduled_index.js";
 
 const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"001_initial": m001,
@@ -150,6 +151,7 @@ const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"071_restore_content_bylines_table": m071,
 	"072_media_folders": m072,
 	"073_media_focal_point": m073,
+	"074_content_deleted_scheduled_index": m074,
 });
 
 /** Ordered names from the statically registered migration set. */

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -1463,10 +1463,10 @@ export class SchemaRegistry {
 			ON ${sql.ref(tableName)} (slug)
 		`.execute(conn);
 
-		// Name must stay identical to migration 074. Leading with `deleted_at` lets
-		// the scheduled-publishing sweep seek the soft-delete equality and walk
-		// `scheduled_at` for both its range and its ORDER BY; a `scheduled_at`-only
-		// index leaves a stats-blind planner reading every live row per tick.
+		// Name must stay identical to migration 074. `deleted_at` leads so the
+		// scheduled-publishing sweep can seek it and walk `scheduled_at` for both
+		// its range and its ORDER BY; a `scheduled_at`-only index leaves a
+		// stats-blind planner reading every live row.
 		await sql`
 			${createIndex} ${sql.ref(`idx_${tableName}_del_sched`)}
 			ON ${sql.ref(tableName)} (deleted_at, scheduled_at)

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -1463,9 +1463,13 @@ export class SchemaRegistry {
 			ON ${sql.ref(tableName)} (slug)
 		`.execute(conn);
 
+		// Name must stay identical to migration 074. Leading with `deleted_at` lets
+		// the scheduled-publishing sweep seek the soft-delete equality and walk
+		// `scheduled_at` for both its range and its ORDER BY; a `scheduled_at`-only
+		// index leaves a stats-blind planner reading every live row per tick.
 		await sql`
-			${createIndex} ${sql.ref(`idx_${tableName}_scheduled`)}
-			ON ${sql.ref(tableName)} (scheduled_at)
+			${createIndex} ${sql.ref(`idx_${tableName}_del_sched`)}
+			ON ${sql.ref(tableName)} (deleted_at, scheduled_at)
 			WHERE scheduled_at IS NOT NULL
 		`.execute(conn);
 

--- a/packages/core/tests/integration/database/migrations.test.ts
+++ b/packages/core/tests/integration/database/migrations.test.ts
@@ -187,6 +187,7 @@ describe("Database Migrations (Integration)", () => {
 			"071_restore_content_bylines_table",
 			"072_media_folders",
 			"073_media_focal_point",
+			"074_content_deleted_scheduled_index",
 		];
 
 		await db.deleteFrom("_emdash_migrations").where("name", "in", trailing).execute();

--- a/packages/core/tests/integration/database/scheduled-publish-plan.test.ts
+++ b/packages/core/tests/integration/database/scheduled-publish-plan.test.ts
@@ -57,7 +57,7 @@ it("seeks due content through the scheduled index instead of scanning live rows"
 
 	const plan = explain(scheduledQuery());
 	expect(contentAccess(plan)).toMatch(
-		/SEARCH ec_post USING (?:COVERING )?INDEX idx_ec_post_del_sched \(deleted_at=\? AND scheduled_at>\? AND scheduled_at<\?\)/,
+		/SEARCH ec_post USING (?:COVERING )?INDEX idx_ec_post_del_sched \(deleted_at=\? AND scheduled_at/,
 	);
 	expect(plan).not.toContain("SCAN ec_post");
 	expect(plan).not.toContain("USE TEMP B-TREE FOR ORDER BY");
@@ -95,7 +95,7 @@ it("migrates a pre-074 table off the deleted_at-leading plan", async () => {
 	await repo.findReadyToPublish("post", 100);
 	const after = explain(scheduledQuery());
 	expect(contentAccess(after)).toMatch(
-		/SEARCH ec_post USING (?:COVERING )?INDEX idx_ec_post_del_sched \(deleted_at=\? AND scheduled_at>\? AND scheduled_at<\?\)/,
+		/SEARCH ec_post USING (?:COVERING )?INDEX idx_ec_post_del_sched \(deleted_at=\? AND scheduled_at/,
 	);
 	expect(after).not.toContain("USE TEMP B-TREE FOR ORDER BY");
 });

--- a/packages/core/tests/integration/database/scheduled-publish-plan.test.ts
+++ b/packages/core/tests/integration/database/scheduled-publish-plan.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Query-plan coverage for the scheduled-publishing sweep.
+ *
+ * SQLite runs without ANALYZE/sqlite_stat1 here, matching D1's stats-blind
+ * planner. Publish behaviour for due content is covered by the
+ * scheduled-publish suite.
+ */
+
+import Database from "better-sqlite3";
+import { Kysely, SqliteDialect } from "kysely";
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import * as migration074 from "../../../src/database/migrations/074_content_deleted_scheduled_index.js";
+import { runMigrations } from "../../../src/database/migrations/runner.js";
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { Database as DatabaseSchema } from "../../../src/database/types.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+
+interface CapturedQuery {
+	sql: string;
+	parameters: readonly unknown[];
+}
+
+let sqlite: Database.Database;
+let db: Kysely<DatabaseSchema>;
+let repo: ContentRepository;
+let captured: CapturedQuery[];
+
+beforeEach(async () => {
+	captured = [];
+	sqlite = new Database(":memory:");
+	db = new Kysely<DatabaseSchema>({
+		dialect: new SqliteDialect({ database: sqlite }),
+		log(event) {
+			if (event.level === "query") {
+				captured.push({ sql: event.query.sql, parameters: event.query.parameters });
+			}
+		},
+	});
+	await runMigrations(db);
+	const registry = new SchemaRegistry(db);
+	await registry.createCollection({ slug: "post", label: "Posts", labelSingular: "Post" });
+	repo = new ContentRepository(db);
+
+	seedLiveRows(2000);
+	captured = [];
+});
+
+afterEach(async () => {
+	await db.destroy();
+});
+
+it("seeks due content through the scheduled index instead of scanning live rows", async () => {
+	const due = await repo.findReadyToPublish("post", 100);
+
+	expect(due).toEqual([]);
+
+	const plan = explain(scheduledQuery());
+	expect(contentAccess(plan)).toMatch(
+		/SEARCH ec_post USING (?:COVERING )?INDEX idx_ec_post_del_sched \(deleted_at=\? AND scheduled_at>\? AND scheduled_at<\?\)/,
+	);
+	expect(plan).not.toContain("SCAN ec_post");
+	expect(plan).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+});
+
+it("still returns due content oldest-first, skipping soft-deleted rows", async () => {
+	insertRow("due-late", { scheduledAt: "2025-06-02T00:00:00.000Z" });
+	insertRow("due-early", { scheduledAt: "2025-06-01T00:00:00.000Z" });
+	insertRow("due-deleted", {
+		scheduledAt: "2025-05-01T00:00:00.000Z",
+		deletedAt: "2025-05-02T00:00:00.000Z",
+	});
+	insertRow("not-yet-due", { scheduledAt: "2099-01-01T00:00:00.000Z" });
+
+	const due = await repo.findReadyToPublish("post", 100);
+
+	expect(due.map((item) => item.id)).toEqual(["due-early", "due-late"]);
+});
+
+it("migrates a pre-074 table off the deleted_at-leading plan", async () => {
+	sqlite.exec(`DROP INDEX idx_ec_post_del_sched`);
+	sqlite.exec(
+		`CREATE INDEX idx_ec_post_scheduled ON ec_post (scheduled_at) WHERE scheduled_at IS NOT NULL`,
+	);
+	captured = [];
+	await repo.findReadyToPublish("post", 100);
+	const before = explain(scheduledQuery());
+	expect(contentAccess(before)).toMatch(/SEARCH ec_post USING INDEX \S+ \(deleted_at=\?\)/);
+	expect(before).toContain("USE TEMP B-TREE FOR ORDER BY");
+
+	await migration074.up(db);
+
+	expect(indexNames()).not.toContain("idx_ec_post_scheduled");
+	captured = [];
+	await repo.findReadyToPublish("post", 100);
+	const after = explain(scheduledQuery());
+	expect(contentAccess(after)).toMatch(
+		/SEARCH ec_post USING (?:COVERING )?INDEX idx_ec_post_del_sched \(deleted_at=\? AND scheduled_at>\? AND scheduled_at<\?\)/,
+	);
+	expect(after).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+});
+
+function seedLiveRows(count: number): void {
+	const insert = sqlite.prepare(
+		`INSERT INTO ec_post (id, slug, status, locale, created_at, updated_at, version)
+		 VALUES (?, ?, 'published', 'en', '2025-01-01', '2025-01-01', 1)`,
+	);
+	for (let index = 1; index <= count; index++) {
+		insert.run(`live-${index}`, `live-${index}`);
+	}
+}
+
+function insertRow(
+	id: string,
+	{ scheduledAt, deletedAt = null }: { scheduledAt: string; deletedAt?: string | null },
+): void {
+	sqlite
+		.prepare(
+			`INSERT INTO ec_post (id, slug, status, locale, created_at, updated_at, version, scheduled_at, deleted_at)
+			 VALUES (?, ?, 'scheduled', 'en', '2025-01-01', '2025-01-01', 1, ?, ?)`,
+		)
+		.run(id, id, scheduledAt, deletedAt);
+}
+
+function indexNames(): string[] {
+	return (
+		sqlite.prepare(`SELECT name FROM sqlite_master WHERE type = 'index'`).all() as {
+			name: string;
+		}[]
+	).map((row) => row.name);
+}
+
+function scheduledQuery(): CapturedQuery {
+	const queries = captured.filter((query) => query.sql.includes("scheduled_at <="));
+	expect(queries).toHaveLength(1);
+	return queries[0]!;
+}
+
+/** better-sqlite3 only binds primitives; coerce values captured from Kysely. */
+function bindable(parameter: unknown): unknown {
+	if (typeof parameter === "boolean") return parameter ? 1 : 0;
+	if (parameter instanceof Date) return parameter.toISOString();
+	if (parameter === undefined) return null;
+	return parameter;
+}
+
+function explain(query: CapturedQuery): string {
+	const rows = sqlite
+		.prepare(`EXPLAIN QUERY PLAN ${query.sql}`)
+		.all(...query.parameters.map(bindable)) as { detail: string }[];
+	return rows.map((row) => row.detail).join("\n");
+}
+
+function contentAccess(plan: string): string | undefined {
+	return plan.split("\n").find((detail) => /\b(?:SCAN|SEARCH) ec_post\b/.test(detail));
+}


### PR DESCRIPTION
## What does this PR do?

The scheduled-publishing sweep runs one query per collection per scheduler tick:

```sql
SELECT * FROM "ec_article"
WHERE scheduled_at IS NOT NULL AND scheduled_at <= ? AND deleted_at IS NULL
ORDER BY scheduled_at ASC LIMIT ?
```

A stats-blind planner cannot seek the `scheduled_at`-only partial index and satisfy `deleted_at IS NULL` at the same time, so it takes a `deleted_at=?` equality on whichever `deleted_at`-leading composite it finds first, reads every live row in the table, and sorts the result in a temp b-tree. Sites with no scheduled content at all still paid their entire content size in reads on every tick, which on D1 is directly billable.

Migration `074` replaces `idx_{table}_scheduled` with `idx_{table}_del_sched` on `(deleted_at, scheduled_at)`, keeping the `WHERE scheduled_at IS NOT NULL` predicate that migration `030` widened so the index stays proportional to scheduled content rather than to the table. Leading with `deleted_at` lets one index serve the equality, the range, and the `ORDER BY` together. `findReadyToPublish`'s SQL is unchanged. `SchemaRegistry` is updated to give newly created tables the same shape.

Measured with `EXPLAIN QUERY PLAN` on SQLite without `ANALYZE`, matching D1's stats-blind planner:

| | Plan |
| --- | --- |
| Before | `SEARCH ec_post USING INDEX idx_ec_post_loc_crt (deleted_at=?)` + `USE TEMP B-TREE FOR ORDER BY` |
| After | `SEARCH ec_post USING INDEX idx_ec_post_del_sched (deleted_at=? AND scheduled_at>? AND scheduled_at<?)` |

`countScheduled`, which backs admin scheduled-content counts, reads the same shape and picks up the new index too.

### Two notes on the issue as filed

**The suggested query fix does not work.** #2843 proposes dropping the redundant `scheduled_at IS NOT NULL` predicate to let the planner match the partial index. I measured this: the plan is byte-for-byte unchanged. `deleted_at IS NULL` is what pulls the planner off the partial index, not the `IS NOT NULL` term. Adding `deleted_at IS NULL` to the partial index's own `WHERE` clause does not help either. Only the composite key does.

**The guard/watermark is deliberately not implemented.** The issue proposes two stacking fixes. With the index corrected, a tick that finds nothing due costs a seek per collection instead of a full scan, so the remaining cost is round trips, not read volume. A "next scheduled at" watermark would buy those back at the price of durable state to invalidate on every schedule, unschedule, and publish write — which also cuts against the "prefer the batch query to a 'has any' probe" guidance in `CLAUDE.md`. Happy to add it in a follow-up if maintainers disagree.

Closes #2843

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

Admin localization, a feature Discussion, and screenshots are not applicable: this changes a background database index and adds no UI or user-facing strings.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5

## Screenshots / test output

Not applicable — no UI change.

Test coverage added in `packages/core/tests/integration/database/scheduled-publish-plan.test.ts`:

- The sweep seeks through `idx_{table}_del_sched` with no scan and no temp b-tree. The assertion matches the plan shape rather than naming a rival index, so it cannot be satisfied by the planner merely switching to a different `deleted_at` composite.
- Due content still comes back oldest-first with soft-deleted and not-yet-due rows excluded.
- A pre-074 table is migrated and its plan flips, asserted before and after `migration074.up()`.

Verification:

- Full `packages/core` suite: 6267 passed, 9 skipped. The single unhandled error is a pre-existing tiptap/jsdom `document is not defined` in `inline-portable-text-media-picker.test.ts`, unrelated to this change and present on `main`.
- `pnpm typecheck` clean. `pnpm lint` reports one diagnostic in `apps/release-service/src/ui/PublisherPage.tsx`, which is pre-existing and unrelated.

**Not verified by me:** Postgres parity. No local Postgres was available and `EMDASH_TEST_PG` was unset, so `dialect-compat.test.ts` skipped. The DDL is valid Postgres and that suite picks up migration `074` automatically via `MIGRATION_NAMES`, so CI should cover it — but I have not run it. Worth a reviewer confirming the composite does not regress a Postgres deployment, which has real statistics and may have planned the original query differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Whic7zpyBYDDVwBAmY7TF4

---

## Review response (review 5100896550)

**`AGENTS.md` index list — fixed.** Valid catch; the canonical list still described the old single-column partial. Updated in place as `(deleted_at, scheduled_at)` (partial, `WHERE scheduled_at IS NOT NULL`) rather than the suggested trailing sentence, which keeps the enumeration's existing shape.

**Migration and registry comments — trimmed, not to the suggested length.** Removed the parts that were PR narrative: the cost analysis, the restatement of the full query, and the rejected-alternative discussion. Kept why `deleted_at` must lead and why the partial predicate stays.

The suggested six-line version states the mechanism but drops the failure mode, and the failure mode is the thing a future reader gets wrong — a `scheduled_at`-only index looks obviously correct for this query, which is exactly how the bug shipped. Migration `055` documents the same class of stats-blind planner constraint at comparable length and is the closest precedent in the tree. Happy to cut further if you'd rather these read as terse.

**Query-plan assertions — loosened, partially.** Agreed the exact bound formatting is planner-output detail; it also caught me out once while writing the test, so the brittleness concern is real. Dropped it.

I kept `\(deleted_at=\? AND scheduled_at` rather than reducing to the index name alone. Matching only the name would pass if the planner seeked `deleted_at` and merely filtered `scheduled_at`, which is a materially worse plan than the one this PR is claiming. The retained fragment asserts both columns participate in the seek without pinning how SQLite renders the bounds.

Both assertions are additionally backed by the `not.toContain("USE TEMP B-TREE FOR ORDER BY")` check and by the pre/post migration test, which asserts the old plan before `migration074.up()` and the new one after.

Verification after these changes: `pnpm typecheck` clean, `pnpm lint:quick` clean, formatted, `git diff --check` clean; 602 passed across the database integration suite plus the scheduled-publish and registry unit suites. Postgres parity remains unverified locally for the reason given above.
