### PR TITLE
Persist rich text image settings as authors edit

### DIFF
--- a/.changeset/fix-image-caption-edits.md
+++ b/.changeset/fix-image-caption-edits.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": patch
+"emdash": patch
+---
+
+Fixes rich text image settings so caption, alt text, tooltip, size, and alignment edits persist when authors click back into the post. Captions and tooltip titles also round-trip independently, so clearing a caption no longer restores it from the tooltip text.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -185,6 +185,7 @@ interface PortableTextImageBlock {
 	asset: { _ref: string; url?: string; provider?: string; meta?: Record<string, unknown> };
 	alt?: string;
 	caption?: string;
+	title?: string;
 	width?: number;
 	height?: number;
 	/** LQIP blurhash — first-class field (legacy snapshots store it in `asset.meta`). */
@@ -567,7 +568,8 @@ function convertPMNode(
 					provider: provider && provider !== "local" ? provider : undefined,
 				},
 				alt: attrStr(attrs.alt),
-				caption: attrStr(attrs.caption) ?? attrStr(attrs.title),
+				caption: Object.hasOwn(attrs, "caption") ? attrStr(attrs.caption) : attrStr(attrs.title),
+				title: attrStr(attrs.title),
 				width: attrNum(attrs.width),
 				height: attrNum(attrs.height),
 				...(blurhash ? { blurhash } : {}),
@@ -1012,7 +1014,7 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 				attrs: {
 					src: imageBlock.asset.url || `/_emdash/api/media/file/${imageBlock.asset._ref}`,
 					alt: imageBlock.alt || "",
-					title: imageBlock.caption || "",
+					title: imageBlock.title || "",
 					caption: imageBlock.caption || "",
 					mediaId: imageBlock.asset._ref,
 					provider: canonicalMediaProviderId(imageBlock.asset.provider),

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -554,6 +554,10 @@ function convertPMNode(
 			const provider = attrStr(attrs.provider);
 			const blurhash = attrStr(attrs.blurhash);
 			const dominantColor = attrStr(attrs.dominantColor);
+			const title = attrStr(attrs.title);
+			const caption = Object.hasOwn(attrs, "caption")
+				? (attrStr(attrs.caption) ?? (title ? "" : undefined))
+				: title;
 			// Persist LQIP as first-class block fields, matching the image-field
 			// path (MediaValue.blurhash/dominantColor) so read sites and normalize
 			// don't need a `asset.meta` dual-shape. `asset.meta` is left to carry
@@ -568,8 +572,8 @@ function convertPMNode(
 					provider: provider && provider !== "local" ? provider : undefined,
 				},
 				alt: attrStr(attrs.alt),
-				caption: Object.hasOwn(attrs, "caption") ? attrStr(attrs.caption) : attrStr(attrs.title),
-				title: attrStr(attrs.title),
+				caption,
+				title,
 				width: attrNum(attrs.width),
 				height: attrNum(attrs.height),
 				...(blurhash ? { blurhash } : {}),
@@ -854,7 +858,8 @@ function isTextBlock(block: PortableTextBlock): block is PortableTextTextBlock {
 }
 
 function isImageBlock(block: PortableTextBlock): block is PortableTextImageBlock {
-	return block._type === "image";
+	const asset = "asset" in block ? block.asset : undefined;
+	return block._type === "image" && typeof asset === "object" && asset !== null;
 }
 
 function isCodeBlock(block: PortableTextBlock): block is PortableTextCodeBlock {
@@ -992,7 +997,23 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 		}
 
 		case "image": {
-			if (!isImageBlock(block)) return null;
+			if (!isImageBlock(block)) {
+				const malformed = block as unknown as Record<string, unknown>;
+				const title = typeof malformed.title === "string" ? malformed.title : "";
+				return {
+					type: "image",
+					attrs: {
+						src: typeof malformed.url === "string" ? malformed.url : "",
+						alt: typeof malformed.alt === "string" ? malformed.alt : "",
+						title,
+						caption: Object.hasOwn(malformed, "caption")
+							? typeof malformed.caption === "string"
+								? malformed.caption
+								: ""
+							: title,
+					},
+				};
+			}
 			const imageBlock = block;
 			const meta = imageBlock.asset.meta;
 			// Prefer first-class LQIP fields; fall back to `asset.meta` for legacy
@@ -1015,7 +1036,9 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 					src: imageBlock.asset.url || `/_emdash/api/media/file/${imageBlock.asset._ref}`,
 					alt: imageBlock.alt || "",
 					title: imageBlock.title || "",
-					caption: imageBlock.caption || "",
+					caption: Object.hasOwn(imageBlock, "caption")
+						? imageBlock.caption || ""
+						: imageBlock.title || "",
 					mediaId: imageBlock.asset._ref,
 					provider: canonicalMediaProviderId(imageBlock.asset.provider),
 					width: imageBlock.width,

--- a/packages/admin/src/components/editor/ImageDetailPanel.tsx
+++ b/packages/admin/src/components/editor/ImageDetailPanel.tsx
@@ -95,23 +95,50 @@ export function ImageDetailPanel({
 
 	const handleWidthChange = (value: string) => {
 		const newWidth = value ? parseInt(value, 10) : undefined;
+		const newHeight =
+			lockAspectRatio && aspectRatio && newWidth
+				? Math.round(newWidth / aspectRatio)
+				: displayHeight;
 		setDisplayWidth(newWidth);
-		if (lockAspectRatio && aspectRatio && newWidth) {
-			setDisplayHeight(Math.round(newWidth / aspectRatio));
-		}
+		setDisplayHeight(newHeight);
+		onUpdate({ displayWidth: newWidth, displayHeight: newHeight });
 	};
 
 	const handleHeightChange = (value: string) => {
 		const newHeight = value ? parseInt(value, 10) : undefined;
+		const newWidth =
+			lockAspectRatio && aspectRatio && newHeight
+				? Math.round(newHeight * aspectRatio)
+				: displayWidth;
 		setDisplayHeight(newHeight);
-		if (lockAspectRatio && aspectRatio && newHeight) {
-			setDisplayWidth(Math.round(newHeight * aspectRatio));
-		}
+		setDisplayWidth(newWidth);
+		onUpdate({ displayWidth: newWidth, displayHeight: newHeight });
 	};
 
 	const handleResetDimensions = () => {
 		setDisplayWidth(attributes.width);
 		setDisplayHeight(attributes.height);
+		onUpdate({ displayWidth: attributes.width, displayHeight: attributes.height });
+	};
+
+	const handleAltChange = (value: string) => {
+		setAlt(value);
+		onUpdate({ alt: value || undefined });
+	};
+
+	const handleCaptionChange = (value: string) => {
+		setCaption(value);
+		onUpdate({ caption: value || undefined });
+	};
+
+	const handleTitleChange = (value: string) => {
+		setTitle(value);
+		onUpdate({ title: value || undefined });
+	};
+
+	const handleAlignmentChange = (value: ImageAttributes["alignment"]) => {
+		setAlignment(value);
+		onUpdate({ alignment: value });
 	};
 
 	const handleMediaSelect = (item: MediaItem) => {
@@ -132,32 +159,6 @@ export function ImageDetailPanel({
 		onClose();
 	};
 
-	// Track if form has unsaved changes
-	const hasChanges = React.useMemo(() => {
-		const originalDisplayWidth = attributes.displayWidth ?? attributes.width;
-		const originalDisplayHeight = attributes.displayHeight ?? attributes.height;
-		return (
-			alt !== (attributes.alt ?? "") ||
-			caption !== (attributes.caption ?? "") ||
-			title !== (attributes.title ?? "") ||
-			displayWidth !== originalDisplayWidth ||
-			displayHeight !== originalDisplayHeight ||
-			alignment !== attributes.alignment
-		);
-	}, [attributes, alt, caption, title, displayWidth, displayHeight, alignment]);
-
-	const handleSave = () => {
-		onUpdate({
-			alt: alt || undefined,
-			caption: caption || undefined,
-			title: title || undefined,
-			displayWidth,
-			displayHeight,
-			alignment,
-		});
-		onClose();
-	};
-
 	const alignmentOptions: { value: ImageAttributes["alignment"]; label: string }[] = [
 		{ value: undefined, label: t`None` },
 		{ value: "left", label: t`Left` },
@@ -172,9 +173,7 @@ export function ImageDetailPanel({
 	const handleDelete = () => {
 		setShowDeleteConfirm(true);
 	};
-
 	const stableOnClose = useStableCallback(onClose);
-	const stableHandleSave = useStableCallback(handleSave);
 
 	// Handle keyboard shortcuts
 	React.useEffect(() => {
@@ -182,15 +181,11 @@ export function ImageDetailPanel({
 			if (e.key === "Escape") {
 				stableOnClose();
 			}
-			if ((e.metaKey || e.ctrlKey) && e.key === "s") {
-				e.preventDefault();
-				stableHandleSave();
-			}
 		};
 
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [stableOnClose, stableHandleSave]);
+	}, [stableOnClose]);
 
 	const dialogs = (
 		<>
@@ -332,7 +327,7 @@ export function ImageDetailPanel({
 									type="button"
 									size="sm"
 									variant={alignment === opt.value ? "primary" : "secondary"}
-									onClick={() => setAlignment(opt.value)}
+									onClick={() => handleAlignmentChange(opt.value)}
 								>
 									{opt.label}
 								</Button>
@@ -346,7 +341,7 @@ export function ImageDetailPanel({
 					<Input
 						label={t`Alt Text`}
 						value={alt}
-						onChange={(e) => setAlt(e.target.value)}
+						onChange={(e) => handleAltChange(e.target.value)}
 						placeholder={t`Describe this image for accessibility`}
 						description={t`Required for accessibility. Describes the image for screen readers.`}
 					/>
@@ -354,7 +349,7 @@ export function ImageDetailPanel({
 					<InputArea
 						label={t`Caption`}
 						value={caption}
-						onChange={(e) => setCaption(e.target.value)}
+						onChange={(e) => handleCaptionChange(e.target.value)}
 						placeholder={t`Optional caption displayed below the image`}
 						description={t`Displayed below the image as a visible caption.`}
 						rows={2}
@@ -363,7 +358,7 @@ export function ImageDetailPanel({
 					<Input
 						label={t`Title (Tooltip)`}
 						value={title}
-						onChange={(e) => setTitle(e.target.value)}
+						onChange={(e) => handleTitleChange(e.target.value)}
 						placeholder={t`Optional tooltip on hover`}
 						description={t`Shown when hovering over the image.`}
 					/>
@@ -390,12 +385,9 @@ export function ImageDetailPanel({
 				</div>
 
 				{/* Actions */}
-				<div className="p-4 border-t flex items-center justify-between gap-2">
+				<div className="p-4 border-t">
 					<Button variant="destructive" size="sm" onClick={handleDelete}>
 						{t`Remove Image`}
-					</Button>
-					<Button size="sm" onClick={handleSave} disabled={!hasChanges}>
-						{t`Save`}
 					</Button>
 				</div>
 
@@ -521,7 +513,7 @@ export function ImageDetailPanel({
 									type="button"
 									size="sm"
 									variant={alignment === opt.value ? "primary" : "secondary"}
-									onClick={() => setAlignment(opt.value)}
+									onClick={() => handleAlignmentChange(opt.value)}
 								>
 									{opt.label}
 								</Button>
@@ -535,7 +527,7 @@ export function ImageDetailPanel({
 					<Input
 						label={t`Alt Text`}
 						value={alt}
-						onChange={(e) => setAlt(e.target.value)}
+						onChange={(e) => handleAltChange(e.target.value)}
 						placeholder={t`Describe this image for accessibility`}
 						description={t`Required for accessibility. Describes the image for screen readers.`}
 					/>
@@ -543,7 +535,7 @@ export function ImageDetailPanel({
 					<InputArea
 						label={t`Caption`}
 						value={caption}
-						onChange={(e) => setCaption(e.target.value)}
+						onChange={(e) => handleCaptionChange(e.target.value)}
 						placeholder={t`Optional caption displayed below the image`}
 						description={t`Displayed below the image as a visible caption.`}
 						rows={2}
@@ -552,7 +544,7 @@ export function ImageDetailPanel({
 					<Input
 						label={t`Title (Tooltip)`}
 						value={title}
-						onChange={(e) => setTitle(e.target.value)}
+						onChange={(e) => handleTitleChange(e.target.value)}
 						placeholder={t`Optional tooltip on hover`}
 						description={t`Shown when hovering over the image.`}
 					/>
@@ -584,14 +576,9 @@ export function ImageDetailPanel({
 				<Button variant="destructive" size="sm" onClick={handleDelete}>
 					{t`Remove Image`}
 				</Button>
-				<div className="flex gap-2">
-					<Button variant="outline" size="sm" onClick={onClose}>
-						{t`Cancel`}
-					</Button>
-					<Button size="sm" onClick={handleSave} disabled={!hasChanges}>
-						{t`Save`}
-					</Button>
-				</div>
+				<Button variant="outline" size="sm" onClick={onClose}>
+					{t`Close`}
+				</Button>
 			</div>
 
 			{dialogs}

--- a/packages/admin/tests/components/ImageDetailPanel.test.tsx
+++ b/packages/admin/tests/components/ImageDetailPanel.test.tsx
@@ -66,3 +66,23 @@ describe("ImageDetailPanel replacement", () => {
 		expect(onReplace).toHaveBeenCalledWith(expect.objectContaining({ provider: expectedProvider }));
 	});
 });
+
+describe("ImageDetailPanel edits", () => {
+	it("applies caption edits without requiring the Save button", async () => {
+		const onUpdate = vi.fn();
+		const screen = await render(
+			<ImageDetailPanel
+				attributes={{ src: "/photo.jpg" }}
+				onUpdate={onUpdate}
+				onReplace={vi.fn()}
+				onDelete={vi.fn()}
+				onClose={vi.fn()}
+				inline
+			/>,
+		);
+
+		await screen.getByLabelText("Caption").fill("A saved caption");
+
+		expect(onUpdate).toHaveBeenLastCalledWith({ caption: "A saved caption" });
+	});
+});

--- a/packages/admin/tests/editor/image-metadata.test.ts
+++ b/packages/admin/tests/editor/image-metadata.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	_portableTextToProsemirror as portableTextToProsemirror,
+	_prosemirrorToPortableText as prosemirrorToPortableText,
+} from "../../src/components/PortableTextEditor";
+
+describe("admin editor image metadata", () => {
+	it("keeps captions and tooltip titles independent through a round trip", () => {
+		const pm = portableTextToProsemirror([
+			{
+				_type: "image",
+				_key: "image-1",
+				asset: { _ref: "media-1", url: "/photo.jpg" },
+				alt: "A photo",
+				caption: "Visible caption",
+				title: "Hover title",
+			} as never,
+		]);
+
+		const restored = prosemirrorToPortableText(pm)[0] as Record<string, unknown>;
+
+		expect(restored.caption).toBe("Visible caption");
+		expect(restored.title).toBe("Hover title");
+	});
+
+	it("does not restore a cleared caption from the tooltip title", () => {
+		const restored = prosemirrorToPortableText({
+			type: "doc",
+			content: [
+				{
+					type: "image",
+					attrs: {
+						src: "/photo.jpg",
+						mediaId: "media-1",
+						caption: "",
+						title: "Hover title",
+					},
+				},
+			],
+		})[0] as Record<string, unknown>;
+
+		expect(restored.caption).toBeUndefined();
+		expect(restored.title).toBe("Hover title");
+	});
+
+	it("reads captions from title-only legacy image nodes", () => {
+		const restored = prosemirrorToPortableText({
+			type: "doc",
+			content: [
+				{
+					type: "image",
+					attrs: {
+						src: "/photo.jpg",
+						mediaId: "media-1",
+						title: "Legacy caption",
+					},
+				},
+			],
+		})[0] as Record<string, unknown>;
+
+		expect(restored.caption).toBe("Legacy caption");
+		expect(restored.title).toBe("Legacy caption");
+	});
+});

--- a/packages/admin/tests/editor/image-metadata.test.ts
+++ b/packages/admin/tests/editor/image-metadata.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	_portableTextToProsemirror as portableTextToProsemirror,
 	_prosemirrorToPortableText as prosemirrorToPortableText,
-} from "../../src/components/PortableTextEditor";
+} from "../../src/components/PortableTextEditor.js";
 
 describe("admin editor image metadata", () => {
 	it("keeps captions and tooltip titles independent through a round trip", () => {
@@ -24,8 +24,8 @@ describe("admin editor image metadata", () => {
 		expect(restored.title).toBe("Hover title");
 	});
 
-	it("does not restore a cleared caption from the tooltip title", () => {
-		const restored = prosemirrorToPortableText({
+	it("keeps a cleared caption separate from the tooltip title across reloads", () => {
+		const portableText = prosemirrorToPortableText({
 			type: "doc",
 			content: [
 				{
@@ -38,28 +38,43 @@ describe("admin editor image metadata", () => {
 					},
 				},
 			],
-		})[0] as Record<string, unknown>;
+		});
+		const restored = prosemirrorToPortableText(
+			portableTextToProsemirror(portableText),
+		)[0] as Record<string, unknown>;
 
-		expect(restored.caption).toBeUndefined();
+		expect(restored.caption).toBe("");
 		expect(restored.title).toBe("Hover title");
 	});
 
-	it("reads captions from title-only legacy image nodes", () => {
-		const restored = prosemirrorToPortableText({
-			type: "doc",
-			content: [
+	it("reads captions from title-only legacy Portable Text blocks", () => {
+		const restored = prosemirrorToPortableText(
+			portableTextToProsemirror([
 				{
-					type: "image",
-					attrs: {
-						src: "/photo.jpg",
-						mediaId: "media-1",
-						title: "Legacy caption",
-					},
-				},
-			],
-		})[0] as Record<string, unknown>;
+					_type: "image",
+					_key: "image-legacy",
+					asset: { _ref: "media-1", url: "/photo.jpg" },
+					title: "Legacy caption",
+				} as never,
+			]),
+		)[0] as Record<string, unknown>;
 
 		expect(restored.caption).toBe("Legacy caption");
 		expect(restored.title).toBe("Legacy caption");
+	});
+
+	it("reads captions from title-only image blocks without an asset wrapper", () => {
+		const pm = portableTextToProsemirror([
+			{
+				_type: "image",
+				_key: "image-malformed",
+				url: "/photo.jpg",
+				title: "Legacy caption",
+			} as never,
+		]);
+		const image = pm.content?.[0] as { attrs?: Record<string, unknown> };
+
+		expect(image.attrs?.src).toBe("/photo.jpg");
+		expect(image.attrs?.caption).toBe("Legacy caption");
 	});
 });

--- a/packages/core/src/components/Image.astro
+++ b/packages/core/src/components/Image.astro
@@ -27,6 +27,7 @@ export interface Props {
 		};
 		alt?: string;
 		caption?: string;
+		title?: string;
 		/** Original image width */
 		width?: number;
 		/** Original image height */
@@ -68,7 +69,7 @@ if (!node?.asset) {
 	return null;
 }
 
-const { asset, alt = "", caption, width, height, displayWidth, displayHeight, alignment } = node;
+const { asset, alt = "", caption, title, width, height, displayWidth, displayHeight, alignment } = node;
 
 // Calculate aspect ratio from original dimensions
 const aspectRatio = width && height ? width / height : undefined;
@@ -172,6 +173,7 @@ if (placeholder && blurhash) {
 			<AstroImage
 				src={astroImageSrc}
 				alt={alt}
+				title={title}
 				width={renderWidth}
 				height={renderHeight}
 				layout="constrained"
@@ -185,6 +187,7 @@ if (placeholder && blurhash) {
 				srcset={srcset}
 				sizes={sizes}
 				alt={alt}
+				title={title}
 				width={renderWidth}
 				height={renderHeight}
 				loading="lazy"

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -273,7 +273,10 @@ function convertPMNode(node: PMNode, path: string): PTBlock | PTBlock[] | null {
 					provider: provider && provider !== "local" ? provider : undefined,
 				},
 				alt: attrStrOpt(node.attrs, "alt"),
-				caption: attrStrOpt(node.attrs, "caption") ?? attrStrOpt(node.attrs, "title"),
+				caption: Object.hasOwn(node.attrs, "caption")
+					? attrStrOpt(node.attrs, "caption")
+					: attrStrOpt(node.attrs, "title"),
+				title: attrStrOpt(node.attrs, "title"),
 				width: attrNum(node.attrs, "width"),
 				height: attrNum(node.attrs, "height"),
 				...(blurhash ? { blurhash } : {}),
@@ -559,6 +562,7 @@ function convertPTBlock(block: PTBlock): PMNode | null {
 			url?: string;
 			alt?: string;
 			caption?: string;
+			title?: string;
 			width?: number;
 			height?: number;
 			/** LQIP — first-class field (legacy snapshots keep it in `asset.meta`). */
@@ -587,7 +591,7 @@ function convertPTBlock(block: PTBlock): PMNode | null {
 			attrs: {
 				src: asset?.url || ib.url || (asset?._ref ? `/_emdash/api/media/file/${asset._ref}` : ""),
 				alt: ib.alt || "",
-				title: ib.caption || "",
+				title: ib.title || "",
 				caption: ib.caption || "",
 				mediaId: asset?._ref,
 				provider: canonicalMediaProviderId(asset?.provider),
@@ -2158,6 +2162,7 @@ export function InlinePortableTextEditor({
 						provider: { default: null },
 						width: { default: null },
 						height: { default: null },
+						caption: { default: null },
 						blurhash: { default: null },
 						dominantColor: { default: null },
 					};

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -259,6 +259,10 @@ function convertPMNode(node: PMNode, path: string): PTBlock | PTBlock[] | null {
 			const provider = attrStrOpt(node.attrs, "provider");
 			const blurhash = attrStrOpt(node.attrs, "blurhash");
 			const dominantColor = attrStrOpt(node.attrs, "dominantColor");
+			const title = attrStrOpt(node.attrs, "title");
+			const caption = Object.hasOwn(node.attrs ?? {}, "caption")
+				? (attrStrOpt(node.attrs, "caption") ?? (title ? "" : undefined))
+				: title;
 			// Persist LQIP as first-class block fields (matching the image-field
 			// MediaValue path) rather than nesting in `asset.meta`, so read sites
 			// and normalize don't need a dual-shape fallback. `asset.meta` is left
@@ -273,10 +277,8 @@ function convertPMNode(node: PMNode, path: string): PTBlock | PTBlock[] | null {
 					provider: provider && provider !== "local" ? provider : undefined,
 				},
 				alt: attrStrOpt(node.attrs, "alt"),
-				caption: Object.hasOwn(node.attrs, "caption")
-					? attrStrOpt(node.attrs, "caption")
-					: attrStrOpt(node.attrs, "title"),
-				title: attrStrOpt(node.attrs, "title"),
+				caption,
+				title,
 				width: attrNum(node.attrs, "width"),
 				height: attrNum(node.attrs, "height"),
 				...(blurhash ? { blurhash } : {}),
@@ -592,7 +594,7 @@ function convertPTBlock(block: PTBlock): PMNode | null {
 				src: asset?.url || ib.url || (asset?._ref ? `/_emdash/api/media/file/${asset._ref}` : ""),
 				alt: ib.alt || "",
 				title: ib.title || "",
-				caption: ib.caption || "",
+				caption: Object.hasOwn(ib, "caption") ? ib.caption || "" : ib.title || "",
 				mediaId: asset?._ref,
 				provider: canonicalMediaProviderId(asset?.provider),
 				width: ib.width,

--- a/packages/core/src/content/converters/portable-text-to-prosemirror.ts
+++ b/packages/core/src/content/converters/portable-text-to-prosemirror.ts
@@ -516,7 +516,8 @@ function convertImage(block: PortableTextImageBlock): ProseMirrorNode {
 		attrs: {
 			src: block.asset.url || block.asset._ref,
 			alt: block.alt || "",
-			title: block.caption || "",
+			title: block.title || "",
+			caption: block.caption || "",
 			mediaId: block.asset._ref,
 			provider: block.asset.provider,
 			width: block.width,
@@ -537,6 +538,7 @@ function convertMalformedImage(block: PortableTextBlock): ProseMirrorNode {
 	const url = "url" in block && typeof block.url === "string" ? block.url : "";
 	const alt = "alt" in block && typeof block.alt === "string" ? block.alt : "";
 	const caption = "caption" in block && typeof block.caption === "string" ? block.caption : "";
+	const title = "title" in block && typeof block.title === "string" ? block.title : "";
 	const width = "width" in block && typeof block.width === "number" ? block.width : undefined;
 	const height = "height" in block && typeof block.height === "number" ? block.height : undefined;
 	const displayWidth =
@@ -552,7 +554,8 @@ function convertMalformedImage(block: PortableTextBlock): ProseMirrorNode {
 		attrs: {
 			src: url,
 			alt,
-			title: caption,
+			title,
+			caption,
 			mediaId: undefined,
 			provider: undefined,
 			width,

--- a/packages/core/src/content/converters/portable-text-to-prosemirror.ts
+++ b/packages/core/src/content/converters/portable-text-to-prosemirror.ts
@@ -517,7 +517,7 @@ function convertImage(block: PortableTextImageBlock): ProseMirrorNode {
 			src: block.asset.url || block.asset._ref,
 			alt: block.alt || "",
 			title: block.title || "",
-			caption: block.caption || "",
+			caption: Object.hasOwn(block, "caption") ? block.caption || "" : block.title || "",
 			mediaId: block.asset._ref,
 			provider: block.asset.provider,
 			width: block.width,
@@ -537,8 +537,13 @@ function convertMalformedImage(block: PortableTextBlock): ProseMirrorNode {
 	// PortableTextUnknownBlock allows indexed access via [key: string]: unknown
 	const url = "url" in block && typeof block.url === "string" ? block.url : "";
 	const alt = "alt" in block && typeof block.alt === "string" ? block.alt : "";
-	const caption = "caption" in block && typeof block.caption === "string" ? block.caption : "";
 	const title = "title" in block && typeof block.title === "string" ? block.title : "";
+	const rawCaption = "caption" in block ? block.caption : undefined;
+	const caption = Object.hasOwn(block, "caption")
+		? typeof rawCaption === "string"
+			? rawCaption
+			: ""
+		: title;
 	const width = "width" in block && typeof block.width === "number" ? block.width : undefined;
 	const height = "height" in block && typeof block.height === "number" ? block.height : undefined;
 	const displayWidth =

--- a/packages/core/src/content/converters/prosemirror-to-portable-text.ts
+++ b/packages/core/src/content/converters/prosemirror-to-portable-text.ts
@@ -346,7 +346,7 @@ function convertImage(node: ProseMirrorNode): PortableTextImageBlock {
 			provider: provider && provider !== "local" ? provider : undefined,
 		},
 		alt: alt || undefined,
-		caption: caption || undefined,
+		caption: caption || (title ? "" : undefined),
 		title: title || undefined,
 		width: width || undefined,
 		height: height || undefined,

--- a/packages/core/src/content/converters/prosemirror-to-portable-text.ts
+++ b/packages/core/src/content/converters/prosemirror-to-portable-text.ts
@@ -323,6 +323,12 @@ function convertImage(node: ProseMirrorNode): PortableTextImageBlock {
 	const src = typeof attrs?.src === "string" ? attrs.src : "";
 	const alt = typeof attrs?.alt === "string" ? attrs.alt : undefined;
 	const title = typeof attrs?.title === "string" ? attrs.title : undefined;
+	const caption =
+		attrs && Object.hasOwn(attrs, "caption")
+			? typeof attrs.caption === "string"
+				? attrs.caption
+				: undefined
+			: title;
 	const width = typeof attrs?.width === "number" ? attrs.width : undefined;
 	const height = typeof attrs?.height === "number" ? attrs.height : undefined;
 	const displayWidth = typeof attrs?.displayWidth === "number" ? attrs.displayWidth : undefined;
@@ -340,7 +346,8 @@ function convertImage(node: ProseMirrorNode): PortableTextImageBlock {
 			provider: provider && provider !== "local" ? provider : undefined,
 		},
 		alt: alt || undefined,
-		caption: title || undefined,
+		caption: caption || undefined,
+		title: title || undefined,
 		width: width || undefined,
 		height: height || undefined,
 		displayWidth: displayWidth || undefined,

--- a/packages/core/src/content/converters/types.ts
+++ b/packages/core/src/content/converters/types.ts
@@ -62,6 +62,7 @@ export interface PortableTextImageBlock {
 	};
 	alt?: string;
 	caption?: string;
+	title?: string;
 	/** Original image width */
 	width?: number;
 	/** Original image height */

--- a/packages/core/tests/repro/image-render.render.test.ts
+++ b/packages/core/tests/repro/image-render.render.test.ts
@@ -114,6 +114,7 @@ describe("faithful render of migrated image node", () => {
 			...node,
 			alt: "Migrated image",
 			caption: "A caption",
+			title: "Image details",
 			alignment: "center",
 			width: 1200,
 			height: 800,
@@ -125,6 +126,7 @@ describe("faithful render of migrated image node", () => {
 		expect(compact(html)).toContain('<figure class="emdash-image emdash-image--align-center"');
 		expect(attr(tag, "src")).toContain("/_emdash/api/media/file/01KTRTJ55S65SADEH9P9TSY89H.png");
 		expect(attr(tag, "alt")).toBe("Migrated image");
+		expect(attr(tag, "title")).toBe("Image details");
 		expect(attr(tag, "width")).toBe("600");
 		expect(attr(tag, "height")).toBe("400");
 		expect(attr(tag, "loading")).toBe("lazy");

--- a/packages/core/tests/unit/components/inline-portable-text-image.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-image.test.ts
@@ -117,3 +117,39 @@ describe("Image LQIP round-trip (inline editor seam)", () => {
 		expect(restored.dominantColor).toBeUndefined();
 	});
 });
+
+describe("Image caption round-trip (inline editor seam)", () => {
+	it("keeps captions and tooltip titles independent", () => {
+		const pm = portableTextToPM([
+			{
+				_type: "image",
+				_key: "img003",
+				asset: { _ref: "01CAPTION", url: "/caption.jpg" },
+				caption: "Visible caption",
+				title: "Hover title",
+			},
+		]);
+
+		const [restored] = pmToPortableText(pm) as Array<{
+			caption?: string;
+			title?: string;
+		}>;
+
+		expect(restored.caption).toBe("Visible caption");
+		expect(restored.title).toBe("Hover title");
+	});
+
+	it("reads captions from title-only legacy image nodes", () => {
+		const [restored] = pmToPortableText({
+			type: "doc",
+			content: [
+				{
+					type: "image",
+					attrs: { src: "/legacy.jpg", title: "Legacy caption" },
+				},
+			],
+		}) as Array<{ caption?: string }>;
+
+		expect(restored.caption).toBe("Legacy caption");
+	});
+});

--- a/packages/core/tests/unit/components/inline-portable-text-image.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-image.test.ts
@@ -139,17 +139,37 @@ describe("Image caption round-trip (inline editor seam)", () => {
 		expect(restored.title).toBe("Hover title");
 	});
 
-	it("reads captions from title-only legacy image nodes", () => {
-		const [restored] = pmToPortableText({
+	it("reads captions from title-only legacy Portable Text blocks", () => {
+		const [restored] = pmToPortableText(
+			portableTextToPM([
+				{
+					_type: "image",
+					_key: "img-legacy",
+					asset: { _ref: "01LEGACY", url: "/legacy.jpg" },
+					title: "Legacy caption",
+				},
+			]),
+		) as Array<{ caption?: string }>;
+
+		expect(restored.caption).toBe("Legacy caption");
+	});
+
+	it("keeps a cleared caption separate from the tooltip title across reloads", () => {
+		const portableText = pmToPortableText({
 			type: "doc",
 			content: [
 				{
 					type: "image",
-					attrs: { src: "/legacy.jpg", title: "Legacy caption" },
+					attrs: { src: "/current.jpg", caption: "", title: "Hover title" },
 				},
 			],
-		}) as Array<{ caption?: string }>;
+		});
+		const [restored] = pmToPortableText(portableTextToPM(portableText)) as Array<{
+			caption?: string;
+			title?: string;
+		}>;
 
-		expect(restored.caption).toBe("Legacy caption");
+		expect(restored.caption).toBe("");
+		expect(restored.title).toBe("Hover title");
 	});
 });

--- a/packages/core/tests/unit/converters/image-dimensions.test.ts
+++ b/packages/core/tests/unit/converters/image-dimensions.test.ts
@@ -61,22 +61,20 @@ describe("Image dimension round-trip", () => {
 		expect(restored.height).toBe(600);
 	});
 
-	it("reads captions from title-only legacy image nodes", () => {
-		const [restored] = prosemirrorToPortableText({
-			type: "doc",
-			content: [
-				{
-					type: "image",
-					attrs: { src: "https://example.com/legacy.jpg", title: "Legacy caption" },
-				},
-			],
-		});
+	it("reads captions from title-only legacy Portable Text blocks", () => {
+		const legacyImage: PortableTextImageBlock = {
+			_type: "image",
+			_key: "legacy",
+			asset: { _ref: "legacy", url: "https://example.com/legacy.jpg" },
+			title: "Legacy caption",
+		};
+		const [restored] = prosemirrorToPortableText(portableTextToProsemirror([legacyImage]));
 
 		expect((restored as PortableTextImageBlock).caption).toBe("Legacy caption");
 	});
 
-	it("does not restore an explicitly cleared caption from the title", () => {
-		const [restored] = prosemirrorToPortableText({
+	it("keeps an explicitly cleared caption separate from the title across reloads", () => {
+		const portableText = prosemirrorToPortableText({
 			type: "doc",
 			content: [
 				{
@@ -89,8 +87,9 @@ describe("Image dimension round-trip", () => {
 				},
 			],
 		});
+		const [restored] = prosemirrorToPortableText(portableTextToProsemirror(portableText));
 
-		expect((restored as PortableTextImageBlock).caption).toBeUndefined();
+		expect((restored as PortableTextImageBlock).caption).toBe("");
 		expect((restored as PortableTextImageBlock).title).toBe("Tooltip");
 	});
 });

--- a/packages/core/tests/unit/converters/image-dimensions.test.ts
+++ b/packages/core/tests/unit/converters/image-dimensions.test.ts
@@ -11,6 +11,7 @@ describe("Image dimension round-trip", () => {
 		asset: { _ref: "media-123", url: "https://example.com/photo.jpg" },
 		alt: "A photo",
 		caption: "My caption",
+		title: "Photo details",
 		width: 1920,
 		height: 1080,
 		displayWidth: 400,
@@ -37,6 +38,8 @@ describe("Image dimension round-trip", () => {
 		expect(restored.displayHeight).toBe(225);
 		expect(restored.width).toBe(1920);
 		expect(restored.height).toBe(1080);
+		expect(restored.caption).toBe("My caption");
+		expect(restored.title).toBe("Photo details");
 	});
 
 	it("handles images without display dimensions", () => {
@@ -56,5 +59,38 @@ describe("Image dimension round-trip", () => {
 		expect(restored.displayHeight).toBeUndefined();
 		expect(restored.width).toBe(800);
 		expect(restored.height).toBe(600);
+	});
+
+	it("reads captions from title-only legacy image nodes", () => {
+		const [restored] = prosemirrorToPortableText({
+			type: "doc",
+			content: [
+				{
+					type: "image",
+					attrs: { src: "https://example.com/legacy.jpg", title: "Legacy caption" },
+				},
+			],
+		});
+
+		expect((restored as PortableTextImageBlock).caption).toBe("Legacy caption");
+	});
+
+	it("does not restore an explicitly cleared caption from the title", () => {
+		const [restored] = prosemirrorToPortableText({
+			type: "doc",
+			content: [
+				{
+					type: "image",
+					attrs: {
+						src: "https://example.com/current.jpg",
+						caption: "",
+						title: "Tooltip",
+					},
+				},
+			],
+		});
+
+		expect((restored as PortableTextImageBlock).caption).toBeUndefined();
+		expect((restored as PortableTextImageBlock).title).toBe("Tooltip");
 	});
 });

--- a/packages/core/tests/unit/converters/image-missing-asset.test.ts
+++ b/packages/core/tests/unit/converters/image-missing-asset.test.ts
@@ -89,4 +89,17 @@ describe("Image blocks without asset wrapper", () => {
 		expect(imageNode.attrs?.alt).toBe("A proper image");
 		expect(imageNode.attrs?.mediaId).toBe("media-123");
 	});
+
+	it("reads the caption from title-only legacy image blocks", () => {
+		const result = portableTextToProsemirror([
+			{
+				_type: "image",
+				_key: "img1",
+				url: "https://example.com/photo.jpg",
+				title: "Legacy caption",
+			} as unknown as PortableTextBlock,
+		]);
+
+		expect(result.content[0].attrs?.caption).toBe("Legacy caption");
+	});
 });


### PR DESCRIPTION
## What does this PR do?

Image settings now apply as authors edit them, so clicking back into the post no longer drops caption, alt text, tooltip, size, or alignment changes.

It also keeps visible captions and tooltip titles as separate values across the admin and inline editors. Existing title-only image nodes still load their title as a caption, while an explicitly cleared caption stays cleared.

Related issue: Not linked.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: Not applicable; this is a bug fix.
- [ ] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode with GPT-5.6 Sol

## Screenshots / test output

The local Astro demo server exited before becoming ready, so a rendered UI screenshot is not included.

Verified with:

- `pnpm typecheck`
- `pnpm lint`
- Admin image panel and metadata tests: 6 passed
- Core image converter and inline editor tests: 9 passed
- Core image render tests: 16 passed
