### PR TITLE
Add in-place media image replacement

### DIFF
--- a/.changeset/bright-images-replace.md
+++ b/.changeset/bright-images-replace.md
@@ -1,0 +1,8 @@
+---
+"emdash": minor
+"@emdash-cms/admin": minor
+---
+
+Adds **Replace image** to the Media Library for ready JPEG, PNG, and WebP files stored by EmDash.
+
+Choose a same-format file to update every existing use of an image while preserving its media ID, filename, URL, alt text, caption, and location. The replacement can use different dimensions or an aspect ratio from the original. EmDash overwrites the original bytes and clears the focal point; it does not retain the previous file. The action works with local disk, R2, and S3-compatible storage.

--- a/docs/src/content/docs/guides/media-library.mdx
+++ b/docs/src/content/docs/guides/media-library.mdx
@@ -234,6 +234,30 @@ references remain unchanged.
 
 For fields configured as image or file types, click the field to open the media picker.
 
+## Replacing an image
+
+Use **Replace image** to update the file behind an existing local media item. Authors can replace
+images they uploaded, and editors can replace any local image. The action is available for JPEG,
+PNG, and WebP images stored on local disk, Cloudflare R2, or S3-compatible storage.
+
+1. Open **Media**, then select an image from the local library.
+2. Stay on **Details**, then select **Replace image**.
+3. Choose a non-empty image in the same format as the existing file.
+4. Review the warning, then select **Replace image** to confirm.
+
+The replacement can use different dimensions or an aspect ratio from the existing image. EmDash
+keeps the media ID, filename, URL, alt text, caption, and location, so every existing reference uses
+the replacement. Replacing the file clears its focal point.
+
+**Replace image** uploads another file from your computer. To trim the current image, select
+**Replace original** from the **Crop** editor.
+
+<Aside type="caution">
+	Replacing an image cannot be undone. EmDash does not keep the previous file. A browser or content
+	delivery network may briefly show cached bytes from the previous image until the cached response
+	refreshes.
+</Aside>
+
 ## Setting a focal point
 
 A focal point keeps the important part of a local image visible when a card, gallery, or other

--- a/e2e/tests/media-library.spec.ts
+++ b/e2e/tests/media-library.spec.ts
@@ -336,10 +336,16 @@ test.describe("Media Library", () => {
 		await expect
 			.poll(() => refreshedPreview.evaluate((image) => image.naturalWidth))
 			.toBe(replaced.width);
-		await expect(refreshedPreview).toHaveAttribute(
-			"src",
-			new RegExp(encodeURIComponent(replaced.contentHash!)),
-		);
+		await expect
+			.poll(async () => {
+				const source = await refreshedPreview.getAttribute("src");
+				if (!source) return null;
+				const previewUrl = new URL(source, page.url());
+				const renditionSource = previewUrl.searchParams.get("href");
+				const mediaUrl = renditionSource ? new URL(renditionSource) : previewUrl;
+				return mediaUrl.searchParams.get("_emdash_media");
+			})
+			.toBe(replaced.contentHash);
 		await details.getByRole("tab", { name: "Edit image" }).click();
 
 		const aspectRatio = details.getByRole("combobox", { name: "Aspect ratio" });

--- a/packages/admin/src/components/ConfirmDialog.tsx
+++ b/packages/admin/src/components/ConfirmDialog.tsx
@@ -74,6 +74,7 @@ export function ConfirmDialog({
 			<Dialog className={compact ? "max-w-md px-5 pt-6 pb-4" : "p-6"} size="sm">
 				<div className={compact ? "grid gap-1" : undefined}>
 					<Dialog.Title
+						dir="auto"
 						className={
 							titleClassName ??
 							(compact ? "text-lg font-semibold leading-6" : "text-lg font-semibold")
@@ -82,6 +83,7 @@ export function ConfirmDialog({
 						{title}
 					</Dialog.Title>
 					<Dialog.Description
+						dir="auto"
 						className={
 							descriptionClassName ??
 							(compact ? "text-sm leading-5 text-pretty text-kumo-subtle" : "text-kumo-subtle")

--- a/packages/admin/src/components/FocalPointEditor.tsx
+++ b/packages/admin/src/components/FocalPointEditor.tsx
@@ -61,6 +61,7 @@ export function FocalPointPreviews({
 						className={`emdash-media-transparency-grid overflow-hidden rounded-lg ring ring-kumo-line ${ratio}`}
 					>
 						<img
+							key={src}
 							src={src}
 							alt=""
 							data-testid={`focal-preview-${id}`}

--- a/packages/admin/src/components/FocalPointEditor.tsx
+++ b/packages/admin/src/components/FocalPointEditor.tsx
@@ -1,11 +1,16 @@
 import { useLingui } from "@lingui/react/macro";
 import * as React from "react";
 
-import { getMediaObjectPosition, type MediaFocalPoint } from "../lib/media-utils.js";
+import {
+	fallbackToOriginalThumbnail,
+	getMediaObjectPosition,
+	type MediaFocalPoint,
+} from "../lib/media-utils.js";
 import { useContainedMediaSize } from "./useContainedMediaSize.js";
 
 interface FocalPointEditorProps {
 	src: string;
+	fallbackSrc?: string;
 	sourceSize?: { width: number; height: number };
 	alt: string;
 	editing: boolean;
@@ -17,7 +22,10 @@ interface FocalPointEditorProps {
 	editorFrameRef?: React.RefObject<HTMLDivElement | null>;
 }
 
-interface FocalPointPreviewsProps extends Pick<FocalPointEditorProps, "src" | "point"> {
+interface FocalPointPreviewsProps extends Pick<
+	FocalPointEditorProps,
+	"src" | "fallbackSrc" | "point"
+> {
 	firstPreviewRef?: React.RefObject<HTMLDivElement | null>;
 }
 
@@ -29,7 +37,12 @@ const KEY_MOVES: Record<string, [number, number]> = {
 };
 const clamp = (value: number) => Math.min(1, Math.max(0, Math.round(value * 10_000) / 10_000));
 
-export function FocalPointPreviews({ src, point, firstPreviewRef }: FocalPointPreviewsProps) {
+export function FocalPointPreviews({
+	src,
+	fallbackSrc,
+	point,
+	firstPreviewRef,
+}: FocalPointPreviewsProps) {
 	const { t } = useLingui();
 	const current = point ?? { focalX: 0.5, focalY: 0.5 };
 	const objectPosition = getMediaObjectPosition(current)!;
@@ -53,6 +66,9 @@ export function FocalPointPreviews({ src, point, firstPreviewRef }: FocalPointPr
 							data-testid={`focal-preview-${id}`}
 							className="h-full w-full object-cover"
 							style={{ objectPosition }}
+							onError={(event) => {
+								if (fallbackSrc) fallbackToOriginalThumbnail(event.currentTarget, fallbackSrc);
+							}}
 						/>
 					</div>
 					<figcaption className="truncate text-center text-sm text-kumo-subtle">{label}</figcaption>
@@ -64,6 +80,7 @@ export function FocalPointPreviews({ src, point, firstPreviewRef }: FocalPointPr
 
 export function FocalPointEditor({
 	src,
+	fallbackSrc,
 	sourceSize: knownSourceSize,
 	alt,
 	editing,
@@ -77,11 +94,13 @@ export function FocalPointEditor({
 	const { t } = useLingui();
 	const activePointerRef = React.useRef<number | null>(null);
 	const frameRef = React.useRef<HTMLDivElement>(null);
-	const [ready, setReady] = React.useState(false);
-	const [loadedSourceSize, setLoadedSourceSize] = React.useState<{
+	const [loadedSource, setLoadedSource] = React.useState<{
+		src: string;
 		width: number;
 		height: number;
 	} | null>(null);
+	const ready = loadedSource?.src === src;
+	const loadedSourceSize = ready ? loadedSource : null;
 	const [announcement, setAnnouncement] = React.useState("");
 	const displaySize = useContainedMediaSize(frameRef, loadedSourceSize ?? knownSourceSize ?? null);
 	const current = point ?? { focalX: 0.5, focalY: 0.5 };
@@ -146,13 +165,15 @@ export function FocalPointEditor({
 		<div className="grid gap-4">
 			<div
 				ref={setFrameRef}
-				className="emdash-media-transparency-grid flex h-64 items-center justify-center overflow-hidden rounded-xl ring ring-kumo-line md:h-80"
+				aria-busy={!ready}
+				className={`${ready ? "emdash-media-transparency-grid" : "bg-kumo-tint"} flex h-64 items-center justify-center overflow-hidden rounded-xl ring ring-kumo-line md:h-80`}
 			>
 				<div
 					className="relative inline-flex max-h-full max-w-full"
 					style={displaySize ?? undefined}
 				>
 					<img
+						key={src}
 						src={src}
 						alt={alt}
 						className="block max-h-64 max-w-full object-contain md:max-h-80"
@@ -160,13 +181,20 @@ export function FocalPointEditor({
 						draggable={false}
 						onLoad={(event) => {
 							const image = event.currentTarget;
-							setLoadedSourceSize({ width: image.naturalWidth, height: image.naturalHeight });
-							setReady(true);
+							setLoadedSource({
+								src,
+								width: image.naturalWidth,
+								height: image.naturalHeight,
+							});
 							onReadyChange?.(true);
 						}}
-						onError={() => {
-							setLoadedSourceSize(null);
-							setReady(false);
+						onError={(event) => {
+							const image = event.currentTarget;
+							if (fallbackSrc && !image.dataset.thumbFallback) {
+								fallbackToOriginalThumbnail(image, fallbackSrc);
+								return;
+							}
+							setLoadedSource(null);
 							onReadyChange?.(false);
 						}}
 					/>

--- a/packages/admin/src/components/MediaDetailPanel.tsx
+++ b/packages/admin/src/components/MediaDetailPanel.tsx
@@ -56,6 +56,7 @@ import {
 	type MediaUpdateInput,
 	type MediaUsageEntryDetail,
 } from "../lib/api";
+import { getImageDimensions } from "../lib/api/media.js";
 import {
 	createCroppedFilename,
 	createCroppedImageFile,
@@ -83,6 +84,11 @@ const DIALOG_RESIZE_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
 type MediaDetailTab = "details" | "used-in" | "edit-image";
 type ImageEditMode = "focal-point" | "crop";
 type CropAction = "duplicate" | "replace";
+
+interface ReplacementImage {
+	file: File;
+	dimensions: { width: number; height: number };
+}
 
 interface CropViewportSize {
 	width: number;
@@ -142,6 +148,7 @@ export interface MediaDetailPanelProps {
 	providerName?: string;
 	canDelete?: boolean;
 	canMoveLocation?: boolean;
+	canReplaceOriginal?: boolean;
 	canCropOriginal?: boolean;
 	canDuplicateCrop?: boolean;
 	restoreFocusTargetRef?: React.RefObject<HTMLElement | null>;
@@ -162,6 +169,7 @@ export function MediaDetailPanel({
 	providerName,
 	canDelete: canDeleteProp,
 	canMoveLocation: canMoveLocationProp,
+	canReplaceOriginal: canReplaceOriginalProp,
 	canCropOriginal = false,
 	canDuplicateCrop = false,
 	restoreFocusTargetRef,
@@ -177,6 +185,9 @@ export function MediaDetailPanel({
 	const navigate = useNavigate();
 	const restoreFocusAfterDeleteRef = React.useRef(false);
 	const savePendingRef = React.useRef(false);
+	const replaceInputRef = React.useRef<HTMLInputElement | null>(null);
+	const replacePendingRef = React.useRef(false);
+	const replaceSelectionTokenRef = React.useRef(0);
 	const closeFallbackTimerRef = React.useRef<number | null>(null);
 	const closeFinishedRef = React.useRef(false);
 	const cropPendingRef = React.useRef(false);
@@ -199,12 +210,19 @@ export function MediaDetailPanel({
 	const canDelete = !isProviderAsset || Boolean(canDeleteProp);
 	const localItem = isLocalMediaItem(item) ? item : null;
 	const canMoveLocation = Boolean(localItem && canMoveLocationProp);
+	const canReplaceOriginal = canReplaceOriginalProp ?? canCropOriginal;
 	const cropMime = normalizeCropMime(item.mimeType);
 	const canShowCrop = Boolean(
 		localItem &&
 		item.status === "ready" &&
 		["image/jpeg", "image/png", "image/webp"].includes(cropMime) &&
-		(canCropOriginal || canDuplicateCrop),
+		(canReplaceOriginal || canDuplicateCrop),
+	);
+	const canReplaceImage = Boolean(
+		localItem &&
+		item.status === "ready" &&
+		["image/jpeg", "image/png", "image/webp"].includes(cropMime) &&
+		canReplaceOriginal,
 	);
 
 	const [filename, setFilename] = React.useState(item.filename);
@@ -237,6 +255,10 @@ export function MediaDetailPanel({
 	const [showDeleteConfirm, setShowDeleteConfirm] = React.useState(false);
 	const [showDiscardConfirm, setShowDiscardConfirm] = React.useState(false);
 	const [showCropConfirm, setShowCropConfirm] = React.useState(false);
+	const [showReplaceConfirm, setShowReplaceConfirm] = React.useState(false);
+	const [replacementImage, setReplacementImage] = React.useState<ReplacementImage | null>(null);
+	const [replaceSelectionError, setReplaceSelectionError] = React.useState("");
+	const [replaceStatus, setReplaceStatus] = React.useState("");
 	const [pendingUsageEntry, setPendingUsageEntry] = React.useState<MediaUsageEntryDetail | null>(
 		null,
 	);
@@ -251,6 +273,8 @@ export function MediaDetailPanel({
 		closeFinishedRef.current = false;
 		restoreFocusAfterDeleteRef.current = false;
 		savePendingRef.current = false;
+		replacePendingRef.current = false;
+		replaceSelectionTokenRef.current += 1;
 		cropPendingRef.current = false;
 		cropImageRef.current = null;
 		if (imageModeOverflowFrameRef.current !== null) {
@@ -280,6 +304,10 @@ export function MediaDetailPanel({
 		setShowDeleteConfirm(false);
 		setShowDiscardConfirm(false);
 		setShowCropConfirm(false);
+		setShowReplaceConfirm(false);
+		setReplacementImage(null);
+		setReplaceSelectionError("");
+		setReplaceStatus("");
 		setPendingUsageEntry(null);
 	}, [item.id, localItem?.folderId, open]);
 
@@ -381,7 +409,8 @@ export function MediaDetailPanel({
 	const canEdit = canEditMetadata || canMoveLocation;
 	const hasTabs = canEditMetadata || hasUsage;
 	const hasChanges = metadataChanged || locationChanged;
-	const isConfirmOpen = showDeleteConfirm || showDiscardConfirm || showCropConfirm;
+	const isConfirmOpen =
+		showDeleteConfirm || showDiscardConfirm || showCropConfirm || showReplaceConfirm;
 	const mediaPreviewUrl = localItem
 		? getMediaPreviewUrl(item.url, item.contentHash ?? cropPreviewKey)
 		: item.url;
@@ -570,6 +599,32 @@ export function MediaDetailPanel({
 			closeDialog();
 		},
 	});
+	const replaceMutation = useMutation({
+		mutationFn: ({ file, dimensions }: ReplacementImage) =>
+			replaceMediaImage(item.id, file, dimensions),
+		onSuccess: (replacedItem) => {
+			void queryClient.invalidateQueries({ queryKey: ["media"] });
+			onItemRefreshed?.(replacedItem);
+			onUpdated?.();
+			setFocalPoint(null);
+			setCropAspectMode("original");
+			setCropSelection(undefined);
+			setCropPixels(null);
+			setCropSourceSize(null);
+			setCropSourceFailed(false);
+			setCropPreviewKey(createCropPreviewKey());
+			setShowReplaceConfirm(false);
+			setReplacementImage(null);
+			setReplaceSelectionError("");
+			setReplaceStatus(t`Image replaced.`);
+		},
+		onError: () => {
+			setReplaceStatus("");
+		},
+		onSettled: () => {
+			replacePendingRef.current = false;
+		},
+	});
 	const cropMutation = useMutation({
 		mutationFn: async (action: CropAction) => {
 			const image = cropImageRef.current;
@@ -641,18 +696,21 @@ export function MediaDetailPanel({
 	});
 	React.useEffect(() => {
 		cropMutation.reset();
+		replaceMutation.reset();
 	}, [item.id, open]);
 	const isSaving = updateMutation.isPending;
 	const isDeleting = deleteMutation.isPending;
 	const isRecovering = recoverMediaMutation.isPending;
+	const isReplacing = replaceMutation.isPending;
 	const isCropping = cropMutation.isPending;
 	const mediaUnavailable =
 		recoverMediaMutation.error instanceof ApiResponseError &&
 		recoverMediaMutation.error.code === "NOT_FOUND";
-	const isBusy = isSaving || isDeleting || isRecovering || isCropping;
+	const isBusy = isSaving || isDeleting || isRecovering || isReplacing || isCropping;
 	const cropFooterActive = activeTab === "edit-image" && imageEditMode === "crop" && canShowCrop;
 	const cropActionDisabled =
 		!cropChanged || cropSourceFailed || hasChanges || isBusy || mediaUnavailable;
+	const replaceActionDisabled = hasChanges || isBusy || mediaUnavailable;
 	const updateNotFound =
 		updateMutation.error instanceof ApiResponseError && updateMutation.error.code === "NOT_FOUND";
 	const updateErrorMessage = mediaUnavailable
@@ -664,6 +722,7 @@ export function MediaDetailPanel({
 					? t`Couldn’t confirm whether the media item or selected folder still exists. Try again.`
 					: t`The selected folder no longer exists. Choose another location and save again.`
 			: getMutationError(updateMutation.error) || getMutationError(recoverMediaMutation.error);
+	const detailErrorMessage = updateErrorMessage || replaceSelectionError;
 	const cropErrorMessage =
 		cropMutation.error instanceof CropFileCreationError
 			? t`The cropped image could not be created.`
@@ -701,6 +760,66 @@ export function MediaDetailPanel({
 		setShowDeleteConfirm(true);
 	};
 
+	const clearReplacement = () => {
+		replaceSelectionTokenRef.current += 1;
+		setShowReplaceConfirm(false);
+		setReplacementImage(null);
+		setReplaceSelectionError("");
+		setReplaceStatus("");
+		replaceMutation.reset();
+		if (replaceInputRef.current) replaceInputRef.current.value = "";
+	};
+
+	const openReplacementPicker = () => {
+		if (!canReplaceImage || replaceActionDisabled) return;
+		replaceSelectionTokenRef.current += 1;
+		setReplacementImage(null);
+		setReplaceSelectionError("");
+		setReplaceStatus("");
+		replaceMutation.reset();
+		replaceInputRef.current?.click();
+	};
+
+	const handleReplacementFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+		const file = event.currentTarget.files?.[0];
+		event.currentTarget.value = "";
+		if (!file || !canReplaceImage || replaceActionDisabled) return;
+		const selectionToken = replaceSelectionTokenRef.current + 1;
+		replaceSelectionTokenRef.current = selectionToken;
+		setReplacementImage(null);
+		setReplaceSelectionError("");
+		setReplaceStatus("");
+		replaceMutation.reset();
+		if (file.size === 0 || normalizeCropMime(file.type) !== cropMime) {
+			setReplaceSelectionError(t`Choose a non-empty ${formatFileFormat(item.mimeType)} image.`);
+			return;
+		}
+
+		const dimensions = await getImageDimensions(file).catch(() => null);
+		if (replaceSelectionTokenRef.current !== selectionToken) return;
+		if (!dimensions) {
+			setReplaceSelectionError(t`The selected image could not be read.`);
+			return;
+		}
+
+		setReplacementImage({ file, dimensions });
+		setShowReplaceConfirm(true);
+	};
+
+	const startReplacement = () => {
+		if (
+			!canReplaceImage ||
+			!replacementImage ||
+			replaceActionDisabled ||
+			replacePendingRef.current
+		) {
+			return;
+		}
+		replacePendingRef.current = true;
+		setReplaceStatus(t`Replacing image...`);
+		replaceMutation.mutate(replacementImage);
+	};
+
 	const startCrop = (action: CropAction) => {
 		if (
 			!canShowCrop ||
@@ -713,7 +832,7 @@ export function MediaDetailPanel({
 		) {
 			return;
 		}
-		if (action === "replace" && (!canCropOriginal || cropAspectMode !== "original")) return;
+		if (action === "replace" && (!canReplaceOriginal || cropAspectMode !== "original")) return;
 		if (action === "duplicate" && !canDuplicateCrop) return;
 		cropPendingRef.current = true;
 		setCropStatus(action === "duplicate" ? t`Creating cropped copy...` : t`Replacing original...`);
@@ -1141,14 +1260,14 @@ export function MediaDetailPanel({
 							style={
 								canEditMetadata
 									? {
-											gridTemplateAreas: updateErrorMessage ? '"panel" "error"' : '"panel"',
+											gridTemplateAreas: detailErrorMessage ? '"panel" "error"' : '"panel"',
 											overflowY:
 												suppressImageModeOverflow || suppressDialogResizeOverflow
 													? "hidden"
 													: undefined,
 											gridTemplateRows:
 												activeTab === "edit-image"
-													? updateErrorMessage
+													? detailErrorMessage
 														? "minmax(0, 1fr) auto"
 														: "minmax(0, 1fr)"
 													: undefined,
@@ -1504,7 +1623,7 @@ export function MediaDetailPanel({
 															: t`Loading...`}
 													</output>
 												</div>
-												{canCropOriginal && cropAspectMode !== "original" ? (
+												{canReplaceOriginal && cropAspectMode !== "original" ? (
 													<p className="text-sm text-kumo-subtle">
 														{t`Replace original is available with the Original aspect ratio.`}
 													</p>
@@ -1528,9 +1647,9 @@ export function MediaDetailPanel({
 									)}
 								</div>
 							) : null}
-							{updateErrorMessage && (
+							{detailErrorMessage && (
 								<div style={{ gridArea: canEditMetadata ? "error" : undefined }}>
-									<DialogError message={updateErrorMessage} />
+									<DialogError message={detailErrorMessage} />
 								</div>
 							)}
 						</div>
@@ -1549,12 +1668,36 @@ export function MediaDetailPanel({
 					<p role="status" className="sr-only">
 						{cropStatus}
 					</p>
+					<p role="status" className="sr-only">
+						{replaceStatus}
+					</p>
 					<div
 						className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-t border-kumo-line"
 						style={{ padding: "1rem 1.5rem" }}
 						data-testid="media-detail-dialog-footer"
 					>
-						<div>
+						<div className="flex flex-wrap gap-2">
+							{canReplaceImage && activeTab === "details" ? (
+								<>
+									<Button
+										variant="outline"
+										onClick={openReplacementPicker}
+										disabled={replaceActionDisabled}
+									>
+										{t`Replace image`}
+									</Button>
+									<input
+										ref={replaceInputRef}
+										type="file"
+										accept={cropMime}
+										className="sr-only"
+										tabIndex={-1}
+										disabled={replaceActionDisabled}
+										aria-label={t`Choose replacement image`}
+										onChange={handleReplacementFile}
+									/>
+								</>
+							) : null}
 							{canDelete && !cropFooterActive && (
 								<Button
 									variant="destructive"
@@ -1572,7 +1715,7 @@ export function MediaDetailPanel({
 							</Button>
 							{cropFooterActive ? (
 								<>
-									{canCropOriginal ? (
+									{canReplaceOriginal ? (
 										<Button
 											variant="secondary-destructive"
 											disabled={cropActionDisabled || cropAspectMode !== "original"}
@@ -1661,6 +1804,41 @@ export function MediaDetailPanel({
 						role="note"
 					/>
 				) : null}
+			</ConfirmDialog>
+
+			<ConfirmDialog
+				open={showReplaceConfirm}
+				onClose={clearReplacement}
+				role="alertdialog"
+				title={t`Replace original image?`}
+				titleClassName="text-[18px] font-semibold leading-6"
+				description={
+					<span className="text-[14px] leading-5">
+						{t`Every place using this image will update to the selected version.`}
+					</span>
+				}
+				descriptionClassName="text-pretty text-[14px] leading-5 text-kumo-subtle"
+				confirmLabel={t`Replace image`}
+				pendingLabel={t`Replacing image...`}
+				isPending={isReplacing}
+				confirmDisabled={!replacementImage || replaceActionDisabled}
+				compact
+				preventCloseWhilePending
+				error={replaceMutation.error}
+				onConfirm={startReplacement}
+			>
+				<Banner
+					variant="error"
+					icon={<WarningCircle className="h-4 w-4" aria-hidden="true" />}
+					title={t`This cannot be undone`}
+					description={
+						<span className="text-[14px] leading-5">
+							{t`EmDash does not keep the previous image.`}
+						</span>
+					}
+					className="mt-4 text-[14px]"
+					role="note"
+				/>
 			</ConfirmDialog>
 
 			<ConfirmDialog

--- a/packages/admin/src/components/MediaDetailPanel.tsx
+++ b/packages/admin/src/components/MediaDetailPanel.tsx
@@ -22,6 +22,7 @@ import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
 	ArrowCounterClockwise,
+	ArrowsClockwise,
 	X,
 	Trash,
 	Calendar,
@@ -68,6 +69,7 @@ import {
 	getFileIcon,
 	formatFileSize,
 	getMediaPreviewUrl,
+	getMediaThumbnailUrl,
 	metaPlayback,
 	normalizeMediaFocalPoint,
 	type MediaFocalPoint,
@@ -81,6 +83,7 @@ import { MediaUsedIn } from "./MediaUsedIn.js";
 const CLOSE_FALLBACK_MS = 500;
 const DIALOG_RESIZE_DURATION_MS = 340;
 const DIALOG_RESIZE_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
+const MEDIA_DETAIL_PREVIEW_WIDTH = 1200;
 type MediaDetailTab = "details" | "used-in" | "edit-image";
 type ImageEditMode = "focal-point" | "crop";
 type CropAction = "duplicate" | "replace";
@@ -101,16 +104,6 @@ let cropPreviewFallbackId = 0;
 
 function createCropPreviewKey(): string {
 	return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${(cropPreviewFallbackId += 1)}`;
-}
-
-function cacheBustMediaUrl(url: string, key: string): string {
-	const result = new URL(url, window.location.origin);
-	if (result.protocol !== "http:" && result.protocol !== "https:") {
-		result.hash = `_emdash_crop=${encodeURIComponent(key)}`;
-		return result.href;
-	}
-	result.searchParams.set("_emdash_crop", key);
-	return result.href;
 }
 
 function normalizeCropMime(mimeType: string): string {
@@ -391,6 +384,7 @@ export function MediaDetailPanel({
 	}, [onClosed, restoreFocusTargetRef]);
 
 	const closeDialog = React.useCallback(() => {
+		replaceSelectionTokenRef.current += 1;
 		onClose();
 		if (closeFallbackTimerRef.current !== null) {
 			window.clearTimeout(closeFallbackTimerRef.current);
@@ -414,9 +408,15 @@ export function MediaDetailPanel({
 	const mediaPreviewUrl = localItem
 		? getMediaPreviewUrl(item.url, item.contentHash ?? cropPreviewKey)
 		: item.url;
-	const cropPreviewUrl = canShowCrop
-		? cacheBustMediaUrl(item.url, cropPreviewKey)
-		: mediaPreviewUrl;
+	const detailPreviewUrl = localItem
+		? getMediaThumbnailUrl(
+				item.url,
+				item.mimeType,
+				MEDIA_DETAIL_PREVIEW_WIDTH,
+				item.contentHash ?? cropPreviewKey,
+			)
+		: item.url;
+	const detailPreviewFallback = detailPreviewUrl === mediaPreviewUrl ? undefined : mediaPreviewUrl;
 	const cropAspectSource =
 		cropSourceSize ??
 		(item.width && item.height ? { width: item.width, height: item.height } : null);
@@ -1095,7 +1095,8 @@ export function MediaDetailPanel({
 									cropSourceFailed ? (
 										<FocalPointEditor
 											key={`${item.id}:${item.url}:crop-fallback`}
-											src={mediaPreviewUrl}
+											src={detailPreviewUrl}
+											fallbackSrc={detailPreviewFallback}
 											sourceSize={cropAspectSource ?? undefined}
 											alt={item.alt || item.filename}
 											editing={false}
@@ -1107,7 +1108,7 @@ export function MediaDetailPanel({
 									) : (
 										<MediaImageCropper
 											key={cropPreviewKey}
-											src={cropPreviewUrl}
+											src={mediaPreviewUrl}
 											sourceSize={cropAspectSource ?? undefined}
 											crop={cropSelection}
 											aspect={
@@ -1129,9 +1130,8 @@ export function MediaDetailPanel({
 								) : (
 									<FocalPointEditor
 										key={`${item.id}:${item.url}`}
-										src={
-											activeTab === "edit-image" && canShowCrop ? cropPreviewUrl : mediaPreviewUrl
-										}
+										src={detailPreviewUrl}
+										fallbackSrc={detailPreviewFallback}
 										sourceSize={cropAspectSource ?? undefined}
 										alt={item.alt || item.filename}
 										editing={activeTab === "edit-image"}
@@ -1570,7 +1570,8 @@ export function MediaDetailPanel({
 											>
 												<h3 className="text-sm font-semibold">{t`Preview`}</h3>
 												<FocalPointPreviews
-													src={mediaPreviewUrl}
+													src={detailPreviewUrl}
+													fallbackSrc={detailPreviewFallback}
 													point={focalPoint}
 													firstPreviewRef={focalPreviewFrameRef}
 												/>
@@ -1677,10 +1678,21 @@ export function MediaDetailPanel({
 						data-testid="media-detail-dialog-footer"
 					>
 						<div className="flex flex-wrap gap-2">
+							{canDelete && !cropFooterActive && (
+								<Button
+									variant="destructive"
+									icon={<Trash />}
+									onClick={handleDelete}
+									disabled={isBusy || mediaUnavailable}
+								>
+									{isDeleting ? t`Deleting...` : t`Delete`}
+								</Button>
+							)}
 							{canReplaceImage && activeTab === "details" ? (
 								<>
 									<Button
 										variant="outline"
+										icon={<ArrowsClockwise />}
 										onClick={openReplacementPicker}
 										disabled={replaceActionDisabled}
 									>
@@ -1698,16 +1710,6 @@ export function MediaDetailPanel({
 									/>
 								</>
 							) : null}
-							{canDelete && !cropFooterActive && (
-								<Button
-									variant="destructive"
-									icon={<Trash />}
-									onClick={handleDelete}
-									disabled={isBusy || mediaUnavailable}
-								>
-									{isDeleting ? t`Deleting...` : t`Delete`}
-								</Button>
-							)}
 						</div>
 						<div className="flex flex-wrap justify-end gap-2">
 							<Button variant="outline" onClick={requestClose} disabled={isBusy}>

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -1382,7 +1382,7 @@ export function MediaLibrary({
 					providerName={detailItem.provider ? activeProviderInfo?.name : undefined}
 					canDelete={detailItem.provider ? activeProviderInfo?.capabilities.delete : undefined}
 					canMoveLocation={isLocalMediaItem(detailItem) ? canMoveMedia?.(detailItem) : undefined}
-					canCropOriginal={Boolean(
+					canReplaceOriginal={Boolean(
 						isLocalMediaItem(detailItem) &&
 						currentUser &&
 						(currentUser.role >= 40 ||

--- a/packages/admin/src/lib/api/media.ts
+++ b/packages/admin/src/lib/api/media.ts
@@ -395,7 +395,7 @@ async function uploadToSignedUrl(
 /**
  * Get image dimensions from a file
  */
-async function getImageDimensions(
+export async function getImageDimensions(
 	file: File,
 	options?: MediaUploadOptions,
 ): Promise<{ width: number; height: number } | null> {

--- a/packages/admin/tests/components/FocalPointEditor.test.tsx
+++ b/packages/admin/tests/components/FocalPointEditor.test.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+
+import { FocalPointPreviews } from "../../src/components/FocalPointEditor.js";
+import { render } from "../utils/render.tsx";
+
+const image = (color: string) =>
+	`data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect width="1" height="1" fill="${color}"/></svg>`;
+
+describe("FocalPointPreviews", () => {
+	it("retries the original fallback after the preview source changes", async () => {
+		const firstFallback = image("blue");
+		const screen = await render(
+			<FocalPointPreviews src={image("red")} fallbackSrc={firstFallback} point={null} />,
+		);
+		const firstPreview = screen.getByTestId("focal-preview-square").element();
+		firstPreview.dispatchEvent(new Event("error"));
+		expect(firstPreview.src).toBe(firstFallback);
+
+		const secondSource = image("green");
+		const secondFallback = image("black");
+		await screen.rerender(
+			<FocalPointPreviews src={secondSource} fallbackSrc={secondFallback} point={null} />,
+		);
+		const secondPreview = screen.getByTestId("focal-preview-square").element();
+		secondPreview.dispatchEvent(new Event("error"));
+
+		expect(secondPreview.src).toBe(secondFallback);
+	});
+});

--- a/packages/admin/tests/components/MediaDetailPanel.test.tsx
+++ b/packages/admin/tests/components/MediaDetailPanel.test.tsx
@@ -11,6 +11,7 @@ import { render } from "../utils/render.tsx";
 
 const TEST_IMAGE_URL =
 	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Crect width='100' height='100' fill='gray'/%3E%3C/svg%3E";
+const INTERNAL_TEST_IMAGE_URL = "/_emdash/api/media/file/media-1.jpg";
 
 vi.mock("../../src/lib/api", async () => {
 	const actual = await vi.importActual("../../src/lib/api");
@@ -375,6 +376,45 @@ describe("MediaDetailPanel", () => {
 		await expect.element(screen.getByRole("dialog", { name: "Media details" })).toBeVisible();
 	});
 
+	it("ignores replacement inspection that finishes after the dialog closes", async () => {
+		const NativeImage = window.Image;
+		let finishImageLoad: (() => void) | undefined;
+		class DeferredImage {
+			naturalWidth = 1;
+			naturalHeight = 1;
+			onload: (() => void) | null = null;
+			onerror: (() => void) | null = null;
+			set src(_value: string) {
+				finishImageLoad = () => this.onload?.();
+			}
+		}
+		vi.stubGlobal("Image", DeferredImage);
+		const onClose = vi.fn();
+
+		try {
+			const screen = await renderPanel({
+				item: makeLocalItem({ filename: "photo.png", mimeType: "image/png" }),
+				canReplaceOriginal: true,
+				onClose,
+			});
+			const replacement = new File(["replacement"], "replacement.png", {
+				type: "image/png",
+			});
+
+			await userEvent.upload(screen.getByLabelText("Choose replacement image"), replacement);
+			screen.getByRole("button", { name: "Close", exact: true }).element().click();
+			expect(onClose).toHaveBeenCalledTimes(1);
+			finishImageLoad?.();
+			await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+			expect(
+				screen.getByRole("alertdialog", { name: "Replace original image?" }).query(),
+			).toBeNull();
+		} finally {
+			vi.stubGlobal("Image", NativeImage);
+		}
+	});
+
 	it("adapts the dialog height to each image task without clipping its actions", async () => {
 		const screen = await renderPanel({
 			item: makeLocalItem({ url: TEST_IMAGE_URL }),
@@ -639,7 +679,7 @@ describe("MediaDetailPanel", () => {
 			.spyOn(HTMLElement.prototype, "getBoundingClientRect")
 			.mockImplementation(function () {
 				if (
-					this.classList.contains("emdash-media-transparency-grid") &&
+					this.hasAttribute("aria-busy") &&
 					this.closest('[data-testid="media-detail-dialog-preview-column"]')
 				) {
 					return { bottom: 320 } as DOMRect;
@@ -691,7 +731,6 @@ describe("MediaDetailPanel", () => {
 				.element()
 				.querySelector<HTMLImageElement>(".emdash-react-image-crop img");
 			expect(image).not.toBeNull();
-			expect(image!.src).toContain("_emdash_crop");
 		});
 	});
 
@@ -868,6 +907,26 @@ describe("MediaDetailPanel", () => {
 		);
 	});
 
+	it("keeps the loaded focal-point image stable when returning to Details", async () => {
+		const screen = await renderPanel({
+			item: makeLocalItem({ url: TEST_IMAGE_URL }),
+			canDuplicateCrop: true,
+		});
+
+		screen.getByRole("tab", { name: "Edit image" }).element().click();
+		screen.getByRole("tab", { name: "Focal point" }).element().click();
+		const focalImage = screen.getByAltText("A nice photo");
+		await expect.element(focalImage).toBeVisible();
+		const loadedElement = focalImage.element();
+		const loadedSource = loadedElement.src;
+
+		screen.getByRole("tab", { name: "Details" }).element().click();
+		const detailsImage = screen.getByAltText("A nice photo");
+		await expect.element(detailsImage).toBeVisible();
+		expect(detailsImage.element()).toBe(loadedElement);
+		expect(detailsImage.element().src).toBe(loadedSource);
+	});
+
 	it("creates a distinct cropped copy and closes the source dialog after success", async () => {
 		const duplicate = makeLocalItem({ id: "media-copy", filename: "photo-80x80.jpg" });
 		vi.mocked(uploadMedia).mockResolvedValueOnce(duplicate);
@@ -900,7 +959,7 @@ describe("MediaDetailPanel", () => {
 
 	it("confirms and replaces the original while keeping the dialog open", async () => {
 		const refreshed = makeLocalItem({
-			url: TEST_IMAGE_URL,
+			url: INTERNAL_TEST_IMAGE_URL,
 			width: 99,
 			height: 99,
 			focalX: null,
@@ -910,7 +969,7 @@ describe("MediaDetailPanel", () => {
 		const onClose = vi.fn();
 		const onItemRefreshed = vi.fn();
 		const screen = await renderPanel({
-			item: makeLocalItem({ url: TEST_IMAGE_URL, focalX: 0.2, focalY: 0.8 }),
+			item: makeLocalItem({ url: INTERNAL_TEST_IMAGE_URL, focalX: 0.2, focalY: 0.8 }),
 			canReplaceOriginal: true,
 			canDuplicateCrop: true,
 			onClose,

--- a/packages/admin/tests/components/MediaDetailPanel.test.tsx
+++ b/packages/admin/tests/components/MediaDetailPanel.test.tsx
@@ -323,6 +323,58 @@ describe("MediaDetailPanel", () => {
 		await expect.element(screen.getByText("1920 × 1080")).toBeVisible();
 	});
 
+	it("replaces a selected image and keeps the media dialog open", async () => {
+		const replacementBytes = Uint8Array.from(
+			atob(
+				"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+			),
+			(character) => character.charCodeAt(0),
+		);
+		const replacement = new File([replacementBytes], "replacement.png", { type: "image/png" });
+		const refreshed = makeLocalItem({
+			filename: "photo.png",
+			mimeType: "image/png",
+			width: 1,
+			height: 1,
+			contentHash: "sha256:replacement",
+			focalX: null,
+			focalY: null,
+		});
+		vi.mocked(replaceMediaImage).mockResolvedValueOnce(refreshed);
+		const onClose = vi.fn();
+		const onUpdated = vi.fn();
+		const onItemRefreshed = vi.fn();
+		const screen = await renderPanel({
+			item: makeLocalItem({ filename: "photo.png", mimeType: "image/png" }),
+			canReplaceOriginal: true,
+			onClose,
+			onUpdated,
+			onItemRefreshed,
+		});
+
+		await expect.element(screen.getByRole("button", { name: "Replace image" })).toBeVisible();
+		await userEvent.upload(screen.getByLabelText("Choose replacement image"), replacement);
+
+		const confirmation = screen.getByRole("alertdialog", { name: "Replace original image?" });
+		await expect.element(confirmation).toBeVisible();
+		await expect
+			.element(confirmation)
+			.toHaveTextContent("Every place using this image will update to the selected version.");
+		confirmation.getByRole("button", { name: "Replace image" }).element().click();
+
+		await vi.waitFor(() => {
+			expect(replaceMediaImage).toHaveBeenCalledWith("media-1", replacement, {
+				width: 1,
+				height: 1,
+			});
+			expect(onItemRefreshed).toHaveBeenCalledWith(refreshed);
+			expect(onUpdated).toHaveBeenCalledTimes(1);
+		});
+		await expect.element(screen.getByText("Image replaced.")).toBeInTheDocument();
+		expect(onClose).not.toHaveBeenCalled();
+		await expect.element(screen.getByRole("dialog", { name: "Media details" })).toBeVisible();
+	});
+
 	it("adapts the dialog height to each image task without clipping its actions", async () => {
 		const screen = await renderPanel({
 			item: makeLocalItem({ url: TEST_IMAGE_URL }),
@@ -714,7 +766,7 @@ describe("MediaDetailPanel", () => {
 	it("offers common aspect ratios and limits replacement to the original ratio", async () => {
 		const screen = await renderPanel({
 			item: makeLocalItem({ url: TEST_IMAGE_URL }),
-			canCropOriginal: true,
+			canReplaceOriginal: true,
 			canDuplicateCrop: true,
 		});
 		await openCropEditor(screen);
@@ -740,10 +792,11 @@ describe("MediaDetailPanel", () => {
 	it("blocks crop actions while metadata is dirty", async () => {
 		const screen = await renderPanel({
 			item: makeLocalItem({ url: TEST_IMAGE_URL }),
-			canCropOriginal: true,
+			canReplaceOriginal: true,
 			canDuplicateCrop: true,
 		});
 		await screen.getByLabelText("Alt Text").fill("Changed alt");
+		await expect.element(screen.getByRole("button", { name: "Replace image" })).toBeDisabled();
 		await openCropEditor(screen);
 		await resizeCrop(screen);
 
@@ -858,7 +911,7 @@ describe("MediaDetailPanel", () => {
 		const onItemRefreshed = vi.fn();
 		const screen = await renderPanel({
 			item: makeLocalItem({ url: TEST_IMAGE_URL, focalX: 0.2, focalY: 0.8 }),
-			canCropOriginal: true,
+			canReplaceOriginal: true,
 			canDuplicateCrop: true,
 			onClose,
 			onItemRefreshed,
@@ -933,7 +986,7 @@ describe("MediaDetailPanel", () => {
 		vi.mocked(replaceMediaImage).mockRejectedValueOnce(new Error("Replace failed"));
 		const screen = await renderPanel({
 			item: makeLocalItem({ url: TEST_IMAGE_URL }),
-			canCropOriginal: true,
+			canReplaceOriginal: true,
 		});
 		await openCropEditor(screen);
 		await resizeCrop(screen);

--- a/packages/core/src/api/openapi/document.ts
+++ b/packages/core/src/api/openapi/document.ts
@@ -914,7 +914,7 @@ function buildMediaPaths(maxUploadSize: number) {
 				operationId: "replaceMediaImage",
 				summary: "Replace a media image",
 				description:
-					"Overwrites a ready local image under its existing storage key and refreshes its file metadata.",
+					"Overwrites a ready local image under its existing storage key and refreshes its file metadata while preserving its media ID, filename, and URL. The replacement may use different dimensions or an aspect ratio from the original.",
 				tags: ["Media"],
 				requestParams: {
 					path: z.object({ id: z.string().meta({ description: "Media ID" }) }),

--- a/packages/core/src/astro/routes/api/media/[id]/replace.ts
+++ b/packages/core/src/astro/routes/api/media/[id]/replace.ts
@@ -11,17 +11,6 @@ export const prerender = false;
 
 const REPLACEABLE_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
 
-function preservesAspectRatio(
-	width: number,
-	height: number,
-	sourceWidth: number,
-	sourceHeight: number,
-): boolean {
-	return (
-		Math.abs(width * sourceHeight - height * sourceWidth) <= Math.max(sourceWidth, sourceHeight)
-	);
-}
-
 export const PUT: APIRoute = async ({ params, request, locals }) => {
 	const { emdash, user } = locals;
 	const { id } = params;
@@ -91,19 +80,6 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 			});
 		}
 		const { width, height } = metadataResult.data;
-		if (
-			(media.width !== null && width > media.width) ||
-			(media.height !== null && height > media.height)
-		) {
-			return apiError("VALIDATION_ERROR", "Replacement dimensions cannot exceed the source", 400);
-		}
-		if (
-			media.width !== null &&
-			media.height !== null &&
-			!preservesAspectRatio(width, height, media.width, media.height)
-		) {
-			return apiError("VALIDATION_ERROR", "Replacement aspect ratio must match the source", 400);
-		}
 
 		const bytes = new Uint8Array(await file.arrayBuffer());
 		const contentHash = await computeContentHash(bytes);

--- a/packages/core/tests/integration/astro/media-replace.test.ts
+++ b/packages/core/tests/integration/astro/media-replace.test.ts
@@ -134,7 +134,12 @@ describe("PUT /media/:id/replace", () => {
 		const croppedBytes = new Uint8Array([9, 8, 7, 6]);
 
 		const response = await putReplace(
-			buildContext({ db, request: replaceRequest({ bytes: croppedBytes }), storage, user }),
+			buildContext({
+				db,
+				request: replaceRequest({ bytes: croppedBytes, width: "1800", height: "900" }),
+				storage,
+				user,
+			}),
 		);
 
 		expect(response.status).toBe(200);
@@ -146,8 +151,8 @@ describe("PUT /media/:id/replace", () => {
 			storageKey: original.storageKey,
 			url: `/_emdash/api/media/file/${original.storageKey}`,
 			size: croppedBytes.byteLength,
-			width: 600,
-			height: 400,
+			width: 1800,
+			height: 900,
 			contentHash: await computeContentHash(croppedBytes),
 			blurhash: null,
 			dominantColor: null,
@@ -250,18 +255,6 @@ describe("PUT /media/:id/replace", () => {
 			label: "unsafe dimensions",
 			source: {},
 			request: { width: "9007199254740992" },
-			status: 400,
-		},
-		{
-			label: "enlargement",
-			source: {},
-			request: { width: "1800", height: "1200" },
-			status: 400,
-		},
-		{
-			label: "aspect ratio change",
-			source: {},
-			request: { width: "600", height: "600" },
 			status: 400,
 		},
 	])("rejects $label before storage mutation", async (testCase) => {


### PR DESCRIPTION
## What does this PR do?

Adds in-place replacement for ready JPEG, PNG, and WebP images managed by EmDash.

- Adds **Replace image** to Media Details for authors replacing their own media and editors replacing any media.
- Keeps the existing media ID, filename, storage key, URL, metadata, folder, and usage relationships while updating the stored bytes and intrinsic dimensions.
- Supports local disk, Cloudflare R2, and S3-compatible storage through the existing storage abstraction.
- Allows the replacement to use different dimensions or an aspect ratio from the original while requiring the same image format.
- Keeps Media Details open after replacement and refreshes every existing usage through the stable media identity.
- Uses a stable 1200px content-hashed rendition in Details and Focal Point, while Crop loads the full-resolution source only when needed.
- Shows a neutral loading surface until the current preview is ready and falls back to the original when rendition generation is unavailable.
- Orders **Delete** before **Replace image** and gives the replacement action a Phosphor icon.
- Documents the replacement workflow and its difference from crop-based **Replace original**.

Related: #2861  
Discussion: https://github.com/emdash-cms/emdash/discussions/990

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/990
- [x] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5.6 Sol), with an independent GPT-5.6 Terra second-opinion review

## Screenshots / test output

### Media Details

The Details footer places **Delete** before **Replace image**. Details and Focal Point use a lightweight content-hashed rendition; Crop keeps the full-resolution source for output quality.

![Media Details showing a loaded image preview with Delete followed by Replace image and its replacement icon](https://github.com/user-attachments/assets/bcacea1e-91c9-493f-aba0-bd291ffc8718)

### Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm --filter @emdash-cms/admin build`
- `pnpm --dir docs build`
- Admin: 146 files passed, 1,871 tests passed
- Core: 523 files passed, 6,304 tests passed, 2 files and 9 tests skipped
- Focused media-detail and thumbnail tests: 88 passed
- Live Node/SQLite check: Details and Focal Point shared one 1200px rendition URL; Crop used the full source
- Iterative GPT-5.6 Terra adversarial review: converged with no remaining findings
