### PR TITLE
fix(admin): let the editor recover from a save conflict instead of resending a refused token

### DIFF
--- a/.changeset/editor-save-conflict-recovery.md
+++ b/.changeset/editor-save-conflict-recovery.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the content editor refusing every later save once another writer changed the same entry, so what you typed is kept and can be saved over the newer version. Autosave pauses for that entry until you decide, so your copy never goes over the other version without you choosing it.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -1,5 +1,6 @@
 import {
 	Badge,
+	Banner,
 	Button,
 	Checkbox,
 	Input,
@@ -157,8 +158,16 @@ export interface ContentEditorProps {
 	isAutosaveFeedbackActive?: boolean;
 	/** Entry-scoped token advanced after a successful autosave. */
 	autosaveCompletionToken?: number;
-	/** Entry-scoped token advanced after the server rejected an autosave payload. */
+	/**
+	 * Entry-scoped token advanced after the server rejected an autosave payload in
+	 * a way that resending cannot fix. A conflict does not count: it recovers
+	 * through `hasSaveConflict`.
+	 */
 	autosaveRejectionToken?: number;
+	/** Whether the server refused the last save because it was based on a stale read. */
+	hasSaveConflict?: boolean;
+	/** Clears the conflict notice, without saving. */
+	onDismissSaveConflict?: () => void;
 	onPublish?: (payload: {
 		data: Record<string, unknown>;
 		slug?: string;
@@ -242,6 +251,8 @@ export function ContentEditor({
 	isAutosaveFeedbackActive,
 	autosaveCompletionToken,
 	autosaveRejectionToken,
+	hasSaveConflict,
+	onDismissSaveConflict,
 	onPublish,
 	onUnpublish,
 	onDiscardDraft,
@@ -526,6 +537,12 @@ export function ContentEditor({
 			return;
 		}
 
+		// Autosaving through a conflict would put the writer's copy over the other
+		// version without them ever choosing to.
+		if (hasSaveConflict) {
+			return;
+		}
+
 		// Clear any pending autosave
 		if (autosaveTimeoutRef.current) {
 			clearTimeout(autosaveTimeoutRef.current);
@@ -563,11 +580,11 @@ export function ContentEditor({
 		hasUnsupportedPortableTextMarks,
 		isPublishing,
 		rejectedAutosaveState,
+		hasSaveConflict,
 	]);
 
 	// Cancel pending autosave on manual save
-	const handleSubmit = (e: React.FormEvent) => {
-		e.preventDefault();
+	const submitSave = () => {
 		if (
 			isContentSaveBlocked ||
 			isPublishingRef.current ||
@@ -577,6 +594,10 @@ export function ContentEditor({
 			return;
 		cancelPendingAutosave();
 		onSave?.(createSavePayload());
+	};
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		submitSave();
 	};
 	const handlePublish = React.useCallback(() => {
 		if (
@@ -892,6 +913,27 @@ export function ContentEditor({
 							isDistractionFree ? "mx-auto max-w-3xl pt-16" : "mx-auto max-w-3xl space-y-6",
 						)}
 					>
+						{hasSaveConflict && (
+							<Banner
+								variant="error"
+								role="alert"
+								title={t`This entry changed somewhere else after you opened it.`}
+								description={t`What you typed is still here. Saving replaces the newer version.`}
+								action={
+									<Button
+										size="sm"
+										variant="secondary"
+										type="button"
+										onClick={() => {
+											onDismissSaveConflict?.();
+											submitSave();
+										}}
+									>
+										{t`Save anyway`}
+									</Button>
+								}
+							/>
+						)}
 						<div className="space-y-6">
 							{Object.entries(fields).map(([name, field]) => {
 								// Key by item id so all field editors remount cleanly when the

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -166,8 +166,6 @@ export interface ContentEditorProps {
 	autosaveRejectionToken?: number;
 	/** Whether the server refused the last save because it was based on a stale read. */
 	hasSaveConflict?: boolean;
-	/** Clears the conflict notice, without saving. */
-	onDismissSaveConflict?: () => void;
 	onPublish?: (payload: {
 		data: Record<string, unknown>;
 		slug?: string;
@@ -252,7 +250,6 @@ export function ContentEditor({
 	autosaveCompletionToken,
 	autosaveRejectionToken,
 	hasSaveConflict,
-	onDismissSaveConflict,
 	onPublish,
 	onUnpublish,
 	onDiscardDraft,
@@ -920,15 +917,7 @@ export function ContentEditor({
 								title={t`This entry changed somewhere else after you opened it.`}
 								description={t`What you typed is still here. Saving replaces the newer version.`}
 								action={
-									<Button
-										size="sm"
-										variant="secondary"
-										type="button"
-										onClick={() => {
-											onDismissSaveConflict?.();
-											submitSave();
-										}}
-									>
+									<Button size="sm" variant="secondary" type="button" onClick={submitSave}>
 										{t`Save anyway`}
 									</Button>
 								}

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -178,6 +178,10 @@ interface AutosaveMutationInput {
 	changes: Pick<ContentUpdateChanges, "data" | "slug" | "bylines" | "_rev">;
 }
 
+function isSaveConflict(error: unknown): boolean {
+	return error instanceof ApiResponseError && error.code === "CONFLICT";
+}
+
 function patchAutosaveQueries(
 	queryClient: QueryClient,
 	params: {
@@ -985,6 +989,7 @@ function ContentEditPage() {
 		autosaveRejectionSequenceRef.current += 1;
 		setAutosaveRejection({ entryId, token: autosaveRejectionSequenceRef.current });
 	}, []);
+	const [conflictedEntryId, setConflictedEntryId] = React.useState("");
 	const { data: bylinesData, isSuccess: bylinesLoaded } = useQuery({
 		queryKey: ["bylines", "picker", itemLocale ?? null],
 		queryFn: () => fetchBylines({ locale: itemLocale, limit: 100 }),
@@ -1033,6 +1038,25 @@ function ContentEditPage() {
 		},
 		[collection, queryClient, rawItem?.draftRevisionId],
 	);
+	const recoverFromSaveConflict = React.useCallback(
+		async (entryId: string) => {
+			setConflictedEntryId(entryId);
+			try {
+				const server = await fetchContent(collection, entryId, {
+					locale: rawItem?.locale ?? activeLocale,
+				});
+				revisionTokensRef.current.set(entryId, server._rev);
+				return true;
+			} catch {
+				// Dropping the refused token would make the next save a blind write, so
+				// it stays. Offering to save over a version that could not be read
+				// would promise a write the server refuses again.
+				setConflictedEntryId((conflicted) => (conflicted === entryId ? "" : conflicted));
+				return false;
+			}
+		},
+		[activeLocale, collection, rawItem?.locale],
+	);
 	const handleContentUpdateError = React.useCallback(
 		(error: unknown) => {
 			toastManager.add({
@@ -1061,9 +1085,13 @@ function ContentEditPage() {
 			}
 		},
 		onSuccess: (_, variables) => {
+			setConflictedEntryId((current) => (current === variables.targetId ? "" : current));
 			handleContentUpdateSuccess(variables.targetId);
 		},
-		onError: handleContentUpdateError,
+		onError: async (error, variables) => {
+			if (isSaveConflict(error) && (await recoverFromSaveConflict(variables.targetId))) return;
+			handleContentUpdateError(error);
+		},
 		onSettled: (_, __, variables) => {
 			if (variables.source === "editor") {
 				updateEditorSavePendingCount(variables.targetId, -1);
@@ -1100,6 +1128,7 @@ function ContentEditPage() {
 			return savedItem;
 		},
 		onSuccess: (savedItem, variables) => {
+			setConflictedEntryId((current) => (current === variables.targetId ? "" : current));
 			recordAutosaveCompletion(variables.targetId);
 			patchAutosaveQueries(queryClient, {
 				collection,
@@ -1113,7 +1142,8 @@ function ContentEditPage() {
 			// Keep the cache fresh without refetching older server state back into the form
 			// while the user is still typing.
 		},
-		onError: (err, variables) => {
+		onError: async (err, variables) => {
+			if (isSaveConflict(err) && (await recoverFromSaveConflict(variables.targetId))) return;
 			if (isTerminalRequestError(err)) recordAutosaveRejection(variables.targetId);
 			toastManager.add({
 				title: t`Autosave failed`,
@@ -1168,6 +1198,7 @@ function ContentEditPage() {
 	const discardDraftMutation = useMutation({
 		mutationFn: () => discardDraft(collection, id, { locale: rawItem?.locale ?? activeLocale }),
 		onSuccess: () => {
+			setConflictedEntryId((conflicted) => (conflicted === id ? "" : conflicted));
 			void queryClient.invalidateQueries({
 				queryKey: ["content", collection, id],
 			});
@@ -1436,6 +1467,8 @@ function ContentEditPage() {
 			}
 			autosaveCompletionToken={autosaveCompletion.entryId === id ? autosaveCompletion.token : 0}
 			autosaveRejectionToken={autosaveRejection.entryId === id ? autosaveRejection.token : 0}
+			hasSaveConflict={conflictedEntryId === id}
+			onDismissSaveConflict={() => setConflictedEntryId("")}
 			onPublish={handlePublish}
 			onUnpublish={handleUnpublish}
 			onDiscardDraft={handleDiscardDraft}

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -1468,7 +1468,6 @@ function ContentEditPage() {
 			autosaveCompletionToken={autosaveCompletion.entryId === id ? autosaveCompletion.token : 0}
 			autosaveRejectionToken={autosaveRejection.entryId === id ? autosaveRejection.token : 0}
 			hasSaveConflict={conflictedEntryId === id}
-			onDismissSaveConflict={() => setConflictedEntryId("")}
 			onPublish={handlePublish}
 			onUnpublish={handleUnpublish}
 			onDiscardDraft={handleDiscardDraft}

--- a/packages/admin/tests/editor-save-conflict.test.tsx
+++ b/packages/admin/tests/editor-save-conflict.test.tsx
@@ -23,7 +23,10 @@ const MANIFEST: AdminManifest = {
 			labelSingular: "Post",
 			supports: ["drafts", "revisions"],
 			hasSeo: false,
-			fields: { title: { kind: "string", label: "Title" } },
+			fields: {
+				title: { kind: "string", label: "Title" },
+				link: { kind: "url", label: "Link" },
+			},
 		},
 	},
 	plugins: {},
@@ -239,6 +242,27 @@ describe("ContentEditPage save conflict", () => {
 
 		await expect.element(screen.getByText("Autosave failed")).toBeVisible();
 		expect(screen.getByRole("button", { name: "Save anyway", exact: true }).query()).toBeNull();
+	});
+
+	it("keeps the notice when the save it offers cannot start", async () => {
+		server = conflictOnFirstPut();
+		const screen = await renderEditPage();
+		const title = screen.getByRole("textbox", { name: "Title" });
+
+		await title.fill("Writer copy");
+		await vi.advanceTimersByTimeAsync(2500);
+
+		const saveAnyway = screen.getByRole("button", { name: "Save anyway", exact: true });
+		await expect.element(saveAnyway).toBeVisible();
+
+		// An invalid URL makes submitSave return before it reaches onSave.
+		await screen.getByRole("textbox", { name: "Link" }).fill("not a url");
+		await saveAnyway.click();
+		await vi.advanceTimersByTimeAsync(10000);
+
+		await expect.element(saveAnyway).toBeVisible();
+		const puts = server.requests.filter((request) => request.method === "PUT");
+		expect(puts).toHaveLength(1);
 	});
 
 	it("takes the notice down when the writer discards instead", async () => {

--- a/packages/admin/tests/editor-save-conflict.test.tsx
+++ b/packages/admin/tests/editor-save-conflict.test.tsx
@@ -1,0 +1,275 @@
+import { Toasty } from "@cloudflare/kumo";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { RouterProvider } from "@tanstack/react-router";
+import { userEvent } from "@vitest/browser/context";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider } from "../src/components/ThemeProvider";
+import type { AdminManifest, ContentItem } from "../src/lib/api";
+import { createAdminRouter } from "../src/router";
+import { render } from "./utils/render.tsx";
+import { createTestQueryClient } from "./utils/test-helpers.tsx";
+
+const MANIFEST: AdminManifest = {
+	version: "1.0.0",
+	hash: "rev-lockout",
+	authMode: "passkey",
+	collections: {
+		posts: {
+			label: "Posts",
+			labelSingular: "Post",
+			supports: ["drafts", "revisions"],
+			hasSeo: false,
+			fields: { title: { kind: "string", label: "Title" } },
+		},
+	},
+	plugins: {},
+	taxonomies: [],
+	i18n: undefined,
+};
+
+type RevisionedContentItem = ContentItem & { _rev: string };
+
+function makeItem(overrides: Partial<RevisionedContentItem> = {}): RevisionedContentItem {
+	return {
+		id: "post_1",
+		type: "posts",
+		slug: "post-one",
+		status: "published",
+		locale: "en",
+		translationGroup: null,
+		data: { title: "Draft title" },
+		authorId: null,
+		primaryBylineId: null,
+		createdAt: "2026-01-01T00:00:00Z",
+		updatedAt: "2026-01-02T00:00:00Z",
+		publishedAt: "2026-01-01T00:00:00Z",
+		scheduledAt: null,
+		liveRevisionId: "revision-live",
+		draftRevisionId: "revision-draft",
+		_rev: "rev-initial",
+		...overrides,
+	};
+}
+
+interface RecordedRequest {
+	method: string;
+	url: string;
+	body: Record<string, unknown> | undefined;
+}
+
+function jsonResponse(body: unknown, status = 200) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function contentResponse(item: RevisionedContentItem) {
+	const { _rev, ...contentItem } = item;
+	return jsonResponse({ data: { item: contentItem, _rev } });
+}
+
+function createMockServer(
+	onPut: (request: RecordedRequest, index: number) => Response,
+	options: { failReadsAfterConflict?: boolean } = {},
+) {
+	const originalFetch = globalThis.fetch;
+	const requests: RecordedRequest[] = [];
+	let putCount = 0;
+	// Moves on with the conflict, so a client that refetches is distinguishable.
+	let currentRevision = "rev-initial";
+
+	globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+		const method = (init?.method ?? "GET").toUpperCase();
+		const body = typeof init?.body === "string" ? JSON.parse(init.body) : undefined;
+		const request = { method, url, body };
+		requests.push(request);
+
+		if (method === "GET" && url === "/_emdash/api/manifest")
+			return jsonResponse({ data: MANIFEST });
+		if (method === "GET" && url === "/_emdash/api/auth/me")
+			return jsonResponse({ data: { id: "user_1", role: 40 } });
+		if (method === "GET" && url.startsWith("/_emdash/api/bylines"))
+			return jsonResponse({ data: { items: [] } });
+		if (method === "GET" && url.startsWith("/_emdash/api/users"))
+			return jsonResponse({ data: { items: [] } });
+		if (method === "GET" && url.startsWith("/_emdash/api/content/posts/post_1")) {
+			if (options.failReadsAfterConflict && putCount > 0)
+				return jsonResponse({ error: { code: "INTERNAL", message: "Read failed" } }, 500);
+			return contentResponse(makeItem({ _rev: currentRevision }));
+		}
+		if (method === "POST" && url.includes("/discard-draft"))
+			return contentResponse(makeItem({ _rev: currentRevision, draftRevisionId: "revision-live" }));
+		if (method === "GET" && url === "/_emdash/api/revisions/revision-draft")
+			return jsonResponse({
+				data: {
+					item: {
+						id: "revision-draft",
+						collection: "posts",
+						entryId: "post_1",
+						data: { title: "Draft title" },
+						authorId: null,
+						createdAt: "2026-01-02T00:00:00Z",
+					},
+				},
+			});
+		if (method === "PUT" && url.startsWith("/_emdash/api/content/posts/post_1")) {
+			const response = onPut(request, putCount++);
+			if (response.status === 409) currentRevision = "rev-moved";
+			return response;
+		}
+
+		throw new Error(`Unhandled request: ${method} ${url}`);
+	}) as typeof fetch;
+
+	return {
+		requests,
+		restore() {
+			globalThis.fetch = originalFetch;
+		},
+	};
+}
+
+async function renderEditPage() {
+	const queryClient = createTestQueryClient();
+	const router = createAdminRouter(queryClient);
+	if (!i18n.locale) i18n.loadAndActivate({ locale: "en", messages: {} });
+
+	function TestApp() {
+		return (
+			<I18nProvider i18n={i18n}>
+				<ThemeProvider defaultTheme="light">
+					<Toasty>
+						<QueryClientProvider client={queryClient}>
+							<RouterProvider router={router} />
+						</QueryClientProvider>
+					</Toasty>
+				</ThemeProvider>
+			</I18nProvider>
+		);
+	}
+
+	await router.navigate({
+		to: "/content/$collection/$id",
+		params: { collection: "posts", id: "post_1" },
+	});
+	const screen = await render(<TestApp />);
+	await expect.element(screen.getByRole("button", { name: "Publish", exact: true })).toBeVisible();
+	return screen;
+}
+
+describe("ContentEditPage save conflict", () => {
+	let server: ReturnType<typeof createMockServer> | undefined;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		server?.restore();
+		server = undefined;
+		vi.useRealTimers();
+	});
+
+	function conflictOnFirstPut(options: { failReadsAfterConflict?: boolean } = {}) {
+		return createMockServer((_request, index) => {
+			if (index === 0)
+				return jsonResponse(
+					{
+						error: {
+							code: "CONFLICT",
+							message: "Content has been modified since last read (version conflict)",
+						},
+					},
+					409,
+				);
+			return contentResponse(makeItem({ _rev: "rev-save-2" }));
+		}, options);
+	}
+
+	it("stops autosaving until the writer decides", async () => {
+		server = conflictOnFirstPut();
+		const screen = await renderEditPage();
+		const title = screen.getByRole("textbox", { name: "Title" });
+
+		await title.fill("First edit");
+		await vi.advanceTimersByTimeAsync(2500);
+
+		await title.fill("Second edit");
+		await vi.advanceTimersByTimeAsync(10000);
+
+		const puts = server.requests.filter((request) => request.method === "PUT");
+		expect(puts).toHaveLength(1);
+	});
+
+	it("keeps what the writer typed and offers to save it anyway", async () => {
+		server = conflictOnFirstPut();
+		const screen = await renderEditPage();
+		const title = screen.getByRole("textbox", { name: "Title" });
+
+		await title.fill("Writer copy");
+		await vi.advanceTimersByTimeAsync(2500);
+
+		await expect
+			.element(screen.getByRole("button", { name: "Save anyway", exact: true }))
+			.toBeVisible();
+		await expect.element(title).toHaveValue("Writer copy");
+
+		await screen.getByRole("button", { name: "Save anyway", exact: true }).click();
+		await vi.advanceTimersByTimeAsync(0);
+
+		const puts = server.requests.filter((request) => request.method === "PUT");
+		expect(puts.at(-1)?.body).toMatchObject({
+			data: { title: "Writer copy" },
+			_rev: "rev-moved",
+		});
+	});
+
+	it("reports the failure when it cannot read the newer version", async () => {
+		server = conflictOnFirstPut({ failReadsAfterConflict: true });
+		const screen = await renderEditPage();
+		const title = screen.getByRole("textbox", { name: "Title" });
+
+		await title.fill("Writer copy");
+		await vi.advanceTimersByTimeAsync(2500);
+
+		await expect.element(screen.getByText("Autosave failed")).toBeVisible();
+		expect(screen.getByRole("button", { name: "Save anyway", exact: true }).query()).toBeNull();
+	});
+
+	it("takes the notice down when the writer discards instead", async () => {
+		// Real timers: the dialog only settles for a click once its transition runs.
+		vi.useRealTimers();
+		server = conflictOnFirstPut();
+		const screen = await renderEditPage();
+		const title = screen.getByRole("textbox", { name: "Title" });
+
+		await title.fill("Writer copy");
+
+		await expect
+			.element(screen.getByRole("button", { name: "Save anyway", exact: true }))
+			.toBeVisible();
+
+		const trigger = screen.getByRole("button", { name: "Discard changes", exact: true });
+		trigger.element().focus();
+		await userEvent.keyboard("{Enter}");
+
+		const dialog = screen.getByRole("dialog");
+		await expect.element(dialog).toBeVisible();
+		const confirm = dialog.getByRole("button", { name: "Discard changes", exact: true });
+		confirm.element().focus();
+		await userEvent.keyboard("{Enter}");
+
+		await vi.waitFor(() =>
+			expect(
+				server?.requests.filter((request) => request.url.includes("discard-draft")),
+			).toHaveLength(1),
+		);
+		// By text, not role: the open dialog marks the content behind it aria-hidden.
+		await vi.waitFor(() => expect(document.body.textContent).not.toContain("Save anyway"));
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Restores saving in the content editor after someone else changes the same entry.
The first refused save used to leave the rejected revision token from #2860 in
place, so every later save and autosave resent it and the writer could not get
their work in at all.

The editor now takes the server's current token when a save comes back as a
conflict, leaves the form untouched, and shows a banner offering to save over
the newer version; the banner stays until a save succeeds. When the recovery
read fails the refused token stays, since dropping it would make the next save
a blind write, so the banner goes and the error is reported. Discarding clears
it too. Saves that do not conflict are unchanged.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a: bug fix)
- [x] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5

## Screenshots / test output

The notice in the content editor after another writer saved the same entry. What
the writer typed is still in the field, and the action offers to put it over the
newer version.

![The content editor with a red conflict banner above the fields, reading "This entry changed somewhere else after you opened it" and offering a Save anyway button. The title field still holds the text the writer typed.](https://github.com/user-attachments/assets/ed22edd8-7d9e-4732-977e-d2db73605fa9)

The same notice in the Arabic locale. The banner and its action follow the
right-to-left direction without any change to the markup.

![The same conflict banner in the Arabic locale, mirrored right to left with the Save anyway button on the left of the banner.](https://github.com/user-attachments/assets/5c4567f8-0dc7-40f4-8c26-db02ce391b4e)
