### PR TITLE
fix(ci): skip CLA checks in forks

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   CLAssistant:
+    if: github.repository == 'emdash-cms/emdash'
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
@@ -32,7 +33,10 @@ jobs:
 
   label:
     needs: CLAssistant
-    if: always() && (github.event_name == 'pull_request_target' || github.event.issue.pull_request)
+    if: >-
+      always() &&
+      github.repository == 'emdash-cms/emdash' &&
+      (github.event_name == 'pull_request_target' || github.event.issue.pull_request)
     runs-on: ubuntu-latest
     steps:
       - name: Label CLA status

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   CLAssistant:
-    if: github.repository == 'emdash-cms/emdash'
+    if: github.repository_id == '1198246700'
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
@@ -35,7 +35,7 @@ jobs:
     needs: CLAssistant
     if: >-
       always() &&
-      github.repository == 'emdash-cms/emdash' &&
+      github.repository_id == '1198246700' &&
       (github.event_name == 'pull_request_target' || github.event.issue.pull_request)
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What does this PR do?

Forks inherit the CLA workflow and can run it against fork-local pull requests. This can cause CLA Assistant to treat authors of commits imported from upstream as contributors to the fork-local pull request and mention them unnecessarily.

This change restricts both the CLA Assistant and its follow-up labeling job to the canonical `emdash-cms/emdash` repository.

The guard uses the canonical repository ID instead of its name so it remains valid if the repository is renamed or transferred. Each fork has a different repository ID.

Pull requests opened from forks against `emdash-cms/emdash` remain covered because the workflow runs in the base repository's context.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — validated the workflow with `actionlint`
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable) — not applicable; a test that only pins the repository ID would restate the configuration rather than test behavior
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — not applicable; there are no UI changes
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package) — not applicable; no published package changes
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... — not applicable; this is a workflow bug fix
- [x] I have included screenshots below if this PR changes the UI — not applicable; there are no UI changes

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Not applicable; there are no UI changes.

Validation completed:

- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:quick`
- `actionlint .github/workflows/cla.yml`
- `pnpm exec prettier --check .github/workflows/cla.yml`
- `pnpm format`
- `git diff --check`
