### PR TITLE
Improve admin media picker workflows

### DIFF
--- a/.changeset/clean-rivers-browse.md
+++ b/.changeset/clean-rivers-browse.md
@@ -1,0 +1,10 @@
+---
+"@emdash-cms/admin": minor
+---
+
+Adds Media Library browsing and inline uploads to admin media pickers. Editors can search, filter
+by type, browse folders, switch between grid and list views, use numbered pages, and select media
+from configured providers or a direct URL without leaving the content editor.
+
+Uploads appear in the picker with an uploading or failed status. Successful uploads become
+selected media cards, and gallery selections can be reordered before they are added.

--- a/.changeset/fresh-astro-loggers.md
+++ b/.changeset/fresh-astro-loggers.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes Cloudflare development servers failing during cold start with Astro 7.3.1 after Vite discovers `astro/logger/console` and invalidates prebundled server chunks.

--- a/docs/src/content/docs/guides/media-library.mdx
+++ b/docs/src/content/docs/guides/media-library.mdx
@@ -35,7 +35,7 @@ Once media usage tracking is on, it cannot be turned off.
 	or external sites, so an empty list does not prove that a file is safe to delete.
 </Aside>
 
-## Uploading Files
+## Uploading files
 
 ### From the Media Library
 
@@ -45,15 +45,21 @@ Once media usage tracking is on, it cannot be turned off.
 
 3. Uploads start automatically. The dialog shows each file's status and lets you cancel or retry individual files.
 
-### From the Content Editor
+### From the content editor
 
-1. In the rich text editor, click the image button
+1. Open an image, file, or gallery field in the content editor.
 
-2. Click **Upload** in the media picker
+2. Search, filter by type, browse a folder, or switch between the available media sources.
 
-3. Select a file from your computer
+3. Select existing media, or select **Upload files** and choose files from your computer. You can
+   also drop files onto the picker. Each upload appears in the results with its current status.
 
-4. Add alt text and click **Insert**
+4. If an upload fails, select **Retry** or **Remove** on that item. A successful upload becomes a
+   selected media card.
+
+5. For a gallery, use the arrow controls under **Selected media** to set the returned order.
+
+6. Select the picker action, such as **Select**, **Insert image**, or **Add 3 images**.
 
 ## Supported File Types
 
@@ -204,21 +210,21 @@ Uploads enter the Main library. Move them into a folder after upload using eithe
 Deleting a folder returns its media to the Main library. The media files, URLs, and content
 references remain unchanged.
 
-## Using Media in Content
+## Using media in content
 
-### In the Rich Text Editor
+### In the rich text editor
 
 1. Place your cursor where you want the image
 
 2. Click the image button in the toolbar
 
-3. Select an image from the media library or upload a new one
+3. Find an image in the picker or upload a new one.
 
-4. Enter alt text
+4. Select **Insert image**.
 
-5. Click **Insert**
+5. Add alt text in the image settings.
 
-### As a Featured Image
+### As a featured image
 
 1. Open a content entry in the editor
 
@@ -226,13 +232,14 @@ references remain unchanged.
 
 3. Click **Select Image**
 
-4. Choose from the media library or upload
+4. Choose an image from the picker or upload one.
 
-5. Click **Save**
+5. Select **Select**, then select **Save**.
 
-### In Custom Fields
+### In custom fields
 
-For fields configured as image or file types, click the field to open the media picker.
+For fields configured as image or file types, select the field action to open the same media
+picker. The field's MIME type rules limit the sources and files you can choose.
 
 ## Replacing an image
 

--- a/e2e/tests/bylines.spec.ts
+++ b/e2e/tests/bylines.spec.ts
@@ -112,6 +112,29 @@ test.describe("Bylines", () => {
 			),
 		).toBeLessThanOrEqual(2);
 		expect(uploadButtonBox!.height).toBe(searchBox!.height);
+		const [libraryTabSizing, uploadButtonSizing] = await Promise.all([
+			dialog.getByRole("tab", { name: "Library" }).evaluate((element) => {
+				const style = getComputedStyle(element);
+				return {
+					height: element.clientHeight,
+					fontSize: style.fontSize,
+					paddingInlineStart: style.paddingInlineStart,
+					paddingInlineEnd: style.paddingInlineEnd,
+				};
+			}),
+			dialog.getByRole("button", { name: "Upload files" }).evaluate((element) => {
+				const style = getComputedStyle(element);
+				return {
+					height: element.clientHeight,
+					fontSize: style.fontSize,
+					paddingInlineStart: style.paddingInlineStart,
+					paddingInlineEnd: style.paddingInlineEnd,
+				};
+			}),
+		]);
+		expect(libraryTabSizing).toEqual(uploadButtonSizing);
+		await expect(dialog.getByRole("tab", { name: "Library" }).locator("svg")).toBeVisible();
+		await expect(dialog.getByRole("tab", { name: "From URL" }).locator("svg")).toBeVisible();
 		const gridDialogWidth = await dialog.evaluate((element) => element.clientWidth);
 		await dialog.getByRole("tab", { name: "List view" }).click();
 		await expect(dialog.locator('[data-media-layout="list"]').first()).toBeVisible();

--- a/e2e/tests/bylines.spec.ts
+++ b/e2e/tests/bylines.spec.ts
@@ -94,10 +94,14 @@ test.describe("Bylines", () => {
 		await expect(dialog).toBeVisible();
 		await expect(dialog).not.toContainText("No media selected");
 		await expect(dialog.locator("[data-media-results-viewport]")).toBeVisible();
+		const libraryTab = dialog.getByRole("tab", { name: "Library" });
+		const fromUrlTab = dialog.getByRole("tab", { name: "From URL" });
+		const uploadButton = dialog.getByRole("button", { name: "Upload files" });
+		await uploadButton.hover();
 
 		const [libraryTabBox, uploadButtonBox, searchBox] = await Promise.all([
-			dialog.getByRole("tab", { name: "Library" }).boundingBox(),
-			dialog.getByRole("button", { name: "Upload files" }).boundingBox(),
+			libraryTab.boundingBox(),
+			uploadButton.boundingBox(),
 			dialog.getByRole("searchbox", { name: "Search media" }).boundingBox(),
 		]);
 		expect(libraryTabBox).not.toBeNull();
@@ -112,9 +116,8 @@ test.describe("Bylines", () => {
 			),
 		).toBeLessThanOrEqual(2);
 		expect(Math.abs(uploadButtonBox!.height - searchBox!.height)).toBeLessThanOrEqual(1);
-		const [sourceTabsBox, libraryTabSizing, uploadButtonSizing] = await Promise.all([
-			dialog.locator("[data-source-tabs]").boundingBox(),
-			dialog.getByRole("tab", { name: "Library" }).evaluate((element) => {
+		const [libraryTabSizing, uploadButtonSizing] = await Promise.all([
+			libraryTab.evaluate((element) => {
 				const style = getComputedStyle(element);
 				return {
 					fontSize: style.fontSize,
@@ -122,7 +125,7 @@ test.describe("Bylines", () => {
 					paddingInlineEnd: style.paddingInlineEnd,
 				};
 			}),
-			dialog.getByRole("button", { name: "Upload files" }).evaluate((element) => {
+			uploadButton.evaluate((element) => {
 				const style = getComputedStyle(element);
 				return {
 					fontSize: style.fontSize,
@@ -131,29 +134,25 @@ test.describe("Bylines", () => {
 				};
 			}),
 		]);
-		expect(sourceTabsBox).not.toBeNull();
-		expect(Math.abs(sourceTabsBox!.height - uploadButtonBox!.height)).toBeLessThanOrEqual(1);
 		expect(libraryTabSizing).toEqual(uploadButtonSizing);
-		expect(libraryTabBox!.y).toBeGreaterThan(sourceTabsBox!.y);
-		expect(libraryTabBox!.y + libraryTabBox!.height).toBeLessThan(
-			sourceTabsBox!.y + sourceTabsBox!.height,
-		);
-		await expect(dialog.getByRole("tab", { name: "Library" }).locator("svg")).toBeVisible();
-		await expect(dialog.getByRole("tab", { name: "From URL" }).locator("svg")).toBeVisible();
+		await expect(libraryTab).toBeInViewport({ ratio: 1 });
+		await expect(fromUrlTab).toBeInViewport({ ratio: 1 });
+		await expect(libraryTab.locator("svg")).toBeVisible();
+		await expect(fromUrlTab.locator("svg")).toBeVisible();
 
-		const [typeFilterBox, viewModeBox, gridTabBox, resultsViewportBox] = await Promise.all([
+		const gridTab = dialog.getByRole("tab", { name: "Grid view" });
+		const listTab = dialog.getByRole("tab", { name: "List view" });
+		const [typeFilterBox, viewModeBox, resultsViewportBox] = await Promise.all([
 			dialog.getByRole("combobox", { name: "Filter by type" }).boundingBox(),
 			dialog.getByRole("group", { name: "View mode" }).boundingBox(),
-			dialog.getByRole("tab", { name: "Grid view" }).boundingBox(),
 			dialog.locator("[data-media-results-viewport]").boundingBox(),
 		]);
 		expect(typeFilterBox).not.toBeNull();
 		expect(viewModeBox).not.toBeNull();
-		expect(gridTabBox).not.toBeNull();
 		expect(resultsViewportBox).not.toBeNull();
 		expect(Math.abs(viewModeBox!.height - searchBox!.height)).toBeLessThanOrEqual(1);
-		expect(gridTabBox!.y).toBeGreaterThan(viewModeBox!.y);
-		expect(gridTabBox!.y + gridTabBox!.height).toBeLessThan(viewModeBox!.y + viewModeBox!.height);
+		await expect(gridTab).toBeInViewport({ ratio: 1 });
+		await expect(listTab).toBeInViewport({ ratio: 1 });
 		const toolbarBottom = Math.max(
 			searchBox!.y + searchBox!.height,
 			typeFilterBox!.y + typeFilterBox!.height,
@@ -161,24 +160,24 @@ test.describe("Bylines", () => {
 		);
 		expect(resultsViewportBox!.y).toBeGreaterThan(toolbarBottom);
 		const gridDialogWidth = await dialog.evaluate((element) => element.clientWidth);
-		await dialog.getByRole("tab", { name: "List view" }).click();
+		await listTab.click();
 		await expect(dialog.locator('[data-media-layout="list"]').first()).toBeVisible();
 		expect(await dialog.evaluate((element) => element.clientWidth)).toBe(gridDialogWidth);
-		await dialog.getByRole("tab", { name: "Grid view" }).click();
+		await gridTab.click();
 		await expect(dialog.locator('[data-media-layout="grid"]').first()).toBeVisible();
 
 		const libraryDialogSize = await dialog.evaluate((element) => ({
 			width: element.clientWidth,
 			height: element.clientHeight,
 		}));
-		await dialog.getByRole("tab", { name: "From URL" }).click();
+		await fromUrlTab.click();
 		await expect(dialog.getByLabel("Image URL")).toBeVisible();
 		const urlDialogSize = await dialog.evaluate((element) => ({
 			width: element.clientWidth,
 			height: element.clientHeight,
 		}));
 		expect(urlDialogSize).toEqual(libraryDialogSize);
-		await dialog.getByRole("tab", { name: "Library" }).click();
+		await libraryTab.click();
 		await expect(dialog.getByRole("searchbox", { name: "Search media" })).toBeVisible();
 
 		const originalViewport = page.viewportSize();

--- a/e2e/tests/bylines.spec.ts
+++ b/e2e/tests/bylines.spec.ts
@@ -126,6 +126,17 @@ test.describe("Bylines", () => {
 		await dialog.getByRole("tab", { name: "Library" }).click();
 		await expect(dialog.getByRole("searchbox", { name: "Search media" })).toBeVisible();
 
+		const originalViewport = page.viewportSize();
+		expect(originalViewport).not.toBeNull();
+		for (const width of [320, 640, 768, 784]) {
+			await page.setViewportSize({ width, height: 800 });
+			const responsiveDialogBox = await dialog.boundingBox();
+			expect(responsiveDialogBox).not.toBeNull();
+			expect(responsiveDialogBox!.x).toBeGreaterThanOrEqual(0);
+			expect(responsiveDialogBox!.x + responsiveDialogBox!.width).toBeLessThanOrEqual(width);
+		}
+		await page.setViewportSize(originalViewport!);
+
 		const uploadDone = page.waitForResponse(
 			(res) => /\/api\/media/.test(res.url()) && res.request().method() === "POST" && res.ok(),
 			{ timeout: 15000 },

--- a/e2e/tests/bylines.spec.ts
+++ b/e2e/tests/bylines.spec.ts
@@ -93,6 +93,7 @@ test.describe("Bylines", () => {
 		const dialog = page.locator('[role="dialog"]').filter({ hasText: "Select Avatar" });
 		await expect(dialog).toBeVisible();
 		await expect(dialog).not.toContainText("No media selected");
+		await expect(dialog.locator("[data-media-results-viewport]")).toBeVisible();
 
 		const [libraryTabBox, uploadButtonBox, searchBox] = await Promise.all([
 			dialog.getByRole("tab", { name: "Library" }).boundingBox(),
@@ -111,6 +112,12 @@ test.describe("Bylines", () => {
 			),
 		).toBeLessThanOrEqual(2);
 		expect(uploadButtonBox!.height).toBe(searchBox!.height);
+		const gridDialogWidth = await dialog.evaluate((element) => element.clientWidth);
+		await dialog.getByRole("tab", { name: "List view" }).click();
+		await expect(dialog.locator('[data-media-layout="list"]').first()).toBeVisible();
+		expect(await dialog.evaluate((element) => element.clientWidth)).toBe(gridDialogWidth);
+		await dialog.getByRole("tab", { name: "Grid view" }).click();
+		await expect(dialog.locator('[data-media-layout="grid"]').first()).toBeVisible();
 
 		const libraryDialogSize = await dialog.evaluate((element) => ({
 			width: element.clientWidth,

--- a/e2e/tests/bylines.spec.ts
+++ b/e2e/tests/bylines.spec.ts
@@ -92,6 +92,25 @@ test.describe("Bylines", () => {
 		await page.getByRole("button", { name: "Select image" }).click();
 		const dialog = page.locator('[role="dialog"]').filter({ hasText: "Select Avatar" });
 		await expect(dialog).toBeVisible();
+		await expect(dialog).not.toContainText("No media selected");
+
+		const [libraryTabBox, uploadButtonBox, searchBox] = await Promise.all([
+			dialog.getByRole("tab", { name: "Library" }).boundingBox(),
+			dialog.getByRole("button", { name: "Upload files" }).boundingBox(),
+			dialog.getByRole("searchbox", { name: "Search media" }).boundingBox(),
+		]);
+		expect(libraryTabBox).not.toBeNull();
+		expect(uploadButtonBox).not.toBeNull();
+		expect(searchBox).not.toBeNull();
+		expect(
+			Math.abs(
+				libraryTabBox!.y +
+					libraryTabBox!.height / 2 -
+					uploadButtonBox!.y -
+					uploadButtonBox!.height / 2,
+			),
+		).toBeLessThanOrEqual(2);
+		expect(uploadButtonBox!.height).toBe(searchBox!.height);
 
 		const uploadDone = page.waitForResponse(
 			(res) => /\/api\/media/.test(res.url()) && res.request().method() === "POST" && res.ok(),

--- a/e2e/tests/bylines.spec.ts
+++ b/e2e/tests/bylines.spec.ts
@@ -87,8 +87,8 @@ test.describe("Bylines", () => {
 		await page.getByRole("button", { name }).click();
 		await expect(page.getByText("Avatar", { exact: true })).toBeVisible();
 
-		// Open the avatar picker and upload an image. The picker auto-selects
-		// the freshly uploaded item, enabling the Insert button.
+		// Open the avatar picker and upload an image. The upload stays inside
+		// this picker and becomes the selected library card when it finishes.
 		await page.getByRole("button", { name: "Select image" }).click();
 		const dialog = page.locator('[role="dialog"]').filter({ hasText: "Select Avatar" });
 		await expect(dialog).toBeVisible();
@@ -99,10 +99,12 @@ test.describe("Bylines", () => {
 		);
 		await dialog.locator('input[type="file"]').setInputFiles(TEST_IMAGE_PATH);
 		await uploadDone;
+		await expect(page.getByRole("dialog")).toHaveCount(1);
+		await expect(
+			dialog.getByRole("button", { name: "test-image.png", exact: true }),
+		).toHaveAttribute("aria-pressed", "true");
 
-		// Two "Insert" buttons exist (the disabled "Insert from URL" action and
-		// the footer confirm); the confirm enables once an item is selected.
-		await dialog.getByRole("button", { name: "Insert", disabled: false }).click();
+		await dialog.getByRole("button", { name: "Select", disabled: false }).click();
 		await expect(dialog).not.toBeVisible();
 
 		// Persist the byline and wait for the PUT to land.

--- a/e2e/tests/bylines.spec.ts
+++ b/e2e/tests/bylines.spec.ts
@@ -111,12 +111,12 @@ test.describe("Bylines", () => {
 					uploadButtonBox!.height / 2,
 			),
 		).toBeLessThanOrEqual(2);
-		expect(uploadButtonBox!.height).toBe(searchBox!.height);
-		const [libraryTabSizing, uploadButtonSizing] = await Promise.all([
+		expect(Math.abs(uploadButtonBox!.height - searchBox!.height)).toBeLessThanOrEqual(1);
+		const [sourceTabsBox, libraryTabSizing, uploadButtonSizing] = await Promise.all([
+			dialog.locator("[data-source-tabs]").boundingBox(),
 			dialog.getByRole("tab", { name: "Library" }).evaluate((element) => {
 				const style = getComputedStyle(element);
 				return {
-					height: element.clientHeight,
 					fontSize: style.fontSize,
 					paddingInlineStart: style.paddingInlineStart,
 					paddingInlineEnd: style.paddingInlineEnd,
@@ -125,16 +125,41 @@ test.describe("Bylines", () => {
 			dialog.getByRole("button", { name: "Upload files" }).evaluate((element) => {
 				const style = getComputedStyle(element);
 				return {
-					height: element.clientHeight,
 					fontSize: style.fontSize,
 					paddingInlineStart: style.paddingInlineStart,
 					paddingInlineEnd: style.paddingInlineEnd,
 				};
 			}),
 		]);
+		expect(sourceTabsBox).not.toBeNull();
+		expect(Math.abs(sourceTabsBox!.height - uploadButtonBox!.height)).toBeLessThanOrEqual(1);
 		expect(libraryTabSizing).toEqual(uploadButtonSizing);
+		expect(libraryTabBox!.y).toBeGreaterThan(sourceTabsBox!.y);
+		expect(libraryTabBox!.y + libraryTabBox!.height).toBeLessThan(
+			sourceTabsBox!.y + sourceTabsBox!.height,
+		);
 		await expect(dialog.getByRole("tab", { name: "Library" }).locator("svg")).toBeVisible();
 		await expect(dialog.getByRole("tab", { name: "From URL" }).locator("svg")).toBeVisible();
+
+		const [typeFilterBox, viewModeBox, gridTabBox, resultsViewportBox] = await Promise.all([
+			dialog.getByRole("combobox", { name: "Filter by type" }).boundingBox(),
+			dialog.getByRole("group", { name: "View mode" }).boundingBox(),
+			dialog.getByRole("tab", { name: "Grid view" }).boundingBox(),
+			dialog.locator("[data-media-results-viewport]").boundingBox(),
+		]);
+		expect(typeFilterBox).not.toBeNull();
+		expect(viewModeBox).not.toBeNull();
+		expect(gridTabBox).not.toBeNull();
+		expect(resultsViewportBox).not.toBeNull();
+		expect(Math.abs(viewModeBox!.height - searchBox!.height)).toBeLessThanOrEqual(1);
+		expect(gridTabBox!.y).toBeGreaterThan(viewModeBox!.y);
+		expect(gridTabBox!.y + gridTabBox!.height).toBeLessThan(viewModeBox!.y + viewModeBox!.height);
+		const toolbarBottom = Math.max(
+			searchBox!.y + searchBox!.height,
+			typeFilterBox!.y + typeFilterBox!.height,
+			viewModeBox!.y + viewModeBox!.height,
+		);
+		expect(resultsViewportBox!.y).toBeGreaterThan(toolbarBottom);
 		const gridDialogWidth = await dialog.evaluate((element) => element.clientWidth);
 		await dialog.getByRole("tab", { name: "List view" }).click();
 		await expect(dialog.locator('[data-media-layout="list"]').first()).toBeVisible();

--- a/e2e/tests/bylines.spec.ts
+++ b/e2e/tests/bylines.spec.ts
@@ -112,6 +112,20 @@ test.describe("Bylines", () => {
 		).toBeLessThanOrEqual(2);
 		expect(uploadButtonBox!.height).toBe(searchBox!.height);
 
+		const libraryDialogSize = await dialog.evaluate((element) => ({
+			width: element.clientWidth,
+			height: element.clientHeight,
+		}));
+		await dialog.getByRole("tab", { name: "From URL" }).click();
+		await expect(dialog.getByLabel("Image URL")).toBeVisible();
+		const urlDialogSize = await dialog.evaluate((element) => ({
+			width: element.clientWidth,
+			height: element.clientHeight,
+		}));
+		expect(urlDialogSize).toEqual(libraryDialogSize);
+		await dialog.getByRole("tab", { name: "Library" }).click();
+		await expect(dialog.getByRole("searchbox", { name: "Search media" })).toBeVisible();
+
 		const uploadDone = page.waitForResponse(
 			(res) => /\/api\/media/.test(res.url()) && res.request().method() === "POST" && res.ok(),
 			{ timeout: 15000 },

--- a/e2e/tests/media-library.spec.ts
+++ b/e2e/tests/media-library.spec.ts
@@ -713,7 +713,9 @@ test.describe("Media Library", () => {
 			.boundingBox();
 		const viewModeBox = await page.getByRole("group", { name: "View mode" }).boundingBox();
 		const mediaGridBox = await page.locator("[data-media-grid]").boundingBox();
-		const mediaCardBox = await page.locator("[data-media-grid] > button").first().boundingBox();
+		const mediaCard = page.locator('[data-media-grid] [data-media-layout="grid"]').first();
+		await expect(mediaCard).toBeVisible();
+		const mediaCardBox = await mediaCard.boundingBox();
 		expect(mediaTitleBox).not.toBeNull();
 		expect(addFolderBox).not.toBeNull();
 		expect(uploadFilesBox).not.toBeNull();

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -1,5 +1,4 @@
 import {
-	Badge,
 	Banner,
 	Breadcrumbs,
 	Button,
@@ -73,31 +72,20 @@ import {
 	getMediaPreviewUrl,
 	getMediaObjectPosition,
 	fallbackToOriginalThumbnail,
-	MEDIA_THUMBNAIL_WIDTH,
 	metaNumber,
 } from "../lib/media-utils";
 import { cn } from "../lib/utils";
+import {
+	MAX_MEDIA_PAGE_DROPDOWN_ITEMS,
+	MEDIA_BROWSER_PAGE_SIZES,
+	MediaBrowserItem,
+	mimeForMediaTypeFilter,
+} from "./media/MediaBrowserItems.js";
 import { MediaDetailPanel } from "./MediaDetailPanel";
 import { MediaFolderDialog } from "./MediaFolderDialog.js";
 import { LOCAL_MEDIA_UPLOAD_ACCEPT, MediaUploadDialog } from "./MediaUploadDialog.js";
 import { RouterLinkButton } from "./RouterLinkButton.js";
 import { TableToolbar, TableToolbarSearch } from "./TableToolbar.js";
-
-/** Maps a coarse type-filter choice to the media list's `mimeType` filter. */
-function mimeForTypeFilter(value: string): string | string[] | undefined {
-	switch (value) {
-		case "image":
-			return "image/";
-		case "video":
-			return "video/";
-		case "audio":
-			return "audio/";
-		case "document":
-			return ["application/", "text/"];
-		default:
-			return undefined;
-	}
-}
 
 export interface MediaLibraryProps {
 	items?: MediaItem[];
@@ -145,8 +133,6 @@ export interface MediaLibraryPagination {
 	onPageSizeChange: (perPage: number) => void;
 }
 
-const MEDIA_PAGE_SIZE_OPTIONS = [35, 70, 90];
-const MAX_DROPDOWN_PAGE_COUNT = 100;
 const MEDIA_DRAG_OVERLAY_MAX_WIDTH = 384;
 const MEDIA_DRAG_OVERLAY_HEIGHT = 36;
 let pendingMediaLibraryScrollTop: number | null = null;
@@ -362,7 +348,7 @@ export function MediaLibrary({
 	);
 	const requestPageSize = React.useCallback(
 		(nextPerPage: number) => {
-			if (!pagination || pagination.isPending || !MEDIA_PAGE_SIZE_OPTIONS.includes(nextPerPage)) {
+			if (!pagination || pagination.isPending || !MEDIA_BROWSER_PAGE_SIZES.includes(nextPerPage)) {
 				return;
 			}
 			paginationRequestedRef.current = true;
@@ -539,7 +525,7 @@ export function MediaLibrary({
 		setSearchQuery("");
 		onLocalSearchChange?.("");
 		setLocalTypeFilter("all");
-		onLocalMimeFilterChange?.(mimeForTypeFilter("all"));
+		onLocalMimeFilterChange?.(mimeForMediaTypeFilter("all"));
 	};
 	const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const next = e.target.value;
@@ -988,7 +974,7 @@ export function MediaLibrary({
 							onValueChange={(v) => {
 								const next = v ?? "all";
 								setLocalTypeFilter(next);
-								onLocalMimeFilterChange?.(mimeForTypeFilter(next));
+								onLocalMimeFilterChange?.(mimeForMediaTypeFilter(next));
 							}}
 							items={{
 								all: t`All types`,
@@ -1336,12 +1322,13 @@ export function MediaLibrary({
 							<Pagination.PageSize
 								value={pagination.perPage}
 								onChange={requestPageSize}
-								options={MEDIA_PAGE_SIZE_OPTIONS}
+								options={MEDIA_BROWSER_PAGE_SIZES}
 								label={t`Per page`}
 							/>
 							<Pagination.Controls
 								pageSelector={
-									Math.ceil(pagination.totalCount / pagination.perPage) <= MAX_DROPDOWN_PAGE_COUNT
+									Math.ceil(pagination.totalCount / pagination.perPage) <=
+									MAX_MEDIA_PAGE_DROPDOWN_ITEMS
 										? "dropdown"
 										: "input"
 								}
@@ -1612,10 +1599,6 @@ function isLocalMediaItem(item: MediaItem): item is LocalMediaItem {
 	);
 }
 
-function formatFileFormat(mimeType: string): string {
-	return (mimeType.split("/").at(-1)?.split("+")[0] || mimeType).toUpperCase();
-}
-
 function MediaDragOverlay({ item }: { item: LocalMediaItem }) {
 	return (
 		<div aria-hidden="true" className="max-w-[calc(100vw-2rem)]" data-media-drag-overlay>
@@ -1682,9 +1665,7 @@ interface MediaGridItemProps {
 }
 
 function MediaGridItem({ item, selected, draggable, isMoving, onClick }: MediaGridItemProps) {
-	const isImage = item.mimeType.startsWith("image/");
 	const localItem = isLocalMediaItem(item) ? item : null;
-	const previewUrl = getMediaPreviewUrl(item.url, item.contentHash);
 	const { setNodeRef, listeners, isDragging } = useDraggable({
 		id: mediaDragId(item.id),
 		data: localItem
@@ -1694,57 +1675,25 @@ function MediaGridItem({ item, selected, draggable, isMoving, onClick }: MediaGr
 	});
 
 	return (
-		<LayerCard
+		<div
 			ref={setNodeRef}
 			{...listeners}
-			render={<button type="button" />}
-			onClick={onClick}
-			aria-label={item.filename}
 			aria-busy={isMoving || undefined}
 			data-media-draggable={draggable || undefined}
 			className={cn(
-				"group w-full min-w-0 text-start transition-opacity focus-visible:ring-2 focus-visible:ring-kumo-brand",
-				selected ? "ring-2 ring-kumo-brand" : "hover:ring-kumo-brand/50",
+				"min-w-0 transition-opacity",
 				draggable && "cursor-grab touch-manipulation active:cursor-grabbing",
 				(isDragging || isMoving) && "opacity-40",
 			)}
 		>
-			<LayerCard.Primary className="aspect-video p-0">
-				{isImage ? (
-					<img
-						src={getMediaThumbnailUrl(
-							item.url,
-							item.mimeType,
-							MEDIA_THUMBNAIL_WIDTH,
-							item.contentHash,
-						)}
-						alt={item.alt || item.filename}
-						draggable={false}
-						className="emdash-media-transparency-grid h-full w-full object-cover"
-						style={{ objectPosition: getMediaObjectPosition(item) }}
-						onError={(e) => fallbackToOriginalThumbnail(e.currentTarget, previewUrl)}
-					/>
-				) : (
-					<div className="flex h-full w-full items-center justify-center bg-kumo-tint">
-						<span className="text-4xl">{getFileIcon(item.mimeType)}</span>
-					</div>
-				)}
-			</LayerCard.Primary>
-			<LayerCard.Secondary className="my-0 min-w-0 justify-between px-3 py-2.5 text-sm text-kumo-default">
-				<span
-					dir="auto"
-					title={item.filename}
-					className="min-w-0 flex-1 truncate font-medium leading-5"
-				>
-					{item.filename}
-				</span>
-				<Badge variant="secondary" className="h-5 min-w-11 justify-center rounded-md px-2 py-0">
-					<span className="text-[11px] leading-none text-kumo-default/75">
-						{formatFileFormat(item.mimeType)}
-					</span>
-				</Badge>
-			</LayerCard.Secondary>
-		</LayerCard>
+			<MediaBrowserItem
+				item={item}
+				layout="grid"
+				selected={selected}
+				onClick={onClick}
+				mediaDraggable={draggable}
+			/>
+		</div>
 	);
 }
 
@@ -1757,53 +1706,14 @@ interface ProviderGridItemProps {
 }
 
 function ProviderGridItem({ item, selected, onClick, onDimensionsLoaded }: ProviderGridItemProps) {
-	const handleImageLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
-		const img = e.currentTarget;
-		// Only report if we don't already have dimensions
-		if (onDimensionsLoaded && (!item.width || !item.height)) {
-			onDimensionsLoaded(img.naturalWidth, img.naturalHeight);
-		}
-	};
-
 	return (
-		<LayerCard
-			render={<button type="button" />}
+		<MediaBrowserItem
+			item={providerItemToMediaItem("provider", item)}
+			layout="grid"
+			selected={selected}
 			onClick={onClick}
-			aria-label={item.filename}
-			className={cn(
-				"group w-full min-w-0 text-start focus-visible:ring-2 focus-visible:ring-kumo-brand",
-				selected ? "ring-2 ring-kumo-brand" : "hover:ring-kumo-brand/50",
-			)}
-		>
-			<LayerCard.Primary className="aspect-[4/3] p-0">
-				{item.previewUrl ? (
-					<img
-						src={item.previewUrl}
-						alt={item.alt || item.filename}
-						className="emdash-media-transparency-grid h-full w-full object-cover"
-						onLoad={handleImageLoad}
-					/>
-				) : (
-					<div className="flex h-full w-full items-center justify-center bg-kumo-tint">
-						<span className="text-4xl">{getFileIcon(item.mimeType)}</span>
-					</div>
-				)}
-			</LayerCard.Primary>
-			<LayerCard.Secondary className="my-0 min-w-0 justify-between px-3 py-2.5 text-sm text-kumo-default">
-				<span
-					dir="auto"
-					title={item.filename}
-					className="min-w-0 flex-1 truncate font-medium leading-5"
-				>
-					{item.filename}
-				</span>
-				<Badge variant="secondary" className="h-5 min-w-11 justify-center rounded-md px-2 py-0">
-					<span className="text-[11px] leading-none text-kumo-default/75">
-						{formatFileFormat(item.mimeType)}
-					</span>
-				</Badge>
-			</LayerCard.Secondary>
-		</LayerCard>
+			onDimensionsLoaded={onDimensionsLoaded}
+		/>
 	);
 }
 

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -83,6 +83,10 @@ function matchesAnyFilter(mime: string, filters: string[] | undefined): boolean 
 	});
 }
 
+function matchesFilenameSearch(filename: string, search: string): boolean {
+	return !search || filename.toLowerCase().includes(search.toLowerCase());
+}
+
 function filtersOverlap(first: string, second: string): string | null {
 	const left = first.toLowerCase();
 	const right = second.toLowerCase();
@@ -659,17 +663,31 @@ export function MediaPickerModal({
 	const fetchedItems: Array<MediaItem | MediaProviderItem> =
 		activeSource === "local" ? localItems : providerItems;
 	const visibleItems = React.useMemo(() => {
+		const pinnedSearch = activeSource === "local" ? activeSearch : searchQuery.trim();
+		const pinnedMimeFilters = activeSource === "local" ? effectiveMimeFilters : filters;
 		const pinned = pinnedItems.filter(
 			(selected) =>
 				selected.providerId === activeSource &&
-				!(activeSource === "local" && folderId && !activeSearch),
+				!(activeSource === "local" && folderId && !activeSearch) &&
+				!(activeSource === "local" && effectiveMimeFilters?.length === 0) &&
+				matchesFilenameSearch(selected.item.filename, pinnedSearch) &&
+				matchesAnyFilter(selected.item.mimeType, pinnedMimeFilters),
 		);
 		const keys = new Set(pinned.map((selected) => selected.key));
 		return [
 			...pinned.map((selected) => selected.item),
 			...fetchedItems.filter((item) => !keys.has(selectionKey(activeSource, item))),
 		];
-	}, [activeSearch, activeSource, fetchedItems, folderId, pinnedItems]);
+	}, [
+		activeSearch,
+		activeSource,
+		effectiveMimeFilters,
+		fetchedItems,
+		filters,
+		folderId,
+		pinnedItems,
+		searchQuery,
+	]);
 	const visibleUploadJobs = uploadQueue.jobs.filter(
 		(job) => job.status !== "complete" && uploadTargetsRef.current.get(job.id) === activeSource,
 	);
@@ -705,7 +723,7 @@ export function MediaPickerModal({
 		>
 			<Dialog
 				size="xl"
-				className="flex h-[min(48rem,calc(100dvh-1rem))] min-h-0 min-w-0 max-w-[calc(100vw-1rem)] flex-col overflow-hidden p-0 sm:min-w-[48rem] sm:max-w-5xl"
+				className="flex h-[min(48rem,calc(100dvh-1rem))] w-[calc(100vw-2rem)] min-h-0 min-w-0 max-w-[48rem] flex-col overflow-hidden p-0 sm:w-[min(48rem,calc(100vw-2rem))]"
 			>
 				<header className="flex shrink-0 items-start justify-between gap-4 border-b border-kumo-line px-5 py-4 sm:px-7">
 					<div className="min-w-0">
@@ -732,11 +750,14 @@ export function MediaPickerModal({
 				<div
 					className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain px-5 py-4 sm:px-7"
 					onDragOver={(event) => {
-						if (canUpload && event.dataTransfer.types.includes("Files")) event.preventDefault();
+						if (!event.dataTransfer.types.includes("Files")) return;
+						event.preventDefault();
+						event.dataTransfer.dropEffect = canUpload ? "copy" : "none";
 					}}
 					onDrop={(event) => {
-						if (!canUpload || !event.dataTransfer.types.includes("Files")) return;
+						if (!event.dataTransfer.types.includes("Files")) return;
 						event.preventDefault();
+						if (!canUpload) return;
 						enqueueFiles([...event.dataTransfer.files]);
 					}}
 				>

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -707,7 +707,7 @@ export function MediaPickerModal({
 				size="xl"
 				className="flex max-h-[calc(100dvh-1rem)] min-h-0 min-w-0 max-w-[calc(100vw-1rem)] flex-col overflow-hidden p-0 sm:max-h-[88dvh] sm:min-w-[48rem] sm:max-w-5xl"
 			>
-				<header className="flex shrink-0 items-start justify-between gap-4 border-b border-kumo-line px-4 py-4 sm:px-6">
+				<header className="flex shrink-0 items-start justify-between gap-4 border-b border-kumo-line px-5 py-4 sm:px-7">
 					<div className="min-w-0">
 						<Dialog.Title className="text-lg font-semibold leading-6">{title}</Dialog.Title>
 						<Dialog.Description className="mt-1 text-sm leading-5 text-kumo-subtle">
@@ -721,7 +721,7 @@ export function MediaPickerModal({
 								{...props}
 								variant="ghost"
 								shape="square"
-								size="sm"
+								size="base"
 								aria-label={t`Close`}
 								icon={<X aria-hidden="true" />}
 							/>
@@ -730,7 +730,7 @@ export function MediaPickerModal({
 				</header>
 
 				<div
-					className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain px-4 py-4 sm:px-6"
+					className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain px-5 py-4 sm:px-7"
 					onDragOver={(event) => {
 						if (canUpload && event.dataTransfer.types.includes("Files")) event.preventDefault();
 					}}
@@ -740,28 +740,65 @@ export function MediaPickerModal({
 						enqueueFiles([...event.dataTransfer.files]);
 					}}
 				>
-					{sourceTabs.length > 1 && (
-						<div aria-disabled={uploadQueue.hasUnfinished || undefined} data-source-tabs>
-							<Tabs
-								variant="underline"
-								value={activeSource}
-								onValueChange={changeSource}
-								tabs={sourceTabs.map((source) => ({
-									value: source.id,
-									render: (props) => <button {...props} disabled={uploadQueue.hasUnfinished} />,
-									label: (
-										<span className="flex items-center gap-2">
-											{source.icon &&
-												(source.icon.startsWith("data:") ? (
-													<img src={source.icon} alt="" className="size-4" aria-hidden="true" />
-												) : (
-													<span aria-hidden="true">{source.icon}</span>
-												))}
-											{source.name}
-										</span>
-									),
-								}))}
-							/>
+					{(sourceTabs.length > 1 || canUpload) && (
+						<div className="flex flex-wrap items-center gap-2">
+							{sourceTabs.length > 1 && (
+								<div aria-disabled={uploadQueue.hasUnfinished || undefined} data-source-tabs>
+									<Tabs
+										variant="segmented"
+										size="base"
+										value={activeSource}
+										onValueChange={changeSource}
+										tabs={sourceTabs.map((source) => ({
+											value: source.id,
+											render: (props) => <button {...props} disabled={uploadQueue.hasUnfinished} />,
+											label: (
+												<span className="flex items-center gap-2">
+													{source.icon &&
+														(source.icon.startsWith("data:") ? (
+															<img src={source.icon} alt="" className="size-4" aria-hidden="true" />
+														) : (
+															<span aria-hidden="true">{source.icon}</span>
+														))}
+													{source.name}
+												</span>
+											),
+										}))}
+									/>
+								</div>
+							)}
+							{canUpload && (
+								<>
+									<Button
+										variant="outline"
+										size="base"
+										className="ms-auto"
+										onClick={() => fileInputRef.current?.click()}
+										icon={<Upload aria-hidden="true" />}
+									>
+										{t`Upload files`}
+									</Button>
+									<input
+										ref={fileInputRef}
+										type="file"
+										multiple={multiple}
+										accept={
+											filters
+												? filters
+														.map((filter) => (filter.endsWith("/") ? `${filter}*` : filter))
+														.join(",")
+												: undefined
+										}
+										className="sr-only"
+										tabIndex={-1}
+										onChange={(event) => {
+											enqueueFiles([...(event.currentTarget.files ?? [])]);
+											event.currentTarget.value = "";
+										}}
+										aria-label={t`Choose files to upload`}
+									/>
+								</>
+							)}
 						</div>
 					)}
 
@@ -919,36 +956,6 @@ export function MediaPickerModal({
 										items={typeItems}
 										aria-label={t`Filter by type`}
 									/>
-								)}
-								{canUpload && (
-									<>
-										<Button
-											size="sm"
-											onClick={() => fileInputRef.current?.click()}
-											icon={<Upload aria-hidden="true" />}
-										>
-											{t`Upload files`}
-										</Button>
-										<input
-											ref={fileInputRef}
-											type="file"
-											multiple={multiple}
-											accept={
-												filters
-													? filters
-															.map((filter) => (filter.endsWith("/") ? `${filter}*` : filter))
-															.join(",")
-													: undefined
-											}
-											className="sr-only"
-											tabIndex={-1}
-											onChange={(event) => {
-												enqueueFiles([...(event.currentTarget.files ?? [])]);
-												event.currentTarget.value = "";
-											}}
-											aria-label={t`Choose files to upload`}
-										/>
-									</>
 								)}
 							</TableToolbar>
 
@@ -1245,22 +1252,13 @@ export function MediaPickerModal({
 					)}
 				</div>
 
-				<footer className="flex shrink-0 flex-col gap-3 border-t border-kumo-line px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-6">
-					<div className="min-w-0 text-sm text-kumo-subtle">
-						{selectedItems.length > 0
-							? multiple
-								? plural(selectedItems.length, {
-										one: "# item selected",
-										other: "# items selected",
-									})
-								: t`Selected: ${selectedItems[0]!.item.filename}`
-							: t`No media selected`}
-					</div>
+				<footer className="flex shrink-0 justify-end border-t border-kumo-line px-5 py-3 sm:px-7">
 					<div className="flex flex-wrap items-center justify-end gap-2">
 						<Button variant="outline" onClick={handleClose}>
 							{t`Cancel`}
 						</Button>
 						<Button
+							variant="primary"
 							onClick={handleConfirm}
 							disabled={selectedItems.length === 0 || uploadQueue.hasUnfinished}
 						>

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -9,6 +9,7 @@ import {
 	Select,
 	Tabs,
 } from "@cloudflare/kumo";
+import { ScrollArea } from "@cloudflare/kumo/primitives/scroll-area";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
@@ -48,7 +49,6 @@ import { useDebouncedValue } from "../lib/hooks.js";
 import { canonicalMediaProviderId, providerItemToMediaItem } from "../lib/media-utils.js";
 import { matchesMimeAllowlist, mimeFromUrl } from "../lib/mime-utils.js";
 import {
-	MAX_MEDIA_PAGE_DROPDOWN_ITEMS,
 	MediaBrowserFolder,
 	MediaBrowserItem,
 	MediaSelectionTrayItem,
@@ -713,6 +713,27 @@ export function MediaPickerModal({
 		},
 		[activeSource, canUpload, filters, multiple, uploadQueue.addFiles],
 	);
+	const selectionTray =
+		multiple && selectedItems.length > 0 ? (
+			<section aria-labelledby="media-picker-selection" className="grid gap-2">
+				<h2 id="media-picker-selection" className="text-sm font-semibold">
+					{t`Selected media`}
+				</h2>
+				<ul className="grid gap-2">
+					{selectedItems.map((selected, index) => (
+						<MediaSelectionTrayItem
+							key={selected.key}
+							item={toMediaItem(selected)}
+							position={index + 1}
+							total={selectedItems.length}
+							onMoveEarlier={() => moveSelectedItem(index, index - 1, selected.item.filename)}
+							onMoveLater={() => moveSelectedItem(index, index + 1, selected.item.filename)}
+							onRemove={() => removeSelectedItem(selected)}
+						/>
+					))}
+				</ul>
+			</section>
+		) : null;
 
 	return (
 		<Dialog.Root
@@ -748,7 +769,7 @@ export function MediaPickerModal({
 				</header>
 
 				<div
-					className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain px-5 py-4 sm:px-7"
+					className="flex min-h-0 flex-1 flex-col overflow-hidden"
 					onDragOver={(event) => {
 						if (!event.dataTransfer.types.includes("Files")) return;
 						event.preventDefault();
@@ -762,7 +783,7 @@ export function MediaPickerModal({
 					}}
 				>
 					{(sourceTabs.length > 1 || canUpload) && (
-						<div className="flex flex-wrap items-center gap-2">
+						<div className="flex shrink-0 flex-wrap items-center gap-2 px-5 pt-4 sm:px-7">
 							{sourceTabs.length > 1 && (
 								<div aria-disabled={uploadQueue.hasUnfinished || undefined} data-source-tabs>
 									<Tabs
@@ -824,442 +845,464 @@ export function MediaPickerModal({
 					)}
 
 					{activeSource === URL_SOURCE ? (
-						<section className="mx-auto grid w-full max-w-2xl gap-4 py-6">
-							<div className="grid gap-1.5">
-								<Label htmlFor="media-picker-url">{t`Image URL`}</Label>
-								<div className="flex flex-col gap-2 sm:flex-row">
-									<div className="relative min-w-0 flex-1">
-										<Globe
-											className="absolute start-3 top-1/2 size-4 -translate-y-1/2 text-kumo-subtle"
-											aria-hidden="true"
-										/>
-										<Input
-											id="media-picker-url"
-											type="url"
-											aria-label={t`Image URL`}
-											placeholder={t`https://example.com/image.jpg`}
-											value={imageUrl}
-											onChange={(event) => {
-												setImageUrl(event.currentTarget.value);
-												setUrlError(null);
-											}}
-											onKeyDown={(event) => {
-												if (event.key !== "Enter") return;
-												event.preventDefault();
-												void handleUrlSubmit();
-											}}
-											className="w-full ps-9"
-										/>
-									</div>
-									<Button
-										onClick={() => void handleUrlSubmit()}
-										disabled={!imageUrl.trim() || isProbing}
-										loading={isProbing}
-									>
-										{t`Use URL`}
-									</Button>
-								</div>
-								{urlError && (
-									<p role="alert" className="text-sm text-kumo-danger">
-										{urlError}
-									</p>
-								)}
-							</div>
-
-							{selectedItems
-								.filter((selected) => selected.providerId === URL_SOURCE)
-								.map((selected) => (
-									<MediaBrowserItem
-										key={selected.key}
-										item={selected.item as MediaItem}
-										layout="list"
-										selected
-										selectable
-										onClick={(event) => {
-											if (event.detail > 1) return;
-											updateSelection(URL_SOURCE, selected.item);
-										}}
-									/>
-								))}
-						</section>
-					) : (
-						<>
-							{folderId && activeSource === "local" && (
-								<div className="flex min-w-0 items-center gap-2">
-									<Button
-										variant="ghost"
-										size="sm"
-										disabled={uploadQueue.hasUnfinished}
-										onClick={() => {
-											setFolderId(undefined);
-											resetPage();
-										}}
-										icon={<ArrowLeft className="rtl:-scale-x-100" aria-hidden="true" />}
-									>
-										{t`Main library`}
-									</Button>
-									<span aria-hidden="true" className="text-kumo-subtle">
-										/
-									</span>
-									<span dir="auto" className="min-w-0 truncate text-sm font-medium">
-										{currentFolderQuery.data?.name ?? t`Folder`}
-									</span>
-								</div>
-							)}
-							{folderId && currentFolderQuery.error && !missingFolder && (
-								<div className="flex flex-wrap items-center justify-between gap-2 rounded-md bg-kumo-danger-tint px-3 py-2 text-sm text-kumo-danger">
-									<span>{t`Could not load this folder.`}</span>
-									<Button
-										variant="outline"
-										size="sm"
-										onClick={() => void currentFolderQuery.refetch()}
-									>
-										{t`Retry`}
-									</Button>
-								</div>
-							)}
-
-							<TableToolbar
-								trailing={
-									<div role="group" aria-label={t`View mode`}>
-										<Tabs
-											variant="segmented"
-											value={viewMode}
-											onValueChange={(value) => {
-												if (value === "grid" || value === "list") setViewMode(value);
-											}}
-											tabs={[
-												{
-													value: "grid",
-													label: (
-														<>
-															<SquaresFour className="size-4" aria-hidden="true" />
-															<span className="sr-only">{t`Grid view`}</span>
-														</>
-													),
-												},
-												{
-													value: "list",
-													label: (
-														<>
-															<List className="size-4" aria-hidden="true" />
-															<span className="sr-only">{t`List view`}</span>
-														</>
-													),
-												},
-											]}
-										/>
-									</div>
-								}
+						<ScrollArea.Root className="relative min-h-0 flex-1" data-media-results-scroll>
+							<ScrollArea.Viewport
+								className="h-full w-full overscroll-contain"
+								data-media-results-viewport
 							>
-								{canSearch && (
-									<TableToolbarSearch
-										size="base"
-										placeholder={activeSource === "local" ? t`Search by filename...` : t`Search...`}
-										aria-label={t`Search media`}
-										value={searchQuery}
-										onChange={(event) => {
-											setSearchQuery(event.currentTarget.value);
-											if (activeSource === "local") resetPage();
-										}}
-										maxLength={MEDIA_SEARCH_MAX_LENGTH}
-										className="basis-full sm:w-72 sm:basis-auto"
-									/>
-								)}
-								{activeSource === "local" && (
-									<Select
-										size="base"
-										value={typeFilter}
-										onValueChange={(value) => {
-											setTypeFilter(value ?? "all");
-											resetPage();
-										}}
-										items={typeItems}
-										aria-label={t`Filter by type`}
-									/>
-								)}
-							</TableToolbar>
-
-							{uploadQueue.overflowCount > 0 && (
-								<p role="alert" className="text-sm text-kumo-danger">
-									{plural(uploadQueue.overflowCount, {
-										one: "# file was not added because the upload list is full.",
-										other: "# files were not added because the upload list is full.",
-									})}
-								</p>
-							)}
-							{activeSource === "local" && localQuery.error && localItems.length > 0 && (
-								<div className="flex flex-wrap items-center justify-between gap-2 rounded-md bg-kumo-danger-tint px-3 py-2 text-sm text-kumo-danger">
-									<span>{t`The latest media request failed. Showing the previous page.`}</span>
-									<Button variant="outline" size="sm" onClick={() => void localQuery.refetch()}>
-										{t`Retry`}
-									</Button>
-								</div>
-							)}
-
-							{showFolderResults &&
-								(foldersQuery.isPending || folders.length > 0 || foldersQuery.error) && (
-									<section aria-labelledby="media-picker-folders" className="grid gap-2">
-										<div className="flex items-center justify-between gap-2">
-											<h2 id="media-picker-folders" className="text-sm font-semibold">
-												{t`Folders`}
-											</h2>
-											{foldersQuery.error && (
-												<div className="flex items-center gap-2">
-													<span className="text-sm text-kumo-danger">
-														{t`Folders could not be loaded.`}
-													</span>
-													<Button
-														variant="outline"
-														size="sm"
-														onClick={() => void foldersQuery.refetch()}
-													>
-														{t`Retry`}
-													</Button>
+								<ScrollArea.Content className="space-y-4 px-5 pb-4 sm:px-7">
+									<section className="mx-auto grid w-full max-w-2xl gap-4 py-6">
+										<div className="grid gap-1.5">
+											<Label htmlFor="media-picker-url">{t`Image URL`}</Label>
+											<div className="flex flex-col gap-2 sm:flex-row">
+												<div className="relative min-w-0 flex-1">
+													<Globe
+														className="absolute start-3 top-1/2 size-4 -translate-y-1/2 text-kumo-subtle"
+														aria-hidden="true"
+													/>
+													<Input
+														id="media-picker-url"
+														type="url"
+														aria-label={t`Image URL`}
+														placeholder={t`https://example.com/image.jpg`}
+														value={imageUrl}
+														onChange={(event) => {
+															setImageUrl(event.currentTarget.value);
+															setUrlError(null);
+														}}
+														onKeyDown={(event) => {
+															if (event.key !== "Enter") return;
+															event.preventDefault();
+															void handleUrlSubmit();
+														}}
+														className="w-full ps-9"
+													/>
 												</div>
+												<Button
+													onClick={() => void handleUrlSubmit()}
+													disabled={!imageUrl.trim() || isProbing}
+													loading={isProbing}
+												>
+													{t`Use URL`}
+												</Button>
+											</div>
+											{urlError && (
+												<p role="alert" className="text-sm text-kumo-danger">
+													{urlError}
+												</p>
 											)}
 										</div>
-										{foldersQuery.isPending && folders.length === 0 ? (
-											<div
-												role="status"
-												className="flex items-center gap-2 text-sm text-kumo-subtle"
-											>
-												<Loader size="sm" />
-												{t`Loading folders`}
-											</div>
-										) : (
-											<div
-												className="grid grid-cols-[repeat(auto-fill,minmax(min(12rem,100%),1fr))] gap-2"
-												inert={uploadQueue.hasUnfinished || undefined}
-											>
-												{folders.map((folder) => (
-													<MediaBrowserFolder
-														key={folder.id}
-														folder={folder}
-														onOpen={() => {
-															if (uploadQueue.hasUnfinished) return;
-															setSearchQuery("");
-															setFolderId(folder.id);
-															resetPage();
-														}}
-													/>
-												))}
-											</div>
-										)}
-										{foldersQuery.hasNextPage && (
-											<Button
-												variant="outline"
-												size="sm"
-												onClick={() => void foldersQuery.fetchNextPage()}
-												disabled={foldersQuery.isFetchingNextPage || uploadQueue.hasUnfinished}
-												loading={foldersQuery.isFetchingNextPage}
-											>
-												{t`Load more folders`}
-											</Button>
-										)}
-									</section>
-								)}
 
-							<div
-								role="region"
-								aria-label={t`Media results`}
-								aria-busy={currentFetching || undefined}
-							>
-								{currentLoading && !hasVisibleItems ? (
-									<div
-										role="status"
-										className="flex min-h-48 items-center justify-center gap-2 text-sm text-kumo-subtle"
-									>
-										<Loader />
-										{t`Loading media`}
+										{selectedItems
+											.filter((selected) => selected.providerId === URL_SOURCE)
+											.map((selected) => (
+												<MediaBrowserItem
+													key={selected.key}
+													item={selected.item as MediaItem}
+													layout="list"
+													selected
+													selectable
+													onClick={(event) => {
+														if (event.detail > 1) return;
+														updateSelection(URL_SOURCE, selected.item);
+													}}
+												/>
+											))}
+									</section>
+									{selectionTray}
+								</ScrollArea.Content>
+							</ScrollArea.Viewport>
+							<ScrollArea.Scrollbar className="pointer-events-none w-2.5 p-0.5 opacity-0 data-[scrolling]:pointer-events-auto data-[scrolling]:opacity-100">
+								<ScrollArea.Thumb className="rounded-full bg-kumo-interact" />
+							</ScrollArea.Scrollbar>
+						</ScrollArea.Root>
+					) : (
+						<>
+							<div className="shrink-0 space-y-4 px-5 pt-4 sm:px-7">
+								{folderId && activeSource === "local" && (
+									<div className="flex min-w-0 items-center gap-2">
+										<Button
+											variant="ghost"
+											size="sm"
+											disabled={uploadQueue.hasUnfinished}
+											onClick={() => {
+												setFolderId(undefined);
+												resetPage();
+											}}
+											icon={<ArrowLeft className="rtl:-scale-x-100" aria-hidden="true" />}
+										>
+											{t`Main library`}
+										</Button>
+										<span aria-hidden="true" className="text-kumo-subtle">
+											/
+										</span>
+										<span dir="auto" className="min-w-0 truncate text-sm font-medium">
+											{currentFolderQuery.data?.name ?? t`Folder`}
+										</span>
 									</div>
-								) : (activeSource === "local" ? localQuery.error : providerQuery.error) &&
-								  !hasVisibleItems ? (
-									<div className="flex min-h-48 flex-col items-center justify-center gap-3 text-center">
-										<p className="text-sm text-kumo-danger">{t`Could not load media.`}</p>
+								)}
+								{folderId && currentFolderQuery.error && !missingFolder && (
+									<div className="flex flex-wrap items-center justify-between gap-2 rounded-md bg-kumo-danger-tint px-3 py-2 text-sm text-kumo-danger">
+										<span>{t`Could not load this folder.`}</span>
 										<Button
 											variant="outline"
-											onClick={() =>
-												void (activeSource === "local"
-													? localQuery.refetch()
-													: providerQuery.refetch())
-											}
+											size="sm"
+											onClick={() => void currentFolderQuery.refetch()}
 										>
 											{t`Retry`}
 										</Button>
 									</div>
-								) : !hasVisibleItems ? (
-									<div className="flex min-h-48 flex-col items-center justify-center gap-3 text-center">
-										<EmptyStateIcon className="size-10 text-kumo-subtle" aria-hidden="true" />
-										<div className="grid gap-1">
-											<h2 className="text-lg font-semibold">{t`No media found`}</h2>
-											<p className="text-sm text-kumo-subtle">
-												{searchQuery.trim()
-													? t`Try another filename or clear your search.`
-													: folderId && activeSource === "local"
-														? t`This folder is empty.`
-														: isFileKind
-															? t`Upload a file to get started`
-															: t`Upload an image to get started`}
-											</p>
-										</div>
-									</div>
-								) : viewMode === "grid" ? (
-									<Grid
-										variant="4up"
-										gap="sm"
-										className="2xl:grid-cols-5"
-										inert={currentFetching || undefined}
-										data-media-items
-									>
-										{visibleUploadJobs.map((job) => (
-											<MediaUploadPlaceholder
-												key={job.id}
-												job={job}
-												layout="grid"
-												onRetry={() => uploadQueue.retry(job.id)}
-												onRemove={() => {
-													uploadTargetsRef.current.delete(job.id);
-													uploadQueue.remove(job.id);
-												}}
-											/>
-										))}
-										{visibleItems.map((rawItem) => {
-											const key = selectionKey(activeSource, rawItem);
-											const item =
-												activeSource === "local"
-													? (rawItem as MediaItem)
-													: toMediaItem({ key, providerId: activeSource, item: rawItem });
-											return (
-												<MediaBrowserItem
-													key={key}
-													item={item}
-													layout="grid"
-													selectable
-													selected={selectedItems.some((selected) => selected.key === key)}
-													onClick={(event) => {
-														if (event.detail > 1) return;
-														updateSelection(activeSource, rawItem);
-													}}
-													onDimensionsLoaded={(width, height) =>
-														handleBrowserDimensions(activeSource, rawItem, key, width, height)
-													}
-												/>
-											);
-										})}
-									</Grid>
-								) : (
-									<div className="grid gap-2" inert={currentFetching || undefined} data-media-items>
-										{visibleUploadJobs.map((job) => (
-											<MediaUploadPlaceholder
-												key={job.id}
-												job={job}
-												layout="list"
-												onRetry={() => uploadQueue.retry(job.id)}
-												onRemove={() => {
-													uploadTargetsRef.current.delete(job.id);
-													uploadQueue.remove(job.id);
-												}}
-											/>
-										))}
-										{visibleItems.map((rawItem) => {
-											const key = selectionKey(activeSource, rawItem);
-											const item =
-												activeSource === "local"
-													? (rawItem as MediaItem)
-													: toMediaItem({ key, providerId: activeSource, item: rawItem });
-											return (
-												<MediaBrowserItem
-													key={key}
-													item={item}
-													layout="list"
-													selectable
-													selected={selectedItems.some((selected) => selected.key === key)}
-													onClick={(event) => {
-														if (event.detail > 1) return;
-														updateSelection(activeSource, rawItem);
-													}}
-													onDimensionsLoaded={(width, height) =>
-														handleBrowserDimensions(activeSource, rawItem, key, width, height)
-													}
-												/>
-											);
-										})}
-									</div>
 								)}
+
+								<TableToolbar
+									trailing={
+										<div role="group" aria-label={t`View mode`}>
+											<Tabs
+												variant="segmented"
+												value={viewMode}
+												onValueChange={(value) => {
+													if (value === "grid" || value === "list") setViewMode(value);
+												}}
+												tabs={[
+													{
+														value: "grid",
+														label: (
+															<>
+																<SquaresFour className="size-4" aria-hidden="true" />
+																<span className="sr-only">{t`Grid view`}</span>
+															</>
+														),
+													},
+													{
+														value: "list",
+														label: (
+															<>
+																<List className="size-4" aria-hidden="true" />
+																<span className="sr-only">{t`List view`}</span>
+															</>
+														),
+													},
+												]}
+											/>
+										</div>
+									}
+								>
+									{canSearch && (
+										<TableToolbarSearch
+											size="base"
+											placeholder={
+												activeSource === "local" ? t`Search by filename...` : t`Search...`
+											}
+											aria-label={t`Search media`}
+											value={searchQuery}
+											onChange={(event) => {
+												setSearchQuery(event.currentTarget.value);
+												if (activeSource === "local") resetPage();
+											}}
+											maxLength={MEDIA_SEARCH_MAX_LENGTH}
+											className="basis-full sm:w-72 sm:basis-auto"
+										/>
+									)}
+									{activeSource === "local" && (
+										<Select
+											size="base"
+											value={typeFilter}
+											onValueChange={(value) => {
+												setTypeFilter(value ?? "all");
+												resetPage();
+											}}
+											items={typeItems}
+											aria-label={t`Filter by type`}
+										/>
+									)}
+								</TableToolbar>
 							</div>
 
-							{activeSource === "local" && totalCount > 0 && (
-								<Pagination
-									page={isRecoveringPage ? lastPage : page}
-									setPage={(nextPage) => {
-										const pageCount = Math.max(1, Math.ceil(totalCount / PICKER_PAGE_SIZE));
-										if (
-											localQuery.isFetching ||
-											!Number.isSafeInteger(nextPage) ||
-											nextPage < 1 ||
-											nextPage > pageCount
-										)
-											return;
-										setPage(nextPage);
-									}}
-									perPage={PICKER_PAGE_SIZE}
-									totalCount={totalCount}
-									className="flex-wrap gap-y-3"
-									labels={{
-										navigation: t`Media pagination`,
-										firstPage: t`First page`,
-										previousPage: t`Previous page`,
-										nextPage: t`Next page`,
-										lastPage: t`Last page`,
-										pageNumber: t`Page number`,
-										pageSize: t`Page size`,
-									}}
+							<ScrollArea.Root className="relative min-h-0 flex-1" data-media-results-scroll>
+								<ScrollArea.Viewport
+									className="h-full w-full overscroll-contain"
+									data-media-results-viewport
 								>
-									<Pagination.Info className="min-w-fit">
-										{({ pageShowingRange, totalCount: count }) => (
-											<span role="status">{t`Showing ${pageShowingRange} of ${count ?? 0}`}</span>
+									<ScrollArea.Content className="space-y-4 px-5 py-4 sm:px-7">
+										{uploadQueue.overflowCount > 0 && (
+											<p role="alert" className="text-sm text-kumo-danger">
+												{plural(uploadQueue.overflowCount, {
+													one: "# file was not added because the upload list is full.",
+													other: "# files were not added because the upload list is full.",
+												})}
+											</p>
 										)}
-									</Pagination.Info>
-									<Pagination.Separator className="hidden sm:block" />
-									<div inert={localQuery.isFetching || undefined} className="contents">
-										<Pagination.Controls
-											pageSelector={
-												Math.ceil(totalCount / PICKER_PAGE_SIZE) <= MAX_MEDIA_PAGE_DROPDOWN_ITEMS
-													? "dropdown"
-													: "input"
-											}
-											className="basis-full sm:basis-auto rtl:[&_svg]:-scale-x-100"
-										/>
-									</div>
-								</Pagination>
+										{activeSource === "local" && localQuery.error && localItems.length > 0 && (
+											<div className="flex flex-wrap items-center justify-between gap-2 rounded-md bg-kumo-danger-tint px-3 py-2 text-sm text-kumo-danger">
+												<span>{t`The latest media request failed. Showing the previous page.`}</span>
+												<Button
+													variant="outline"
+													size="sm"
+													onClick={() => void localQuery.refetch()}
+												>
+													{t`Retry`}
+												</Button>
+											</div>
+										)}
+
+										{showFolderResults &&
+											(foldersQuery.isPending || folders.length > 0 || foldersQuery.error) && (
+												<section aria-labelledby="media-picker-folders" className="grid gap-2">
+													<div className="flex items-center justify-between gap-2">
+														<h2 id="media-picker-folders" className="text-sm font-semibold">
+															{t`Folders`}
+														</h2>
+														{foldersQuery.error && (
+															<div className="flex items-center gap-2">
+																<span className="text-sm text-kumo-danger">
+																	{t`Folders could not be loaded.`}
+																</span>
+																<Button
+																	variant="outline"
+																	size="sm"
+																	onClick={() => void foldersQuery.refetch()}
+																>
+																	{t`Retry`}
+																</Button>
+															</div>
+														)}
+													</div>
+													{foldersQuery.isPending && folders.length === 0 ? (
+														<div
+															role="status"
+															className="flex items-center gap-2 text-sm text-kumo-subtle"
+														>
+															<Loader size="sm" />
+															{t`Loading folders`}
+														</div>
+													) : (
+														<div
+															className="grid grid-cols-[repeat(auto-fill,minmax(min(12rem,100%),1fr))] gap-2"
+															inert={uploadQueue.hasUnfinished || undefined}
+														>
+															{folders.map((folder) => (
+																<MediaBrowserFolder
+																	key={folder.id}
+																	folder={folder}
+																	onOpen={() => {
+																		if (uploadQueue.hasUnfinished) return;
+																		setSearchQuery("");
+																		setFolderId(folder.id);
+																		resetPage();
+																	}}
+																/>
+															))}
+														</div>
+													)}
+													{foldersQuery.hasNextPage && (
+														<Button
+															variant="outline"
+															size="sm"
+															onClick={() => void foldersQuery.fetchNextPage()}
+															disabled={
+																foldersQuery.isFetchingNextPage || uploadQueue.hasUnfinished
+															}
+															loading={foldersQuery.isFetchingNextPage}
+														>
+															{t`Load more folders`}
+														</Button>
+													)}
+												</section>
+											)}
+
+										<div
+											role="region"
+											aria-label={t`Media results`}
+											aria-busy={currentFetching || undefined}
+										>
+											{currentLoading && !hasVisibleItems ? (
+												<div
+													role="status"
+													className="flex min-h-48 items-center justify-center gap-2 text-sm text-kumo-subtle"
+												>
+													<Loader />
+													{t`Loading media`}
+												</div>
+											) : (activeSource === "local" ? localQuery.error : providerQuery.error) &&
+											  !hasVisibleItems ? (
+												<div className="flex min-h-48 flex-col items-center justify-center gap-3 text-center">
+													<p className="text-sm text-kumo-danger">{t`Could not load media.`}</p>
+													<Button
+														variant="outline"
+														onClick={() =>
+															void (activeSource === "local"
+																? localQuery.refetch()
+																: providerQuery.refetch())
+														}
+													>
+														{t`Retry`}
+													</Button>
+												</div>
+											) : !hasVisibleItems ? (
+												<div className="flex min-h-48 flex-col items-center justify-center gap-3 text-center">
+													<EmptyStateIcon className="size-10 text-kumo-subtle" aria-hidden="true" />
+													<div className="grid gap-1">
+														<h2 className="text-lg font-semibold">{t`No media found`}</h2>
+														<p className="text-sm text-kumo-subtle">
+															{searchQuery.trim()
+																? t`Try another filename or clear your search.`
+																: folderId && activeSource === "local"
+																	? t`This folder is empty.`
+																	: isFileKind
+																		? t`Upload a file to get started`
+																		: t`Upload an image to get started`}
+														</p>
+													</div>
+												</div>
+											) : viewMode === "grid" ? (
+												<Grid
+													variant="4up"
+													gap="sm"
+													className="2xl:grid-cols-5"
+													inert={currentFetching || undefined}
+													data-media-items
+												>
+													{visibleUploadJobs.map((job) => (
+														<MediaUploadPlaceholder
+															key={job.id}
+															job={job}
+															layout="grid"
+															onRetry={() => uploadQueue.retry(job.id)}
+															onRemove={() => {
+																uploadTargetsRef.current.delete(job.id);
+																uploadQueue.remove(job.id);
+															}}
+														/>
+													))}
+													{visibleItems.map((rawItem) => {
+														const key = selectionKey(activeSource, rawItem);
+														const item =
+															activeSource === "local"
+																? (rawItem as MediaItem)
+																: toMediaItem({ key, providerId: activeSource, item: rawItem });
+														return (
+															<MediaBrowserItem
+																key={key}
+																item={item}
+																layout="grid"
+																selectable
+																selected={selectedItems.some((selected) => selected.key === key)}
+																onClick={(event) => {
+																	if (event.detail > 1) return;
+																	updateSelection(activeSource, rawItem);
+																}}
+																onDimensionsLoaded={(width, height) =>
+																	handleBrowserDimensions(activeSource, rawItem, key, width, height)
+																}
+															/>
+														);
+													})}
+												</Grid>
+											) : (
+												<div
+													className="grid gap-2"
+													inert={currentFetching || undefined}
+													data-media-items
+												>
+													{visibleUploadJobs.map((job) => (
+														<MediaUploadPlaceholder
+															key={job.id}
+															job={job}
+															layout="list"
+															onRetry={() => uploadQueue.retry(job.id)}
+															onRemove={() => {
+																uploadTargetsRef.current.delete(job.id);
+																uploadQueue.remove(job.id);
+															}}
+														/>
+													))}
+													{visibleItems.map((rawItem) => {
+														const key = selectionKey(activeSource, rawItem);
+														const item =
+															activeSource === "local"
+																? (rawItem as MediaItem)
+																: toMediaItem({ key, providerId: activeSource, item: rawItem });
+														return (
+															<MediaBrowserItem
+																key={key}
+																item={item}
+																layout="list"
+																selectable
+																selected={selectedItems.some((selected) => selected.key === key)}
+																onClick={(event) => {
+																	if (event.detail > 1) return;
+																	updateSelection(activeSource, rawItem);
+																}}
+																onDimensionsLoaded={(width, height) =>
+																	handleBrowserDimensions(activeSource, rawItem, key, width, height)
+																}
+															/>
+														);
+													})}
+												</div>
+											)}
+										</div>
+										{selectionTray}
+									</ScrollArea.Content>
+								</ScrollArea.Viewport>
+								<ScrollArea.Scrollbar className="pointer-events-none w-2.5 p-0.5 opacity-0 data-[scrolling]:pointer-events-auto data-[scrolling]:opacity-100">
+									<ScrollArea.Thumb className="rounded-full bg-kumo-interact" />
+								</ScrollArea.Scrollbar>
+							</ScrollArea.Root>
+
+							{activeSource === "local" && totalCount > 0 && (
+								<div
+									className="shrink-0 border-t border-kumo-line px-5 py-3 sm:px-7"
+									data-media-pagination
+								>
+									<Pagination
+										page={isRecoveringPage ? lastPage : page}
+										setPage={(nextPage) => {
+											const pageCount = Math.max(1, Math.ceil(totalCount / PICKER_PAGE_SIZE));
+											if (
+												localQuery.isFetching ||
+												!Number.isSafeInteger(nextPage) ||
+												nextPage < 1 ||
+												nextPage > pageCount
+											)
+												return;
+											setPage(nextPage);
+										}}
+										perPage={PICKER_PAGE_SIZE}
+										totalCount={totalCount}
+										className="flex-wrap gap-y-2"
+										labels={{
+											navigation: t`Media pagination`,
+											firstPage: t`First page`,
+											previousPage: t`Previous page`,
+											nextPage: t`Next page`,
+											lastPage: t`Last page`,
+											pageNumber: t`Page number`,
+											pageSize: t`Page size`,
+										}}
+									>
+										<Pagination.Info className="min-w-0 flex-1">
+											{({ pageShowingRange, totalCount: count }) => (
+												<span role="status">{t`Showing ${pageShowingRange} of ${count ?? 0}`}</span>
+											)}
+										</Pagination.Info>
+										<div inert={localQuery.isFetching || undefined} className="contents">
+											<Pagination.Controls
+												controls="full"
+												className="basis-full sm:basis-auto sm:grow-0 rtl:[&_svg]:-scale-x-100"
+											/>
+										</div>
+									</Pagination>
+								</div>
 							)}
 						</>
 					)}
-
-					{multiple && selectedItems.length > 0 && (
-						<section aria-labelledby="media-picker-selection" className="grid gap-2">
-							<h2 id="media-picker-selection" className="text-sm font-semibold">
-								{t`Selected media`}
-							</h2>
-							<ul className="grid gap-2">
-								{selectedItems.map((selected, index) => (
-									<MediaSelectionTrayItem
-										key={selected.key}
-										item={toMediaItem(selected)}
-										position={index + 1}
-										total={selectedItems.length}
-										onMoveEarlier={() => moveSelectedItem(index, index - 1, selected.item.filename)}
-										onMoveLater={() => moveSelectedItem(index, index + 1, selected.item.filename)}
-										onRemove={() => removeSelectedItem(selected)}
-									/>
-								))}
-							</ul>
-						</section>
-					)}
 				</div>
 
-				<footer className="flex shrink-0 justify-end border-t border-kumo-line px-5 py-3 sm:px-7">
+				<footer
+					className="flex shrink-0 justify-end border-t border-kumo-line px-5 py-3 sm:px-7"
+					data-media-actions
+				>
 					<div className="flex flex-wrap items-center justify-end gap-2">
 						<Button variant="outline" onClick={handleClose}>
 							{t`Cancel`}

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -16,7 +16,9 @@ import {
 	ArrowLeft,
 	Globe,
 	Image,
+	ImagesSquare,
 	List,
+	LinkSimple,
 	Paperclip,
 	SquaresFour,
 	Upload,
@@ -789,19 +791,27 @@ export function MediaPickerModal({
 									<Tabs
 										variant="segmented"
 										size="base"
+										listClassName="px-0"
+										indicatorClassName="rounded-lg"
 										value={activeSource}
 										onValueChange={changeSource}
 										tabs={sourceTabs.map((source) => ({
 											value: source.id,
+											className: "my-0 h-9 rounded-lg px-3",
 											render: (props) => <button {...props} disabled={uploadQueue.hasUnfinished} />,
 											label: (
 												<span className="flex items-center gap-2">
-													{source.icon &&
-														(source.icon.startsWith("data:") ? (
+													{source.id === "local" ? (
+														<ImagesSquare className="size-4" aria-hidden="true" />
+													) : source.id === URL_SOURCE ? (
+														<LinkSimple className="size-4" aria-hidden="true" />
+													) : source.icon ? (
+														source.icon.startsWith("data:") ? (
 															<img src={source.icon} alt="" className="size-4" aria-hidden="true" />
 														) : (
 															<span aria-hidden="true">{source.icon}</span>
-														))}
+														)
+													) : null}
 													{source.name}
 												</span>
 											),
@@ -850,8 +860,8 @@ export function MediaPickerModal({
 								className="h-full w-full overscroll-contain"
 								data-media-results-viewport
 							>
-								<ScrollArea.Content className="space-y-4 px-5 pb-4 sm:px-7">
-									<section className="mx-auto grid w-full max-w-2xl gap-4 py-6">
+								<ScrollArea.Content className="grid min-h-full content-center gap-4 px-5 py-4 sm:px-7">
+									<section className="mx-auto grid w-full max-w-2xl gap-4">
 										<div className="grid gap-1.5">
 											<Label htmlFor="media-picker-url">{t`Image URL`}</Label>
 											<div className="flex flex-col gap-2 sm:flex-row">
@@ -1158,7 +1168,6 @@ export function MediaPickerModal({
 												<Grid
 													variant="4up"
 													gap="sm"
-													className="2xl:grid-cols-5"
 													inert={currentFetching || undefined}
 													data-media-items
 												>

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -47,14 +47,16 @@ import {
 import { useDebouncedValue } from "../lib/hooks.js";
 import { canonicalMediaProviderId, providerItemToMediaItem } from "../lib/media-utils.js";
 import { matchesMimeAllowlist, mimeFromUrl } from "../lib/mime-utils.js";
-import { DialogError } from "./DialogError.js";
 import {
 	MAX_MEDIA_PAGE_DROPDOWN_ITEMS,
 	MEDIA_BROWSER_PAGE_SIZES,
 	MediaBrowserFolder,
 	MediaBrowserItem,
+	MediaSelectionTrayItem,
+	MediaUploadPlaceholder,
 	mimeForMediaTypeFilter,
 } from "./media/MediaBrowserItems.js";
+import { useMediaUploadQueue } from "./media/useMediaUploadQueue.js";
 import { TableToolbar, TableToolbarSearch } from "./TableToolbar.js";
 
 const URL_SOURCE = "__url";
@@ -62,6 +64,12 @@ const DEFAULT_PAGE_SIZE = MEDIA_BROWSER_PAGE_SIZES[0]!;
 
 interface SelectedMedia {
 	key: string;
+	providerId: string;
+	item: MediaItem | MediaProviderItem;
+	uploadJobId?: number;
+}
+
+interface UploadedMedia {
 	providerId: string;
 	item: MediaItem | MediaProviderItem;
 }
@@ -107,6 +115,37 @@ function intersectMimeFilters(
 function selectionKey(providerId: string, item: MediaItem | MediaProviderItem): string {
 	if (providerId === URL_SOURCE) return `external:${(item as MediaItem).url}`;
 	return `${canonicalMediaProviderId(providerId)}:${item.id}`;
+}
+
+function appendUniqueSelections(
+	current: SelectedMedia[],
+	additions: SelectedMedia[],
+	sortUploads = true,
+) {
+	const keys = new Set(current.map((selected) => selected.key));
+	const next = [...current];
+	for (const selected of additions) {
+		if (keys.has(selected.key)) continue;
+		keys.add(selected.key);
+		next.push(selected);
+	}
+	if (sortUploads) {
+		const uploadPositions = next.flatMap((selected, index) =>
+			selected.uploadJobId === undefined ? [] : [index],
+		);
+		const uploads = uploadPositions
+			.map((index) => next[index]!)
+			.toSorted((first, second) => first.uploadJobId! - second.uploadJobId!);
+		uploadPositions.forEach((position, index) => {
+			next[position] = uploads[index]!;
+		});
+	}
+	return next;
+}
+
+function withLocalMediaUrl(item: MediaItem): MediaItem {
+	if (item.url || !item.storageKey) return item;
+	return { ...item, url: `/_emdash/api/media/file/${item.storageKey}` };
 }
 
 function probeImageDimensions(
@@ -181,18 +220,41 @@ export function MediaPickerModal({
 	const [imageUrl, setImageUrl] = React.useState("");
 	const [urlError, setUrlError] = React.useState<string | null>(null);
 	const [isProbing, setIsProbing] = React.useState(false);
-	const [uploadError, setUploadError] = React.useState<string | null>(null);
 	const [liveMessage, setLiveMessage] = React.useState("");
+	const [pinnedItems, setPinnedItems] = React.useState<SelectedMedia[]>([]);
 	const [providerDimensions, setProviderDimensions] = React.useState<
 		Record<string, { width: number; height: number }>
 	>({});
 	const fileInputRef = React.useRef<HTMLInputElement>(null);
 	const updatedDimensionsRef = React.useRef(new Set<string>());
 	const urlProbeIdRef = React.useRef(0);
+	const uploadTargetsRef = React.useRef(new Map<number, string>());
+	const selectionOrderEditedRef = React.useRef(false);
 	const invalidateUrlProbe = React.useCallback(() => {
 		urlProbeIdRef.current += 1;
 		setIsProbing(false);
 	}, []);
+	const uploadFile = React.useCallback(
+		async (
+			file: File,
+			{ signal, jobId }: { signal: AbortSignal; jobId: number; attempt: number },
+		): Promise<UploadedMedia> => {
+			const providerId = uploadTargetsRef.current.get(jobId);
+			if (!providerId) throw new Error("Missing upload target");
+			if (providerId === "local") {
+				return {
+					providerId,
+					item: withLocalMediaUrl(await uploadMedia(file, { fieldId, signal })),
+				};
+			}
+			return {
+				providerId,
+				item: await uploadToProvider(providerId, file, undefined, { signal }),
+			};
+		},
+		[fieldId],
+	);
+	const uploadQueue = useMediaUploadQueue<UploadedMedia>({ upload: uploadFile });
 
 	React.useEffect(() => {
 		if (!open) return;
@@ -208,11 +270,14 @@ export function MediaPickerModal({
 		setImageUrl("");
 		setUrlError(null);
 		invalidateUrlProbe();
-		setUploadError(null);
 		setLiveMessage("");
+		setPinnedItems([]);
 		setProviderDimensions({});
 		updatedDimensionsRef.current.clear();
-	}, [invalidateUrlProbe, localOnly, open]);
+		uploadQueue.reset();
+		uploadTargetsRef.current.clear();
+		selectionOrderEditedRef.current = false;
+	}, [invalidateUrlProbe, localOnly, open, uploadQueue.reset]);
 
 	const providersQuery = useQuery({
 		queryKey: ["media-providers"],
@@ -405,26 +470,34 @@ export function MediaPickerModal({
 		[providerDimensions],
 	);
 
-	const uploadLocalMutation = useMutation({
-		mutationFn: (file: File) => uploadMedia(file, { fieldId }),
-		onSuccess: (item) => {
-			void queryClient.invalidateQueries({ queryKey: ["media"] });
-			ensureSelection("local", item);
-			setUploadError(null);
-		},
-		onError: (error: Error) => setUploadError(error.message),
-	});
-	const uploadProviderMutation = useMutation({
-		mutationFn: ({ providerId, file }: { providerId: string; file: File }) =>
-			uploadToProvider(providerId, file),
-		onSuccess: (item, { providerId }) => {
-			void queryClient.invalidateQueries({ queryKey: ["provider-media", providerId] });
-			ensureSelection(providerId, item);
-			setUploadError(null);
-		},
-		onError: (error: Error) => setUploadError(error.message),
-	});
-	const isUploading = uploadLocalMutation.isPending || uploadProviderMutation.isPending;
+	React.useEffect(() => {
+		if (uploadQueue.hasUnfinished) return;
+		const completed = uploadQueue.jobs.filter(
+			(job): job is typeof job & { result: UploadedMedia } =>
+				job.status === "complete" && job.result !== undefined,
+		);
+		if (completed.length === 0) return;
+		const additions = completed.map(({ id, result }) => ({
+			key: selectionKey(result.providerId, result.item),
+			providerId: result.providerId,
+			item: result.item,
+			uploadJobId: id,
+		}));
+		setPinnedItems((current) => appendUniqueSelections(current, additions));
+		setSelectedItems((current) => {
+			if (!multiple) return [additions.at(-1)!];
+			return appendUniqueSelections(current, additions, !selectionOrderEditedRef.current);
+		});
+		for (const providerId of new Set(additions.map((selected) => selected.providerId))) {
+			void queryClient.invalidateQueries({
+				queryKey: providerId === "local" ? ["media"] : ["provider-media", providerId],
+			});
+		}
+		for (const job of completed) {
+			uploadTargetsRef.current.delete(job.id);
+			uploadQueue.remove(job.id);
+		}
+	}, [multiple, queryClient, uploadQueue.hasUnfinished, uploadQueue.jobs, uploadQueue.remove]);
 
 	const dimensionsMutation = useMutation({
 		mutationFn: ({ id, width, height }: { id: string; width: number; height: number }) =>
@@ -477,21 +550,10 @@ export function MediaPickerModal({
 		setRetainedTotalCount(0);
 	}, []);
 	const changeSource = (source: string) => {
-		if (!source || source === activeSource) return;
+		if (!source || source === activeSource || uploadQueue.hasUnfinished) return;
 		if (activeSource === URL_SOURCE) invalidateUrlProbe();
 		setActiveSource(source);
 		setSearchQuery("");
-		setUploadError(null);
-	};
-	const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
-		const file = event.currentTarget.files?.[0];
-		if (file) {
-			if (activeSource === "local") uploadLocalMutation.mutate(file);
-			else if (activeProviderInfo?.capabilities.upload) {
-				uploadProviderMutation.mutate({ providerId: activeSource, file });
-			}
-		}
-		event.currentTarget.value = "";
 	};
 	const handleUrlSubmit = async () => {
 		if (!imageUrl.trim()) return;
@@ -546,8 +608,28 @@ export function MediaPickerModal({
 	};
 	const handleClose = () => {
 		invalidateUrlProbe();
+		uploadQueue.reset();
+		uploadTargetsRef.current.clear();
+		setPinnedItems([]);
 		onOpenChange(false);
 		setSelectedItems([]);
+	};
+	const moveSelectedItem = (from: number, to: number, filename: string) => {
+		if (to < 0 || to >= selectedItems.length) return;
+		selectionOrderEditedRef.current = true;
+		setSelectedItems((current) => {
+			if (!current[from] || !current[to]) return current;
+			const next = [...current];
+			const [moved] = next.splice(from, 1);
+			next.splice(to, 0, moved!);
+			return next;
+		});
+		setLiveMessage(t`Moved ${filename} to position ${to + 1}.`);
+	};
+	const removeSelectedItem = (selected: SelectedMedia) => {
+		selectionOrderEditedRef.current = true;
+		setSelectedItems((current) => current.filter((item) => item.key !== selected.key));
+		setLiveMessage(t`Removed ${selected.item.filename} from selection.`);
 	};
 	const confirmText =
 		confirmLabel ??
@@ -574,8 +656,45 @@ export function MediaPickerModal({
 	const currentLoading = activeSource === "local" ? localQuery.isPending : providerQuery.isPending;
 	const currentFetching =
 		activeSource === "local" ? localQuery.isFetching : providerQuery.isFetching;
-	const hasVisibleItems =
-		activeSource === "local" ? localItems.length > 0 : providerItems.length > 0;
+	const fetchedItems: Array<MediaItem | MediaProviderItem> =
+		activeSource === "local" ? localItems : providerItems;
+	const visibleItems = React.useMemo(() => {
+		const pinned = pinnedItems.filter(
+			(selected) =>
+				selected.providerId === activeSource &&
+				!(activeSource === "local" && folderId && !activeSearch),
+		);
+		const keys = new Set(pinned.map((selected) => selected.key));
+		return [
+			...pinned.map((selected) => selected.item),
+			...fetchedItems.filter((item) => !keys.has(selectionKey(activeSource, item))),
+		];
+	}, [activeSearch, activeSource, fetchedItems, folderId, pinnedItems]);
+	const visibleUploadJobs = uploadQueue.jobs.filter(
+		(job) => job.status !== "complete" && uploadTargetsRef.current.get(job.id) === activeSource,
+	);
+	const hasVisibleItems = visibleItems.length > 0 || visibleUploadJobs.length > 0;
+	const enqueueFiles = React.useCallback(
+		(files: readonly File[]) => {
+			if (!canUpload || files.length === 0) return;
+			const compatible = filters?.length
+				? files.filter((file) => matchesAnyFilter(file.type, filters))
+				: [...files];
+			const accepted = multiple ? compatible : compatible.slice(0, 1);
+			const rejectedCount = files.length - accepted.length;
+			const jobs = uploadQueue.addFiles(accepted);
+			for (const job of jobs) uploadTargetsRef.current.set(job.id, activeSource);
+			if (rejectedCount > 0) {
+				setLiveMessage(
+					plural(rejectedCount, {
+						one: "# file was not added.",
+						other: "# files were not added.",
+					}),
+				);
+			}
+		},
+		[activeSource, canUpload, filters, multiple, uploadQueue.addFiles],
+	);
 
 	return (
 		<Dialog.Root
@@ -610,27 +729,40 @@ export function MediaPickerModal({
 					/>
 				</header>
 
-				<div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain px-4 py-4 sm:px-6">
+				<div
+					className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain px-4 py-4 sm:px-6"
+					onDragOver={(event) => {
+						if (canUpload && event.dataTransfer.types.includes("Files")) event.preventDefault();
+					}}
+					onDrop={(event) => {
+						if (!canUpload || !event.dataTransfer.types.includes("Files")) return;
+						event.preventDefault();
+						enqueueFiles([...event.dataTransfer.files]);
+					}}
+				>
 					{sourceTabs.length > 1 && (
-						<Tabs
-							variant="underline"
-							value={activeSource}
-							onValueChange={changeSource}
-							tabs={sourceTabs.map((source) => ({
-								value: source.id,
-								label: (
-									<span className="flex items-center gap-2">
-										{source.icon &&
-											(source.icon.startsWith("data:") ? (
-												<img src={source.icon} alt="" className="size-4" aria-hidden="true" />
-											) : (
-												<span aria-hidden="true">{source.icon}</span>
-											))}
-										{source.name}
-									</span>
-								),
-							}))}
-						/>
+						<div aria-disabled={uploadQueue.hasUnfinished || undefined} data-source-tabs>
+							<Tabs
+								variant="underline"
+								value={activeSource}
+								onValueChange={changeSource}
+								tabs={sourceTabs.map((source) => ({
+									value: source.id,
+									render: (props) => <button {...props} disabled={uploadQueue.hasUnfinished} />,
+									label: (
+										<span className="flex items-center gap-2">
+											{source.icon &&
+												(source.icon.startsWith("data:") ? (
+													<img src={source.icon} alt="" className="size-4" aria-hidden="true" />
+												) : (
+													<span aria-hidden="true">{source.icon}</span>
+												))}
+											{source.name}
+										</span>
+									),
+								}))}
+							/>
+						</div>
 					)}
 
 					{activeSource === URL_SOURCE ? (
@@ -699,6 +831,7 @@ export function MediaPickerModal({
 									<Button
 										variant="ghost"
 										size="sm"
+										disabled={uploadQueue.hasUnfinished}
 										onClick={() => {
 											setFolderId(undefined);
 											resetPage();
@@ -772,7 +905,7 @@ export function MediaPickerModal({
 											if (activeSource === "local") resetPage();
 										}}
 										maxLength={MEDIA_SEARCH_MAX_LENGTH}
-										className="w-full flex-1 sm:w-72"
+										className="basis-full sm:w-72 sm:basis-auto"
 									/>
 								)}
 								{activeSource === "local" && (
@@ -792,8 +925,6 @@ export function MediaPickerModal({
 										<Button
 											size="sm"
 											onClick={() => fileInputRef.current?.click()}
-											disabled={isUploading}
-											loading={isUploading}
 											icon={<Upload aria-hidden="true" />}
 										>
 											{t`Upload files`}
@@ -801,6 +932,7 @@ export function MediaPickerModal({
 										<input
 											ref={fileInputRef}
 											type="file"
+											multiple={multiple}
 											accept={
 												filters
 													? filters
@@ -810,14 +942,24 @@ export function MediaPickerModal({
 											}
 											className="sr-only"
 											tabIndex={-1}
-											onChange={handleFileSelect}
+											onChange={(event) => {
+												enqueueFiles([...(event.currentTarget.files ?? [])]);
+												event.currentTarget.value = "";
+											}}
 											aria-label={t`Choose files to upload`}
 										/>
 									</>
 								)}
 							</TableToolbar>
 
-							<DialogError message={uploadError ? t`Upload failed: ${uploadError}` : null} />
+							{uploadQueue.overflowCount > 0 && (
+								<p role="alert" className="text-sm text-kumo-danger">
+									{plural(uploadQueue.overflowCount, {
+										one: "# file was not added because the upload list is full.",
+										other: "# files were not added because the upload list is full.",
+									})}
+								</p>
+							)}
 							{activeSource === "local" && localQuery.error && localItems.length > 0 && (
 								<div className="flex flex-wrap items-center justify-between gap-2 rounded-md bg-kumo-danger-tint px-3 py-2 text-sm text-kumo-danger">
 									<span>{t`The latest media request failed. Showing the previous page.`}</span>
@@ -858,12 +1000,16 @@ export function MediaPickerModal({
 												{t`Loading folders`}
 											</div>
 										) : (
-											<div className="grid grid-cols-[repeat(auto-fill,minmax(min(12rem,100%),1fr))] gap-2">
+											<div
+												className="grid grid-cols-[repeat(auto-fill,minmax(min(12rem,100%),1fr))] gap-2"
+												inert={uploadQueue.hasUnfinished || undefined}
+											>
 												{folders.map((folder) => (
 													<MediaBrowserFolder
 														key={folder.id}
 														folder={folder}
 														onOpen={() => {
+															if (uploadQueue.hasUnfinished) return;
 															setSearchQuery("");
 															setFolderId(folder.id);
 															resetPage();
@@ -877,7 +1023,7 @@ export function MediaPickerModal({
 												variant="outline"
 												size="sm"
 												onClick={() => void foldersQuery.fetchNextPage()}
-												disabled={foldersQuery.isFetchingNextPage}
+												disabled={foldersQuery.isFetchingNextPage || uploadQueue.hasUnfinished}
 												loading={foldersQuery.isFetchingNextPage}
 											>
 												{t`Load more folders`}
@@ -938,7 +1084,19 @@ export function MediaPickerModal({
 										inert={currentFetching || undefined}
 										data-media-items
 									>
-										{(activeSource === "local" ? localItems : providerItems).map((rawItem) => {
+										{visibleUploadJobs.map((job) => (
+											<MediaUploadPlaceholder
+												key={job.id}
+												job={job}
+												layout="grid"
+												onRetry={() => uploadQueue.retry(job.id)}
+												onRemove={() => {
+													uploadTargetsRef.current.delete(job.id);
+													uploadQueue.remove(job.id);
+												}}
+											/>
+										))}
+										{visibleItems.map((rawItem) => {
 											const key = selectionKey(activeSource, rawItem);
 											const item =
 												activeSource === "local"
@@ -964,7 +1122,19 @@ export function MediaPickerModal({
 									</Grid>
 								) : (
 									<div className="grid gap-2" inert={currentFetching || undefined} data-media-items>
-										{(activeSource === "local" ? localItems : providerItems).map((rawItem) => {
+										{visibleUploadJobs.map((job) => (
+											<MediaUploadPlaceholder
+												key={job.id}
+												job={job}
+												layout="list"
+												onRetry={() => uploadQueue.retry(job.id)}
+												onRemove={() => {
+													uploadTargetsRef.current.delete(job.id);
+													uploadQueue.remove(job.id);
+												}}
+											/>
+										))}
+										{visibleItems.map((rawItem) => {
 											const key = selectionKey(activeSource, rawItem);
 											const item =
 												activeSource === "local"
@@ -1052,6 +1222,27 @@ export function MediaPickerModal({
 							)}
 						</>
 					)}
+
+					{multiple && selectedItems.length > 0 && (
+						<section aria-labelledby="media-picker-selection" className="grid gap-2">
+							<h2 id="media-picker-selection" className="text-sm font-semibold">
+								{t`Selected media`}
+							</h2>
+							<ul className="grid gap-2">
+								{selectedItems.map((selected, index) => (
+									<MediaSelectionTrayItem
+										key={selected.key}
+										item={toMediaItem(selected)}
+										position={index + 1}
+										total={selectedItems.length}
+										onMoveEarlier={() => moveSelectedItem(index, index - 1, selected.item.filename)}
+										onMoveLater={() => moveSelectedItem(index, index + 1, selected.item.filename)}
+										onRemove={() => removeSelectedItem(selected)}
+									/>
+								))}
+							</ul>
+						</section>
+					)}
 				</div>
 
 				<footer className="flex shrink-0 flex-col gap-3 border-t border-kumo-line px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-6">
@@ -1069,13 +1260,28 @@ export function MediaPickerModal({
 						<Button variant="outline" onClick={handleClose}>
 							{t`Cancel`}
 						</Button>
-						<Button onClick={handleConfirm} disabled={selectedItems.length === 0 || isUploading}>
+						<Button
+							onClick={handleConfirm}
+							disabled={selectedItems.length === 0 || uploadQueue.hasUnfinished}
+						>
 							{confirmText}
 						</Button>
 					</div>
 				</footer>
 				<span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
-					{liveMessage}
+					{uploadQueue.hasUnfinished
+						? plural(
+								uploadQueue.jobs.filter(
+									(job) => job.status === "queued" || job.status === "uploading",
+								).length,
+								{ one: "# file uploading", other: "# files uploading" },
+							)
+						: uploadQueue.failedCount > 0
+							? plural(uploadQueue.failedCount, {
+									one: "# upload failed",
+									other: "# uploads failed",
+								})
+							: liveMessage}
 				</span>
 			</Dialog>
 		</Dialog.Root>

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -658,6 +658,7 @@ export function MediaPickerModal({
 				);
 	const canUpload =
 		activeSource === "local" ? !folderId : Boolean(activeProviderInfo?.capabilities.upload);
+	const hasSourceControls = sourceTabs.length > 1 || canUpload;
 	const canSearch = activeSource === "local" || Boolean(activeProviderInfo?.capabilities.search);
 	const currentLoading = activeSource === "local" ? localQuery.isPending : providerQuery.isPending;
 	const currentFetching =
@@ -784,20 +785,20 @@ export function MediaPickerModal({
 						enqueueFiles([...event.dataTransfer.files]);
 					}}
 				>
-					{(sourceTabs.length > 1 || canUpload) && (
-						<div className="flex shrink-0 flex-wrap items-center gap-2 px-5 pt-4 sm:px-7">
+					{hasSourceControls && (
+						<div className="flex shrink-0 flex-wrap items-center gap-2 px-5 py-4 sm:px-7">
 							{sourceTabs.length > 1 && (
 								<div aria-disabled={uploadQueue.hasUnfinished || undefined} data-source-tabs>
 									<Tabs
 										variant="segmented"
 										size="base"
-										listClassName="px-0"
-										indicatorClassName="rounded-lg"
+										listClassName="px-px"
+										indicatorClassName="rounded-[7px]"
 										value={activeSource}
 										onValueChange={changeSource}
 										tabs={sourceTabs.map((source) => ({
 											value: source.id,
-											className: "my-0 h-9 rounded-lg px-3",
+											className: "my-px h-[34px] rounded-[7px] px-3",
 											render: (props) => <button {...props} disabled={uploadQueue.hasUnfinished} />,
 											label: (
 												<span className="flex items-center gap-2">
@@ -928,7 +929,9 @@ export function MediaPickerModal({
 						</ScrollArea.Root>
 					) : (
 						<>
-							<div className="shrink-0 space-y-4 px-5 pt-4 sm:px-7">
+							<div
+								className={`shrink-0 space-y-4 px-5 sm:px-7 ${hasSourceControls ? "pb-4" : "py-4"}`}
+							>
 								{folderId && activeSource === "local" && (
 									<div className="flex min-w-0 items-center gap-2">
 										<Button
@@ -969,6 +972,9 @@ export function MediaPickerModal({
 										<div role="group" aria-label={t`View mode`}>
 											<Tabs
 												variant="segmented"
+												size="base"
+												listClassName="px-px"
+												indicatorClassName="rounded-[7px]"
 												value={viewMode}
 												onValueChange={(value) => {
 													if (value === "grid" || value === "list") setViewMode(value);
@@ -976,6 +982,7 @@ export function MediaPickerModal({
 												tabs={[
 													{
 														value: "grid",
+														className: "my-px h-[34px] rounded-[7px] px-3",
 														label: (
 															<>
 																<SquaresFour className="size-4" aria-hidden="true" />
@@ -985,6 +992,7 @@ export function MediaPickerModal({
 													},
 													{
 														value: "list",
+														className: "my-px h-[34px] rounded-[7px] px-3",
 														label: (
 															<>
 																<List className="size-4" aria-hidden="true" />

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -1,21 +1,40 @@
-/**
- * Media Picker Modal
- *
- * A modal dialog for selecting media from the library or uploading new files.
- * Supports multiple media providers with tabbed navigation.
- * Used by the rich text editor and image field components.
- */
-
-import { Button, Dialog, Input, Label, Loader } from "@cloudflare/kumo";
+import {
+	Button,
+	Dialog,
+	Grid,
+	Input,
+	Label,
+	Loader,
+	Pagination,
+	Select,
+	Tabs,
+} from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
-import { Upload, Image, Check, Globe, MagnifyingGlass, Paperclip } from "@phosphor-icons/react";
-import { X } from "@phosphor-icons/react";
-import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+	ArrowLeft,
+	Globe,
+	Image,
+	List,
+	Paperclip,
+	SquaresFour,
+	Upload,
+	X,
+} from "@phosphor-icons/react";
+import {
+	keepPreviousData,
+	useInfiniteQuery,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
 import * as React from "react";
 
 import {
+	ApiResponseError,
 	MEDIA_SEARCH_MAX_LENGTH,
+	fetchMediaFolder,
+	fetchMediaFolders,
 	fetchMediaList,
 	fetchMediaProviders,
 	fetchProviderMedia,
@@ -24,104 +43,98 @@ import {
 	updateMedia,
 	type MediaItem,
 	type MediaProviderItem,
-} from "../lib/api";
+} from "../lib/api.js";
 import { useDebouncedValue } from "../lib/hooks.js";
-import {
-	providerItemToMediaItem,
-	getFileIcon,
-	getMediaThumbnailUrl,
-	getMediaPreviewUrl,
-	getMediaObjectPosition,
-	fallbackToOriginalThumbnail,
-} from "../lib/media-utils";
+import { canonicalMediaProviderId, providerItemToMediaItem } from "../lib/media-utils.js";
 import { matchesMimeAllowlist, mimeFromUrl } from "../lib/mime-utils.js";
-import { cn } from "../lib/utils";
 import { DialogError } from "./DialogError.js";
+import {
+	MAX_MEDIA_PAGE_DROPDOWN_ITEMS,
+	MEDIA_BROWSER_PAGE_SIZES,
+	MediaBrowserFolder,
+	MediaBrowserItem,
+	mimeForMediaTypeFilter,
+} from "./media/MediaBrowserItems.js";
+import { TableToolbar, TableToolbarSearch } from "./TableToolbar.js";
 
-/** Selected item can be either a local MediaItem or a provider item with provider context */
+const URL_SOURCE = "__url";
+const DEFAULT_PAGE_SIZE = MEDIA_BROWSER_PAGE_SIZES[0]!;
+
 interface SelectedMedia {
+	key: string;
 	providerId: string;
 	item: MediaItem | MediaProviderItem;
 }
 
-/**
- * Returns true if the given MIME type matches any entry in the filters array.
- * Each filter entry is either an exact MIME type (e.g. "image/png") or a
- * type prefix ending with "/" (e.g. "image/").
- */
 function matchesAnyFilter(mime: string, filters: string[] | undefined): boolean {
 	if (!filters || filters.length === 0) return true;
-	const normalizedMime = mime.toLowerCase();
-	for (const entry of filters) {
-		if (!entry || !entry.includes("/")) continue;
-		const normalizedEntry = entry.toLowerCase();
-		if (normalizedEntry.endsWith("/")) {
-			if (normalizedMime.startsWith(normalizedEntry)) return true;
-		} else if (normalizedMime === normalizedEntry) {
-			return true;
-		}
+	return filters.some((entry) => {
+		if (!entry || !entry.includes("/")) return false;
+		return entry.endsWith("/")
+			? mime.toLowerCase().startsWith(entry.toLowerCase())
+			: mime.toLowerCase() === entry.toLowerCase();
+	});
+}
+
+function filtersOverlap(first: string, second: string): string | null {
+	const left = first.toLowerCase();
+	const right = second.toLowerCase();
+	if (left === right) return left;
+	if (left.endsWith("/") && right.startsWith(left)) return right;
+	if (right.endsWith("/") && left.startsWith(right)) return left;
+	return null;
+}
+
+function intersectMimeFilters(
+	allowed: string[] | undefined,
+	chosen: string | string[] | undefined,
+): string[] | undefined {
+	if (!allowed?.length) {
+		if (!chosen) return undefined;
+		return Array.isArray(chosen) ? chosen : [chosen];
 	}
-	return false;
+	if (!chosen) return allowed;
+	const chosenFilters = Array.isArray(chosen) ? chosen : [chosen];
+	return [
+		...new Set(
+			allowed.flatMap((allowedMime) =>
+				chosenFilters.flatMap((chosenMime) => filtersOverlap(allowedMime, chosenMime) ?? []),
+			),
+		),
+	];
+}
+
+function selectionKey(providerId: string, item: MediaItem | MediaProviderItem): string {
+	if (providerId === URL_SOURCE) return `external:${(item as MediaItem).url}`;
+	return `${canonicalMediaProviderId(providerId)}:${item.id}`;
+}
+
+function probeImageDimensions(
+	url: string,
+	errorMessage: string,
+): Promise<{ width: number; height: number }> {
+	return new Promise((resolve, reject) => {
+		const image = new window.Image();
+		image.onload = () => resolve({ width: image.naturalWidth, height: image.naturalHeight });
+		image.onerror = () => reject(new Error(errorMessage));
+		image.src = url;
+	});
 }
 
 export interface MediaPickerModalProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	onSelect: (item: MediaItem) => void;
-	/** Allow selecting several items at once; confirms through `onSelectMany`. */
 	multiple?: boolean;
-	/** Called instead of `onSelect` when `multiple` is set. */
 	onSelectMany?: (items: MediaItem[]) => void;
-	/** Filter by mime type prefix, e.g. "image/" */
 	mimeTypeFilter?: string;
 	title?: string;
-	/**
-	 * Hide the "Insert from URL" input. Defaults to false.
-	 * The URL input probes image dimensions and is only meaningful for image pickers,
-	 * so non-image pickers (e.g. generic file pickers) should hide it.
-	 */
+	confirmLabel?: string;
 	hideUrlInput?: boolean;
-	/**
-	 * What kind of media this picker is for. Drives user-facing copy
-	 * (default title, empty-state message, upload button label, empty-state icon).
-	 * Defaults to "image" — set to "file" for generic file pickers.
-	 */
 	mediaKind?: "image" | "file";
-	/** MIME allowlist — array of exact MIMEs or `type/` prefixes. */
 	mimeTypeFilters?: string[];
-	/** `_emdash_fields` row id for server-side MIME widening. */
 	fieldId?: string;
-	/**
-	 * Restrict the picker to the local Library only — hides the "Insert from URL"
-	 * input and suppresses external provider tabs.
-	 *
-	 * Use this for fields whose storage model only persists a local `mediaId`.
-	 * Selecting an external URL or provider item would return an item the
-	 * server cannot later resolve back to a URL (the `id` is either empty
-	 * for "Insert from URL" or a provider-namespaced string that won't match
-	 * a row in the `media` table). Site settings (logo, favicon,
-	 * `seo.defaultOgImage`) are the canonical callers.
-	 */
 	localOnly?: boolean;
-}
-
-/**
- * Probe image URL to get dimensions
- */
-function probeImageDimensions(
-	url: string,
-	errorMessage: string,
-): Promise<{ width: number; height: number }> {
-	return new Promise((resolve, reject) => {
-		const img = new window.Image();
-		img.onload = () => {
-			resolve({ width: img.naturalWidth, height: img.naturalHeight });
-		};
-		img.onerror = () => {
-			reject(new Error(errorMessage));
-		};
-		img.src = url;
-	});
 }
 
 export function MediaPickerModal({
@@ -134,214 +147,306 @@ export function MediaPickerModal({
 	mimeTypeFilters,
 	fieldId,
 	title: providedTitle,
+	confirmLabel,
 	hideUrlInput = false,
 	mediaKind = "image",
 	localOnly = false,
 }: MediaPickerModalProps) {
 	const { t } = useLingui();
-	const isFileKind = mediaKind === "file";
-
-	// Unified filters: mimeTypeFilters (plural array) takes precedence over the
-	// legacy mimeTypeFilter (singular string).
-	const filters = React.useMemo(() => {
-		if (mimeTypeFilters !== undefined)
-			return mimeTypeFilters.length > 0 ? mimeTypeFilters : undefined;
-		if (mimeTypeFilter && mimeTypeFilter.length > 0) return [mimeTypeFilter];
-		return undefined;
-	}, [mimeTypeFilters, mimeTypeFilter]);
-	const title = providedTitle ?? (isFileKind ? t`Select File` : t`Select Image`);
-	const emptyStateUploadHint = isFileKind
-		? t`Upload a file to get started`
-		: t`Upload an image to get started`;
-	const emptyStateUploadCta = isFileKind ? t`Upload File` : t`Upload Image`;
-	const EmptyStateIcon = isFileKind ? Paperclip : Image;
 	const queryClient = useQueryClient();
-	const [selectedItem, setSelectedItem] = React.useState<SelectedMedia | null>(null);
-	// Multi-select mode keeps items in click order — it becomes the gallery order.
+	const isFileKind = mediaKind === "file";
+	const filters = React.useMemo(() => {
+		if (mimeTypeFilters !== undefined) {
+			return mimeTypeFilters.length > 0 ? mimeTypeFilters : undefined;
+		}
+		return mimeTypeFilter ? [mimeTypeFilter] : undefined;
+	}, [mimeTypeFilter, mimeTypeFilters]);
+	const title = providedTitle ?? (isFileKind ? t`Select file` : t`Select image`);
+	const description = isFileKind
+		? t`Choose a file from the library or upload a new one.`
+		: t`Choose an image from the library or upload a new one.`;
+	const EmptyStateIcon = isFileKind ? Paperclip : Image;
+
+	const [activeSource, setActiveSource] = React.useState("local");
 	const [selectedItems, setSelectedItems] = React.useState<SelectedMedia[]>([]);
-	const [activeProvider, setActiveProvider] = React.useState<string>("local");
 	const [searchQuery, setSearchQuery] = React.useState("");
-	// Debounced for the local library's server-side filename search.
-	const debouncedSearch = useDebouncedValue(searchQuery, 300);
-	const fileInputRef = React.useRef<HTMLInputElement>(null);
-
-	// URL input state
+	const debouncedSearch = useDebouncedValue(searchQuery, 300).trim();
+	const activeSearch = searchQuery.trim() ? debouncedSearch : "";
+	const [typeFilter, setTypeFilter] = React.useState("all");
+	const [viewMode, setViewMode] = React.useState<"grid" | "list">("grid");
+	const [folderId, setFolderId] = React.useState<string | undefined>();
+	const [page, setPage] = React.useState(1);
+	const [pageSize, setPageSize] = React.useState(DEFAULT_PAGE_SIZE);
+	const [retainedTotalCount, setRetainedTotalCount] = React.useState(0);
 	const [imageUrl, setImageUrl] = React.useState("");
-	const [isProbing, setIsProbing] = React.useState(false);
 	const [urlError, setUrlError] = React.useState<string | null>(null);
-
-	// Track loaded image dimensions for providers that don't return them (e.g., CF Images)
+	const [isProbing, setIsProbing] = React.useState(false);
+	const [uploadError, setUploadError] = React.useState<string | null>(null);
+	const [liveMessage, setLiveMessage] = React.useState("");
 	const [providerDimensions, setProviderDimensions] = React.useState<
 		Record<string, { width: number; height: number }>
 	>({});
+	const fileInputRef = React.useRef<HTMLInputElement>(null);
+	const updatedDimensionsRef = React.useRef(new Set<string>());
+	const urlProbeIdRef = React.useRef(0);
+	const invalidateUrlProbe = React.useCallback(() => {
+		urlProbeIdRef.current += 1;
+		setIsProbing(false);
+	}, []);
 
-	// Reset state when modal opens, or when `localOnly` flips on while it's
-	// already open. Without the `localOnly` dependency a parent that toggles
-	// the prop mid-session could leave `activeProvider` on a non-local tab
-	// (the tab UI is suppressed, but the selection state and provider-media
-	// query would still target the external provider).
 	React.useEffect(() => {
-		if (open) {
-			setSelectedItem(null);
-			setSelectedItems([]);
-			setActiveProvider("local");
-			setSearchQuery("");
-			setImageUrl("");
-			setUrlError(null);
-			setUploadError(null);
-			setProviderDimensions({});
-		}
-	}, [open, localOnly]);
+		if (!open) return;
+		setActiveSource("local");
+		setSelectedItems([]);
+		setSearchQuery("");
+		setTypeFilter("all");
+		setViewMode("grid");
+		setFolderId(undefined);
+		setPage(1);
+		setPageSize(DEFAULT_PAGE_SIZE);
+		setRetainedTotalCount(0);
+		setImageUrl("");
+		setUrlError(null);
+		invalidateUrlProbe();
+		setUploadError(null);
+		setLiveMessage("");
+		setProviderDimensions({});
+		updatedDimensionsRef.current.clear();
+	}, [invalidateUrlProbe, localOnly, open]);
 
-	// Fetch available providers — skipped when `localOnly` is set since the
-	// list isn't used (provider tabs are suppressed and the active provider
-	// stays "local"). Avoids a request to /providers on every modal open
-	// when we'll just throw the result away.
-	const { data: providers } = useQuery({
+	const providersQuery = useQuery({
 		queryKey: ["media-providers"],
 		queryFn: fetchMediaProviders,
 		enabled: open && !localOnly,
-		// Default to just local if fetch fails
 		placeholderData: [],
 	});
-
-	// Get active provider info
-	const activeProviderInfo = React.useMemo(() => {
-		if (activeProvider === "local") {
-			return {
-				id: "local",
-				name: t`Library`,
-				icon: undefined,
-				capabilities: { browse: true, search: false, upload: true, delete: true },
-			};
+	const providers = providersQuery.data ?? [];
+	const urlSourceAvailable =
+		!hideUrlInput &&
+		!localOnly &&
+		(!filters || filters.some((mime) => filtersOverlap(mime, "image/")));
+	const sourceTabs = React.useMemo(() => {
+		const tabs: Array<{ id: string; name: string; icon?: string }> = [
+			{ id: "local", name: t`Library` },
+		];
+		for (const provider of providers) {
+			if (provider.id !== "local") tabs.push(provider);
 		}
-		return providers?.find((p) => p.id === activeProvider);
-	}, [activeProvider, providers, t]);
+		if (urlSourceAvailable) tabs.push({ id: URL_SOURCE, name: t`From URL` });
+		return tabs;
+	}, [providers, t, urlSourceAvailable]);
+	React.useEffect(() => {
+		if (sourceTabs.some((source) => source.id === activeSource)) return;
+		if (activeSource === URL_SOURCE) invalidateUrlProbe();
+		setActiveSource("local");
+	}, [activeSource, invalidateUrlProbe, sourceTabs]);
+	const activeProviderInfo =
+		activeSource === "local"
+			? {
+					id: "local",
+					name: t`Library`,
+					capabilities: { browse: true, search: true, upload: true, delete: false },
+				}
+			: providers.find((provider) => provider.id === activeSource);
 
-	// Fetch local media list (cursor-paginated so libraries beyond the
-	// first page remain selectable from the picker, not just the first 50).
-	// setQueryData is exact-match, so the optimistic dimension update below
-	// must share this exact key with the query that populates it.
-	const mediaQueryKey = ["media", filters?.join(",") ?? "", debouncedSearch.trim()];
-	const {
-		data: localData,
-		isLoading: localLoading,
-		fetchNextPage: fetchNextLocalPage,
-		hasNextPage: hasNextLocalPage,
-		isFetchingNextPage: isFetchingNextLocalPage,
-	} = useInfiniteQuery({
-		queryKey: mediaQueryKey,
-		queryFn: ({ pageParam }) =>
+	const typeItems = React.useMemo(() => {
+		const items: Record<string, string> = { all: t`All types` };
+		for (const [value, label] of [
+			["image", t`Images`],
+			["video", t`Video`],
+			["audio", t`Audio`],
+			["document", t`Documents`],
+		] as const) {
+			const category = mimeForMediaTypeFilter(value);
+			if (intersectMimeFilters(filters, category)?.length !== 0) items[value] = label;
+		}
+		return items;
+	}, [filters, t]);
+	React.useEffect(() => {
+		if (typeFilter in typeItems) return;
+		setTypeFilter("all");
+		setPage(1);
+		setRetainedTotalCount(0);
+	}, [typeFilter, typeItems]);
+	const effectiveMimeFilters = React.useMemo(
+		() => intersectMimeFilters(filters, mimeForMediaTypeFilter(typeFilter)),
+		[filters, typeFilter],
+	);
+	const mimeKey = effectiveMimeFilters?.join(",") ?? "";
+	const localQueryKey = React.useMemo(
+		() =>
+			[
+				"media",
+				"picker",
+				{
+					search: activeSearch,
+					mime: mimeKey,
+					folder: activeSearch ? "all" : (folderId ?? "main"),
+					page,
+					pageSize,
+				},
+			] as const,
+		[activeSearch, folderId, mimeKey, page, pageSize],
+	);
+	const localQuery = useQuery({
+		queryKey: localQueryKey,
+		queryFn: () =>
 			fetchMediaList({
-				mimeType: filters,
-				cursor: pageParam,
-				limit: 100,
-				search: debouncedSearch.trim() || undefined,
+				page,
+				limit: pageSize,
+				search: activeSearch || undefined,
+				mimeType: effectiveMimeFilters,
+				folderId: activeSearch ? undefined : (folderId ?? null),
 			}),
-		initialPageParam: undefined as string | undefined,
-		getNextPageParam: (lastPage) => lastPage.nextCursor,
-		enabled: open && activeProvider === "local",
+		enabled: open && activeSource === "local" && effectiveMimeFilters?.length !== 0,
+		placeholderData: keepPreviousData,
 	});
 
-	// Fetch provider media list. Belt-and-suspenders: the reset effect
-	// forces `activeProvider` back to "local" when `localOnly` is true, but
-	// also gate this query directly so a stale render can't fire an
-	// external request between state updates.
-	const { data: providerData, isLoading: providerLoading } = useQuery({
-		queryKey: ["provider-media", activeProvider, filters?.join(",") ?? "", searchQuery],
+	React.useEffect(() => {
+		if (localQuery.data?.totalCount !== undefined) {
+			setRetainedTotalCount(localQuery.data.totalCount);
+		}
+	}, [localQuery.data?.totalCount]);
+	const fallbackItemCount = localQuery.data?.items.length ?? 0;
+	const totalCount = localQuery.data?.totalCount ?? (retainedTotalCount || fallbackItemCount);
+	const lastPage = Math.max(1, Math.ceil((localQuery.data?.totalCount ?? totalCount) / pageSize));
+	const isRecoveringPage =
+		localQuery.data?.totalCount !== undefined && page > lastPage && activeSource === "local";
+	React.useEffect(() => {
+		if (isRecoveringPage) setPage(lastPage);
+	}, [isRecoveringPage, lastPage]);
+
+	const showFolderResults =
+		activeSource === "local" &&
+		page === 1 &&
+		typeFilter === "all" &&
+		(!folderId || Boolean(activeSearch));
+	const foldersQuery = useInfiniteQuery({
+		queryKey: ["media-folders", "picker", { search: activeSearch }],
+		queryFn: ({ pageParam }) =>
+			fetchMediaFolders({ limit: 100, cursor: pageParam, search: activeSearch || undefined }),
+		initialPageParam: undefined as string | undefined,
+		getNextPageParam: (lastFolderPage) => lastFolderPage.nextCursor,
+		enabled: open && showFolderResults,
+	});
+	const folders = React.useMemo(
+		() => foldersQuery.data?.pages.flatMap((folderPage) => folderPage.items) ?? [],
+		[foldersQuery.data?.pages],
+	);
+	const currentFolderQuery = useQuery({
+		queryKey: ["media-folder", folderId],
+		queryFn: () => fetchMediaFolder(folderId!),
+		enabled: open && activeSource === "local" && Boolean(folderId),
+		retry: (failureCount, error) =>
+			!(error instanceof ApiResponseError && error.code === "NOT_FOUND") && failureCount < 2,
+	});
+	const missingFolder =
+		currentFolderQuery.error instanceof ApiResponseError &&
+		currentFolderQuery.error.code === "NOT_FOUND";
+	React.useEffect(() => {
+		if (!folderId || !missingFolder) return;
+		setFolderId(undefined);
+		setPage(1);
+		setLiveMessage(t`Folder no longer exists. Returned to the main library.`);
+	}, [folderId, missingFolder, t]);
+
+	const providerQuery = useQuery({
+		queryKey: ["provider-media", activeSource, filters?.join(",") ?? "", searchQuery],
 		queryFn: () =>
-			fetchProviderMedia(activeProvider, {
+			fetchProviderMedia(activeSource, {
 				mimeType: filters,
 				limit: 50,
-				query: searchQuery || undefined,
+				query: searchQuery.trim() || undefined,
 			}),
-		enabled: open && !localOnly && activeProvider !== "local",
+		enabled: open && !localOnly && activeSource !== "local" && activeSource !== URL_SOURCE,
 	});
 
-	const isLoading =
-		activeProvider === "local" ? localLoading || isFetchingNextLocalPage : providerLoading;
+	const updateSelection = React.useCallback(
+		(providerId: string, item: MediaItem | MediaProviderItem) => {
+			const key = selectionKey(providerId, item);
+			setSelectedItems((current) => {
+				const exists = current.some((selected) => selected.key === key);
+				if (exists) return current.filter((selected) => selected.key !== key);
+				const next = { key, providerId, item };
+				return multiple ? [...current, next] : [next];
+			});
+		},
+		[multiple],
+	);
+	const ensureSelection = React.useCallback(
+		(providerId: string, item: MediaItem | MediaProviderItem) => {
+			const key = selectionKey(providerId, item);
+			setSelectedItems((current) => {
+				if (current.some((selected) => selected.key === key)) return current;
+				const next = { key, providerId, item };
+				return multiple ? [...current, next] : [next];
+			});
+		},
+		[multiple],
+	);
+	const toMediaItem = React.useCallback(
+		(selected: SelectedMedia): MediaItem => {
+			if (selected.providerId === "local" || selected.providerId === URL_SOURCE) {
+				return selected.item as MediaItem;
+			}
+			const providerItem = selected.item as MediaProviderItem;
+			const dimensions = providerDimensions[selected.key];
+			return providerItemToMediaItem(
+				selected.providerId,
+				dimensions
+					? {
+							...providerItem,
+							width: providerItem.width ?? dimensions.width,
+							height: providerItem.height ?? dimensions.height,
+						}
+					: providerItem,
+			);
+		},
+		[providerDimensions],
+	);
 
-	const [uploadError, setUploadError] = React.useState<string | null>(null);
-
-	// Upload mutation for local provider
 	const uploadLocalMutation = useMutation({
 		mutationFn: (file: File) => uploadMedia(file, { fieldId }),
 		onSuccess: (item) => {
 			void queryClient.invalidateQueries({ queryKey: ["media"] });
-			if (multiple) {
-				setSelectedItems((prev) => [...prev, { providerId: "local", item }]);
-			} else {
-				setSelectedItem({ providerId: "local", item });
-			}
+			ensureSelection("local", item);
 			setUploadError(null);
 		},
-		onError: (err: Error) => {
-			setUploadError(err.message);
-		},
+		onError: (error: Error) => setUploadError(error.message),
 	});
-
-	// Upload mutation for external providers
 	const uploadProviderMutation = useMutation({
 		mutationFn: ({ providerId, file }: { providerId: string; file: File }) =>
 			uploadToProvider(providerId, file),
 		onSuccess: (item, { providerId }) => {
 			void queryClient.invalidateQueries({ queryKey: ["provider-media", providerId] });
-			if (multiple) {
-				setSelectedItems((prev) => [...prev, { providerId, item }]);
-			} else {
-				setSelectedItem({ providerId, item });
-			}
+			ensureSelection(providerId, item);
 			setUploadError(null);
 		},
-		onError: (err: Error) => {
-			setUploadError(err.message);
-		},
+		onError: (error: Error) => setUploadError(error.message),
 	});
-
 	const isUploading = uploadLocalMutation.isPending || uploadProviderMutation.isPending;
 
-	// Track which items we've already updated dimensions for
-	const updatedDimensionsRef = React.useRef<Set<string>>(new Set());
-
-	// Mutation for updating media dimensions
 	const dimensionsMutation = useMutation({
 		mutationFn: ({ id, width, height }: { id: string; width: number; height: number }) =>
 			updateMedia(id, { width, height }),
-		onSuccess: (_updated, { id, width, height }) => {
-			queryClient.setQueryData(
-				mediaQueryKey,
-				(
-					old:
-						| {
-								pages: { items: MediaItem[]; nextCursor?: string }[];
-								pageParams: unknown[];
-						  }
-						| undefined,
-				) => {
-					if (!old) return old;
-					return {
-						...old,
-						pages: old.pages.map((page) => ({
-							...page,
-							items: page.items.map((item) => (item.id === id ? { ...item, width, height } : item)),
-						})),
-					};
-				},
+		onSuccess: (_item, { id, width, height }) => {
+			queryClient.setQueryData(localQueryKey, (current: typeof localQuery.data) => {
+				if (!current) return current;
+				return {
+					...current,
+					items: current.items.map((item) => (item.id === id ? { ...item, width, height } : item)),
+				};
+			});
+			setSelectedItems((current) =>
+				current.map((selected) =>
+					selected.providerId === "local" && selected.item.id === id
+						? { ...selected, item: { ...selected.item, width, height } }
+						: selected,
+				),
 			);
-
-			if (selectedItem?.providerId === "local" && selectedItem.item.id === id) {
-				setSelectedItem({
-					providerId: "local",
-					item: { ...selectedItem.item, width, height },
-				});
-			}
 		},
-		onError: (error) => {
-			console.warn("Failed to update media dimensions:", error);
-		},
+		onError: (error) => console.warn("Failed to update media dimensions:", error),
 	});
-
-	// Handle dimensions detected for local images missing them
 	const handleDimensionsDetected = React.useCallback(
 		(id: string, width: number, height: number) => {
 			if (updatedDimensionsRef.current.has(id)) return;
@@ -350,93 +455,46 @@ export function MediaPickerModal({
 		},
 		[dimensionsMutation],
 	);
+	const handleBrowserDimensions = React.useCallback(
+		(
+			providerId: string,
+			item: MediaItem | MediaProviderItem,
+			key: string,
+			width: number,
+			height: number,
+		) => {
+			if (providerId === "local") {
+				handleDimensionsDetected(item.id, width, height);
+				return;
+			}
+			setProviderDimensions((current) => ({ ...current, [key]: { width, height } }));
+		},
+		[handleDimensionsDetected],
+	);
 
-	// Get items for current view
-	const items = React.useMemo(() => {
-		if (activeProvider === "local") {
-			const localItems = localData?.pages.flatMap((page) => page.items) || [];
-			return localItems.filter((item) => matchesAnyFilter(item.mimeType, filters));
-		}
-		return providerData?.items || [];
-	}, [activeProvider, localData, providerData?.items, filters]);
-
-	const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const files = e.target.files;
-		const file = files?.[0];
+	const resetPage = React.useCallback(() => {
+		setPage(1);
+		setRetainedTotalCount(0);
+	}, []);
+	const changeSource = (source: string) => {
+		if (!source || source === activeSource) return;
+		if (activeSource === URL_SOURCE) invalidateUrlProbe();
+		setActiveSource(source);
+		setSearchQuery("");
+		setUploadError(null);
+	};
+	const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const file = event.currentTarget.files?.[0];
 		if (file) {
-			if (activeProvider === "local") {
-				uploadLocalMutation.mutate(file);
-			} else if (activeProviderInfo?.capabilities.upload) {
-				uploadProviderMutation.mutate({ providerId: activeProvider, file });
+			if (activeSource === "local") uploadLocalMutation.mutate(file);
+			else if (activeProviderInfo?.capabilities.upload) {
+				uploadProviderMutation.mutate({ providerId: activeSource, file });
 			}
 		}
-		if (fileInputRef.current) {
-			fileInputRef.current.value = "";
-		}
+		event.currentTarget.value = "";
 	};
-
-	// When providerId is "local", item is always MediaItem; otherwise MediaProviderItem
-	const toMediaItem = (selected: SelectedMedia): MediaItem => {
-		if (selected.providerId === "local") {
-			return selected.item as MediaItem;
-		}
-		const providerItem = selected.item as MediaProviderItem;
-		const dims = providerDimensions[providerItem.id];
-		const itemWithDims = dims
-			? {
-					...providerItem,
-					width: providerItem.width ?? dims.width,
-					height: providerItem.height ?? dims.height,
-				}
-			: providerItem;
-		return providerItemToMediaItem(selected.providerId, itemWithDims);
-	};
-
-	const isItemSelected = (providerId: string, id: string) =>
-		multiple
-			? selectedItems.some((s) => s.providerId === providerId && s.item.id === id)
-			: selectedItem?.providerId === providerId && selectedItem.item.id === id;
-
-	const handleItemClick = (providerId: string, item: MediaItem | MediaProviderItem) => {
-		if (multiple) {
-			setSelectedItems((prev) =>
-				prev.some((s) => s.providerId === providerId && s.item.id === item.id)
-					? prev.filter((s) => !(s.providerId === providerId && s.item.id === item.id))
-					: [...prev, { providerId, item }],
-			);
-		} else {
-			setSelectedItem({ providerId, item });
-		}
-	};
-
-	const handleConfirm = () => {
-		if (multiple) {
-			if (selectedItems.length === 0) return;
-			onSelectMany?.(selectedItems.map(toMediaItem));
-			onOpenChange(false);
-			setSelectedItems([]);
-			setImageUrl("");
-			return;
-		}
-		if (selectedItem) {
-			onSelect(toMediaItem(selectedItem));
-			onOpenChange(false);
-			setSelectedItem(null);
-			setImageUrl("");
-		}
-	};
-
-	const handleClose = () => {
-		onOpenChange(false);
-		setSelectedItem(null);
-		setSelectedItems([]);
-		setImageUrl("");
-		setUrlError(null);
-	};
-
 	const handleUrlSubmit = async () => {
 		if (!imageUrl.trim()) return;
-
 		let url: URL;
 		try {
 			url = new URL(imageUrl.trim());
@@ -444,89 +502,99 @@ export function MediaPickerModal({
 			setUrlError(t`Please enter a valid URL`);
 			return;
 		}
-
+		const probeId = (urlProbeIdRef.current += 1);
 		setIsProbing(true);
 		setUrlError(null);
-
 		try {
-			const sniffedMime = mimeFromUrl(url) ?? "image/unknown";
-
-			// Pre-validate against the field's allowlist so the user sees the error
-			// here rather than at content-save time (where it becomes INVALID_MIME_FOR_FIELD).
-			if (sniffedMime === "image/unknown" && filters && filters.length > 0) {
-				setUrlError(
-					t`Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp).`,
-				);
+			const mimeType = mimeFromUrl(url) ?? "image/unknown";
+			if (mimeType === "image/unknown" && filters?.length) {
+				setUrlError(t`Use a URL ending in a recognized image extension, such as .jpg or .png.`);
 				return;
 			}
-			if (filters && filters.length > 0 && !matchesMimeAllowlist(sniffedMime, filters)) {
-				setUrlError(t`This field does not accept ${sniffedMime} files.`);
+			if (filters?.length && !matchesMimeAllowlist(mimeType, filters)) {
+				setUrlError(t`This field does not accept ${mimeType} files.`);
 				return;
 			}
-
 			const dimensions = await probeImageDimensions(url.href, t`Failed to load image`);
-			const externalItem: MediaItem = {
+			if (urlProbeIdRef.current !== probeId) return;
+			const item: MediaItem = {
 				id: "",
 				filename: url.pathname.split("/").pop() || "external-image",
-				mimeType: sniffedMime,
+				mimeType,
 				url: url.href,
-				provider: "external-url",
+				provider: "external",
 				size: 0,
 				width: dimensions.width,
 				height: dimensions.height,
 				createdAt: new Date().toISOString(),
 			};
-
-			if (multiple) {
-				onSelectMany?.([externalItem]);
-			} else {
-				onSelect(externalItem);
-			}
-			onOpenChange(false);
+			ensureSelection(URL_SOURCE, item);
 			setImageUrl("");
 		} catch {
-			setUrlError(t`Could not load image from URL`);
+			if (urlProbeIdRef.current === probeId) setUrlError(t`Could not load image from URL`);
 		} finally {
-			setIsProbing(false);
+			if (urlProbeIdRef.current === probeId) setIsProbing(false);
 		}
 	};
 
-	const handleUrlKeyDown = (e: React.KeyboardEvent) => {
-		if (e.key === "Enter") {
-			e.preventDefault();
-			void handleUrlSubmit();
-		}
+	const handleConfirm = () => {
+		if (selectedItems.length === 0) return;
+		const items = selectedItems.map(toMediaItem);
+		if (multiple) onSelectMany?.(items);
+		else onSelect(items[0]!);
+		onOpenChange(false);
 	};
-
+	const handleClose = () => {
+		invalidateUrlProbe();
+		onOpenChange(false);
+		setSelectedItems([]);
+	};
+	const confirmText =
+		confirmLabel ??
+		(multiple
+			? isFileKind
+				? plural(selectedItems.length, { one: "Add # file", other: "Add # files" })
+				: plural(selectedItems.length, { one: "Add # image", other: "Add # images" })
+			: t`Select`);
+	const providerItems = React.useMemo(
+		() =>
+			(providerQuery.data?.items ?? []).filter((item) => matchesAnyFilter(item.mimeType, filters)),
+		[filters, providerQuery.data?.items],
+	);
+	const localItems = isRecoveringPage
+		? []
+		: effectiveMimeFilters?.length === 0
+			? []
+			: (localQuery.data?.items ?? []).filter((item) =>
+					matchesAnyFilter(item.mimeType, effectiveMimeFilters),
+				);
 	const canUpload =
-		activeProvider === "local" || (activeProviderInfo?.capabilities.upload ?? false);
-	const canSearch = activeProviderInfo?.capabilities.search ?? false;
-
-	// Build provider tabs - always show local first, then add external providers
-	// Filter out "local" from API response since we add it manually.
-	// When `localOnly` is set, suppress external providers entirely so the
-	// picker can only return locally-stored media (see prop docs).
-	const providerTabs = React.useMemo(() => {
-		const tabs: Array<{ id: string; name: string; icon?: string }> = [
-			{ id: "local", name: t`Library`, icon: undefined },
-		];
-		if (providers && !localOnly) {
-			for (const p of providers) {
-				if (p.id !== "local") {
-					tabs.push({ id: p.id, name: p.name, icon: p.icon });
-				}
-			}
-		}
-		return tabs;
-	}, [providers, localOnly, t]);
+		activeSource === "local" ? !folderId : Boolean(activeProviderInfo?.capabilities.upload);
+	const canSearch = activeSource === "local" || Boolean(activeProviderInfo?.capabilities.search);
+	const currentLoading = activeSource === "local" ? localQuery.isPending : providerQuery.isPending;
+	const currentFetching =
+		activeSource === "local" ? localQuery.isFetching : providerQuery.isFetching;
+	const hasVisibleItems =
+		activeSource === "local" ? localItems.length > 0 : providerItems.length > 0;
 
 	return (
-		<Dialog.Root open={open} onOpenChange={handleClose}>
-			<Dialog className="p-6 max-w-4xl max-h-[80vh] flex flex-col overflow-hidden" size="xl">
-				<div className="flex items-start justify-between gap-4 mb-4">
-					<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-						{title}
-					</Dialog.Title>
+		<Dialog.Root
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen) handleClose();
+			}}
+		>
+			<Dialog
+				size="xl"
+				className="flex max-h-[calc(100dvh-1rem)] min-h-0 min-w-0 max-w-[calc(100vw-1rem)] flex-col overflow-hidden p-0 sm:max-h-[88dvh] sm:min-w-[48rem] sm:max-w-5xl"
+			>
+				<header className="flex shrink-0 items-start justify-between gap-4 border-b border-kumo-line px-4 py-4 sm:px-6">
+					<div className="min-w-0">
+						<Dialog.Title className="text-lg font-semibold leading-6">{title}</Dialog.Title>
+						<Dialog.Description className="mt-1 text-sm leading-5 text-kumo-subtle">
+							{description}
+						</Dialog.Description>
+					</div>
 					<Dialog.Close
 						aria-label={t`Close`}
 						render={(props) => (
@@ -534,461 +602,483 @@ export function MediaPickerModal({
 								{...props}
 								variant="ghost"
 								shape="square"
+								size="sm"
 								aria-label={t`Close`}
-								className="absolute end-4 top-4"
-							>
-								<X className="h-4 w-4" />
-								<span className="sr-only">{t`Close`}</span>
-							</Button>
+								icon={<X aria-hidden="true" />}
+							/>
 						)}
 					/>
-				</div>
+				</header>
 
-				{/* URL Input (image pickers only — probes image dimensions) */}
-				{!hideUrlInput && !localOnly && (
-					<>
-						<div className="border-b pb-4">
-							<Label>{t`Insert from URL`}</Label>
-							<div className="flex gap-2 mt-1.5">
-								<div className="flex-1 relative">
-									<Globe className="absolute start-3 top-1/2 -translate-y-1/2 h-4 w-4 text-kumo-subtle" />
-									<Input
-										type="url"
-										placeholder={t`https://example.com/image.jpg`}
-										aria-label={t`Image URL`}
-										value={imageUrl}
-										onChange={(e) => {
-											setImageUrl(e.target.value);
-											setUrlError(null);
-										}}
-										onKeyDown={handleUrlKeyDown}
-										className="ps-9"
-									/>
-								</div>
-								<Button onClick={handleUrlSubmit} disabled={!imageUrl.trim() || isProbing}>
-									{isProbing ? <Loader size="sm" /> : t`Insert`}
-								</Button>
-							</div>
-							{urlError && <p className="text-sm text-kumo-danger mt-1">{urlError}</p>}
-						</div>
-
-						{/* Divider with "or" */}
-						<div className="relative py-2">
-							<div className="absolute inset-0 flex items-center">
-								<span className="w-full border-t" />
-							</div>
-							<div className="relative flex justify-center text-xs uppercase">
-								<span className="bg-kumo-base px-2 text-kumo-subtle">{t`or choose from library`}</span>
-							</div>
-						</div>
-					</>
-				)}
-
-				{/* Provider Tabs */}
-				{providerTabs.length > 1 && (
-					<div className="flex gap-2 border-b pb-3 flex-wrap">
-						{providerTabs.map((tab) => (
-							<button
-								key={tab.id}
-								type="button"
-								onClick={() => {
-									setActiveProvider(tab.id);
-									setSelectedItem(null);
-									setSelectedItems([]);
-									setSearchQuery("");
-								}}
-								className={cn(
-									"flex items-center gap-2 px-4 h-9 text-sm font-medium rounded-md transition-colors whitespace-nowrap",
-									activeProvider === tab.id
-										? "bg-kumo-brand text-white"
-										: "bg-kumo-tint hover:bg-kumo-tint/80 text-kumo-subtle",
-								)}
-							>
-								{tab.icon &&
-									(tab.icon.startsWith("data:") ? (
-										<img src={tab.icon} alt="" className="h-4 w-4" aria-hidden="true" />
-									) : (
-										<span aria-hidden="true">{tab.icon}</span>
-									))}
-								{tab.name}
-							</button>
-						))}
-					</div>
-				)}
-
-				{/* Toolbar */}
-				<div className="flex items-center justify-between pb-3 gap-4">
-					{/* Search — providers that support it, plus the local library
-					    (filename/extension search, handled server-side). */}
-					{canSearch || activeProvider === "local" ? (
-						<div className="relative flex-1 max-w-xs">
-							<MagnifyingGlass className="absolute start-3 top-1/2 -translate-y-1/2 h-4 w-4 text-kumo-subtle" />
-							<Input
-								type="search"
-								placeholder={activeProvider === "local" ? t`Search by filename...` : t`Search...`}
-								aria-label={t`Search media`}
-								value={searchQuery}
-								onChange={(e) => setSearchQuery(e.target.value)}
-								maxLength={MEDIA_SEARCH_MAX_LENGTH}
-								className="ps-9"
-							/>
-						</div>
-					) : (
-						<p className="text-sm text-kumo-subtle">
-							{plural(items.length, { one: "# item", other: "# items" })}
-						</p>
+				<div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain px-4 py-4 sm:px-6">
+					{sourceTabs.length > 1 && (
+						<Tabs
+							variant="underline"
+							value={activeSource}
+							onValueChange={changeSource}
+							tabs={sourceTabs.map((source) => ({
+								value: source.id,
+								label: (
+									<span className="flex items-center gap-2">
+										{source.icon &&
+											(source.icon.startsWith("data:") ? (
+												<img src={source.icon} alt="" className="size-4" aria-hidden="true" />
+											) : (
+												<span aria-hidden="true">{source.icon}</span>
+											))}
+										{source.name}
+									</span>
+								),
+							}))}
+						/>
 					)}
 
-					{/* Upload button (if provider supports it) */}
-					{canUpload && (
+					{activeSource === URL_SOURCE ? (
+						<section className="mx-auto grid w-full max-w-2xl gap-4 py-6">
+							<div className="grid gap-1.5">
+								<Label htmlFor="media-picker-url">{t`Image URL`}</Label>
+								<div className="flex flex-col gap-2 sm:flex-row">
+									<div className="relative min-w-0 flex-1">
+										<Globe
+											className="absolute start-3 top-1/2 size-4 -translate-y-1/2 text-kumo-subtle"
+											aria-hidden="true"
+										/>
+										<Input
+											id="media-picker-url"
+											type="url"
+											aria-label={t`Image URL`}
+											placeholder={t`https://example.com/image.jpg`}
+											value={imageUrl}
+											onChange={(event) => {
+												setImageUrl(event.currentTarget.value);
+												setUrlError(null);
+											}}
+											onKeyDown={(event) => {
+												if (event.key !== "Enter") return;
+												event.preventDefault();
+												void handleUrlSubmit();
+											}}
+											className="ps-9"
+										/>
+									</div>
+									<Button
+										onClick={() => void handleUrlSubmit()}
+										disabled={!imageUrl.trim() || isProbing}
+										loading={isProbing}
+									>
+										{t`Use URL`}
+									</Button>
+								</div>
+								{urlError && (
+									<p role="alert" className="text-sm text-kumo-danger">
+										{urlError}
+									</p>
+								)}
+							</div>
+
+							{selectedItems
+								.filter((selected) => selected.providerId === URL_SOURCE)
+								.map((selected) => (
+									<MediaBrowserItem
+										key={selected.key}
+										item={selected.item as MediaItem}
+										layout="list"
+										selected
+										selectable
+										onClick={(event) => {
+											if (event.detail > 1) return;
+											updateSelection(URL_SOURCE, selected.item);
+										}}
+									/>
+								))}
+						</section>
+					) : (
 						<>
-							<Button
-								size="sm"
-								icon={<Upload />}
-								onClick={() => fileInputRef.current?.click()}
-								disabled={isUploading}
-							>
-								{isUploading ? t`Uploading...` : t`Upload`}
-							</Button>
-							<input
-								ref={fileInputRef}
-								type="file"
-								accept={
-									filters
-										? filters.map((f) => (f.endsWith("/") ? f + "*" : f)).join(",")
-										: undefined
+							{folderId && activeSource === "local" && (
+								<div className="flex min-w-0 items-center gap-2">
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={() => {
+											setFolderId(undefined);
+											resetPage();
+										}}
+										icon={<ArrowLeft className="rtl:-scale-x-100" aria-hidden="true" />}
+									>
+										{t`Main library`}
+									</Button>
+									<span aria-hidden="true" className="text-kumo-subtle">
+										/
+									</span>
+									<span dir="auto" className="min-w-0 truncate text-sm font-medium">
+										{currentFolderQuery.data?.name ?? t`Folder`}
+									</span>
+								</div>
+							)}
+							{folderId && currentFolderQuery.error && !missingFolder && (
+								<div className="flex flex-wrap items-center justify-between gap-2 rounded-md bg-kumo-danger-tint px-3 py-2 text-sm text-kumo-danger">
+									<span>{t`Could not load this folder.`}</span>
+									<Button
+										variant="outline"
+										size="sm"
+										onClick={() => void currentFolderQuery.refetch()}
+									>
+										{t`Retry`}
+									</Button>
+								</div>
+							)}
+
+							<TableToolbar
+								trailing={
+									<div role="group" aria-label={t`View mode`}>
+										<Tabs
+											variant="segmented"
+											value={viewMode}
+											onValueChange={(value) => {
+												if (value === "grid" || value === "list") setViewMode(value);
+											}}
+											tabs={[
+												{
+													value: "grid",
+													label: (
+														<>
+															<SquaresFour className="size-4" aria-hidden="true" />
+															<span className="sr-only">{t`Grid view`}</span>
+														</>
+													),
+												},
+												{
+													value: "list",
+													label: (
+														<>
+															<List className="size-4" aria-hidden="true" />
+															<span className="sr-only">{t`List view`}</span>
+														</>
+													),
+												},
+											]}
+										/>
+									</div>
 								}
-								className="sr-only"
-								onChange={handleFileSelect}
-								aria-label={t`Upload file`}
-							/>
+							>
+								{canSearch && (
+									<TableToolbarSearch
+										size="base"
+										placeholder={activeSource === "local" ? t`Search by filename...` : t`Search...`}
+										aria-label={t`Search media`}
+										value={searchQuery}
+										onChange={(event) => {
+											setSearchQuery(event.currentTarget.value);
+											if (activeSource === "local") resetPage();
+										}}
+										maxLength={MEDIA_SEARCH_MAX_LENGTH}
+										className="w-full flex-1 sm:w-72"
+									/>
+								)}
+								{activeSource === "local" && (
+									<Select
+										size="base"
+										value={typeFilter}
+										onValueChange={(value) => {
+											setTypeFilter(value ?? "all");
+											resetPage();
+										}}
+										items={typeItems}
+										aria-label={t`Filter by type`}
+									/>
+								)}
+								{canUpload && (
+									<>
+										<Button
+											size="sm"
+											onClick={() => fileInputRef.current?.click()}
+											disabled={isUploading}
+											loading={isUploading}
+											icon={<Upload aria-hidden="true" />}
+										>
+											{t`Upload files`}
+										</Button>
+										<input
+											ref={fileInputRef}
+											type="file"
+											accept={
+												filters
+													? filters
+															.map((filter) => (filter.endsWith("/") ? `${filter}*` : filter))
+															.join(",")
+													: undefined
+											}
+											className="sr-only"
+											tabIndex={-1}
+											onChange={handleFileSelect}
+											aria-label={t`Choose files to upload`}
+										/>
+									</>
+								)}
+							</TableToolbar>
+
+							<DialogError message={uploadError ? t`Upload failed: ${uploadError}` : null} />
+							{activeSource === "local" && localQuery.error && localItems.length > 0 && (
+								<div className="flex flex-wrap items-center justify-between gap-2 rounded-md bg-kumo-danger-tint px-3 py-2 text-sm text-kumo-danger">
+									<span>{t`The latest media request failed. Showing the previous page.`}</span>
+									<Button variant="outline" size="sm" onClick={() => void localQuery.refetch()}>
+										{t`Retry`}
+									</Button>
+								</div>
+							)}
+
+							{showFolderResults &&
+								(foldersQuery.isPending || folders.length > 0 || foldersQuery.error) && (
+									<section aria-labelledby="media-picker-folders" className="grid gap-2">
+										<div className="flex items-center justify-between gap-2">
+											<h2 id="media-picker-folders" className="text-sm font-semibold">
+												{t`Folders`}
+											</h2>
+											{foldersQuery.error && (
+												<div className="flex items-center gap-2">
+													<span className="text-sm text-kumo-danger">
+														{t`Folders could not be loaded.`}
+													</span>
+													<Button
+														variant="outline"
+														size="sm"
+														onClick={() => void foldersQuery.refetch()}
+													>
+														{t`Retry`}
+													</Button>
+												</div>
+											)}
+										</div>
+										{foldersQuery.isPending && folders.length === 0 ? (
+											<div
+												role="status"
+												className="flex items-center gap-2 text-sm text-kumo-subtle"
+											>
+												<Loader size="sm" />
+												{t`Loading folders`}
+											</div>
+										) : (
+											<div className="grid grid-cols-[repeat(auto-fill,minmax(min(12rem,100%),1fr))] gap-2">
+												{folders.map((folder) => (
+													<MediaBrowserFolder
+														key={folder.id}
+														folder={folder}
+														onOpen={() => {
+															setSearchQuery("");
+															setFolderId(folder.id);
+															resetPage();
+														}}
+													/>
+												))}
+											</div>
+										)}
+										{foldersQuery.hasNextPage && (
+											<Button
+												variant="outline"
+												size="sm"
+												onClick={() => void foldersQuery.fetchNextPage()}
+												disabled={foldersQuery.isFetchingNextPage}
+												loading={foldersQuery.isFetchingNextPage}
+											>
+												{t`Load more folders`}
+											</Button>
+										)}
+									</section>
+								)}
+
+							<div
+								role="region"
+								aria-label={t`Media results`}
+								aria-busy={currentFetching || undefined}
+							>
+								{currentLoading && !hasVisibleItems ? (
+									<div
+										role="status"
+										className="flex min-h-48 items-center justify-center gap-2 text-sm text-kumo-subtle"
+									>
+										<Loader />
+										{t`Loading media`}
+									</div>
+								) : (activeSource === "local" ? localQuery.error : providerQuery.error) &&
+								  !hasVisibleItems ? (
+									<div className="flex min-h-48 flex-col items-center justify-center gap-3 text-center">
+										<p className="text-sm text-kumo-danger">{t`Could not load media.`}</p>
+										<Button
+											variant="outline"
+											onClick={() =>
+												void (activeSource === "local"
+													? localQuery.refetch()
+													: providerQuery.refetch())
+											}
+										>
+											{t`Retry`}
+										</Button>
+									</div>
+								) : !hasVisibleItems ? (
+									<div className="flex min-h-48 flex-col items-center justify-center gap-3 text-center">
+										<EmptyStateIcon className="size-10 text-kumo-subtle" aria-hidden="true" />
+										<div className="grid gap-1">
+											<h2 className="text-lg font-semibold">{t`No media found`}</h2>
+											<p className="text-sm text-kumo-subtle">
+												{searchQuery.trim()
+													? t`Try another filename or clear your search.`
+													: folderId && activeSource === "local"
+														? t`This folder is empty.`
+														: isFileKind
+															? t`Upload a file to get started`
+															: t`Upload an image to get started`}
+											</p>
+										</div>
+									</div>
+								) : viewMode === "grid" ? (
+									<Grid
+										variant="4up"
+										gap="sm"
+										className="2xl:grid-cols-5"
+										inert={currentFetching || undefined}
+										data-media-items
+									>
+										{(activeSource === "local" ? localItems : providerItems).map((rawItem) => {
+											const key = selectionKey(activeSource, rawItem);
+											const item =
+												activeSource === "local"
+													? (rawItem as MediaItem)
+													: toMediaItem({ key, providerId: activeSource, item: rawItem });
+											return (
+												<MediaBrowserItem
+													key={key}
+													item={item}
+													layout="grid"
+													selectable
+													selected={selectedItems.some((selected) => selected.key === key)}
+													onClick={(event) => {
+														if (event.detail > 1) return;
+														updateSelection(activeSource, rawItem);
+													}}
+													onDimensionsLoaded={(width, height) =>
+														handleBrowserDimensions(activeSource, rawItem, key, width, height)
+													}
+												/>
+											);
+										})}
+									</Grid>
+								) : (
+									<div className="grid gap-2" inert={currentFetching || undefined} data-media-items>
+										{(activeSource === "local" ? localItems : providerItems).map((rawItem) => {
+											const key = selectionKey(activeSource, rawItem);
+											const item =
+												activeSource === "local"
+													? (rawItem as MediaItem)
+													: toMediaItem({ key, providerId: activeSource, item: rawItem });
+											return (
+												<MediaBrowserItem
+													key={key}
+													item={item}
+													layout="list"
+													selectable
+													selected={selectedItems.some((selected) => selected.key === key)}
+													onClick={(event) => {
+														if (event.detail > 1) return;
+														updateSelection(activeSource, rawItem);
+													}}
+													onDimensionsLoaded={(width, height) =>
+														handleBrowserDimensions(activeSource, rawItem, key, width, height)
+													}
+												/>
+											);
+										})}
+									</div>
+								)}
+							</div>
+
+							{activeSource === "local" && totalCount > 0 && (
+								<Pagination
+									page={isRecoveringPage ? lastPage : page}
+									setPage={(nextPage) => {
+										const pageCount = Math.max(1, Math.ceil(totalCount / pageSize));
+										if (
+											localQuery.isFetching ||
+											!Number.isSafeInteger(nextPage) ||
+											nextPage < 1 ||
+											nextPage > pageCount
+										)
+											return;
+										setPage(nextPage);
+									}}
+									perPage={pageSize}
+									totalCount={totalCount}
+									className="flex-wrap gap-y-3"
+									labels={{
+										navigation: t`Media pagination`,
+										firstPage: t`First page`,
+										previousPage: t`Previous page`,
+										nextPage: t`Next page`,
+										lastPage: t`Last page`,
+										pageNumber: t`Page number`,
+										pageSize: t`Page size`,
+									}}
+								>
+									<Pagination.Info className="min-w-fit">
+										{({ pageShowingRange, totalCount: count }) => (
+											<span role="status">{t`Showing ${pageShowingRange} of ${count ?? 0}`}</span>
+										)}
+									</Pagination.Info>
+									<Pagination.Separator className="hidden sm:block" />
+									<div inert={localQuery.isFetching || undefined} className="contents">
+										<Pagination.PageSize
+											value={pageSize}
+											onChange={(nextPageSize) => {
+												if (
+													localQuery.isFetching ||
+													!MEDIA_BROWSER_PAGE_SIZES.includes(nextPageSize)
+												)
+													return;
+												setPageSize(nextPageSize);
+												resetPage();
+											}}
+											options={MEDIA_BROWSER_PAGE_SIZES}
+											label={t`Per page`}
+										/>
+										<Pagination.Controls
+											pageSelector={
+												Math.ceil(totalCount / pageSize) <= MAX_MEDIA_PAGE_DROPDOWN_ITEMS
+													? "dropdown"
+													: "input"
+											}
+											className="basis-full sm:basis-auto rtl:[&_svg]:-scale-x-100"
+										/>
+									</div>
+								</Pagination>
+							)}
 						</>
 					)}
 				</div>
 
-				{/* Upload error */}
-				<DialogError
-					message={uploadError ? t`Upload failed: ${uploadError}` : null}
-					className="mb-3"
-				/>
-
-				{/* Media Grid */}
-				<div className="flex-1 overflow-y-auto min-h-0">
-					{/*
-					 * Gate the centered loader on items being empty so that "Load More"
-					 * (which sets isLoading=true while fetching the next cursor page)
-					 * does not blank out already-rendered items / lose the user's
-					 * selection. Mirrors the ContentList pattern from #135.
-					 */}
-					{isLoading && items.length === 0 ? (
-						<div className="flex items-center justify-center h-full">
-							<Loader />
-						</div>
-					) : items.length === 0 ? (
-						<div className="flex flex-col items-center justify-center h-full text-center p-8">
-							<EmptyStateIcon className="h-12 w-12 text-kumo-subtle mb-4" aria-hidden="true" />
-							<h3 className="text-lg font-medium">{t`No media found`}</h3>
-							<p className="text-sm text-kumo-subtle mt-1">
-								{canSearch && searchQuery
-									? t`Try a different search term`
-									: canUpload
-										? emptyStateUploadHint
-										: t`No media available from this provider`}
-							</p>
-							{canUpload && !searchQuery && (
-								<Button
-									className="mt-4"
-									icon={<Upload />}
-									onClick={() => fileInputRef.current?.click()}
-								>
-									{emptyStateUploadCta}
-								</Button>
-							)}
-						</div>
-					) : (
-						<ul
-							className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3 p-1"
-							role="listbox"
-							aria-label={t`Available media`}
-						>
-							{activeProvider === "local"
-								? (items as MediaItem[]).map((item) => (
-										<MediaPickerItem
-											key={item.id}
-											item={item}
-											selected={isItemSelected("local", item.id)}
-											onClick={() => handleItemClick("local", item)}
-											onDoubleClick={() => {
-												// Multi-select: double-click is just a toggle, no instant insert
-												if (multiple) {
-													handleItemClick("local", item);
-													return;
-												}
-												onSelect(item);
-												onOpenChange(false);
-											}}
-											onDimensionsDetected={handleDimensionsDetected}
-										/>
-									))
-								: (items as MediaProviderItem[]).map((item) => (
-										<ProviderMediaItem
-											key={item.id}
-											item={item}
-											selected={isItemSelected(activeProvider, item.id)}
-											onClick={() => handleItemClick(activeProvider, item)}
-											onDoubleClick={() => {
-												if (multiple) {
-													handleItemClick(activeProvider, item);
-													return;
-												}
-												// Merge loaded dimensions for double-click select
-												const dims = providerDimensions[item.id];
-												const itemWithDims = dims
-													? {
-															...item,
-															width: item.width ?? dims.width,
-															height: item.height ?? dims.height,
-														}
-													: item;
-												const mediaItem = providerItemToMediaItem(activeProvider, itemWithDims);
-												onSelect(mediaItem);
-												onOpenChange(false);
-											}}
-											onDimensionsLoaded={(width, height) => {
-												setProviderDimensions((prev) => ({
-													...prev,
-													[item.id]: { width, height },
-												}));
-											}}
-										/>
-									))}
-						</ul>
-					)}
-
-					{/* Load more (local library only — providers handle pagination internally) */}
-					{activeProvider === "local" && hasNextLocalPage && (
-						<div className="flex justify-center py-3">
-							<Button
-								variant="outline"
-								size="sm"
-								onClick={() => void fetchNextLocalPage()}
-								disabled={isFetchingNextLocalPage}
-							>
-								{isFetchingNextLocalPage ? t`Loading...` : t`Load More`}
-							</Button>
-						</div>
-					)}
-				</div>
-
-				{/* Footer */}
-				<div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 border-t pt-4">
-					<div className="flex-1 text-sm text-kumo-subtle">
-						{multiple
-							? selectedItems.length > 0 && (
-									<span>
-										{plural(selectedItems.length, {
-											one: "# item selected",
-											other: "# items selected",
-										})}
-									</span>
-								)
-							: selectedItem && (
-									<span>
-										{t`Selected:`} <strong>{selectedItem.item.filename}</strong>
-										{selectedItem.providerId !== "local" && (
-											<span className="ms-2 text-xs">
-												{t`(from ${providers?.find((p) => p.id === selectedItem.providerId)?.name})`}
-											</span>
-										)}
-									</span>
-								)}
+				<footer className="flex shrink-0 flex-col gap-3 border-t border-kumo-line px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+					<div className="min-w-0 text-sm text-kumo-subtle">
+						{selectedItems.length > 0
+							? multiple
+								? plural(selectedItems.length, {
+										one: "# item selected",
+										other: "# items selected",
+									})
+								: t`Selected: ${selectedItems[0]!.item.filename}`
+							: t`No media selected`}
 					</div>
-					<Button variant="outline" onClick={handleClose}>
-						{t`Cancel`}
-					</Button>
-					<Button
-						onClick={handleConfirm}
-						disabled={multiple ? selectedItems.length === 0 : !selectedItem}
-					>
-						{t`Insert`}
-					</Button>
-				</div>
+					<div className="flex flex-wrap items-center justify-end gap-2">
+						<Button variant="outline" onClick={handleClose}>
+							{t`Cancel`}
+						</Button>
+						<Button onClick={handleConfirm} disabled={selectedItems.length === 0 || isUploading}>
+							{confirmText}
+						</Button>
+					</div>
+				</footer>
+				<span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+					{liveMessage}
+				</span>
 			</Dialog>
 		</Dialog.Root>
-	);
-}
-
-interface MediaPickerItemProps {
-	item: MediaItem;
-	selected: boolean;
-	onClick: () => void;
-	onDoubleClick: () => void;
-	onDimensionsDetected?: (id: string, width: number, height: number) => void;
-}
-
-function MediaPickerItem({
-	item,
-	selected,
-	onClick,
-	onDoubleClick,
-	onDimensionsDetected,
-}: MediaPickerItemProps) {
-	const { t } = useLingui();
-	const isImage = item.mimeType.startsWith("image/");
-	const needsDimensions = isImage && (!item.width || !item.height);
-	const previewUrl = getMediaPreviewUrl(item.url, item.contentHash);
-
-	// Serve a resized thumbnail only when the original dimensions are already
-	// known. When they're missing we display the original so `onLoad` can read
-	// the true `naturalWidth`/`naturalHeight` to backfill them — a resized
-	// rendition would report the thumbnail's dimensions and corrupt the record.
-	const displayUrl = needsDimensions
-		? previewUrl
-		: getMediaThumbnailUrl(item.url, item.mimeType, undefined, item.contentHash);
-
-	const handleImageLoad = React.useCallback(
-		(e: React.SyntheticEvent<HTMLImageElement>) => {
-			if (needsDimensions && onDimensionsDetected) {
-				const img = e.currentTarget;
-				if (img.naturalWidth && img.naturalHeight) {
-					onDimensionsDetected(item.id, img.naturalWidth, img.naturalHeight);
-				}
-			}
-		},
-		[needsDimensions, onDimensionsDetected, item.id],
-	);
-
-	return (
-		<li role="option" aria-selected={selected}>
-			<button
-				type="button"
-				className={cn(
-					"relative aspect-square w-full rounded-lg border-2 overflow-hidden transition-all",
-					"hover:border-kumo-brand/50 focus:outline-none focus:ring-2 focus:ring-kumo-ring",
-					selected ? "border-kumo-brand ring-2 ring-kumo-brand/20" : "border-transparent",
-				)}
-				onClick={onClick}
-				onDoubleClick={onDoubleClick}
-				aria-label={t`${item.filename}${selected ? t` (selected)` : ""}`}
-			>
-				{isImage ? (
-					<img
-						src={displayUrl}
-						alt=""
-						className="emdash-media-transparency-grid h-full w-full object-cover"
-						style={{ objectPosition: getMediaObjectPosition(item) }}
-						onLoad={handleImageLoad}
-						onError={(e) => fallbackToOriginalThumbnail(e.currentTarget, previewUrl)}
-					/>
-				) : (
-					<div className="flex h-full w-full items-center justify-center bg-kumo-tint">
-						<span className="text-3xl" aria-hidden="true">
-							{getFileIcon(item.mimeType)}
-						</span>
-					</div>
-				)}
-
-				{selected && (
-					<div
-						className="absolute inset-0 bg-kumo-brand/20 flex items-center justify-center"
-						aria-hidden="true"
-					>
-						<div className="bg-kumo-brand text-white rounded-full p-1">
-							<Check className="h-4 w-4" />
-						</div>
-					</div>
-				)}
-
-				<div
-					className="absolute bottom-0 start-0 end-0 bg-gradient-to-t from-black/60 to-transparent p-2"
-					aria-hidden="true"
-				>
-					<p className="text-xs text-white truncate">{item.filename}</p>
-				</div>
-			</button>
-		</li>
-	);
-}
-
-interface ProviderMediaItemProps {
-	item: MediaProviderItem;
-	selected: boolean;
-	onClick: () => void;
-	onDoubleClick: () => void;
-	/** Callback when image dimensions are loaded (for providers that don't return dimensions) */
-	onDimensionsLoaded?: (width: number, height: number) => void;
-}
-
-function ProviderMediaItem({
-	item,
-	selected,
-	onClick,
-	onDoubleClick,
-	onDimensionsLoaded,
-}: ProviderMediaItemProps) {
-	const { t } = useLingui();
-	const isImage = item.mimeType.startsWith("image/");
-	const needsDimensions = isImage && (!item.width || !item.height);
-
-	const handleImageLoad = React.useCallback(
-		(e: React.SyntheticEvent<HTMLImageElement>) => {
-			if (needsDimensions && onDimensionsLoaded) {
-				const img = e.currentTarget;
-				if (img.naturalWidth && img.naturalHeight) {
-					onDimensionsLoaded(img.naturalWidth, img.naturalHeight);
-				}
-			}
-		},
-		[needsDimensions, onDimensionsLoaded],
-	);
-
-	return (
-		<li role="option" aria-selected={selected}>
-			<button
-				type="button"
-				className={cn(
-					"relative aspect-square w-full rounded-lg border-2 overflow-hidden transition-all",
-					"hover:border-kumo-brand/50 focus:outline-none focus:ring-2 focus:ring-kumo-ring",
-					selected ? "border-kumo-brand ring-2 ring-kumo-brand/20" : "border-transparent",
-				)}
-				onClick={onClick}
-				onDoubleClick={onDoubleClick}
-				aria-label={t`${item.filename}${selected ? t` (selected)` : ""}`}
-			>
-				{isImage && item.previewUrl ? (
-					<img
-						src={item.previewUrl}
-						alt=""
-						className="emdash-media-transparency-grid h-full w-full object-cover"
-						onLoad={handleImageLoad}
-					/>
-				) : (
-					<div className="flex h-full w-full items-center justify-center bg-kumo-tint">
-						<span className="text-3xl" aria-hidden="true">
-							{getFileIcon(item.mimeType)}
-						</span>
-					</div>
-				)}
-
-				{selected && (
-					<div
-						className="absolute inset-0 bg-kumo-brand/20 flex items-center justify-center"
-						aria-hidden="true"
-					>
-						<div className="bg-kumo-brand text-white rounded-full p-1">
-							<Check className="h-4 w-4" />
-						</div>
-					</div>
-				)}
-
-				<div
-					className="absolute bottom-0 start-0 end-0 bg-gradient-to-t from-black/60 to-transparent p-2"
-					aria-hidden="true"
-				>
-					<p className="text-xs text-white truncate">{item.filename}</p>
-				</div>
-			</button>
-		</li>
 	);
 }
 

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -49,7 +49,6 @@ import { canonicalMediaProviderId, providerItemToMediaItem } from "../lib/media-
 import { matchesMimeAllowlist, mimeFromUrl } from "../lib/mime-utils.js";
 import {
 	MAX_MEDIA_PAGE_DROPDOWN_ITEMS,
-	MEDIA_BROWSER_PAGE_SIZES,
 	MediaBrowserFolder,
 	MediaBrowserItem,
 	MediaSelectionTrayItem,
@@ -60,7 +59,7 @@ import { useMediaUploadQueue } from "./media/useMediaUploadQueue.js";
 import { TableToolbar, TableToolbarSearch } from "./TableToolbar.js";
 
 const URL_SOURCE = "__url";
-const DEFAULT_PAGE_SIZE = MEDIA_BROWSER_PAGE_SIZES[0]!;
+const PICKER_PAGE_SIZE = 12;
 
 interface SelectedMedia {
 	key: string;
@@ -215,7 +214,6 @@ export function MediaPickerModal({
 	const [viewMode, setViewMode] = React.useState<"grid" | "list">("grid");
 	const [folderId, setFolderId] = React.useState<string | undefined>();
 	const [page, setPage] = React.useState(1);
-	const [pageSize, setPageSize] = React.useState(DEFAULT_PAGE_SIZE);
 	const [retainedTotalCount, setRetainedTotalCount] = React.useState(0);
 	const [imageUrl, setImageUrl] = React.useState("");
 	const [urlError, setUrlError] = React.useState<string | null>(null);
@@ -265,7 +263,6 @@ export function MediaPickerModal({
 		setViewMode("grid");
 		setFolderId(undefined);
 		setPage(1);
-		setPageSize(DEFAULT_PAGE_SIZE);
 		setRetainedTotalCount(0);
 		setImageUrl("");
 		setUrlError(null);
@@ -348,17 +345,17 @@ export function MediaPickerModal({
 					mime: mimeKey,
 					folder: activeSearch ? "all" : (folderId ?? "main"),
 					page,
-					pageSize,
+					limit: PICKER_PAGE_SIZE,
 				},
 			] as const,
-		[activeSearch, folderId, mimeKey, page, pageSize],
+		[activeSearch, folderId, mimeKey, page],
 	);
 	const localQuery = useQuery({
 		queryKey: localQueryKey,
 		queryFn: () =>
 			fetchMediaList({
 				page,
-				limit: pageSize,
+				limit: PICKER_PAGE_SIZE,
 				search: activeSearch || undefined,
 				mimeType: effectiveMimeFilters,
 				folderId: activeSearch ? undefined : (folderId ?? null),
@@ -374,7 +371,10 @@ export function MediaPickerModal({
 	}, [localQuery.data?.totalCount]);
 	const fallbackItemCount = localQuery.data?.items.length ?? 0;
 	const totalCount = localQuery.data?.totalCount ?? (retainedTotalCount || fallbackItemCount);
-	const lastPage = Math.max(1, Math.ceil((localQuery.data?.totalCount ?? totalCount) / pageSize));
+	const lastPage = Math.max(
+		1,
+		Math.ceil((localQuery.data?.totalCount ?? totalCount) / PICKER_PAGE_SIZE),
+	);
 	const isRecoveringPage =
 		localQuery.data?.totalCount !== undefined && page > lastPage && activeSource === "local";
 	React.useEffect(() => {
@@ -705,7 +705,7 @@ export function MediaPickerModal({
 		>
 			<Dialog
 				size="xl"
-				className="flex max-h-[calc(100dvh-1rem)] min-h-0 min-w-0 max-w-[calc(100vw-1rem)] flex-col overflow-hidden p-0 sm:max-h-[88dvh] sm:min-w-[48rem] sm:max-w-5xl"
+				className="flex h-[min(48rem,calc(100dvh-1rem))] min-h-0 min-w-0 max-w-[calc(100vw-1rem)] flex-col overflow-hidden p-0 sm:min-w-[48rem] sm:max-w-5xl"
 			>
 				<header className="flex shrink-0 items-start justify-between gap-4 border-b border-kumo-line px-5 py-4 sm:px-7">
 					<div className="min-w-0">
@@ -827,7 +827,7 @@ export function MediaPickerModal({
 												event.preventDefault();
 												void handleUrlSubmit();
 											}}
-											className="ps-9"
+											className="w-full ps-9"
 										/>
 									</div>
 									<Button
@@ -1172,7 +1172,7 @@ export function MediaPickerModal({
 								<Pagination
 									page={isRecoveringPage ? lastPage : page}
 									setPage={(nextPage) => {
-										const pageCount = Math.max(1, Math.ceil(totalCount / pageSize));
+										const pageCount = Math.max(1, Math.ceil(totalCount / PICKER_PAGE_SIZE));
 										if (
 											localQuery.isFetching ||
 											!Number.isSafeInteger(nextPage) ||
@@ -1182,7 +1182,7 @@ export function MediaPickerModal({
 											return;
 										setPage(nextPage);
 									}}
-									perPage={pageSize}
+									perPage={PICKER_PAGE_SIZE}
 									totalCount={totalCount}
 									className="flex-wrap gap-y-3"
 									labels={{
@@ -1202,23 +1202,9 @@ export function MediaPickerModal({
 									</Pagination.Info>
 									<Pagination.Separator className="hidden sm:block" />
 									<div inert={localQuery.isFetching || undefined} className="contents">
-										<Pagination.PageSize
-											value={pageSize}
-											onChange={(nextPageSize) => {
-												if (
-													localQuery.isFetching ||
-													!MEDIA_BROWSER_PAGE_SIZES.includes(nextPageSize)
-												)
-													return;
-												setPageSize(nextPageSize);
-												resetPage();
-											}}
-											options={MEDIA_BROWSER_PAGE_SIZES}
-											label={t`Per page`}
-										/>
 										<Pagination.Controls
 											pageSelector={
-												Math.ceil(totalCount / pageSize) <= MAX_MEDIA_PAGE_DROPDOWN_ITEMS
+												Math.ceil(totalCount / PICKER_PAGE_SIZE) <= MAX_MEDIA_PAGE_DROPDOWN_ITEMS
 													? "dropdown"
 													: "input"
 											}

--- a/packages/admin/src/components/MediaUploadDialog.tsx
+++ b/packages/admin/src/components/MediaUploadDialog.tsx
@@ -17,13 +17,15 @@ import {
 import * as React from "react";
 
 import { formatFileSize } from "../lib/media-utils.js";
+import {
+	useMediaUploadQueue,
+	type MediaUploadJob,
+	type MediaUploadJobStatus,
+} from "./media/useMediaUploadQueue.js";
 
 export const LOCAL_MEDIA_UPLOAD_ACCEPT =
 	"image/png,image/jpeg,image/gif,image/webp,image/avif,video/*,audio/*,application/pdf";
 
-const DEFAULT_CONCURRENCY = 3;
-const MAX_CONCURRENCY = 6;
-const MAX_VISIBLE_ROWS = 100;
 const MAX_PREVIEW_BYTES = 8 * 1024 * 1024;
 const PREVIEW_MIME_TYPES = new Set([
 	"image/jpeg",
@@ -32,16 +34,6 @@ const PREVIEW_MIME_TYPES = new Set([
 	"image/webp",
 	"image/avif",
 ]);
-
-type UploadStatus = "queued" | "uploading" | "complete" | "failed";
-
-interface UploadRow {
-	id: number;
-	file: File;
-	status: UploadStatus;
-	attempt: number;
-	previewUrl?: string;
-}
 
 export interface MediaUploadDialogProps {
 	open: boolean;
@@ -77,7 +69,7 @@ function FileKindIcon({ file }: { file: File }) {
 	return <File className={className} aria-hidden="true" />;
 }
 
-function UploadStatusLabel({ status }: { status: UploadStatus }) {
+function UploadStatusLabel({ status }: { status: MediaUploadJobStatus }) {
 	const { t } = useLingui();
 	if (status === "uploading") {
 		return (
@@ -112,7 +104,7 @@ function UploadFileRow({
 	onRetry,
 	onRemove,
 }: {
-	row: UploadRow;
+	row: MediaUploadJob<void>;
 	onCancel: () => void;
 	onRetry: () => void;
 	onRemove: () => void;
@@ -186,49 +178,30 @@ export function MediaUploadDialog({
 	onCloseComplete,
 	onQueueIdle,
 	upload,
-	concurrency = DEFAULT_CONCURRENCY,
+	concurrency,
 }: MediaUploadDialogProps) {
 	const { t } = useLingui();
-	const [rows, setRows] = React.useState<UploadRow[]>([]);
-	const [overflowCount, setOverflowCount] = React.useState(0);
-	const rowsRef = React.useRef<UploadRow[]>([]);
-	const activeRef = React.useRef(
-		new Map<number, { attempt: number; controller: AbortController }>(),
-	);
-	const nextIdRef = React.useRef(0);
 	const lastRequestIdRef = React.useRef<number | null>(null);
-	const busyRunRef = React.useRef(false);
-	const unmountingRef = React.useRef(false);
 	const inputRef = React.useRef<HTMLInputElement>(null);
-	const requestedConcurrency = Number.isFinite(concurrency)
-		? Math.floor(concurrency)
-		: DEFAULT_CONCURRENCY;
-	const maxConcurrent = Math.min(MAX_CONCURRENCY, Math.max(1, requestedConcurrency));
-
-	const updateRows = React.useCallback((update: (current: UploadRow[]) => UploadRow[]) => {
-		const next = update(rowsRef.current);
-		rowsRef.current = next;
-		setRows(next);
-	}, []);
-
-	const addFiles = React.useCallback(
-		(files: readonly File[]) => {
-			const available = Math.max(0, MAX_VISIBLE_ROWS - rowsRef.current.length);
-			const accepted = files.slice(0, available);
-			setOverflowCount(Math.max(0, files.length - accepted.length));
-			if (accepted.length === 0) return;
-			busyRunRef.current = true;
-			const added = accepted.map((file) => ({
-				id: (nextIdRef.current += 1),
-				file,
-				status: "queued" as const,
-				attempt: 1,
-				previewUrl: previewUrlFor(file),
-			}));
-			updateRows((current) => [...current, ...added]);
-		},
-		[updateRows],
-	);
+	const {
+		jobs: rows,
+		overflowCount,
+		hasUnfinished,
+		completedCount,
+		failedCount,
+		addFiles,
+		remove: removeRow,
+		retry: retryRow,
+		retryFailed,
+		cancelUnfinished: cancelRemaining,
+		clearCompleted,
+		reset,
+	} = useMediaUploadQueue({
+		upload,
+		concurrency,
+		createPreviewUrl: previewUrlFor,
+		onQueueIdle,
+	});
 
 	React.useEffect(() => {
 		if (!open || !enqueueRequest || enqueueRequest.id === lastRequestIdRef.current) return;
@@ -237,143 +210,6 @@ export function MediaUploadDialog({
 		onEnqueueRequestConsumed(enqueueRequest.id);
 	}, [addFiles, enqueueRequest, onEnqueueRequestConsumed, open]);
 
-	React.useEffect(() => {
-		const slots = maxConcurrent - activeRef.current.size;
-		if (slots <= 0) return;
-		const candidates = rowsRef.current
-			.filter((row) => row.status === "queued" && !activeRef.current.has(row.id))
-			.slice(0, slots);
-		if (candidates.length === 0) return;
-
-		for (const row of candidates) {
-			const controller = new AbortController();
-			activeRef.current.set(row.id, { attempt: row.attempt, controller });
-			updateRows((current) =>
-				current.map((item) =>
-					item.id === row.id && item.attempt === row.attempt
-						? { ...item, status: "uploading" }
-						: item,
-				),
-			);
-
-			Promise.resolve()
-				.then(() => upload(row.file, { signal: controller.signal }))
-				.then(
-					() => {
-						const active = activeRef.current.get(row.id);
-						if (active?.attempt !== row.attempt) return undefined;
-						activeRef.current.delete(row.id);
-						updateRows((current) =>
-							current.map((item) =>
-								item.id === row.id && item.attempt === row.attempt
-									? { ...item, status: "complete" }
-									: item,
-							),
-						);
-						return undefined;
-					},
-					() => {
-						const active = activeRef.current.get(row.id);
-						if (active?.attempt !== row.attempt) return undefined;
-						activeRef.current.delete(row.id);
-						if (controller.signal.aborted) return undefined;
-						updateRows((current) =>
-							current.map((item) =>
-								item.id === row.id && item.attempt === row.attempt
-									? { ...item, status: "failed" }
-									: item,
-							),
-						);
-						return undefined;
-					},
-				);
-		}
-	}, [maxConcurrent, rows, updateRows, upload]);
-
-	const hasUnfinished = rows.some((row) => row.status === "queued" || row.status === "uploading");
-	React.useEffect(() => {
-		if (hasUnfinished || !busyRunRef.current || unmountingRef.current) return;
-		busyRunRef.current = false;
-		onQueueIdle?.();
-	}, [hasUnfinished, onQueueIdle]);
-
-	React.useEffect(
-		() => () => {
-			unmountingRef.current = true;
-			activeRef.current.forEach(({ controller }) => controller.abort());
-			activeRef.current.clear();
-			rowsRef.current.forEach((row) => row.previewUrl && URL.revokeObjectURL(row.previewUrl));
-		},
-		[],
-	);
-
-	const removeRow = React.useCallback(
-		(id: number) => {
-			const row = rowsRef.current.find((item) => item.id === id);
-			if (!row) return;
-			activeRef.current.get(id)?.controller.abort();
-			activeRef.current.delete(id);
-			if (row.previewUrl) URL.revokeObjectURL(row.previewUrl);
-			updateRows((current) => current.filter((item) => item.id !== id));
-		},
-		[updateRows],
-	);
-
-	const retryRow = React.useCallback(
-		(id: number) => {
-			busyRunRef.current = true;
-			updateRows((current) =>
-				current.map((row) =>
-					row.id === id && row.status === "failed"
-						? { ...row, status: "queued", attempt: row.attempt + 1 }
-						: row,
-				),
-			);
-		},
-		[updateRows],
-	);
-
-	const retryFailed = () => {
-		if (!rowsRef.current.some((row) => row.status === "failed")) return;
-		busyRunRef.current = true;
-		updateRows((current) =>
-			current.map((row) =>
-				row.status === "failed" ? { ...row, status: "queued", attempt: row.attempt + 1 } : row,
-			),
-		);
-	};
-
-	const cancelRemaining = () => {
-		activeRef.current.forEach(({ controller }) => controller.abort());
-		activeRef.current.clear();
-		const removed = rowsRef.current.filter(
-			(row) => row.status === "queued" || row.status === "uploading",
-		);
-		removed.forEach((row) => row.previewUrl && URL.revokeObjectURL(row.previewUrl));
-		updateRows((current) =>
-			current.filter((row) => row.status !== "queued" && row.status !== "uploading"),
-		);
-	};
-
-	const clearCompleted = () => {
-		rowsRef.current
-			.filter((row) => row.status === "complete")
-			.forEach((row) => row.previewUrl && URL.revokeObjectURL(row.previewUrl));
-		updateRows((current) => current.filter((row) => row.status !== "complete"));
-	};
-
-	const reset = () => {
-		activeRef.current.forEach(({ controller }) => controller.abort());
-		activeRef.current.clear();
-		rowsRef.current.forEach((row) => row.previewUrl && URL.revokeObjectURL(row.previewUrl));
-		rowsRef.current = [];
-		setRows([]);
-		setOverflowCount(0);
-		busyRunRef.current = false;
-	};
-
-	const completedCount = rows.filter((row) => row.status === "complete").length;
-	const failedCount = rows.filter((row) => row.status === "failed").length;
 	const liveMessage = hasUnfinished
 		? t`${completedCount} of ${rows.length} uploads complete`
 		: failedCount > 0

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -3450,7 +3450,8 @@ export function PortableTextEditor({
 					}}
 					onSelect={handleImageSelect}
 					mimeTypeFilter="image/"
-					title={t`Select Image`}
+					title={t`Select image`}
+					confirmLabel={t`Insert image`}
 				/>
 
 				{/* Multi-select media picker for gallery insertion */}
@@ -3464,7 +3465,7 @@ export function PortableTextEditor({
 					onSelect={() => {}}
 					onSelectMany={handleGallerySelect}
 					mimeTypeFilter="image/"
-					title={t`Select Gallery Images`}
+					title={t`Select gallery images`}
 				/>
 
 				{/* Plugin block insertion/editing modal */}

--- a/packages/admin/src/components/SeoImageField.tsx
+++ b/packages/admin/src/components/SeoImageField.tsx
@@ -86,7 +86,7 @@ export function SeoImageField({ seo, onChange }: SeoImageFieldProps) {
 				onOpenChange={setPickerOpen}
 				onSelect={handleSelect}
 				mimeTypeFilter="image/"
-				title={t`Select OG Image`}
+				title={t`Select OG image`}
 			/>
 		</div>
 	);

--- a/packages/admin/src/components/editor/GalleryDetailPanel.tsx
+++ b/packages/admin/src/components/editor/GalleryDetailPanel.tsx
@@ -399,6 +399,7 @@ function GalleryImageSettings({ image, onChange, onReplace }: GalleryImageSettin
 				}}
 				mimeTypeFilters={["image/"]}
 				title={t`Replace image`}
+				confirmLabel={t`Replace image`}
 			/>
 		</div>
 	);

--- a/packages/admin/src/components/editor/ImageDetailPanel.tsx
+++ b/packages/admin/src/components/editor/ImageDetailPanel.tsx
@@ -213,7 +213,8 @@ export function ImageDetailPanel({
 				onOpenChange={setShowMediaPicker}
 				onSelect={handleMediaSelect}
 				mimeTypeFilter="image/"
-				title={t`Replace Image`}
+				title={t`Replace image`}
+				confirmLabel={t`Replace image`}
 			/>
 		</>
 	);

--- a/packages/admin/src/components/media/MediaBrowserItems.tsx
+++ b/packages/admin/src/components/media/MediaBrowserItems.tsx
@@ -1,6 +1,6 @@
-import { Badge, LayerCard } from "@cloudflare/kumo";
+import { Badge, Button, LayerCard, Loader } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { Check, FolderSimple } from "@phosphor-icons/react";
+import { ArrowDown, ArrowUp, Check, FolderSimple, WarningCircle, X } from "@phosphor-icons/react";
 import * as React from "react";
 
 import type { MediaFolder, MediaItem } from "../../lib/api/media.js";
@@ -13,6 +13,7 @@ import {
 	getMediaThumbnailUrl,
 } from "../../lib/media-utils.js";
 import { cn } from "../../lib/utils.js";
+import type { MediaUploadJob } from "./useMediaUploadQueue.js";
 
 export const MEDIA_BROWSER_PAGE_SIZES = [35, 70, 90];
 export const MAX_MEDIA_PAGE_DROPDOWN_ITEMS = 100;
@@ -60,7 +61,7 @@ export function MediaBrowserItem({
 	const isImage = item.mimeType.startsWith("image/");
 	const hasVisualPreview = Boolean(item.url) && (isImage || Boolean(item.provider));
 	const needsDimensions = hasVisualPreview && (!item.width || !item.height);
-	const previewUrl = getMediaPreviewUrl(item.url, item.contentHash);
+	const previewUrl = item.url ? getMediaPreviewUrl(item.url, item.contentHash) : "";
 	const imageUrl =
 		needsDimensions && onDimensionsLoaded
 			? previewUrl
@@ -188,6 +189,148 @@ export function MediaBrowserFolder({
 			<span dir="auto" className="min-w-0 truncate text-sm font-medium" title={folder.name}>
 				{folder.name}
 			</span>
+		</LayerCard>
+	);
+}
+
+export function MediaUploadPlaceholder({
+	job,
+	layout,
+	onRetry,
+	onRemove,
+}: {
+	job: MediaUploadJob<unknown>;
+	layout: "grid" | "list";
+	onRetry: () => void;
+	onRemove: () => void;
+}) {
+	const { t } = useLingui();
+	const failed = job.status === "failed";
+	const status = failed ? t`Upload failed` : t`Uploading`;
+	const statusIcon = failed ? (
+		<WarningCircle className="size-5 text-kumo-danger" weight="fill" aria-hidden="true" />
+	) : (
+		<Loader size="sm" />
+	);
+	const actions = failed ? (
+		<div className="flex flex-wrap items-center gap-1">
+			<Button variant="ghost" size="sm" onClick={onRetry} aria-label={t`Retry ${job.file.name}`}>
+				{t`Retry`}
+			</Button>
+			<Button variant="ghost" size="sm" onClick={onRemove} aria-label={t`Remove ${job.file.name}`}>
+				{t`Remove`}
+			</Button>
+		</div>
+	) : null;
+
+	if (layout === "list") {
+		return (
+			<LayerCard
+				data-upload-status={job.status}
+				className="grid min-w-0 grid-cols-[3.5rem_minmax(0,1fr)_auto] items-center gap-3 bg-kumo-tint/60 px-3 py-2 opacity-75"
+			>
+				<div className="flex h-10 w-14 items-center justify-center rounded-md bg-kumo-recessed">
+					{statusIcon}
+				</div>
+				<div className="min-w-0">
+					<p dir="auto" className="truncate text-sm font-medium" title={job.file.name}>
+						{job.file.name}
+					</p>
+					<p className={cn("text-sm", failed ? "text-kumo-danger" : "text-kumo-subtle")}>
+						{status}
+					</p>
+				</div>
+				{actions}
+			</LayerCard>
+		);
+	}
+
+	return (
+		<LayerCard data-upload-status={job.status} className="min-w-0 bg-kumo-tint/60 opacity-75">
+			<LayerCard.Primary className="flex aspect-video items-center justify-center bg-kumo-recessed p-0">
+				{statusIcon}
+			</LayerCard.Primary>
+			<LayerCard.Secondary className="my-0 grid min-w-0 gap-1 px-3 py-2.5">
+				<p dir="auto" className="truncate text-sm font-medium" title={job.file.name}>
+					{job.file.name}
+				</p>
+				<p className={cn("text-sm", failed ? "text-kumo-danger" : "text-kumo-subtle")}>{status}</p>
+				{actions}
+			</LayerCard.Secondary>
+		</LayerCard>
+	);
+}
+
+export function MediaSelectionTrayItem({
+	item,
+	position,
+	total,
+	onMoveEarlier,
+	onMoveLater,
+	onRemove,
+}: {
+	item: MediaItem;
+	position: number;
+	total: number;
+	onMoveEarlier: () => void;
+	onMoveLater: () => void;
+	onRemove: () => void;
+}) {
+	const { t } = useLingui();
+	const image = item.mimeType.startsWith("image/") && item.url;
+	return (
+		<LayerCard
+			render={<li />}
+			className="grid min-w-0 grid-cols-[3.5rem_minmax(0,1fr)_auto] items-center gap-3 px-3 py-2"
+		>
+			<div className="h-10 w-14 overflow-hidden rounded-md bg-kumo-tint">
+				{image ? (
+					<img
+						src={getMediaThumbnailUrl(item.url, item.mimeType, 80, item.contentHash)}
+						alt=""
+						className="emdash-media-transparency-grid h-full w-full object-cover"
+						style={{ objectPosition: getMediaObjectPosition(item) }}
+					/>
+				) : (
+					<span className="flex h-full items-center justify-center text-xl" aria-hidden="true">
+						{getFileIcon(item.mimeType)}
+					</span>
+				)}
+			</div>
+			<div className="min-w-0">
+				<p dir="auto" className="truncate text-sm font-medium" title={item.filename}>
+					{item.filename}
+				</p>
+				<p className="text-sm text-kumo-subtle">{t`${position} of ${total}`}</p>
+			</div>
+			<div className="flex items-center gap-1">
+				<Button
+					variant="ghost"
+					shape="square"
+					size="sm"
+					disabled={position === 1}
+					onClick={onMoveEarlier}
+					aria-label={t`Move ${item.filename} earlier`}
+					icon={<ArrowUp aria-hidden="true" />}
+				/>
+				<Button
+					variant="ghost"
+					shape="square"
+					size="sm"
+					disabled={position === total}
+					onClick={onMoveLater}
+					aria-label={t`Move ${item.filename} later`}
+					icon={<ArrowDown aria-hidden="true" />}
+				/>
+				<Button
+					variant="ghost"
+					shape="square"
+					size="sm"
+					onClick={onRemove}
+					aria-label={t`Remove ${item.filename} from selection`}
+					icon={<X aria-hidden="true" />}
+				/>
+			</div>
 		</LayerCard>
 	);
 }

--- a/packages/admin/src/components/media/MediaBrowserItems.tsx
+++ b/packages/admin/src/components/media/MediaBrowserItems.tsx
@@ -1,0 +1,193 @@
+import { Badge, LayerCard } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
+import { Check, FolderSimple } from "@phosphor-icons/react";
+import * as React from "react";
+
+import type { MediaFolder, MediaItem } from "../../lib/api/media.js";
+import {
+	fallbackToOriginalThumbnail,
+	formatFileSize,
+	getFileIcon,
+	getMediaObjectPosition,
+	getMediaPreviewUrl,
+	getMediaThumbnailUrl,
+} from "../../lib/media-utils.js";
+import { cn } from "../../lib/utils.js";
+
+export const MEDIA_BROWSER_PAGE_SIZES = [35, 70, 90];
+export const MAX_MEDIA_PAGE_DROPDOWN_ITEMS = 100;
+
+export function mimeForMediaTypeFilter(value: string): string | string[] | undefined {
+	switch (value) {
+		case "image":
+			return "image/";
+		case "video":
+			return "video/";
+		case "audio":
+			return "audio/";
+		case "document":
+			return ["application/", "text/"];
+		default:
+			return undefined;
+	}
+}
+
+function formatFileFormat(mimeType: string): string {
+	return (mimeType.split("/").at(-1)?.split("+")[0] || mimeType).toUpperCase();
+}
+
+interface MediaBrowserItemProps {
+	item: MediaItem;
+	layout: "grid" | "list";
+	selected?: boolean;
+	selectable?: boolean;
+	onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+	onDimensionsLoaded?: (width: number, height: number) => void;
+	className?: string;
+	mediaDraggable?: boolean;
+}
+
+export function MediaBrowserItem({
+	item,
+	layout,
+	selected = false,
+	selectable = false,
+	onClick,
+	onDimensionsLoaded,
+	className,
+	mediaDraggable,
+}: MediaBrowserItemProps) {
+	const isImage = item.mimeType.startsWith("image/");
+	const hasVisualPreview = Boolean(item.url) && (isImage || Boolean(item.provider));
+	const needsDimensions = hasVisualPreview && (!item.width || !item.height);
+	const previewUrl = getMediaPreviewUrl(item.url, item.contentHash);
+	const imageUrl =
+		needsDimensions && onDimensionsLoaded
+			? previewUrl
+			: getMediaThumbnailUrl(item.url, item.mimeType, undefined, item.contentHash);
+
+	const preview = hasVisualPreview ? (
+		<img
+			src={imageUrl}
+			alt={selectable ? "" : item.alt || item.filename}
+			draggable={false}
+			className="emdash-media-transparency-grid h-full w-full object-cover"
+			style={{ objectPosition: getMediaObjectPosition(item) }}
+			onLoad={(event) => {
+				if (!needsDimensions || !onDimensionsLoaded) return;
+				const image = event.currentTarget;
+				if (image.naturalWidth && image.naturalHeight) {
+					onDimensionsLoaded(image.naturalWidth, image.naturalHeight);
+				}
+			}}
+			onError={(event) => fallbackToOriginalThumbnail(event.currentTarget, previewUrl)}
+		/>
+	) : (
+		<div className="flex h-full w-full items-center justify-center bg-kumo-tint">
+			<span className={layout === "grid" ? "text-4xl" : "text-2xl"} aria-hidden="true">
+				{getFileIcon(item.mimeType)}
+			</span>
+		</div>
+	);
+
+	if (layout === "list") {
+		return (
+			<LayerCard
+				render={<button type="button" />}
+				onClick={onClick}
+				aria-label={item.filename}
+				aria-pressed={selectable ? selected : undefined}
+				data-media-layout="list"
+				data-media-draggable={mediaDraggable || undefined}
+				className={cn(
+					"grid w-full min-w-0 grid-cols-[3.5rem_minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 text-start focus-visible:ring-2 focus-visible:ring-kumo-brand",
+					selected ? "ring-2 ring-kumo-brand" : "hover:ring-kumo-brand/50",
+					className,
+				)}
+			>
+				<div className="h-10 w-14 overflow-hidden rounded-md">{preview}</div>
+				<div className="min-w-0">
+					<p dir="auto" className="truncate text-sm font-medium leading-5" title={item.filename}>
+						{item.filename}
+					</p>
+					<p className="truncate text-sm text-kumo-subtle">
+						{item.mimeType} · {formatFileSize(item.size)}
+					</p>
+				</div>
+				{selectable && selected ? (
+					<span className="flex size-6 items-center justify-center rounded-full bg-kumo-brand text-kumo-inverse">
+						<Check className="size-4" weight="bold" aria-hidden="true" />
+					</span>
+				) : (
+					<Badge variant="secondary" className="hidden h-5 min-w-11 justify-center sm:flex">
+						<span className="text-[11px] leading-none text-kumo-default/75">
+							{formatFileFormat(item.mimeType)}
+						</span>
+					</Badge>
+				)}
+			</LayerCard>
+		);
+	}
+
+	return (
+		<LayerCard
+			render={<button type="button" />}
+			onClick={onClick}
+			aria-label={item.filename}
+			aria-pressed={selectable ? selected : undefined}
+			data-media-layout="grid"
+			data-media-draggable={mediaDraggable || undefined}
+			className={cn(
+				"group relative w-full min-w-0 text-start focus-visible:ring-2 focus-visible:ring-kumo-brand",
+				selected ? "ring-2 ring-kumo-brand" : "hover:ring-kumo-brand/50",
+				className,
+			)}
+		>
+			<LayerCard.Primary className="aspect-video p-0">{preview}</LayerCard.Primary>
+			<LayerCard.Secondary className="my-0 min-w-0 justify-between px-3 py-2.5 text-sm text-kumo-default">
+				<span
+					dir="auto"
+					title={item.filename}
+					className="min-w-0 flex-1 truncate font-medium leading-5"
+				>
+					{item.filename}
+				</span>
+				<Badge variant="secondary" className="h-5 min-w-11 justify-center rounded-md px-2 py-0">
+					<span className="text-[11px] leading-none text-kumo-default/75">
+						{formatFileFormat(item.mimeType)}
+					</span>
+				</Badge>
+			</LayerCard.Secondary>
+			{selectable && selected && (
+				<span className="absolute end-2 top-2 flex size-6 items-center justify-center rounded-full bg-kumo-brand text-kumo-inverse ring-2 ring-kumo-base">
+					<Check className="size-4" weight="bold" aria-hidden="true" />
+				</span>
+			)}
+		</LayerCard>
+	);
+}
+
+export function MediaBrowserFolder({
+	folder,
+	onOpen,
+}: {
+	folder: MediaFolder;
+	onOpen: () => void;
+}) {
+	const { t } = useLingui();
+	return (
+		<LayerCard
+			render={<button type="button" />}
+			onClick={onOpen}
+			aria-label={t`Open folder ${folder.name}`}
+			className="flex w-full min-w-0 items-center gap-3 px-3 py-3 text-start hover:ring-kumo-brand/50 focus-visible:ring-2 focus-visible:ring-kumo-brand"
+		>
+			<span className="flex size-10 shrink-0 items-center justify-center rounded-md bg-kumo-tint text-emdash-media-folder">
+				<FolderSimple className="size-5" weight="fill" aria-hidden="true" />
+			</span>
+			<span dir="auto" className="min-w-0 truncate text-sm font-medium" title={folder.name}>
+				{folder.name}
+			</span>
+		</LayerCard>
+	);
+}

--- a/packages/admin/src/components/media/useMediaUploadQueue.ts
+++ b/packages/admin/src/components/media/useMediaUploadQueue.ts
@@ -16,7 +16,10 @@ export interface MediaUploadJob<TResult> {
 }
 
 interface UseMediaUploadQueueOptions<TResult> {
-	upload: (file: File, options: { signal: AbortSignal }) => Promise<TResult>;
+	upload: (
+		file: File,
+		options: { signal: AbortSignal; jobId: number; attempt: number },
+	) => Promise<TResult>;
 	concurrency?: number;
 	createPreviewUrl?: (file: File) => string | undefined;
 	onQueueIdle?: () => void;
@@ -56,7 +59,7 @@ export function useMediaUploadQueue<TResult>({
 			const available = Math.max(0, MAX_VISIBLE_JOBS - jobsRef.current.length);
 			const accepted = files.slice(0, available);
 			setOverflowCount(Math.max(0, files.length - accepted.length));
-			if (accepted.length === 0) return;
+			if (accepted.length === 0) return [];
 
 			busyRunRef.current = true;
 			const added = accepted.map((file): MediaUploadJob<TResult> => {
@@ -75,6 +78,7 @@ export function useMediaUploadQueue<TResult>({
 				};
 			});
 			updateJobs((current) => [...current, ...added]);
+			return added;
 		},
 		[createPreviewUrl, updateJobs],
 	);
@@ -99,7 +103,13 @@ export function useMediaUploadQueue<TResult>({
 			);
 
 			void Promise.resolve()
-				.then(() => upload(job.file, { signal: controller.signal }))
+				.then(() =>
+					upload(job.file, {
+						signal: controller.signal,
+						jobId: job.id,
+						attempt: job.attempt,
+					}),
+				)
 				.then(
 					(result) => {
 						const active = activeRef.current.get(job.id);

--- a/packages/admin/src/components/media/useMediaUploadQueue.ts
+++ b/packages/admin/src/components/media/useMediaUploadQueue.ts
@@ -1,0 +1,233 @@
+import * as React from "react";
+
+const DEFAULT_CONCURRENCY = 3;
+const MAX_CONCURRENCY = 6;
+const MAX_VISIBLE_JOBS = 100;
+
+export type MediaUploadJobStatus = "queued" | "uploading" | "complete" | "failed";
+
+export interface MediaUploadJob<TResult> {
+	id: number;
+	file: File;
+	status: MediaUploadJobStatus;
+	attempt: number;
+	previewUrl?: string;
+	result?: TResult;
+}
+
+interface UseMediaUploadQueueOptions<TResult> {
+	upload: (file: File, options: { signal: AbortSignal }) => Promise<TResult>;
+	concurrency?: number;
+	createPreviewUrl?: (file: File) => string | undefined;
+	onQueueIdle?: () => void;
+}
+
+export function useMediaUploadQueue<TResult>({
+	upload,
+	concurrency = DEFAULT_CONCURRENCY,
+	createPreviewUrl,
+	onQueueIdle,
+}: UseMediaUploadQueueOptions<TResult>) {
+	const [jobs, setJobs] = React.useState<MediaUploadJob<TResult>[]>([]);
+	const [overflowCount, setOverflowCount] = React.useState(0);
+	const jobsRef = React.useRef<MediaUploadJob<TResult>[]>([]);
+	const activeRef = React.useRef(
+		new Map<number, { attempt: number; controller: AbortController }>(),
+	);
+	const nextIdRef = React.useRef(0);
+	const busyRunRef = React.useRef(false);
+	const unmountingRef = React.useRef(false);
+	const requestedConcurrency = Number.isFinite(concurrency)
+		? Math.floor(concurrency)
+		: DEFAULT_CONCURRENCY;
+	const maxConcurrent = Math.min(MAX_CONCURRENCY, Math.max(1, requestedConcurrency));
+
+	const updateJobs = React.useCallback(
+		(update: (current: MediaUploadJob<TResult>[]) => MediaUploadJob<TResult>[]) => {
+			const next = update(jobsRef.current);
+			jobsRef.current = next;
+			setJobs(next);
+		},
+		[],
+	);
+
+	const addFiles = React.useCallback(
+		(files: readonly File[]) => {
+			const available = Math.max(0, MAX_VISIBLE_JOBS - jobsRef.current.length);
+			const accepted = files.slice(0, available);
+			setOverflowCount(Math.max(0, files.length - accepted.length));
+			if (accepted.length === 0) return;
+
+			busyRunRef.current = true;
+			const added = accepted.map((file): MediaUploadJob<TResult> => {
+				let previewUrl: string | undefined;
+				try {
+					previewUrl = createPreviewUrl?.(file);
+				} catch {
+					previewUrl = undefined;
+				}
+				return {
+					id: (nextIdRef.current += 1),
+					file,
+					status: "queued",
+					attempt: 1,
+					previewUrl,
+				};
+			});
+			updateJobs((current) => [...current, ...added]);
+		},
+		[createPreviewUrl, updateJobs],
+	);
+
+	React.useEffect(() => {
+		const slots = maxConcurrent - activeRef.current.size;
+		if (slots <= 0) return;
+		const candidates = jobsRef.current
+			.filter((job) => job.status === "queued" && !activeRef.current.has(job.id))
+			.slice(0, slots);
+		if (candidates.length === 0) return;
+
+		for (const job of candidates) {
+			const controller = new AbortController();
+			activeRef.current.set(job.id, { attempt: job.attempt, controller });
+			updateJobs((current) =>
+				current.map((item) =>
+					item.id === job.id && item.attempt === job.attempt
+						? { ...item, status: "uploading" }
+						: item,
+				),
+			);
+
+			void Promise.resolve()
+				.then(() => upload(job.file, { signal: controller.signal }))
+				.then(
+					(result) => {
+						const active = activeRef.current.get(job.id);
+						if (active?.attempt !== job.attempt) return undefined;
+						activeRef.current.delete(job.id);
+						updateJobs((current) =>
+							current.map((item) =>
+								item.id === job.id && item.attempt === job.attempt
+									? { ...item, status: "complete", result }
+									: item,
+							),
+						);
+						return undefined;
+					},
+					() => {
+						const active = activeRef.current.get(job.id);
+						if (active?.attempt !== job.attempt) return undefined;
+						activeRef.current.delete(job.id);
+						if (controller.signal.aborted) return undefined;
+						updateJobs((current) =>
+							current.map((item) =>
+								item.id === job.id && item.attempt === job.attempt
+									? { ...item, status: "failed" }
+									: item,
+							),
+						);
+						return undefined;
+					},
+				);
+		}
+	}, [jobs, maxConcurrent, updateJobs, upload]);
+
+	const hasUnfinished = jobs.some((job) => job.status === "queued" || job.status === "uploading");
+	React.useEffect(() => {
+		if (hasUnfinished || !busyRunRef.current || unmountingRef.current) return;
+		busyRunRef.current = false;
+		onQueueIdle?.();
+	}, [hasUnfinished, onQueueIdle]);
+
+	React.useEffect(() => {
+		unmountingRef.current = false;
+		return () => {
+			unmountingRef.current = true;
+			activeRef.current.forEach(({ controller }) => controller.abort());
+			activeRef.current.clear();
+			jobsRef.current.forEach((job) => job.previewUrl && URL.revokeObjectURL(job.previewUrl));
+		};
+	}, []);
+
+	const remove = React.useCallback(
+		(id: number) => {
+			const job = jobsRef.current.find((item) => item.id === id);
+			if (!job) return;
+			activeRef.current.get(id)?.controller.abort();
+			activeRef.current.delete(id);
+			if (job.previewUrl) URL.revokeObjectURL(job.previewUrl);
+			updateJobs((current) => current.filter((item) => item.id !== id));
+		},
+		[updateJobs],
+	);
+
+	const retry = React.useCallback(
+		(id: number) => {
+			if (!jobsRef.current.some((job) => job.id === id && job.status === "failed")) return;
+			busyRunRef.current = true;
+			updateJobs((current) =>
+				current.map((job) =>
+					job.id === id && job.status === "failed"
+						? { ...job, status: "queued", attempt: job.attempt + 1, result: undefined }
+						: job,
+				),
+			);
+		},
+		[updateJobs],
+	);
+
+	const retryFailed = React.useCallback(() => {
+		if (!jobsRef.current.some((job) => job.status === "failed")) return;
+		busyRunRef.current = true;
+		updateJobs((current) =>
+			current.map((job) =>
+				job.status === "failed"
+					? { ...job, status: "queued", attempt: job.attempt + 1, result: undefined }
+					: job,
+			),
+		);
+	}, [updateJobs]);
+
+	const cancelUnfinished = React.useCallback(() => {
+		activeRef.current.forEach(({ controller }) => controller.abort());
+		activeRef.current.clear();
+		jobsRef.current
+			.filter((job) => job.status === "queued" || job.status === "uploading")
+			.forEach((job) => job.previewUrl && URL.revokeObjectURL(job.previewUrl));
+		updateJobs((current) =>
+			current.filter((job) => job.status !== "queued" && job.status !== "uploading"),
+		);
+	}, [updateJobs]);
+
+	const clearCompleted = React.useCallback(() => {
+		jobsRef.current
+			.filter((job) => job.status === "complete")
+			.forEach((job) => job.previewUrl && URL.revokeObjectURL(job.previewUrl));
+		updateJobs((current) => current.filter((job) => job.status !== "complete"));
+	}, [updateJobs]);
+
+	const reset = React.useCallback(() => {
+		activeRef.current.forEach(({ controller }) => controller.abort());
+		activeRef.current.clear();
+		jobsRef.current.forEach((job) => job.previewUrl && URL.revokeObjectURL(job.previewUrl));
+		jobsRef.current = [];
+		setJobs([]);
+		setOverflowCount(0);
+		busyRunRef.current = false;
+	}, []);
+
+	return {
+		jobs,
+		overflowCount,
+		hasUnfinished,
+		completedCount: jobs.filter((job) => job.status === "complete").length,
+		failedCount: jobs.filter((job) => job.status === "failed").length,
+		addFiles,
+		remove,
+		retry,
+		retryFailed,
+		cancelUnfinished,
+		clearCompleted,
+		reset,
+	};
+}

--- a/packages/admin/src/components/settings/GeneralSettings.tsx
+++ b/packages/admin/src/components/settings/GeneralSettings.tsx
@@ -353,7 +353,7 @@ export function GeneralSettings() {
 				onSelect={handleLogoSelect}
 				mimeTypeFilter="image/"
 				localOnly
-				title={t`Select Logo`}
+				title={t`Select logo`}
 			/>
 			<MediaPickerModal
 				open={faviconPickerOpen}
@@ -361,7 +361,7 @@ export function GeneralSettings() {
 				onSelect={handleFaviconSelect}
 				mimeTypeFilter="image/"
 				localOnly
-				title={t`Select Favicon`}
+				title={t`Select favicon`}
 			/>
 		</SettingsFrame>
 	);

--- a/packages/admin/src/components/settings/SeoSettings.tsx
+++ b/packages/admin/src/components/settings/SeoSettings.tsx
@@ -281,7 +281,7 @@ export function SeoSettings() {
 				onSelect={handleDefaultOgImageSelect}
 				mimeTypeFilters={["image/jpeg", "image/png", "image/webp", "image/gif"]}
 				localOnly
-				title={t`Select Default Social Image`}
+				title={t`Select default social image`}
 			/>
 		</SettingsFrame>
 	);

--- a/packages/admin/tests/components/MediaLibrary.test.tsx
+++ b/packages/admin/tests/components/MediaLibrary.test.tsx
@@ -1592,6 +1592,20 @@ describe("MediaLibrary", () => {
 			await expect.element(screen.getByText("MP4", { exact: true })).toBeInTheDocument();
 		});
 
+		it("uses the file fallback when a provider image has no preview URL", async () => {
+			const screen = await renderStreamTab(
+				makeStreamProviderItem({
+					filename: "no-preview.jpg",
+					mimeType: "image/jpeg",
+					previewUrl: undefined,
+				}),
+			);
+
+			const item = screen.getByRole("button", { name: "no-preview.jpg" }).element();
+			expect(item.querySelector("img")).toBeNull();
+			await expect.element(screen.getByText("JPEG", { exact: true })).toBeInTheDocument();
+		});
+
 		it("shows a size the provider reports only under meta", async () => {
 			const screen = await renderStreamTab();
 			await screen.getByRole("tab", { name: "List view" }).click();

--- a/packages/admin/tests/components/MediaPickerModal.test.tsx
+++ b/packages/admin/tests/components/MediaPickerModal.test.tsx
@@ -116,7 +116,17 @@ describe("MediaPickerModal", () => {
 			item.element().click();
 
 			await expect.element(item).toHaveAttribute("aria-pressed", "true");
-			await expect.element(screen.getByText("Selected: photo.jpg")).toBeInTheDocument();
+		});
+
+		it("keeps the footer free of redundant selection copy", async () => {
+			const screen = await renderModal();
+			expect(document.body.textContent).not.toContain("No media selected");
+
+			const item = screen.getByRole("button", { name: "photo.jpg" });
+			await expect.element(item).toBeInTheDocument();
+			item.element().click();
+
+			expect(document.body.textContent).not.toContain("Selected: photo.jpg");
 		});
 
 		it("double click does not bypass confirmation", async () => {

--- a/packages/admin/tests/components/MediaPickerModal.test.tsx
+++ b/packages/admin/tests/components/MediaPickerModal.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MediaPickerModal } from "../../src/components/MediaPickerModal";
 import { render } from "../utils/render.tsx";
@@ -12,7 +12,7 @@ import { render } from "../utils/render.tsx";
 // Anchored to the button's exact accessible name. Without anchors this also
 // matches the hidden file `<input aria-label="Upload file">` and trips
 // playwright's strict-mode "resolved to N elements" guard.
-const UPLOAD_BUTTON_REGEX = /^Upload$/;
+const UPLOAD_BUTTON_REGEX = /^Upload files$/;
 
 vi.mock("../../src/lib/api", async () => {
 	const actual = await vi.importActual("../../src/lib/api");
@@ -43,7 +43,12 @@ vi.mock("../../src/lib/api", async () => {
 					createdAt: "2024-01-02",
 				},
 			],
+			totalCount: 2,
 		}),
+		fetchMediaFolders: vi.fn().mockResolvedValue({
+			items: [{ id: "folder-1", name: "Photography" }],
+		}),
+		fetchMediaFolder: vi.fn().mockResolvedValue({ id: "folder-1", name: "Photography" }),
 		fetchMediaProviders: vi.fn().mockResolvedValue([]),
 		fetchProviderMedia: vi.fn().mockResolvedValue({ items: [] }),
 		uploadMedia: vi.fn().mockResolvedValue({ id: "m3", filename: "new.jpg" }),
@@ -73,20 +78,25 @@ function renderModal(props: Partial<React.ComponentProps<typeof MediaPickerModal
 	);
 }
 
+async function openUrlSource(screen: Awaited<ReturnType<typeof renderModal>>) {
+	screen.getByRole("tab", { name: "From URL" }).element().click();
+}
+
 describe("MediaPickerModal", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
+	afterEach(() => vi.unstubAllGlobals());
 
 	describe("displaying items", () => {
 		it("shows media items when open", async () => {
 			const screen = await renderModal({ open: true });
-			await expect.element(screen.getByRole("option", { name: "photo.jpg" })).toBeInTheDocument();
+			await expect.element(screen.getByRole("button", { name: "photo.jpg" })).toBeInTheDocument();
 			await expect
-				.element(screen.getByRole("option", { name: "landscape.png" }))
+				.element(screen.getByRole("button", { name: "landscape.png" }))
 				.toBeInTheDocument();
 			const image = screen
-				.getByRole("option", { name: "photo.jpg" })
+				.getByRole("button", { name: "photo.jpg" })
 				.element()
 				.querySelector("img");
 			expect(image?.style.objectPosition).toBe("20% 80%");
@@ -101,69 +111,42 @@ describe("MediaPickerModal", () => {
 	describe("selection", () => {
 		it("single click selects item (highlighted)", async () => {
 			const screen = await renderModal();
-			const option = screen.getByRole("option", { name: "photo.jpg" });
-			await expect.element(option).toBeInTheDocument();
+			const item = screen.getByRole("button", { name: "photo.jpg" });
+			await expect.element(item).toBeInTheDocument();
+			item.element().click();
 
-			// Direct DOM click to bypass inert overlay
-			const btn = option.element().querySelector("button")!;
-			btn.click();
-
-			// Should show selected state via aria-selected
-			await expect.element(option).toHaveAttribute("aria-selected", "true");
-			// Footer should show selected filename in a <strong> tag
-			await expect.element(screen.getByRole("strong")).toBeInTheDocument();
+			await expect.element(item).toHaveAttribute("aria-pressed", "true");
+			await expect.element(screen.getByText("Selected: photo.jpg")).toBeInTheDocument();
 		});
 
-		it("double click selects and calls onSelect", async () => {
+		it("double click does not bypass confirmation", async () => {
 			const onSelect = vi.fn();
 			const screen = await renderModal({ onSelect });
 
-			const option = screen.getByRole("option", { name: "photo.jpg" });
-			await expect.element(option).toBeInTheDocument();
+			const item = screen.getByRole("button", { name: "photo.jpg" });
+			await expect.element(item).toBeInTheDocument();
+			item.element().dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
+			item.element().dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 2 }));
+			item.element().dispatchEvent(new MouseEvent("dblclick", { bubbles: true, detail: 2 }));
 
-			// Use direct DOM dblclick to bypass inert overlay
-			const btn = option.element().querySelector("button")!;
-			btn.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
-
-			expect(onSelect).toHaveBeenCalledWith(
-				expect.objectContaining({ id: "m1", filename: "photo.jpg" }),
-			);
+			expect(onSelect).not.toHaveBeenCalled();
+			await expect.element(item).toHaveAttribute("aria-pressed", "true");
 		});
 
-		it("Insert button disabled when nothing selected", async () => {
-			await renderModal();
-			// There are two Insert buttons — URL section and footer.
-			// The footer Insert is the last one and should be disabled.
-			await vi.waitFor(() => {
-				const allInsertBtns = document.querySelectorAll("button");
-				const insertBtns = [...allInsertBtns].filter((b) => b.textContent?.trim() === "Insert");
-				// The footer Insert (last one) should be disabled
-				const lastInsert = insertBtns.at(-1);
-				expect(lastInsert?.disabled).toBe(true);
-			});
+		it("Select button is disabled when nothing is selected", async () => {
+			const screen = await renderModal();
+			await expect.element(screen.getByRole("button", { name: "Select" })).toBeDisabled();
 		});
 
-		it("Insert button enabled when item selected, calls onSelect", async () => {
+		it("Select button confirms the selected item", async () => {
 			const onSelect = vi.fn();
 			const screen = await renderModal({ onSelect });
 
-			// Select an item via direct DOM click
-			const option = screen.getByRole("option", { name: "photo.jpg" });
-			await expect.element(option).toBeInTheDocument();
-			const itemBtn = option.element().querySelector("button")!;
-			itemBtn.click();
-
-			// Wait for selection to register
-			await expect.element(option).toHaveAttribute("aria-selected", "true");
-
-			// Click the footer Insert button (last Insert button)
-			await vi.waitFor(() => {
-				const allInsertBtns = document.querySelectorAll("button");
-				const insertBtns = [...allInsertBtns].filter((b) => b.textContent?.trim() === "Insert");
-				const lastInsert = insertBtns.at(-1)!;
-				expect(lastInsert.disabled).toBe(false);
-				lastInsert.click();
-			});
+			const item = screen.getByRole("button", { name: "photo.jpg" });
+			await expect.element(item).toBeInTheDocument();
+			item.element().click();
+			await expect.element(item).toHaveAttribute("aria-pressed", "true");
+			screen.getByRole("button", { name: "Select" }).element().click();
 
 			expect(onSelect).toHaveBeenCalledWith(
 				expect.objectContaining({ id: "m1", filename: "photo.jpg" }),
@@ -174,8 +157,8 @@ describe("MediaPickerModal", () => {
 	describe("URL input", () => {
 		it("invalid URL shows error", async () => {
 			const screen = await renderModal();
+			await openUrlSource(screen);
 
-			// The URL input has aria-label "Image URL"
 			const urlInput = screen.getByLabelText("Image URL");
 			await expect.element(urlInput).toBeInTheDocument();
 
@@ -190,14 +173,7 @@ describe("MediaPickerModal", () => {
 			inputEl.dispatchEvent(new Event("input", { bubbles: true }));
 			inputEl.dispatchEvent(new Event("change", { bubbles: true }));
 
-			// Click the URL Insert button (first Insert button)
-			await vi.waitFor(() => {
-				const urlInsert = [...document.querySelectorAll("button")].find(
-					(b) => b.textContent?.trim() === "Insert",
-				)!;
-				expect(urlInsert.disabled).toBe(false);
-				urlInsert.click();
-			});
+			screen.getByRole("button", { name: "Use URL" }).element().click();
 
 			await expect.element(screen.getByText("Please enter a valid URL")).toBeInTheDocument();
 		});
@@ -205,6 +181,7 @@ describe("MediaPickerModal", () => {
 		it("URL input: typing a URL and submitting triggers probe", async () => {
 			const onSelect = vi.fn();
 			const screen = await renderModal({ onSelect });
+			await openUrlSource(screen);
 
 			const urlInput = screen.getByLabelText("Image URL");
 			const inputEl = urlInput.element() as HTMLInputElement;
@@ -216,13 +193,7 @@ describe("MediaPickerModal", () => {
 			inputEl.dispatchEvent(new Event("input", { bubbles: true }));
 			inputEl.dispatchEvent(new Event("change", { bubbles: true }));
 
-			// Click URL Insert button
-			await vi.waitFor(() => {
-				const urlInsert = [...document.querySelectorAll("button")].find(
-					(b) => b.textContent?.trim() === "Insert",
-				)!;
-				urlInsert.click();
-			});
+			screen.getByRole("button", { name: "Use URL" }).element().click();
 
 			// Image probe will fail in test env, so either onSelect called or error shown
 			await vi.waitFor(
@@ -240,7 +211,7 @@ describe("MediaPickerModal", () => {
 			const screen = await renderModal({ hideUrlInput: true });
 
 			// "Insert from URL" label should not appear when hidden
-			await expect.element(screen.getByText("Select Image")).toBeInTheDocument();
+			await expect.element(screen.getByText("Select image")).toBeInTheDocument();
 			expect(document.body.textContent).not.toContain("Insert from URL");
 			expect(document.body.textContent).not.toContain("or choose from library");
 
@@ -255,7 +226,7 @@ describe("MediaPickerModal", () => {
 			// an external URL would return an item the server cannot resolve later.
 			const screen = await renderModal({ localOnly: true });
 
-			await expect.element(screen.getByText("Select Image")).toBeInTheDocument();
+			await expect.element(screen.getByText("Select image")).toBeInTheDocument();
 			expect(document.body.textContent).not.toContain("Insert from URL");
 
 			const urlInput = document.querySelector('input[aria-label="Image URL"]');
@@ -296,7 +267,7 @@ describe("MediaPickerModal", () => {
 
 			const screen = await renderModal({ localOnly: true });
 
-			await expect.element(screen.getByText("Select Image")).toBeInTheDocument();
+			await expect.element(screen.getByText("Select image")).toBeInTheDocument();
 			// External providers must not be reachable through any tab when
 			// localOnly is set, even if the API would report them.
 			expect(document.body.textContent).not.toContain("Cloudflare Images");
@@ -316,15 +287,14 @@ describe("MediaPickerModal", () => {
 
 			const screen = await renderModal({ mediaKind: "file", hideUrlInput: true });
 
-			// Default title should be "Select File", not "Select Image"
-			await expect.element(screen.getByText("Select File")).toBeInTheDocument();
-			expect(document.body.textContent).not.toContain("Select Image");
+			await expect.element(screen.getByText("Select file")).toBeInTheDocument();
+			expect(document.body.textContent).not.toContain("Select image");
 
-			// Empty-state hint and CTA should reference files, not images
 			await expect.element(screen.getByText("Upload a file to get started")).toBeInTheDocument();
-			await expect.element(screen.getByText("Upload File")).toBeInTheDocument();
+			await expect
+				.element(screen.getByRole("button", { name: UPLOAD_BUTTON_REGEX }))
+				.toBeInTheDocument();
 			expect(document.body.textContent).not.toContain("Upload an image to get started");
-			expect(document.body.textContent).not.toContain("Upload Image");
 		});
 
 		it("defaults to image-specific copy when mediaKind is unset", async () => {
@@ -333,7 +303,7 @@ describe("MediaPickerModal", () => {
 
 			const screen = await renderModal();
 
-			await expect.element(screen.getByText("Select Image")).toBeInTheDocument();
+			await expect.element(screen.getByText("Select image")).toBeInTheDocument();
 			await expect.element(screen.getByText("Upload an image to get started")).toBeInTheDocument();
 		});
 	});
@@ -343,7 +313,7 @@ describe("MediaPickerModal", () => {
 			const onOpenChange = vi.fn();
 			const screen = await renderModal({ onOpenChange });
 
-			await expect.element(screen.getByText("Select Image")).toBeInTheDocument();
+			await expect.element(screen.getByText("Select image")).toBeInTheDocument();
 			// Direct DOM click to bypass inert overlay
 			const cancelEl = screen.getByText("Cancel").element();
 			const cancelBtn = cancelEl.closest("button")!;
@@ -360,13 +330,11 @@ describe("MediaPickerModal", () => {
 			const screen = await renderModal({ open: true, onSelect, onOpenChange });
 
 			// Select an item
-			const option = screen.getByRole("option", { name: "photo.jpg" });
-			await expect.element(option).toBeInTheDocument();
-			const btn = option.element().querySelector("button")!;
-			btn.click();
+			const item = screen.getByRole("button", { name: "photo.jpg" });
+			await expect.element(item).toBeInTheDocument();
+			item.element().click();
 
-			// Verify selection
-			await expect.element(option).toHaveAttribute("aria-selected", "true");
+			await expect.element(item).toHaveAttribute("aria-pressed", "true");
 
 			// Close modal
 			await screen.rerender(
@@ -382,13 +350,7 @@ describe("MediaPickerModal", () => {
 				</QueryWrapper>,
 			);
 
-			// Footer Insert should be disabled (no selection after reset)
-			await vi.waitFor(() => {
-				const allInsertBtns = document.querySelectorAll("button");
-				const insertBtns = [...allInsertBtns].filter((b) => b.textContent?.trim() === "Insert");
-				const lastInsert = insertBtns.at(-1);
-				expect(lastInsert?.disabled).toBe(true);
-			});
+			await expect.element(screen.getByRole("button", { name: "Select" })).toBeDisabled();
 		});
 	});
 
@@ -398,52 +360,14 @@ describe("MediaPickerModal", () => {
 			await expect
 				.element(screen.getByRole("button", { name: UPLOAD_BUTTON_REGEX }))
 				.toBeInTheDocument();
-			await expect.element(screen.getByLabelText("Upload file")).toBeInTheDocument();
+			await expect.element(screen.getByLabelText("Choose files to upload")).toBeInTheDocument();
 		});
 	});
 
-	describe("load more pagination", () => {
-		it("renders Load More button when first page returns nextCursor", async () => {
-			const api = await import("../../src/lib/api");
-			(api.fetchMediaList as any).mockResolvedValueOnce({
-				items: [
-					{
-						id: "p1",
-						filename: "page1.jpg",
-						mimeType: "image/jpeg",
-						url: "/media/page1.jpg",
-						size: 1024,
-						width: 800,
-						height: 600,
-						createdAt: "2024-01-01",
-					},
-				],
-				nextCursor: "cursor-2",
-			});
-
-			const screen = await renderModal();
-			await expect.element(screen.getByRole("option", { name: "page1.jpg" })).toBeInTheDocument();
-			await expect.element(screen.getByRole("button", { name: "Load More" })).toBeInTheDocument();
-		});
-
-		it("does not render Load More button when no nextCursor", async () => {
-			const screen = await renderModal();
-			// Default mock returns 2 items with no nextCursor → button should be absent
-			await expect.element(screen.getByRole("option", { name: "photo.jpg" })).toBeInTheDocument();
-			expect(screen.getByRole("button", { name: "Load More" }).query()).toBeNull();
-		});
-
-		it("keeps already-loaded items visible while fetching the next page", async () => {
-			// Reproduces the Copilot review concern: when the next-page fetch is
-			// in flight, the picker grid must not blank out into a centered
-			// loader — the user's prior selection / scroll context would be lost.
+	describe("library browsing", () => {
+		it("uses numbered pagination and requests the selected page", async () => {
 			const api = await import("../../src/lib/api");
 			const mock = api.fetchMediaList as any;
-			mock.mockReset();
-			let resolveSecond: (value: unknown) => void = () => {};
-			const secondPagePromise = new Promise((resolve) => {
-				resolveSecond = resolve;
-			});
 			mock
 				.mockResolvedValueOnce({
 					items: [
@@ -458,44 +382,7 @@ describe("MediaPickerModal", () => {
 							createdAt: "2024-01-01",
 						},
 					],
-					nextCursor: "cursor-2",
-				})
-				.mockReturnValueOnce(secondPagePromise);
-
-			const screen = await renderModal();
-			await expect.element(screen.getByRole("option", { name: "page1.jpg" })).toBeInTheDocument();
-
-			const loadMoreBtn = [...document.querySelectorAll("button")].find(
-				(b) => b.textContent?.trim() === "Load More",
-			)!;
-			loadMoreBtn.click();
-
-			// While the second page is still pending, the first-page item must
-			// stay in the DOM (not be replaced by a centered loader).
-			await expect.element(screen.getByRole("option", { name: "page1.jpg" })).toBeInTheDocument();
-
-			resolveSecond({ items: [] });
-		});
-
-		it("Load More click fetches the next page with the previous cursor", async () => {
-			const api = await import("../../src/lib/api");
-			const mock = api.fetchMediaList as any;
-			mock.mockReset();
-			mock
-				.mockResolvedValueOnce({
-					items: [
-						{
-							id: "p1",
-							filename: "page1.jpg",
-							mimeType: "image/jpeg",
-							url: "/media/page1.jpg",
-							size: 1024,
-							width: 800,
-							height: 600,
-							createdAt: "2024-01-01",
-						},
-					],
-					nextCursor: "cursor-2",
+					totalCount: 36,
 				})
 				.mockResolvedValueOnce({
 					items: [
@@ -510,24 +397,318 @@ describe("MediaPickerModal", () => {
 							createdAt: "2024-01-02",
 						},
 					],
+					totalCount: 36,
 				});
 
 			const screen = await renderModal();
-			await expect.element(screen.getByRole("option", { name: "page1.jpg" })).toBeInTheDocument();
-
-			// Direct DOM click to bypass the dialog's inert overlay
-			const loadMoreBtn = [...document.querySelectorAll("button")].find(
-				(b) => b.textContent?.trim() === "Load More",
-			)!;
-			loadMoreBtn.click();
-
-			await expect.element(screen.getByRole("option", { name: "page2.jpg" })).toBeInTheDocument();
-
-			// Second call should have been made with the previous response's cursor.
+			await expect.element(screen.getByRole("button", { name: "page1.jpg" })).toBeInTheDocument();
+			screen.getByRole("button", { name: "Next page" }).element().click();
+			await expect.element(screen.getByRole("button", { name: "page2.jpg" })).toBeInTheDocument();
 			expect(mock).toHaveBeenCalledTimes(2);
-			expect(mock.mock.calls[1][0]).toEqual(
-				expect.objectContaining({ cursor: "cursor-2", limit: 100 }),
+			expect(mock.mock.calls[1][0]).toEqual(expect.objectContaining({ page: 2, limit: 35 }));
+		});
+
+		it("opens a folder and filters the media query", async () => {
+			const api = await import("../../src/lib/api");
+			const screen = await renderModal();
+
+			await expect
+				.element(screen.getByRole("button", { name: "Open folder Photography" }))
+				.toBeInTheDocument();
+			screen.getByRole("button", { name: "Open folder Photography" }).element().click();
+
+			await vi.waitFor(() => {
+				expect(api.fetchMediaList).toHaveBeenLastCalledWith(
+					expect.objectContaining({ folderId: "folder-1", page: 1, limit: 35 }),
+				);
+			});
+		});
+
+		it("keeps uploads in the main library by hiding upload inside a folder", async () => {
+			const screen = await renderModal();
+			await expect
+				.element(screen.getByRole("button", { name: "Open folder Photography" }))
+				.toBeInTheDocument();
+			screen.getByRole("button", { name: "Open folder Photography" }).element().click();
+
+			await expect.element(screen.getByText("Photography", { exact: true })).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: UPLOAD_BUTTON_REGEX }).query()).toBeNull();
+		});
+
+		it("offers grid and list views", async () => {
+			const screen = await renderModal();
+
+			await expect.element(screen.getByRole("tab", { name: "Grid view" })).toBeInTheDocument();
+			screen.getByRole("tab", { name: "List view" }).element().click();
+			await expect
+				.element(screen.getByRole("button", { name: "photo.jpg" }))
+				.toHaveAttribute("data-media-layout", "list");
+		});
+
+		it("keeps detected image dimensions when selecting from list view", async () => {
+			const api = await import("../../src/lib/api");
+			(api.fetchMediaList as any).mockResolvedValueOnce({
+				items: [
+					{
+						id: "missing-size",
+						filename: "missing-size.jpg",
+						mimeType: "image/jpeg",
+						url: "/media/missing-size.jpg",
+						size: 1024,
+						createdAt: "2024-01-01",
+					},
+				],
+				totalCount: 1,
+			});
+			const onSelect = vi.fn();
+			const screen = await renderModal({ onSelect });
+			screen.getByRole("tab", { name: "List view" }).element().click();
+			const item = screen.getByRole("button", { name: "missing-size.jpg" });
+			await expect.element(item).toHaveAttribute("data-media-layout", "list");
+			const image = item.element().querySelector("img")!;
+			Object.defineProperties(image, {
+				naturalWidth: { configurable: true, value: 1280 },
+				naturalHeight: { configurable: true, value: 720 },
+			});
+			image.dispatchEvent(new Event("load", { bubbles: true }));
+			await vi.waitFor(() => {
+				expect(api.updateMedia).toHaveBeenCalledWith("missing-size", {
+					width: 1280,
+					height: 720,
+				});
+			});
+
+			item.element().click();
+			await expect.element(item).toHaveAttribute("aria-pressed", "true");
+			screen.getByRole("button", { name: "Select" }).element().click();
+			expect(onSelect).toHaveBeenCalledWith(
+				expect.objectContaining({ id: "missing-size", width: 1280, height: 720 }),
 			);
+		});
+
+		it("shows direct URLs as a source", async () => {
+			const screen = await renderModal();
+
+			await expect.element(screen.getByRole("tab", { name: "From URL" })).toBeInTheDocument();
+			screen.getByRole("tab", { name: "From URL" }).element().click();
+			await expect.element(screen.getByLabelText("Image URL")).toBeInTheDocument();
+		});
+
+		it("combines the caller allowlist with the selected type", async () => {
+			const api = await import("../../src/lib/api");
+			const screen = await renderModal({ mimeTypeFilters: [] });
+
+			screen.getByRole("combobox", { name: "Filter by type" }).element().click();
+			await expect.element(screen.getByRole("option", { name: "Video" })).toBeInTheDocument();
+			screen.getByRole("option", { name: "Video" }).element().click();
+
+			await vi.waitFor(() => {
+				expect(api.fetchMediaList).toHaveBeenLastCalledWith(
+					expect.objectContaining({ mimeType: ["video/"], page: 1 }),
+				);
+			});
+		});
+
+		it("selects a direct URL only after confirmation", async () => {
+			class LoadedImage {
+				naturalWidth = 640;
+				naturalHeight = 480;
+				onload: (() => void) | null = null;
+				onerror: (() => void) | null = null;
+				set src(_value: string) {
+					queueMicrotask(() => this.onload?.());
+				}
+			}
+			vi.stubGlobal("Image", LoadedImage);
+			const onSelect = vi.fn();
+			const screen = await renderModal({ onSelect });
+			await openUrlSource(screen);
+			const input = screen.getByLabelText("Image URL").element() as HTMLInputElement;
+			const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+			setValue.call(input, "https://example.com/cover.png");
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+			input.dispatchEvent(new Event("change", { bubbles: true }));
+			screen.getByRole("button", { name: "Use URL" }).element().click();
+
+			await expect
+				.element(screen.getByRole("button", { name: "cover.png" }))
+				.toHaveAttribute("aria-pressed", "true");
+			expect(onSelect).not.toHaveBeenCalled();
+			screen.getByRole("button", { name: "Select" }).element().click();
+
+			expect(onSelect).toHaveBeenCalledWith(
+				expect.objectContaining({
+					url: "https://example.com/cover.png",
+					provider: "external",
+					width: 640,
+					height: 480,
+				}),
+			);
+		});
+
+		it("keeps the previous page visible but inert while the next page loads", async () => {
+			const api = await import("../../src/lib/api");
+			let resolveNextPage!: (value: {
+				items: Array<Record<string, unknown>>;
+				totalCount: number;
+			}) => void;
+			const nextPage = new Promise<{
+				items: Array<Record<string, unknown>>;
+				totalCount: number;
+			}>((resolve) => {
+				resolveNextPage = resolve;
+			});
+			(api.fetchMediaList as any)
+				.mockResolvedValueOnce({
+					items: [
+						{
+							id: "p1",
+							filename: "page1.jpg",
+							mimeType: "image/jpeg",
+							url: "/media/page1.jpg",
+							size: 1024,
+							width: 800,
+							height: 600,
+							createdAt: "2024-01-01",
+						},
+					],
+					totalCount: 36,
+				})
+				.mockReturnValueOnce(nextPage);
+			const screen = await renderModal();
+			await expect.element(screen.getByRole("button", { name: "page1.jpg" })).toBeInTheDocument();
+
+			screen.getByRole("button", { name: "Next page" }).element().click();
+			await vi.waitFor(() => expect(api.fetchMediaList).toHaveBeenCalledTimes(2));
+			const results = screen.getByRole("region", { name: "Media results" });
+			const itemSurface = document.querySelector<HTMLElement>("[data-media-items]")!;
+			await expect.element(results).toHaveAttribute("aria-busy", "true");
+			expect(itemSurface).toHaveAttribute("inert");
+			await expect.element(screen.getByRole("button", { name: "page1.jpg" })).toBeInTheDocument();
+
+			resolveNextPage({
+				items: [
+					{
+						id: "p2",
+						filename: "page2.jpg",
+						mimeType: "image/jpeg",
+						url: "/media/page2.jpg",
+						size: 1024,
+						width: 800,
+						height: 600,
+						createdAt: "2024-01-02",
+					},
+				],
+				totalCount: 36,
+			});
+			await expect.element(screen.getByRole("button", { name: "page2.jpg" })).toBeInTheDocument();
+			expect(itemSurface).not.toHaveAttribute("inert");
+		});
+
+		it("ignores a URL probe that finishes after a newer request", async () => {
+			class ControlledImage {
+				static instances: ControlledImage[] = [];
+				naturalWidth = 640;
+				naturalHeight = 480;
+				onload: (() => void) | null = null;
+				onerror: (() => void) | null = null;
+				constructor() {
+					ControlledImage.instances.push(this);
+				}
+				set src(_value: string) {}
+			}
+			vi.stubGlobal("Image", ControlledImage);
+			const screen = await renderModal();
+			await openUrlSource(screen);
+			const input = screen.getByLabelText("Image URL").element() as HTMLInputElement;
+			const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+
+			setValue.call(input, "https://example.com/first.png");
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+			input.dispatchEvent(new Event("change", { bubbles: true }));
+			screen.getByRole("button", { name: "Use URL" }).element().click();
+			await vi.waitFor(() => expect(ControlledImage.instances).toHaveLength(1));
+
+			setValue.call(input, "https://example.com/second.png");
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+			input.dispatchEvent(new Event("change", { bubbles: true }));
+			input.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+			await vi.waitFor(() => expect(ControlledImage.instances).toHaveLength(2));
+
+			ControlledImage.instances[1]!.onload?.();
+			await expect
+				.element(screen.getByRole("button", { name: "second.png" }))
+				.toHaveAttribute("aria-pressed", "true");
+			ControlledImage.instances[0]!.onload?.();
+			await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+			await expect
+				.element(screen.getByRole("button", { name: "second.png" }))
+				.toHaveAttribute("aria-pressed", "true");
+			expect(screen.getByRole("button", { name: "first.png" }).query()).toBeNull();
+		});
+
+		it("ignores a URL probe after selecting from the library", async () => {
+			class ControlledImage {
+				static instance: ControlledImage;
+				naturalWidth = 640;
+				naturalHeight = 480;
+				onload: (() => void) | null = null;
+				onerror: (() => void) | null = null;
+				constructor() {
+					ControlledImage.instance = this;
+				}
+				set src(_value: string) {}
+			}
+			vi.stubGlobal("Image", ControlledImage);
+			const onSelect = vi.fn();
+			const screen = await renderModal({ onSelect });
+			await openUrlSource(screen);
+			const input = screen.getByLabelText("Image URL").element() as HTMLInputElement;
+			const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+			setValue.call(input, "https://example.com/slow.png");
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+			input.dispatchEvent(new Event("change", { bubbles: true }));
+			screen.getByRole("button", { name: "Use URL" }).element().click();
+			await vi.waitFor(() => expect(ControlledImage.instance).toBeDefined());
+
+			screen.getByRole("tab", { name: "Library" }).element().click();
+			await expect.element(screen.getByRole("button", { name: "photo.jpg" })).toBeInTheDocument();
+			screen.getByRole("button", { name: "photo.jpg" }).element().click();
+			await expect
+				.element(screen.getByRole("button", { name: "photo.jpg" }))
+				.toHaveAttribute("aria-pressed", "true");
+			ControlledImage.instance.onload?.();
+			await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+			screen.getByRole("button", { name: "Select" }).element().click();
+			expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ filename: "photo.jpg" }));
+		});
+
+		it("clears a global search before opening one of its folder results", async () => {
+			const api = await import("../../src/lib/api");
+			const screen = await renderModal();
+			const search = screen.getByRole("searchbox", { name: "Search media" }).element();
+			const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+			setValue.call(search, "report");
+			search.dispatchEvent(new Event("input", { bubbles: true }));
+			search.dispatchEvent(new Event("change", { bubbles: true }));
+			await vi.waitFor(() => {
+				expect(api.fetchMediaList).toHaveBeenLastCalledWith(
+					expect.objectContaining({ search: "report", folderId: undefined }),
+				);
+			});
+
+			await expect
+				.element(screen.getByRole("button", { name: "Open folder Photography" }))
+				.toBeInTheDocument();
+			screen.getByRole("button", { name: "Open folder Photography" }).element().click();
+
+			await vi.waitFor(() => {
+				expect(api.fetchMediaList).toHaveBeenLastCalledWith(
+					expect.objectContaining({ search: undefined, folderId: "folder-1", page: 1 }),
+				);
+			});
 		});
 	});
 });

--- a/packages/admin/tests/components/MediaPickerModal.test.tsx
+++ b/packages/admin/tests/components/MediaPickerModal.test.tsx
@@ -413,6 +413,10 @@ describe("MediaPickerModal", () => {
 			const screen = await renderModal();
 			await expect.element(screen.getByRole("button", { name: "page1.jpg" })).toBeInTheDocument();
 			expect(screen.getByRole("combobox", { name: "Page size" }).query()).toBeNull();
+			await expect
+				.element(screen.getByRole("textbox", { name: "Page number" }))
+				.toBeInTheDocument();
+			expect(screen.getByRole("combobox", { name: "Page number" }).query()).toBeNull();
 			screen.getByRole("button", { name: "Next page" }).element().click();
 			await expect.element(screen.getByRole("button", { name: "page2.jpg" })).toBeInTheDocument();
 			expect(mock).toHaveBeenCalledTimes(2);

--- a/packages/admin/tests/components/MediaPickerModal.test.tsx
+++ b/packages/admin/tests/components/MediaPickerModal.test.tsx
@@ -375,7 +375,7 @@ describe("MediaPickerModal", () => {
 	});
 
 	describe("library browsing", () => {
-		it("uses numbered pagination and requests the selected page", async () => {
+		it("uses fixed twelve-item pages without a page-size control", async () => {
 			const api = await import("../../src/lib/api");
 			const mock = api.fetchMediaList as any;
 			mock
@@ -412,10 +412,11 @@ describe("MediaPickerModal", () => {
 
 			const screen = await renderModal();
 			await expect.element(screen.getByRole("button", { name: "page1.jpg" })).toBeInTheDocument();
+			expect(screen.getByRole("combobox", { name: "Page size" }).query()).toBeNull();
 			screen.getByRole("button", { name: "Next page" }).element().click();
 			await expect.element(screen.getByRole("button", { name: "page2.jpg" })).toBeInTheDocument();
 			expect(mock).toHaveBeenCalledTimes(2);
-			expect(mock.mock.calls[1][0]).toEqual(expect.objectContaining({ page: 2, limit: 35 }));
+			expect(mock.mock.calls[1][0]).toEqual(expect.objectContaining({ page: 2, limit: 12 }));
 		});
 
 		it("opens a folder and filters the media query", async () => {
@@ -429,7 +430,7 @@ describe("MediaPickerModal", () => {
 
 			await vi.waitFor(() => {
 				expect(api.fetchMediaList).toHaveBeenLastCalledWith(
-					expect.objectContaining({ folderId: "folder-1", page: 1, limit: 35 }),
+					expect.objectContaining({ folderId: "folder-1", page: 1, limit: 12 }),
 				);
 			});
 		});

--- a/packages/admin/tests/components/MediaPickerUpload.test.tsx
+++ b/packages/admin/tests/components/MediaPickerUpload.test.tsx
@@ -1,0 +1,260 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MediaPickerModal } from "../../src/components/MediaPickerModal.js";
+import type { MediaItem } from "../../src/lib/api/media.js";
+import { render } from "../utils/render.js";
+
+const apiMocks = vi.hoisted(() => ({
+	uploadMedia: vi.fn<(file: File, options?: unknown) => Promise<MediaItem>>(),
+}));
+
+vi.mock("../../src/lib/api", async () => {
+	const actual = await vi.importActual<typeof import("../../src/lib/api")>("../../src/lib/api");
+	return {
+		...actual,
+		fetchMediaList: vi.fn().mockResolvedValue({ items: [], totalCount: 0 }),
+		fetchMediaFolders: vi.fn().mockResolvedValue({ items: [] }),
+		fetchMediaFolder: vi.fn().mockResolvedValue({ id: "folder-1", name: "Photography" }),
+		fetchMediaProviders: vi.fn().mockResolvedValue([]),
+		fetchProviderMedia: vi.fn().mockResolvedValue({ items: [] }),
+		uploadMedia: apiMocks.uploadMedia,
+	};
+});
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+function mediaItem(id: string, filename: string): MediaItem {
+	return {
+		id,
+		filename,
+		mimeType: "image/jpeg",
+		url: `/_emdash/api/media/file/${filename}`,
+		storageKey: filename,
+		size: 1024,
+		width: 800,
+		height: 600,
+		createdAt: "2026-09-03T00:00:00.000Z",
+	};
+}
+
+function setInputFiles(input: HTMLInputElement, files: File[]) {
+	const transfer = new DataTransfer();
+	for (const file of files) transfer.items.add(file);
+	input.files = transfer.files;
+	input.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+async function renderPicker(props: Partial<React.ComponentProps<typeof MediaPickerModal>> = {}) {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<MediaPickerModal open onOpenChange={vi.fn()} onSelect={vi.fn()} {...props} />
+		</QueryClientProvider>,
+	);
+}
+
+describe("MediaPickerModal inline uploads", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("uploads one file inline and turns it into the selected card", async () => {
+		const pending = deferred<MediaItem>();
+		apiMocks.uploadMedia.mockReturnValueOnce(pending.promise);
+		const screen = await renderPicker();
+		const files = [
+			new File(["first"], "first.jpg", { type: "image/jpeg" }),
+			new File(["ignored"], "ignored.jpg", { type: "image/jpeg" }),
+		];
+
+		setInputFiles(
+			screen.getByLabelText("Choose files to upload").element() as HTMLInputElement,
+			files,
+		);
+
+		await vi.waitFor(() => expect(apiMocks.uploadMedia).toHaveBeenCalledTimes(1));
+		await expect.element(screen.getByText("Uploading", { exact: true })).toBeInTheDocument();
+		const placeholder = screen
+			.getByText("first.jpg", { exact: true })
+			.element()
+			.closest("[data-upload-status]")!;
+		expect(placeholder).toHaveAttribute("data-upload-status", "uploading");
+		expect(placeholder.querySelector("img")).toBeNull();
+		expect(screen.getByRole("dialog").all()).toHaveLength(1);
+		await expect.element(screen.getByRole("tab", { name: "From URL" })).toBeDisabled();
+		await expect.element(screen.getByRole("button", { name: "Select" })).toBeDisabled();
+
+		pending.resolve(mediaItem("uploaded-1", "first.jpg"));
+		await expect
+			.element(screen.getByRole("button", { name: "first.jpg" }))
+			.toHaveAttribute("aria-pressed", "true");
+		await expect.element(screen.getByRole("button", { name: "Select" })).toBeEnabled();
+		await expect.element(screen.getByRole("tab", { name: "From URL" })).toBeEnabled();
+		expect(apiMocks.uploadMedia.mock.calls[0]?.[0].name).toBe("first.jpg");
+	});
+
+	it("accepts files dropped onto the picker results", async () => {
+		apiMocks.uploadMedia.mockImplementation(() => new Promise<MediaItem>(() => undefined));
+		const screen = await renderPicker();
+		const transfer = new DataTransfer();
+		transfer.items.add(new File(["drop"], "dropped.jpg", { type: "image/jpeg" }));
+		const results = screen.getByRole("region", { name: "Media results" }).element();
+		results.dispatchEvent(new DragEvent("dragover", { bubbles: true, dataTransfer: transfer }));
+		results.dispatchEvent(new DragEvent("drop", { bubbles: true, dataTransfer: transfer }));
+
+		await vi.waitFor(() => expect(apiMocks.uploadMedia).toHaveBeenCalledTimes(1));
+		await expect.element(screen.getByText("dropped.jpg", { exact: true })).toBeInTheDocument();
+		await expect.element(screen.getByText("Uploading", { exact: true })).toBeInTheDocument();
+	});
+
+	it("derives the local URL when a deduplicated upload omits it", async () => {
+		const uploaded = mediaItem("existing-1", "existing.jpg");
+		apiMocks.uploadMedia.mockResolvedValueOnce({
+			...uploaded,
+			url: undefined as unknown as string,
+		});
+		const screen = await renderPicker();
+		setInputFiles(screen.getByLabelText("Choose files to upload").element() as HTMLInputElement, [
+			new File(["existing"], "existing.jpg", { type: "image/jpeg" }),
+		]);
+
+		const card = screen.getByRole("button", { name: "existing.jpg", exact: true });
+		await expect.element(card).toHaveAttribute("aria-pressed", "true");
+		expect(
+			decodeURIComponent(card.element().querySelector("img")?.getAttribute("src") ?? ""),
+		).toContain("/_emdash/api/media/file/existing.jpg");
+	});
+
+	it("does not show a Main-library upload inside a folder", async () => {
+		const api = await import("../../src/lib/api");
+		(api.fetchMediaFolders as any).mockResolvedValueOnce({
+			items: [{ id: "folder-1", name: "Photography" }],
+		});
+		apiMocks.uploadMedia.mockResolvedValueOnce(mediaItem("uploaded-1", "main-only.jpg"));
+		const screen = await renderPicker();
+		setInputFiles(screen.getByLabelText("Choose files to upload").element() as HTMLInputElement, [
+			new File(["main"], "main-only.jpg", { type: "image/jpeg" }),
+		]);
+		await expect
+			.element(screen.getByRole("button", { name: "main-only.jpg", exact: true }))
+			.toBeInTheDocument();
+
+		screen.getByRole("button", { name: "Open folder Photography" }).element().click();
+		await expect.element(screen.getByText("Photography", { exact: true })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "main-only.jpg", exact: true }).query()).toBeNull();
+	});
+
+	it("shows failed files inline and retries only that file", async () => {
+		apiMocks.uploadMedia
+			.mockRejectedValueOnce(new Error("network"))
+			.mockResolvedValueOnce(mediaItem("uploaded-2", "retry.jpg"));
+		const screen = await renderPicker();
+		setInputFiles(screen.getByLabelText("Choose files to upload").element() as HTMLInputElement, [
+			new File(["retry"], "retry.jpg", { type: "image/jpeg" }),
+		]);
+
+		await expect.element(screen.getByText("Upload failed", { exact: true })).toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("button", { name: "Remove retry.jpg" }))
+			.toBeInTheDocument();
+		screen.getByRole("button", { name: "Retry retry.jpg" }).element().click();
+
+		await vi.waitFor(() => expect(apiMocks.uploadMedia).toHaveBeenCalledTimes(2));
+		await expect
+			.element(screen.getByRole("button", { name: "retry.jpg" }))
+			.toHaveAttribute("aria-pressed", "true");
+	});
+
+	it("aborts an unfinished upload when the picker is cancelled", async () => {
+		let signal: AbortSignal | undefined;
+		apiMocks.uploadMedia.mockImplementation((_file, options) => {
+			signal = (options as { signal?: AbortSignal } | undefined)?.signal;
+			return new Promise<MediaItem>(() => undefined);
+		});
+		const onOpenChange = vi.fn();
+		const screen = await renderPicker({ onOpenChange });
+		setInputFiles(screen.getByLabelText("Choose files to upload").element() as HTMLInputElement, [
+			new File(["cancel"], "cancel.jpg", { type: "image/jpeg" }),
+		]);
+		await vi.waitFor(() => expect(signal).toBeDefined());
+
+		screen.getByRole("button", { name: "Cancel" }).element().click();
+
+		expect(signal?.aborted).toBe(true);
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+	});
+
+	it("selects uploads in file order and returns the reordered tray", async () => {
+		const first = deferred<MediaItem>();
+		const second = deferred<MediaItem>();
+		apiMocks.uploadMedia.mockImplementation((file) =>
+			file.name === "first.jpg" ? first.promise : second.promise,
+		);
+		const onSelectMany = vi.fn();
+		const screen = await renderPicker({ multiple: true, onSelectMany });
+		setInputFiles(screen.getByLabelText("Choose files to upload").element() as HTMLInputElement, [
+			new File(["first"], "first.jpg", { type: "image/jpeg" }),
+			new File(["second"], "second.jpg", { type: "image/jpeg" }),
+		]);
+		await vi.waitFor(() => expect(apiMocks.uploadMedia).toHaveBeenCalledTimes(2));
+
+		second.resolve(mediaItem("uploaded-2", "second.jpg"));
+		first.resolve(mediaItem("uploaded-1", "first.jpg"));
+		await expect.element(screen.getByText("1 of 2", { exact: true })).toBeInTheDocument();
+		await expect.element(screen.getByText("2 of 2", { exact: true })).toBeInTheDocument();
+		screen.getByRole("button", { name: "Move first.jpg later" }).element().click();
+		await expect
+			.element(screen.getByText("second.jpg", { exact: true }).first())
+			.toBeInTheDocument();
+		apiMocks.uploadMedia.mockResolvedValueOnce(mediaItem("uploaded-3", "third.jpg"));
+		setInputFiles(screen.getByLabelText("Choose files to upload").element() as HTMLInputElement, [
+			new File(["third"], "third.jpg", { type: "image/jpeg" }),
+		]);
+		await expect.element(screen.getByText("3 of 3", { exact: true })).toBeInTheDocument();
+		screen.getByRole("button", { name: "Add 3 images" }).element().click();
+
+		const selected = onSelectMany.mock.calls[0]![0] as MediaItem[];
+		expect(selected.map((item) => item.filename)).toEqual(["second.jpg", "first.jpg", "third.jpg"]);
+	});
+
+	it("restores file order when an earlier upload succeeds on retry", async () => {
+		let firstAttempt = true;
+		apiMocks.uploadMedia.mockImplementation((file) => {
+			if (file.name === "first.jpg" && firstAttempt) {
+				firstAttempt = false;
+				return Promise.reject(new Error("network"));
+			}
+			return Promise.resolve(
+				mediaItem(file.name === "first.jpg" ? "uploaded-1" : "uploaded-2", file.name),
+			);
+		});
+		const onSelectMany = vi.fn();
+		const screen = await renderPicker({ multiple: true, onSelectMany });
+		setInputFiles(screen.getByLabelText("Choose files to upload").element() as HTMLInputElement, [
+			new File(["first"], "first.jpg", { type: "image/jpeg" }),
+			new File(["second"], "second.jpg", { type: "image/jpeg" }),
+		]);
+
+		await expect.element(screen.getByText("Upload failed", { exact: true })).toBeInTheDocument();
+		await expect.element(screen.getByText("1 of 1", { exact: true })).toBeInTheDocument();
+		screen.getByRole("button", { name: "Retry first.jpg" }).element().click();
+		await expect.element(screen.getByText("1 of 2", { exact: true })).toBeInTheDocument();
+		await expect.element(screen.getByText("2 of 2", { exact: true })).toBeInTheDocument();
+		screen.getByRole("button", { name: "Add 2 images" }).element().click();
+
+		const selected = onSelectMany.mock.calls[0]![0] as MediaItem[];
+		expect(selected.map((item) => item.filename)).toEqual(["first.jpg", "second.jpg"]);
+	});
+});

--- a/packages/admin/tests/components/MediaPickerUpload.test.tsx
+++ b/packages/admin/tests/components/MediaPickerUpload.test.tsx
@@ -156,6 +156,60 @@ describe("MediaPickerModal inline uploads", () => {
 		expect(screen.getByRole("button", { name: "main-only.jpg", exact: true }).query()).toBeNull();
 	});
 
+	it("prevents a disabled-source file drop from leaving the editor", async () => {
+		const api = await import("../../src/lib/api");
+		(api.fetchMediaFolders as any).mockResolvedValueOnce({
+			items: [{ id: "folder-1", name: "Photography" }],
+		});
+		const screen = await renderPicker();
+		await expect
+			.element(screen.getByRole("button", { name: "Open folder Photography" }))
+			.toBeInTheDocument();
+		screen.getByRole("button", { name: "Open folder Photography" }).element().click();
+		await expect.element(screen.getByText("Photography", { exact: true })).toBeInTheDocument();
+
+		const transfer = new DataTransfer();
+		transfer.items.add(new File(["blocked"], "blocked.jpg", { type: "image/jpeg" }));
+		const results = screen.getByRole("region", { name: "Media results" }).element();
+		const dragOver = new DragEvent("dragover", {
+			bubbles: true,
+			cancelable: true,
+			dataTransfer: transfer,
+		});
+		const drop = new DragEvent("drop", {
+			bubbles: true,
+			cancelable: true,
+			dataTransfer: transfer,
+		});
+		results.dispatchEvent(dragOver);
+		results.dispatchEvent(drop);
+
+		expect(dragOver.defaultPrevented).toBe(true);
+		expect(drop.defaultPrevented).toBe(true);
+		expect(apiMocks.uploadMedia).not.toHaveBeenCalled();
+	});
+
+	it("keeps an uploaded selection while hiding it from a nonmatching search", async () => {
+		apiMocks.uploadMedia.mockResolvedValueOnce(mediaItem("uploaded-1", "new.jpg"));
+		const screen = await renderPicker({ multiple: true });
+		setInputFiles(screen.getByLabelText("Choose files to upload").element() as HTMLInputElement, [
+			new File(["new"], "new.jpg", { type: "image/jpeg" }),
+		]);
+
+		await expect
+			.element(screen.getByRole("button", { name: "new.jpg", exact: true }))
+			.toHaveAttribute("aria-pressed", "true");
+		await screen.getByRole("searchbox", { name: "Search media" }).fill("report");
+
+		await vi.waitFor(() => {
+			expect(screen.getByRole("button", { name: "new.jpg", exact: true }).query()).toBeNull();
+		});
+		await expect
+			.element(screen.getByRole("button", { name: "Remove new.jpg from selection" }))
+			.toBeInTheDocument();
+		await expect.element(screen.getByRole("button", { name: "Add 1 image" })).toBeEnabled();
+	});
+
 	it("shows failed files inline and retries only that file", async () => {
 		apiMocks.uploadMedia
 			.mockRejectedValueOnce(new Error("network"))

--- a/packages/admin/tests/components/settings/GeneralSettings.test.tsx
+++ b/packages/admin/tests/components/settings/GeneralSettings.test.tsx
@@ -43,7 +43,7 @@ vi.mock("../../../src/components/MediaPickerModal", () => ({
 	}) => {
 		if (!open) return null;
 		const modalTitle = typeof title === "string" ? title : "";
-		const isLogo = modalTitle === "Select Logo";
+		const isLogo = modalTitle === "Select logo";
 		return (
 			<div role="dialog" aria-label={modalTitle}>
 				<button

--- a/packages/admin/tests/components/settings/SeoSettings.test.tsx
+++ b/packages/admin/tests/components/settings/SeoSettings.test.tsx
@@ -218,7 +218,7 @@ describe("SeoSettings", () => {
 
 		await userEvent.click(screen.getByRole("button", { name: "Select Image" }));
 		await expect
-			.element(screen.getByRole("dialog", { name: "Select Default Social Image" }))
+			.element(screen.getByRole("dialog", { name: "Select default social image" }))
 			.toBeInTheDocument();
 		await userEvent.click(screen.getByRole("button", { name: "Choose image" }));
 		await expect.element(screen.getByRole("img", { name: "Social card" })).toBeInTheDocument();

--- a/packages/admin/tests/components/useMediaUploadQueue.test.tsx
+++ b/packages/admin/tests/components/useMediaUploadQueue.test.tsx
@@ -1,0 +1,125 @@
+import { expect, it, vi } from "vitest";
+import { renderHook } from "vitest-browser-react";
+
+import { useMediaUploadQueue } from "../../src/components/media/useMediaUploadQueue.js";
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+it("keeps file order and starts no more than the configured upload limit", async () => {
+	const files = ["first.png", "second.png", "third.png"].map(
+		(name) => new File([name], name, { type: "image/png" }),
+	);
+	const pending = new Map(files.map((file) => [file.name, deferred<string>()]));
+	const upload = vi.fn((file: File) => pending.get(file.name)!.promise);
+	const onQueueIdle = vi.fn();
+	const { result, act } = await renderHook(() =>
+		useMediaUploadQueue({ upload, concurrency: 2, onQueueIdle }),
+	);
+
+	await act(() => result.current.addFiles(files));
+	await vi.waitFor(() => expect(upload).toHaveBeenCalledTimes(2));
+	expect(result.current.jobs.map((job) => job.file.name)).toEqual([
+		"first.png",
+		"second.png",
+		"third.png",
+	]);
+	expect(result.current.jobs.map((job) => job.status)).toEqual([
+		"uploading",
+		"uploading",
+		"queued",
+	]);
+
+	pending.get("second.png")!.resolve("second-result");
+	await vi.waitFor(() => expect(upload).toHaveBeenCalledTimes(3));
+	pending.get("third.png")!.resolve("third-result");
+	pending.get("first.png")!.resolve("first-result");
+
+	await vi.waitFor(() => expect(result.current.hasUnfinished).toBe(false));
+	expect(result.current.jobs.map((job) => job.result)).toEqual([
+		"first-result",
+		"second-result",
+		"third-result",
+	]);
+	expect(onQueueIdle).toHaveBeenCalledTimes(1);
+});
+
+it("retries a failed file as a new attempt", async () => {
+	const file = new File(["image"], "retry.png", { type: "image/png" });
+	const upload = vi
+		.fn<(file: File, options: { signal: AbortSignal }) => Promise<string>>()
+		.mockRejectedValueOnce(new Error("network failure"))
+		.mockResolvedValueOnce("uploaded");
+	const { result, act } = await renderHook(() => useMediaUploadQueue({ upload }));
+
+	await act(() => result.current.addFiles([file]));
+	await vi.waitFor(() => expect(result.current.jobs[0]?.status).toBe("failed"));
+
+	await act(() => result.current.retry(result.current.jobs[0]!.id));
+	await vi.waitFor(() => expect(result.current.jobs[0]?.status).toBe("complete"));
+	expect(result.current.jobs[0]).toMatchObject({ attempt: 2, result: "uploaded" });
+});
+
+it("aborts a removed upload and ignores its late completion", async () => {
+	const file = new File(["image"], "cancel.png", { type: "image/png" });
+	const pending = deferred<string>();
+	let signal: AbortSignal | undefined;
+	const upload = vi.fn((_file: File, options: { signal: AbortSignal }) => {
+		signal = options.signal;
+		return pending.promise;
+	});
+	const { result, act } = await renderHook(() => useMediaUploadQueue({ upload }));
+
+	await act(() => result.current.addFiles([file]));
+	await vi.waitFor(() => expect(result.current.jobs[0]?.status).toBe("uploading"));
+	await act(() => result.current.remove(result.current.jobs[0]!.id));
+
+	expect(signal?.aborted).toBe(true);
+	pending.resolve("too late");
+	await vi.waitFor(() => expect(result.current.jobs).toHaveLength(0));
+});
+
+it("aborts active work and revokes previews when unmounted", async () => {
+	const file = new File(["image"], "unmount.png", { type: "image/png" });
+	let signal: AbortSignal | undefined;
+	const upload = vi.fn((_file: File, options: { signal: AbortSignal }) => {
+		signal = options.signal;
+		return new Promise<void>(() => undefined);
+	});
+	const revokeObjectUrl = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+	const { result, act, unmount } = await renderHook(() =>
+		useMediaUploadQueue({
+			upload,
+			createPreviewUrl: () => "blob:queue-preview",
+		}),
+	);
+
+	await act(() => result.current.addFiles([file]));
+	await vi.waitFor(() => expect(signal).toBeDefined());
+	await unmount();
+
+	expect(signal?.aborted).toBe(true);
+	expect(revokeObjectUrl).toHaveBeenCalledWith("blob:queue-preview");
+	revokeObjectUrl.mockRestore();
+});
+
+it("bounds the visible queue to 100 files", async () => {
+	const files = Array.from(
+		{ length: 101 },
+		(_, index) => new File([String(index)], `file-${index}.txt`, { type: "text/plain" }),
+	);
+	const upload = vi.fn(() => new Promise<void>(() => undefined));
+	const { result, act } = await renderHook(() => useMediaUploadQueue({ upload, concurrency: 1 }));
+
+	await act(() => result.current.addFiles(files));
+
+	expect(result.current.jobs).toHaveLength(100);
+	expect(result.current.overflowCount).toBe(1);
+});

--- a/packages/admin/tests/media-picker-multiselect.test.tsx
+++ b/packages/admin/tests/media-picker-multiselect.test.tsx
@@ -84,7 +84,7 @@ function renderModal(props: Partial<React.ComponentProps<typeof MediaPickerModal
 }
 
 function optionButton(screen: Awaited<ReturnType<typeof renderModal>>, name: string) {
-	return screen.getByRole("button", { name }).element() as HTMLButtonElement;
+	return screen.getByRole("button", { name, exact: true }).element() as HTMLButtonElement;
 }
 
 function confirmationButton(): HTMLButtonElement {
@@ -102,23 +102,25 @@ describe("MediaPickerModal — multi-select", () => {
 		const onSelectMany = vi.fn();
 		const screen = await renderModal({ multiple: true, onSelectMany });
 
-		await expect.element(screen.getByRole("button", { name: "photo.jpg" })).toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("button", { name: "photo.jpg", exact: true }))
+			.toBeInTheDocument();
 
 		// Click landscape, then photo, then portrait — order should be preserved
 		// as the gallery insertion order, not the grid's display order.
 		optionButton(screen, "landscape.png").click();
 		await expect
-			.element(screen.getByRole("button", { name: "landscape.png" }))
+			.element(screen.getByRole("button", { name: "landscape.png", exact: true }))
 			.toHaveAttribute("aria-pressed", "true");
 
 		optionButton(screen, "photo.jpg").click();
 		await expect
-			.element(screen.getByRole("button", { name: "photo.jpg" }))
+			.element(screen.getByRole("button", { name: "photo.jpg", exact: true }))
 			.toHaveAttribute("aria-pressed", "true");
 
 		optionButton(screen, "portrait.png").click();
 		await expect
-			.element(screen.getByRole("button", { name: "portrait.png" }))
+			.element(screen.getByRole("button", { name: "portrait.png", exact: true }))
 			.toHaveAttribute("aria-pressed", "true");
 
 		await vi.waitFor(() => {
@@ -139,22 +141,24 @@ describe("MediaPickerModal — multi-select", () => {
 		const onSelectMany = vi.fn();
 		const screen = await renderModal({ multiple: true, onSelectMany });
 
-		await expect.element(screen.getByRole("button", { name: "photo.jpg" })).toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("button", { name: "photo.jpg", exact: true }))
+			.toBeInTheDocument();
 
 		optionButton(screen, "photo.jpg").click();
 		await expect
-			.element(screen.getByRole("button", { name: "photo.jpg" }))
+			.element(screen.getByRole("button", { name: "photo.jpg", exact: true }))
 			.toHaveAttribute("aria-pressed", "true");
 
 		optionButton(screen, "landscape.png").click();
 		await expect
-			.element(screen.getByRole("button", { name: "landscape.png" }))
+			.element(screen.getByRole("button", { name: "landscape.png", exact: true }))
 			.toHaveAttribute("aria-pressed", "true");
 
 		// Deselect the first click
 		optionButton(screen, "photo.jpg").click();
 		await expect
-			.element(screen.getByRole("button", { name: "photo.jpg" }))
+			.element(screen.getByRole("button", { name: "photo.jpg", exact: true }))
 			.toHaveAttribute("aria-pressed", "false");
 
 		await vi.waitFor(() => {
@@ -177,7 +181,9 @@ describe("MediaPickerModal — multi-select", () => {
 
 	it("confirmation follows the current selection count", async () => {
 		const screen = await renderModal({ multiple: true });
-		await expect.element(screen.getByRole("button", { name: "photo.jpg" })).toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("button", { name: "photo.jpg", exact: true }))
+			.toBeInTheDocument();
 
 		optionButton(screen, "photo.jpg").click();
 		await vi.waitFor(() => {
@@ -195,11 +201,13 @@ describe("MediaPickerModal — multi-select", () => {
 		const onSelectMany = vi.fn();
 		const screen = await renderModal({ onSelect, onSelectMany });
 
-		await expect.element(screen.getByRole("button", { name: "photo.jpg" })).toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("button", { name: "photo.jpg", exact: true }))
+			.toBeInTheDocument();
 
 		optionButton(screen, "photo.jpg").click();
 		await expect
-			.element(screen.getByRole("button", { name: "photo.jpg" }))
+			.element(screen.getByRole("button", { name: "photo.jpg", exact: true }))
 			.toHaveAttribute("aria-pressed", "true");
 
 		screen.getByRole("button", { name: "Select" }).element().click();
@@ -234,13 +242,17 @@ describe("MediaPickerModal — multi-select", () => {
 		});
 		const onSelectMany = vi.fn();
 		const screen = await renderModal({ multiple: true, onSelectMany });
-		await expect.element(screen.getByRole("button", { name: "photo.jpg" })).toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("button", { name: "photo.jpg", exact: true }))
+			.toBeInTheDocument();
 		optionButton(screen, "photo.jpg").click();
 		screen.getByRole("tab", { name: "Cloudflare Images" }).element().click();
-		await expect.element(screen.getByRole("button", { name: "provider.jpg" })).toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("button", { name: "provider.jpg", exact: true }))
+			.toBeInTheDocument();
 		optionButton(screen, "provider.jpg").click();
 		await expect
-			.element(screen.getByRole("button", { name: "provider.jpg" }))
+			.element(screen.getByRole("button", { name: "provider.jpg", exact: true }))
 			.toHaveAttribute("aria-pressed", "true");
 		confirmationButton().click();
 

--- a/packages/admin/tests/media-picker-multiselect.test.tsx
+++ b/packages/admin/tests/media-picker-multiselect.test.tsx
@@ -50,7 +50,10 @@ vi.mock("../src/lib/api", async () => {
 					createdAt: "2024-01-03",
 				},
 			],
+			totalCount: 3,
 		}),
+		fetchMediaFolders: vi.fn().mockResolvedValue({ items: [] }),
+		fetchMediaFolder: vi.fn().mockResolvedValue({ id: "folder-1", name: "Photography" }),
 		fetchMediaProviders: vi.fn().mockResolvedValue([]),
 		fetchProviderMedia: vi.fn().mockResolvedValue({ items: [] }),
 		uploadMedia: vi.fn().mockResolvedValue({ id: "m4", filename: "new.jpg" }),
@@ -81,14 +84,13 @@ function renderModal(props: Partial<React.ComponentProps<typeof MediaPickerModal
 }
 
 function optionButton(screen: Awaited<ReturnType<typeof renderModal>>, name: string) {
-	const option = screen.getByRole("option", { name });
-	return option.element().querySelector("button")!;
+	return screen.getByRole("button", { name }).element() as HTMLButtonElement;
 }
 
-function footerInsertButton(): HTMLButtonElement {
-	const allInsertBtns = [...document.querySelectorAll("button")];
-	const insertBtns = allInsertBtns.filter((b) => b.textContent?.trim() === "Insert");
-	return insertBtns.at(-1) as HTMLButtonElement;
+function confirmationButton(): HTMLButtonElement {
+	return [...document.querySelectorAll("button")].find((button) =>
+		/^Add \d+ images?$/.test(button.textContent?.trim() ?? ""),
+	)!;
 }
 
 describe("MediaPickerModal — multi-select", () => {
@@ -100,29 +102,29 @@ describe("MediaPickerModal — multi-select", () => {
 		const onSelectMany = vi.fn();
 		const screen = await renderModal({ multiple: true, onSelectMany });
 
-		await expect.element(screen.getByRole("option", { name: "photo.jpg" })).toBeInTheDocument();
+		await expect.element(screen.getByRole("button", { name: "photo.jpg" })).toBeInTheDocument();
 
 		// Click landscape, then photo, then portrait — order should be preserved
 		// as the gallery insertion order, not the grid's display order.
 		optionButton(screen, "landscape.png").click();
 		await expect
-			.element(screen.getByRole("option", { name: "landscape.png" }))
-			.toHaveAttribute("aria-selected", "true");
+			.element(screen.getByRole("button", { name: "landscape.png" }))
+			.toHaveAttribute("aria-pressed", "true");
 
 		optionButton(screen, "photo.jpg").click();
 		await expect
-			.element(screen.getByRole("option", { name: "photo.jpg" }))
-			.toHaveAttribute("aria-selected", "true");
+			.element(screen.getByRole("button", { name: "photo.jpg" }))
+			.toHaveAttribute("aria-pressed", "true");
 
 		optionButton(screen, "portrait.png").click();
 		await expect
-			.element(screen.getByRole("option", { name: "portrait.png" }))
-			.toHaveAttribute("aria-selected", "true");
+			.element(screen.getByRole("button", { name: "portrait.png" }))
+			.toHaveAttribute("aria-pressed", "true");
 
 		await vi.waitFor(() => {
-			expect(footerInsertButton().disabled).toBe(false);
+			expect(confirmationButton().disabled).toBe(false);
 		});
-		footerInsertButton().click();
+		confirmationButton().click();
 
 		expect(onSelectMany).toHaveBeenCalledTimes(1);
 		const selected = onSelectMany.mock.calls[0]![0] as Array<{ filename: string }>;
@@ -137,54 +139,54 @@ describe("MediaPickerModal — multi-select", () => {
 		const onSelectMany = vi.fn();
 		const screen = await renderModal({ multiple: true, onSelectMany });
 
-		await expect.element(screen.getByRole("option", { name: "photo.jpg" })).toBeInTheDocument();
+		await expect.element(screen.getByRole("button", { name: "photo.jpg" })).toBeInTheDocument();
 
 		optionButton(screen, "photo.jpg").click();
 		await expect
-			.element(screen.getByRole("option", { name: "photo.jpg" }))
-			.toHaveAttribute("aria-selected", "true");
+			.element(screen.getByRole("button", { name: "photo.jpg" }))
+			.toHaveAttribute("aria-pressed", "true");
 
 		optionButton(screen, "landscape.png").click();
 		await expect
-			.element(screen.getByRole("option", { name: "landscape.png" }))
-			.toHaveAttribute("aria-selected", "true");
+			.element(screen.getByRole("button", { name: "landscape.png" }))
+			.toHaveAttribute("aria-pressed", "true");
 
 		// Deselect the first click
 		optionButton(screen, "photo.jpg").click();
 		await expect
-			.element(screen.getByRole("option", { name: "photo.jpg" }))
-			.toHaveAttribute("aria-selected", "false");
+			.element(screen.getByRole("button", { name: "photo.jpg" }))
+			.toHaveAttribute("aria-pressed", "false");
 
 		await vi.waitFor(() => {
-			expect(footerInsertButton().disabled).toBe(false);
+			expect(confirmationButton().disabled).toBe(false);
 		});
-		footerInsertButton().click();
+		confirmationButton().click();
 
 		expect(onSelectMany).toHaveBeenCalledTimes(1);
 		const selected = onSelectMany.mock.calls[0]![0] as Array<{ filename: string }>;
 		expect(selected.map((item) => item.filename)).toEqual(["landscape.png"]);
 	});
 
-	it("Insert button is disabled at zero selections", async () => {
+	it("confirmation is disabled at zero selections", async () => {
 		await renderModal({ multiple: true });
 
 		await vi.waitFor(() => {
-			expect(footerInsertButton().disabled).toBe(true);
+			expect(confirmationButton().disabled).toBe(true);
 		});
 	});
 
-	it("Insert button becomes enabled after one selection and disabled again after deselecting it", async () => {
+	it("confirmation follows the current selection count", async () => {
 		const screen = await renderModal({ multiple: true });
-		await expect.element(screen.getByRole("option", { name: "photo.jpg" })).toBeInTheDocument();
+		await expect.element(screen.getByRole("button", { name: "photo.jpg" })).toBeInTheDocument();
 
 		optionButton(screen, "photo.jpg").click();
 		await vi.waitFor(() => {
-			expect(footerInsertButton().disabled).toBe(false);
+			expect(confirmationButton().disabled).toBe(false);
 		});
 
 		optionButton(screen, "photo.jpg").click();
 		await vi.waitFor(() => {
-			expect(footerInsertButton().disabled).toBe(true);
+			expect(confirmationButton().disabled).toBe(true);
 		});
 	});
 
@@ -193,22 +195,61 @@ describe("MediaPickerModal — multi-select", () => {
 		const onSelectMany = vi.fn();
 		const screen = await renderModal({ onSelect, onSelectMany });
 
-		await expect.element(screen.getByRole("option", { name: "photo.jpg" })).toBeInTheDocument();
+		await expect.element(screen.getByRole("button", { name: "photo.jpg" })).toBeInTheDocument();
 
 		optionButton(screen, "photo.jpg").click();
 		await expect
-			.element(screen.getByRole("option", { name: "photo.jpg" }))
-			.toHaveAttribute("aria-selected", "true");
+			.element(screen.getByRole("button", { name: "photo.jpg" }))
+			.toHaveAttribute("aria-pressed", "true");
 
-		await vi.waitFor(() => {
-			expect(footerInsertButton().disabled).toBe(false);
-		});
-		footerInsertButton().click();
+		screen.getByRole("button", { name: "Select" }).element().click();
 
 		expect(onSelect).toHaveBeenCalledTimes(1);
 		expect(onSelect).toHaveBeenCalledWith(
 			expect.objectContaining({ id: "m1", filename: "photo.jpg" }),
 		);
 		expect(onSelectMany).not.toHaveBeenCalled();
+	});
+
+	it("keeps selections when switching to a configured provider", async () => {
+		const api = await import("../src/lib/api");
+		(api.fetchMediaProviders as any).mockResolvedValueOnce([
+			{
+				id: "cloudflare-images",
+				name: "Cloudflare Images",
+				capabilities: { browse: true, search: false, upload: true, delete: false },
+			},
+		]);
+		(api.fetchProviderMedia as any).mockResolvedValueOnce({
+			items: [
+				{
+					id: "provider-1",
+					filename: "provider.jpg",
+					mimeType: "image/jpeg",
+					previewUrl: "https://example.com/provider.jpg",
+					width: 800,
+					height: 600,
+				},
+			],
+		});
+		const onSelectMany = vi.fn();
+		const screen = await renderModal({ multiple: true, onSelectMany });
+		await expect.element(screen.getByRole("button", { name: "photo.jpg" })).toBeInTheDocument();
+		optionButton(screen, "photo.jpg").click();
+		screen.getByRole("tab", { name: "Cloudflare Images" }).element().click();
+		await expect.element(screen.getByRole("button", { name: "provider.jpg" })).toBeInTheDocument();
+		optionButton(screen, "provider.jpg").click();
+		await expect
+			.element(screen.getByRole("button", { name: "provider.jpg" }))
+			.toHaveAttribute("aria-pressed", "true");
+		confirmationButton().click();
+
+		const selected = onSelectMany.mock.calls[0]![0] as Array<{
+			filename: string;
+			provider?: string;
+		}>;
+		expect(selected.map((item) => item.filename)).toEqual(["photo.jpg", "provider.jpg"]);
+		expect(selected[0]?.provider).toBeUndefined();
+		expect(selected[1]?.provider).toBe("cloudflare-images");
 	});
 });

--- a/packages/admin/vitest.config.ts
+++ b/packages/admin/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	resolve: { dedupe: ["react", "react-dom"] },
-	optimizeDeps: { include: ["react-image-crop"] },
+	optimizeDeps: { include: ["@cloudflare/kumo/primitives/scroll-area", "react-image-crop"] },
 	plugins: [
 		react({
 			babel: {

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -372,6 +372,15 @@ function isCloudflareAdapter(astroConfig: AstroConfig): boolean {
 	return astroConfig.adapter?.name === "@astrojs/cloudflare";
 }
 
+function canResolveProjectDependency(projectRoot: string, specifier: string): boolean {
+	try {
+		createRequire(resolve(projectRoot, "package.json")).resolve(specifier);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 /**
  * Creates the Vite config update for EmDash.
  */
@@ -383,6 +392,7 @@ export function createViteConfig(
 	const cloudflare = isCloudflareAdapter(options.astroConfig);
 	const isDev = command === "dev";
 	const projectRoot = fileURLToPath(options.astroConfig.root);
+	const hasAstroConsoleLogger = canResolveProjectDependency(projectRoot, "astro/logger/console");
 
 	const adminSourcePath = isDev ? resolveAdminSource(projectRoot) : undefined;
 	const useSource = adminSourcePath !== undefined;
@@ -541,6 +551,7 @@ export function createViteConfig(
 							"@emdash-cms/cloudflare > kysely-d1",
 							// Astro internal deps not covered by @astrojs/cloudflare adapter
 							"astro/app/manifest",
+							...(hasAstroConsoleLogger ? ["astro/logger/console"] : []),
 							"astro/virtual-modules/middleware.js",
 							"astro/virtual-modules/live-config",
 							"astro/content/runtime",

--- a/packages/core/tests/integration/smoke/isolated-install.test.ts
+++ b/packages/core/tests/integration/smoke/isolated-install.test.ts
@@ -147,6 +147,36 @@ function parseCatalog(): Map<string, string> {
 	return catalog;
 }
 
+function parseWorkspaceStringList(key: string): string[] {
+	const workspaceConfig = readFileSync(join(WORKSPACE_ROOT, "pnpm-workspace.yaml"), "utf8");
+	const values: string[] = [];
+	let inList = false;
+	for (const line of workspaceConfig.split(/\r?\n/)) {
+		if (line === `${key}:`) {
+			inList = true;
+			continue;
+		}
+		if (inList && /^\S/.test(line)) break;
+		if (!inList) continue;
+
+		const match = line.match(/^\s{2}-\s+(.+)$/);
+		if (!match) continue;
+		const value = match[1]!.replace(/\s+#.*$/, "").replace(/^["']|["']$/g, "");
+		if (value) values.push(value);
+	}
+	return values;
+}
+
+function parseWorkspaceNumber(key: string): number {
+	const workspaceConfig = readFileSync(join(WORKSPACE_ROOT, "pnpm-workspace.yaml"), "utf8");
+	const match = workspaceConfig.match(new RegExp(`^${key}:\\s+(\\d+)`, "m"));
+	const value = Number(match?.[1]);
+	if (!Number.isSafeInteger(value) || value < 0) {
+		throw new Error(`Missing numeric ${key} in pnpm-workspace.yaml`);
+	}
+	return value;
+}
+
 function consumerEnvironment(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
 	const environment = { ...process.env, ...overrides };
 	for (const key of Object.keys(environment)) {
@@ -248,12 +278,16 @@ function prepareStandaloneTemplate(
 		platform.id === "cloudflare"
 			? "  esbuild: true\n  workerd: true\n  sharp: false"
 			: "  esbuild: true\n  sharp: true\n  workerd: false";
+	const releaseAgeExcludes = Array.from(
+		new Set([...parseWorkspaceStringList("minimumReleaseAgeExclude"), "emdash", "@emdash-cms/*"]),
+		(value) => `  - ${JSON.stringify(value)}`,
+	).join("\n");
+	const minimumReleaseAge = parseWorkspaceNumber("minimumReleaseAge");
 	writeFileSync(
 		join(projectDir, "pnpm-workspace.yaml"),
-		`minimumReleaseAge: 1440
+		`minimumReleaseAge: ${minimumReleaseAge}
 minimumReleaseAgeExclude:
-  - emdash
-  - "@emdash-cms/*"
+${releaseAgeExcludes}
 blockExoticSubdeps: true
 strictDepBuilds: true
 overrides:
@@ -356,6 +390,18 @@ describe.sequential("Isolated template installs", () => {
 
 	afterAll(() => {
 		if (temporaryDirectory) rmSync(temporaryDirectory, { recursive: true, force: true });
+	});
+
+	it("inherits workspace release-age exclusions", () => {
+		const expected = parseWorkspaceStringList("minimumReleaseAgeExclude");
+		const expectedAge = parseWorkspaceNumber("minimumReleaseAge");
+		for (const projectDir of projectDirs.values()) {
+			const workspaceConfig = readFileSync(join(projectDir, "pnpm-workspace.yaml"), "utf8");
+			expect(workspaceConfig).toContain(`minimumReleaseAge: ${expectedAge}`);
+			for (const value of expected) {
+				expect(workspaceConfig).toContain(`  - ${JSON.stringify(value)}`);
+			}
+		}
 	});
 
 	for (const platform of PLATFORM_CASES) {

--- a/packages/core/tests/unit/astro/vite-config.test.ts
+++ b/packages/core/tests/unit/astro/vite-config.test.ts
@@ -170,3 +170,35 @@ describe("createViteConfig use-sync-external-store shim aliasing", () => {
 		});
 	}
 });
+
+describe("createViteConfig Astro logger optimization", () => {
+	const astroSevenRoot = new URL("../../../../../demos/cloudflare/", import.meta.url);
+	const astroSixRoot = new URL("../../../../../docs/", import.meta.url);
+
+	function buildConfig(root: URL) {
+		return createViteConfig(
+			{
+				serializableConfig: {},
+				resolvedConfig: {} as never,
+				pluginDescriptors: [],
+				astroConfig: {
+					root,
+					adapter: { name: "@astrojs/cloudflare" },
+				} as AstroConfig,
+			},
+			"dev",
+		);
+	}
+
+	it("pre-bundles the public logger export for Astro 7", () => {
+		const config = buildConfig(astroSevenRoot);
+
+		expect(config.ssr?.optimizeDeps?.include).toContain("astro/logger/console");
+	});
+
+	it("does not require the unavailable logger export from Astro 6", () => {
+		const config = buildConfig(astroSixRoot);
+
+		expect(config.ssr?.optimizeDeps?.include).not.toContain("astro/logger/console");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Brings admin media pickers in line with the Media Library while keeping them focused on choosing
media:

- adds folders, filename search, type filters, grid/list views, and numbered local pagination;
- keeps selections across pages, searches, folders, and configured provider tabs;
- treats direct URLs as a source and uses task-specific confirmation labels;
- uploads files inline with a grey spinner card, retry/remove failure actions, and no nested dialog;
- preserves upload and gallery selection order in an accessible reorderable tray; and
- uses the same Kumo media-card presentation in the picker and Media Library.

Asset metadata editing, cropping, focal points, deletion, folder management, and public visual
editing remain outside this PR.

Closes #2784

Approved direction: https://github.com/emdash-cms/emdash/discussions/990

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/990
- [x] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5) with GPT-5.6 Terra used for iterative second-opinion review

## Screenshots / test output

Desktop, dark appearance:

![Admin media picker with source tabs, search, type filter, view controls, and media cards in dark appearance](https://github.com/user-attachments/assets/cf1633d4-1458-44f5-ac8e-eb2366615cc5)

Mobile-width, light appearance:

![Admin media picker reflowed to 320 pixels with a full-width search field and one-column media cards](https://github.com/user-attachments/assets/52312775-681d-41ba-a2a7-058e3dc1a4e0)

Inline upload failure:

![Admin media picker showing a grey failed upload card with Retry and Remove actions](https://github.com/user-attachments/assets/a25b8ad6-04b2-4588-8995-2184f18a4673)

Arabic right-to-left layout:

![Admin media picker at 320 pixels in Arabic with right-to-left control and card alignment](https://github.com/user-attachments/assets/c4c9f14e-1787-474a-af8f-af3e4cf38c11)

Verified locally:

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- all 1,892 admin tests
- focused Playwright byline media-picker upload and persistence flow
- admin package and documentation builds
- desktop and 320px light/dark, Arabic RTL, extracted pseudo-locale, keyboard, focus restoration,
  inline failure/retry, and browser-console checks
