### PR TITLE
Add in-context media asset editing

### DIFF
--- a/.changeset/bright-otters-edit.md
+++ b/.changeset/bright-otters-edit.md
@@ -1,0 +1,8 @@
+---
+"@emdash-cms/admin": minor
+---
+
+Adds in-context Media Library asset editing to admin image pickers, image fields, and rich text
+images and galleries. Editors can update asset metadata and focal points, create and select cropped
+copies, or replace original image data while staying in the content editor. Gallery images also
+support keyboard reordering.

--- a/docs/src/content/docs/guides/media-library.mdx
+++ b/docs/src/content/docs/guides/media-library.mdx
@@ -241,6 +241,21 @@ references remain unchanged.
 For fields configured as image or file types, select the field action to open the same media
 picker. The field's MIME type rules limit the sources and files you can choose.
 
+### Edit a selected image asset
+
+Local image fields, rich text images, and gallery images provide three actions:
+
+- **Replace** changes the image used in the current field, block, or gallery position.
+- **Edit asset** opens Media Details for the selected Media Library item. You can update its alt
+  text, caption, focal point, or crop while staying in the content editor.
+- **Remove** clears the current content reference. The Media Library item remains available.
+
+**Create cropped copy** selects the new copy for the current usage. Rich text and gallery images
+keep their per-use alt text, caption, layout, and position. **Replace original** keeps the same media
+reference and changes the image anywhere that asset is used.
+
+External-provider images and file fields provide **Replace** and **Remove**, but not **Edit asset**.
+
 ## Replacing an image
 
 Use **Replace image** to update the file behind an existing local media item. Authors can replace
@@ -270,7 +285,8 @@ the replacement. Replacing the file clears its focal point.
 A focal point keeps the important part of a local image visible when a card, gallery, or other
 layout crops it to fill a fixed shape.
 
-1. Open **Media**, then select an image from the local library.
+1. Open **Media** and select an image from the local library, or select **Edit asset** for a local
+   image in the content editor.
 2. Select **Edit image**, then **Focal point**.
 3. Click or drag the marker onto the important part of the image. You can also use the Arrow keys.
 4. Check the square, landscape, and portrait previews, then select **Save**.

--- a/docs/src/content/docs/guides/media-library.mdx
+++ b/docs/src/content/docs/guides/media-library.mdx
@@ -292,8 +292,9 @@ layout crops it to fill a fixed shape.
 4. Check the square, landscape, and portrait previews, then select **Save**.
 
 Select **Reset** to remove a custom focal point. The saved point is copied when you select
-the image for a content field or gallery. Content that already uses the image keeps its stored point
-until you select the image again.
+the image for a content field or gallery. Other content already using the image keeps its stored point
+until you select the image again. When you edit an asset from a content field or gallery, that current
+usage refreshes with the saved focal point.
 
 ## Cropping an image
 

--- a/e2e/tests/media-library.spec.ts
+++ b/e2e/tests/media-library.spec.ts
@@ -418,15 +418,31 @@ test.describe("Media Library", () => {
 		await admin.waitForLoading();
 		const editorUrl = page.url();
 		await page.getByRole("button", { name: "Select image" }).click();
-		const picker = page.getByRole("dialog").filter({ hasText: "Select Featured Image" });
+		const picker = page.getByRole("dialog", { name: "Select Featured Image" });
+		const workspaceElement = await picker.elementHandle();
+		expect(workspaceElement).not.toBeNull();
 		await picker.getByRole("searchbox", { name: "Search media" }).fill(filename);
 		await picker.getByRole("button", { name: filename, exact: true }).click();
 		await picker.getByRole("button", { name: "Edit asset" }).click();
 		const pickerDetails = page.getByRole("dialog", { name: "Media details" });
 		await expect(pickerDetails).toBeVisible();
-		await expect(picker).not.toBeVisible();
-		await pickerDetails.getByRole("button", { name: "Close" }).first().click();
+		expect(
+			await pickerDetails.evaluate(
+				(dialog, originalDialog) => dialog === originalDialog,
+				workspaceElement,
+			),
+		).toBe(true);
+		await expect(page.getByRole("dialog")).toHaveCount(1);
+		await expect(pickerDetails.getByRole("searchbox", { name: "Search media" })).toHaveCount(0);
+		await pickerDetails.getByRole("button", { name: "Back to library" }).click();
 		await expect(picker).toBeVisible();
+		await expect(picker.getByRole("button", { name: "Edit asset" })).toBeFocused();
+		expect(
+			await picker.evaluate(
+				(dialog, originalDialog) => dialog === originalDialog,
+				workspaceElement,
+			),
+		).toBe(true);
 		await expect(picker.getByRole("button", { name: filename, exact: true })).toHaveAttribute(
 			"aria-pressed",
 			"true",

--- a/e2e/tests/media-library.spec.ts
+++ b/e2e/tests/media-library.spec.ts
@@ -399,6 +399,81 @@ test.describe("Media Library", () => {
 		).toBe(true);
 	});
 
+	test("edits a selected content image and uses a cropped copy without leaving the editor", async ({
+		admin,
+		page,
+		serverInfo,
+	}) => {
+		test.setTimeout(90_000);
+		const marker = Date.now();
+		const filename = `editor-asset-${marker}.png`;
+		const duplicateFilename = `editor-asset-${marker}-square.png`;
+		await admin.goToMedia();
+		await admin.waitForLoading();
+		await uploadCropTestImage(page, filename);
+		const original = await findMediaByFilename(serverInfo, filename);
+
+		await admin.goto("/content/posts/new");
+		await admin.waitForShell();
+		await admin.waitForLoading();
+		const editorUrl = page.url();
+		await page.getByRole("button", { name: "Select image" }).click();
+		const picker = page.getByRole("dialog").filter({ hasText: "Select Featured Image" });
+		await picker.getByRole("searchbox", { name: "Search media" }).fill(filename);
+		await picker.getByRole("button", { name: filename, exact: true }).click();
+		await picker.getByRole("button", { name: "Edit asset" }).click();
+		const pickerDetails = page.getByRole("dialog", { name: "Media details" });
+		await expect(pickerDetails).toBeVisible();
+		await expect(picker).not.toBeVisible();
+		await pickerDetails.getByRole("button", { name: "Close" }).first().click();
+		await expect(picker).toBeVisible();
+		await expect(picker.getByRole("button", { name: filename, exact: true })).toHaveAttribute(
+			"aria-pressed",
+			"true",
+		);
+		await picker.getByRole("button", { name: "Select", exact: true }).click();
+		const featuredImageField = page.locator("#field-featured_image");
+		await expect(featuredImageField.getByText(filename, { exact: true })).toBeVisible();
+
+		await featuredImageField.getByRole("button", { name: "Edit asset" }).click();
+		const details = page.getByRole("dialog", { name: "Media details" });
+		await expect(details).toBeVisible();
+		await expect(picker).not.toBeVisible();
+		await expect(details.getByRole("tab", { name: "Used in" })).toHaveCount(0);
+		await expect(details.getByRole("button", { name: "Delete" })).toHaveCount(0);
+		expect(page.url()).toBe(editorUrl);
+
+		await details.getByRole("tab", { name: "Edit image" }).click();
+		const aspectRatio = details.getByRole("combobox", { name: "Aspect ratio" });
+		await aspectRatio.click();
+		await page.getByRole("option", { name: "Square (1:1)" }).click();
+		const duplicateResponse = page.waitForResponse(
+			(response) =>
+				response.request().method() === "POST" &&
+				new URL(response.url()).pathname.endsWith("/confirm") &&
+				response.status() === 200,
+		);
+		await details.getByRole("button", { name: "Create cropped copy" }).click();
+		await duplicateResponse;
+
+		await expect(details).not.toBeVisible();
+		await expect(featuredImageField.getByText(duplicateFilename, { exact: true })).toBeVisible();
+		expect(page.url()).toBe(editorUrl);
+		const duplicate = await findMediaByFilename(serverInfo, duplicateFilename);
+		expect(duplicate.id).not.toBe(original.id);
+
+		await page.setViewportSize({ width: 320, height: 800 });
+		await expect(featuredImageField.getByRole("button", { name: "Choose another" })).toBeVisible();
+		await expect(featuredImageField.getByRole("button", { name: "Edit asset" })).toBeVisible();
+		await expect(featuredImageField.getByRole("button", { name: "Remove image" })).toBeVisible();
+		expect(
+			await featuredImageField.evaluate((element) => element.scrollWidth <= element.clientWidth),
+		).toBe(true);
+		expect(
+			await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+		).toBe(true);
+	});
+
 	test.describe("List View", () => {
 		test("shows file details in list view", async ({ admin, page }) => {
 			// Upload a file first so there's something to show

--- a/e2e/tests/media-library.spec.ts
+++ b/e2e/tests/media-library.spec.ts
@@ -481,7 +481,7 @@ test.describe("Media Library", () => {
 		expect(duplicate.id).not.toBe(original.id);
 
 		await page.setViewportSize({ width: 320, height: 800 });
-		await expect(featuredImageField.getByRole("button", { name: "Choose another" })).toBeVisible();
+		await expect(featuredImageField.getByRole("button", { name: "Replace" })).toBeVisible();
 		await expect(featuredImageField.getByRole("button", { name: "Edit asset" })).toBeVisible();
 		await expect(featuredImageField.getByRole("button", { name: "Remove image" })).toBeVisible();
 		expect(

--- a/e2e/tests/media-library.spec.ts
+++ b/e2e/tests/media-library.spec.ts
@@ -421,11 +421,13 @@ test.describe("Media Library", () => {
 		const picker = page.getByRole("dialog", { name: "Select Featured Image" });
 		const workspaceElement = await picker.elementHandle();
 		expect(workspaceElement).not.toBeNull();
+		const workspaceWidth = await picker.evaluate((dialog) => dialog.clientWidth);
 		await picker.getByRole("searchbox", { name: "Search media" }).fill(filename);
 		await picker.getByRole("button", { name: filename, exact: true }).click();
 		await picker.getByRole("button", { name: "Edit asset" }).click();
 		const pickerDetails = page.getByRole("dialog", { name: "Media details" });
 		await expect(pickerDetails).toBeVisible();
+		expect(await pickerDetails.evaluate((dialog) => dialog.clientWidth)).toBe(workspaceWidth);
 		expect(
 			await pickerDetails.evaluate(
 				(dialog, originalDialog) => dialog === originalDialog,

--- a/e2e/tests/media-library.spec.ts
+++ b/e2e/tests/media-library.spec.ts
@@ -434,7 +434,7 @@ test.describe("Media Library", () => {
 		).toBe(true);
 		await expect(page.getByRole("dialog")).toHaveCount(1);
 		await expect(pickerDetails.getByRole("searchbox", { name: "Search media" })).toHaveCount(0);
-		await pickerDetails.getByRole("button", { name: "Back to library" }).click();
+		await pickerDetails.getByRole("button", { name: "Back" }).click();
 		await expect(picker).toBeVisible();
 		await expect(picker.getByRole("button", { name: "Edit asset" })).toBeFocused();
 		expect(

--- a/e2e/tests/media-library.spec.ts
+++ b/e2e/tests/media-library.spec.ts
@@ -479,8 +479,21 @@ test.describe("Media Library", () => {
 		expect(page.url()).toBe(editorUrl);
 		const duplicate = await findMediaByFilename(serverInfo, duplicateFilename);
 		expect(duplicate.id).not.toBe(original.id);
+	});
 
+	test("keeps featured image actions compact and reachable on mobile", async ({ admin, page }) => {
+		test.setTimeout(60_000);
+		await admin.goto("/content/posts/new");
+		await admin.waitForShell();
+		await admin.waitForLoading();
 		await page.setViewportSize({ width: 320, height: 800 });
+		await page.getByRole("button", { name: "Select image" }).click();
+		const picker = page.getByRole("dialog", { name: "Select Featured Image" });
+		await picker.getByRole("button", { name: "test-image.png", exact: true }).click();
+		await picker.getByRole("button", { name: "Select", exact: true }).click();
+
+		const featuredImageField = page.locator("#field-featured_image");
+		await expect(featuredImageField.getByText("test-image.png", { exact: true })).toBeVisible();
 		const featuredPreview = featuredImageField.locator(".emdash-featured-image-preview");
 		const featuredCard = featuredPreview.locator("..");
 		expect(
@@ -513,6 +526,7 @@ test.describe("Media Library", () => {
 
 		await imageActions.click();
 		await page.getByRole("menuitem", { name: "Edit asset" }).click();
+		const details = page.getByRole("dialog", { name: "Media details" });
 		await expect(details).toBeVisible();
 		await details.getByRole("button", { name: "Close" }).click();
 		await expect(details).not.toBeVisible();

--- a/e2e/tests/media-library.spec.ts
+++ b/e2e/tests/media-library.spec.ts
@@ -481,9 +481,52 @@ test.describe("Media Library", () => {
 		expect(duplicate.id).not.toBe(original.id);
 
 		await page.setViewportSize({ width: 320, height: 800 });
+		const featuredPreview = featuredImageField.locator(".emdash-featured-image-preview");
+		const featuredCard = featuredPreview.locator("..");
+		expect(
+			await featuredPreview.evaluate((element) => element.getBoundingClientRect().height),
+		).toBeLessThan(80);
+		expect(
+			await featuredCard.evaluate((element) => element.getBoundingClientRect().height),
+		).toBeLessThan(120);
+		const imageActions = featuredImageField.getByRole("button", { name: "Image actions" });
+		await expect(imageActions).toBeVisible();
+		await expect(featuredImageField.getByRole("button", { name: "Replace" })).toHaveCount(0);
+		await expect(featuredImageField.getByRole("button", { name: "Edit asset" })).toHaveCount(0);
+		await expect(featuredImageField.getByRole("button", { name: "Remove image" })).toHaveCount(0);
+
+		await imageActions.click();
+		await expect(imageActions).toHaveAttribute("aria-expanded", "true");
+		await expect(page.getByRole("menuitem", { name: "Replace" })).toBeVisible();
+		await expect(page.getByRole("menuitem", { name: "Edit asset" })).toBeVisible();
+		await expect(page.getByRole("menuitem", { name: "Remove" })).toBeVisible();
+		await page.setViewportSize({ width: 640, height: 800 });
+		await expect(page.getByRole("menu", { name: "Image actions" })).not.toBeVisible();
 		await expect(featuredImageField.getByRole("button", { name: "Replace" })).toBeVisible();
-		await expect(featuredImageField.getByRole("button", { name: "Edit asset" })).toBeVisible();
-		await expect(featuredImageField.getByRole("button", { name: "Remove image" })).toBeVisible();
+		await page.setViewportSize({ width: 320, height: 800 });
+		await expect(imageActions).toHaveAttribute("aria-expanded", "false");
+		await imageActions.click();
+		await page.getByRole("menuitem", { name: "Replace" }).click();
+		const replacePicker = page.getByRole("dialog", { name: "Replace Featured Image" });
+		await expect(replacePicker).toBeVisible();
+		await replacePicker.getByRole("button", { name: "Close" }).click();
+
+		await imageActions.click();
+		await page.getByRole("menuitem", { name: "Edit asset" }).click();
+		await expect(details).toBeVisible();
+		await details.getByRole("button", { name: "Close" }).click();
+		await expect(details).not.toBeVisible();
+		await expect(imageActions).toBeFocused();
+		await featuredPreview.locator("img").dispatchEvent("error");
+		await expect(featuredPreview.getByText("Image not found")).toHaveCount(1);
+		expect(
+			await featuredCard.evaluate((element) => element.getBoundingClientRect().height),
+		).toBeLessThan(120);
+		await expect(imageActions).toBeVisible();
+
+		await imageActions.click();
+		await page.getByRole("menuitem", { name: "Remove" }).click();
+		await expect(featuredImageField.getByRole("button", { name: "Select image" })).toBeVisible();
 		expect(
 			await featuredImageField.evaluate((element) => element.scrollWidth <= element.clientWidth),
 		).toBe(true);

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -1858,19 +1858,19 @@ function FileFieldRenderer({
 							</p>
 						)}
 					</div>
-					<div className="flex gap-1">
+					<div className="flex flex-wrap gap-2">
 						<Button type="button" size="sm" variant="secondary" onClick={() => setPickerOpen(true)}>
-							{t`Change`}
+							{t`Choose another`}
 						</Button>
 						<Button
 							type="button"
-							shape="square"
-							variant="destructive"
-							className="h-8 w-8"
+							size="sm"
+							variant="secondary-destructive"
+							icon={<X aria-hidden="true" />}
 							onClick={handleRemove}
 							aria-label={t`Remove ${label}`}
 						>
-							<X className="h-4 w-4" />
+							{t`Remove`}
 						</Button>
 					</div>
 				</div>

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -1860,7 +1860,7 @@ function FileFieldRenderer({
 					</div>
 					<div className="flex flex-wrap gap-2">
 						<Button type="button" size="sm" variant="secondary" onClick={() => setPickerOpen(true)}>
-							{t`Choose another`}
+							{t`Replace`}
 						</Button>
 						<Button
 							type="button"
@@ -1896,7 +1896,8 @@ function FileFieldRenderer({
 				fieldId={fieldId}
 				hideUrlInput
 				mediaKind="file"
-				title={t`Select ${label}`}
+				title={normalized ? t`Replace ${label}` : t`Select ${label}`}
+				confirmLabel={normalized ? t`Replace` : undefined}
 			/>
 			{required && !normalized && (
 				<p className="-mt-1 text-sm text-kumo-danger">{t`This field is required`}</p>

--- a/packages/admin/src/components/ImageFieldRenderer.tsx
+++ b/packages/admin/src/components/ImageFieldRenderer.tsx
@@ -332,7 +332,7 @@ export function ImageFieldRenderer({
 								type="button"
 								size="sm"
 								variant="secondary"
-								icon={<ImageSquare />}
+								icon={<ImageSquare aria-hidden="true" />}
 								onClick={() => openPicker("darkVariant")}
 								disabled={assetEditor.isActive}
 								aria-label={t`Replace dark mode image`}
@@ -359,7 +359,7 @@ export function ImageFieldRenderer({
 								type="button"
 								size="sm"
 								variant="secondary-destructive"
-								icon={<X />}
+								icon={<X aria-hidden="true" />}
 								onClick={handleRemoveDarkVariant}
 								disabled={assetEditor.isActive}
 								aria-label={t`Remove dark mode variant`}

--- a/packages/admin/src/components/ImageFieldRenderer.tsx
+++ b/packages/admin/src/components/ImageFieldRenderer.tsx
@@ -10,7 +10,14 @@
 
 import { Button, Label, LayerCard, Text } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { Image as ImageIcon, ImageBroken, ImageSquare, Moon, X } from "@phosphor-icons/react";
+import {
+	Image as ImageIcon,
+	ImageBroken,
+	ImageSquare,
+	Moon,
+	PencilSimple,
+	X,
+} from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import * as React from "react";
 
@@ -22,6 +29,7 @@ import {
 	metaString,
 } from "../lib/media-utils.js";
 import { FieldHelpLabel } from "./FieldHelpLabel.js";
+import { useMediaAssetEditor } from "./media/useMediaAssetEditor.js";
 import { MediaPickerModal } from "./MediaPickerModal";
 
 /**
@@ -68,6 +76,28 @@ function mediaDisplayUrl(value: ImageFieldValue | string | undefined): string | 
 	return undefined;
 }
 
+function mediaItemToImageFieldValue(item: MediaItem): ImageFieldValue {
+	const provider = canonicalMediaProviderId(item.provider);
+	const isLocalProvider = provider === "local";
+	const isDirectUrl = provider === "external";
+	return {
+		id: item.id,
+		provider,
+		src: isDirectUrl ? item.url : undefined,
+		previewUrl: !isLocalProvider && !isDirectUrl ? item.url : undefined,
+		alt: item.alt || "",
+		width: item.width,
+		height: item.height,
+		focalX: item.focalX ?? undefined,
+		focalY: item.focalY ?? undefined,
+		filename: item.filename,
+		mimeType: item.mimeType,
+		blurhash: item.blurhash ?? metaString(item.meta, "blurhash"),
+		dominantColor: item.dominantColor ?? metaString(item.meta, "dominantColor"),
+		meta: isLocalProvider ? { ...item.meta, storageKey: item.storageKey } : item.meta,
+	};
+}
+
 export interface ImageFieldRendererProps {
 	id?: string;
 	label: string;
@@ -99,6 +129,9 @@ export function ImageFieldRenderer({
 	const [pickerTarget, setPickerTarget] = React.useState<"image" | "darkVariant">("image");
 	const [imageBroken, setImageBroken] = React.useState(false);
 	const [darkImageBroken, setDarkImageBroken] = React.useState(false);
+	const [editedContentHashes, setEditedContentHashes] = React.useState<
+		Record<string, string | null | undefined>
+	>({});
 	// A legacy string URL needs object form to carry a dark variant. The runtime
 	// resolves the URL in `src` on save, so the provider linkage survives.
 	const objectValue: ImageFieldValue | undefined =
@@ -108,6 +141,19 @@ export function ImageFieldRenderer({
 				? { id: "", src: value }
 				: undefined;
 	const darkValue = objectValue?.darkVariant;
+	const handleAssetItemChanged = React.useCallback(
+		(item: MediaItem) => {
+			const selected = mediaItemToImageFieldValue(item);
+			setEditedContentHashes((current) => ({ ...current, [item.id]: item.contentHash }));
+			if (pickerTarget === "darkVariant") {
+				if (objectValue) onChange({ ...objectValue, darkVariant: selected });
+				return;
+			}
+			onChange(darkValue ? { ...selected, darkVariant: darkValue } : selected);
+		},
+		[darkValue, objectValue, onChange, pickerTarget],
+	);
+	const assetEditor = useMediaAssetEditor(handleAssetItemChanged);
 	const currentMediaId =
 		variant === "featured" &&
 		objectValue?.id &&
@@ -131,12 +177,20 @@ export function ImageFieldRenderer({
 		enabled: currentDarkMediaId !== null,
 	});
 	const storedDisplayUrl = mediaDisplayUrl(value);
+	const primaryContentHash =
+		objectValue?.id && Object.hasOwn(editedContentHashes, objectValue.id)
+			? editedContentHashes[objectValue.id]
+			: currentMedia?.contentHash;
 	const displayUrl = storedDisplayUrl
-		? getMediaPreviewUrl(storedDisplayUrl, currentMedia?.contentHash)
+		? getMediaPreviewUrl(storedDisplayUrl, primaryContentHash)
 		: undefined;
 	const storedDarkDisplayUrl = mediaDisplayUrl(darkValue);
+	const darkContentHash =
+		darkValue?.id && Object.hasOwn(editedContentHashes, darkValue.id)
+			? editedContentHashes[darkValue.id]
+			: currentDarkMedia?.contentHash;
 	const darkDisplayUrl = storedDarkDisplayUrl
-		? getMediaPreviewUrl(storedDarkDisplayUrl, currentDarkMedia?.contentHash)
+		? getMediaPreviewUrl(storedDarkDisplayUrl, darkContentHash)
 		: undefined;
 
 	React.useEffect(() => {
@@ -153,30 +207,7 @@ export function ImageFieldRenderer({
 	};
 
 	const handleSelect = (item: MediaItem) => {
-		const provider = canonicalMediaProviderId(item.provider);
-		const isLocalProvider = provider === "local";
-		const isDirectUrl = provider === "external";
-
-		const selected: ImageFieldValue = {
-			id: item.id,
-			provider,
-			// Local media derives its URL from storageKey. Direct URLs persist src,
-			// while external providers cache a preview URL for the admin.
-			src: isDirectUrl ? item.url : undefined,
-			previewUrl: !isLocalProvider && !isDirectUrl ? item.url : undefined,
-			alt: item.alt || "",
-			width: item.width,
-			height: item.height,
-			focalX: item.focalX ?? undefined,
-			focalY: item.focalY ?? undefined,
-			filename: item.filename,
-			mimeType: item.mimeType,
-			// Cache LQIP alongside dimensions so embeds render a placeholder without a
-			// runtime lookup. Fall back to `meta` for providers that stash it there.
-			blurhash: item.blurhash ?? metaString(item.meta, "blurhash"),
-			dominantColor: item.dominantColor ?? metaString(item.meta, "dominantColor"),
-			meta: isLocalProvider ? { ...item.meta, storageKey: item.storageKey } : item.meta,
-		};
+		const selected = mediaItemToImageFieldValue(item);
 
 		if (pickerTarget === "darkVariant") {
 			if (objectValue) onChange({ ...objectValue, darkVariant: selected });
@@ -214,6 +245,52 @@ export function ImageFieldRenderer({
 		typeof value === "object" && value ? getMediaObjectPosition(value) : undefined;
 	const darkObjectPosition = darkValue ? getMediaObjectPosition(darkValue) : undefined;
 	const darkFilename = darkValue?.filename || t`Selected image`;
+	const canEditPrimaryAsset = Boolean(
+		objectValue?.id && canonicalMediaProviderId(objectValue.provider) === "local",
+	);
+	const canEditDarkAsset = Boolean(
+		darkValue?.id && canonicalMediaProviderId(darkValue.provider) === "local",
+	);
+	const primaryActions = (
+		<div className="flex flex-wrap items-center gap-2">
+			<Button
+				type="button"
+				size="sm"
+				variant="secondary"
+				icon={<ImageSquare aria-hidden="true" />}
+				onClick={() => openPicker("image")}
+				disabled={assetEditor.isActive}
+			>
+				{t`Choose another`}
+			</Button>
+			{canEditPrimaryAsset && (
+				<Button
+					type="button"
+					size="sm"
+					variant="secondary"
+					icon={<PencilSimple aria-hidden="true" />}
+					loading={assetEditor.isOpening && pickerTarget === "image"}
+					onClick={(event) => {
+						setPickerTarget("image");
+						void assetEditor.openAssetEditor(objectValue!.id, event.currentTarget);
+					}}
+				>
+					{t`Edit asset`}
+				</Button>
+			)}
+			<Button
+				type="button"
+				size="sm"
+				variant="secondary-destructive"
+				icon={<X aria-hidden="true" />}
+				onClick={handleRemove}
+				disabled={assetEditor.isActive}
+				aria-label={t`Remove image`}
+			>
+				{t`Remove`}
+			</Button>
+		</div>
+	);
 
 	const darkVariantSlot =
 		darkVariant && objectValue && displayUrl ? (
@@ -243,23 +320,41 @@ export function ImageFieldRenderer({
 								{darkFilename}
 							</Text>
 						</div>
-						<div className="flex shrink-0 items-center gap-2">
+						<div className="flex basis-full flex-wrap items-center gap-2 sm:basis-auto">
 							<Button
 								type="button"
 								size="sm"
 								variant="secondary"
 								icon={<ImageSquare />}
 								onClick={() => openPicker("darkVariant")}
-								aria-label={t`Replace dark mode variant`}
+								disabled={assetEditor.isActive}
+								aria-label={t`Choose another dark mode image`}
 							>
-								{t`Replace`}
+								{t`Choose another`}
 							</Button>
+							{canEditDarkAsset && (
+								<Button
+									type="button"
+									size="sm"
+									variant="secondary"
+									icon={<PencilSimple aria-hidden="true" />}
+									loading={assetEditor.isOpening && pickerTarget === "darkVariant"}
+									onClick={(event) => {
+										setPickerTarget("darkVariant");
+										void assetEditor.openAssetEditor(darkValue!.id, event.currentTarget);
+									}}
+									aria-label={t`Edit dark mode asset`}
+								>
+									{t`Edit asset`}
+								</Button>
+							)}
 							<Button
 								type="button"
 								size="sm"
 								variant="secondary-destructive"
 								icon={<X />}
 								onClick={handleRemoveDarkVariant}
+								disabled={assetEditor.isActive}
 								aria-label={t`Remove dark mode variant`}
 							>
 								{t`Remove`}
@@ -273,6 +368,7 @@ export function ImageFieldRenderer({
 						variant="secondary"
 						icon={<Moon />}
 						onClick={() => openPicker("darkVariant")}
+						disabled={assetEditor.isActive}
 					>
 						{t`Add dark mode variant`}
 					</Button>
@@ -311,27 +407,7 @@ export function ImageFieldRenderer({
 						</Text>
 					)}
 				</div>
-				<div className="flex shrink-0 items-center gap-2">
-					<Button
-						type="button"
-						size="sm"
-						variant="secondary"
-						icon={<ImageSquare />}
-						onClick={() => openPicker("image")}
-					>
-						{t`Replace`}
-					</Button>
-					<Button
-						type="button"
-						size="sm"
-						variant="secondary-destructive"
-						icon={<X />}
-						onClick={handleRemove}
-						aria-label={t`Remove image`}
-					>
-						{t`Remove`}
-					</Button>
-				</div>
+				{primaryActions}
 			</div>
 		</LayerCard>
 	) : null;
@@ -353,34 +429,15 @@ export function ImageFieldRenderer({
 				featuredCard
 			) : displayUrl ? (
 				imageBroken ? (
-					<div className="relative group">
+					<div className="grid gap-2">
 						<div className="flex min-h-20 items-center justify-center gap-2 rounded-lg border bg-kumo-tint text-kumo-subtle">
 							<ImageBroken className="h-5 w-5" />
 							<span className="text-sm">{t`Image not found`}</span>
 						</div>
-						<div className="absolute top-2 end-2 opacity-0 group-hover:opacity-100 transition-opacity flex gap-1">
-							<Button
-								type="button"
-								size="sm"
-								variant="secondary"
-								onClick={() => openPicker("image")}
-							>
-								{t`Change`}
-							</Button>
-							<Button
-								type="button"
-								shape="square"
-								variant="destructive"
-								className="h-8 w-8"
-								onClick={handleRemove}
-								aria-label={t`Remove image`}
-							>
-								<X className="h-4 w-4" />
-							</Button>
-						</div>
+						{primaryActions}
 					</div>
 				) : (
-					<div className="relative group">
+					<div className="grid gap-2">
 						<img
 							src={displayUrl}
 							alt=""
@@ -388,26 +445,7 @@ export function ImageFieldRenderer({
 							style={{ objectPosition }}
 							onError={() => setImageBroken(true)}
 						/>
-						<div className="absolute top-2 end-2 opacity-0 group-hover:opacity-100 transition-opacity flex gap-1">
-							<Button
-								type="button"
-								size="sm"
-								variant="secondary"
-								onClick={() => openPicker("image")}
-							>
-								{t`Change`}
-							</Button>
-							<Button
-								type="button"
-								shape="square"
-								variant="destructive"
-								className="h-8 w-8"
-								onClick={handleRemove}
-								aria-label={t`Remove image`}
-							>
-								<X className="h-4 w-4" />
-							</Button>
-						</div>
+						{primaryActions}
 					</div>
 				)
 			) : (
@@ -438,6 +476,12 @@ export function ImageFieldRenderer({
 						: t`Select ${label}`
 				}
 			/>
+			{assetEditor.dialog}
+			{assetEditor.error && (
+				<p role="alert" className="text-sm text-kumo-danger">
+					{assetEditor.error}
+				</p>
+			)}
 			{required && !displayUrl && (
 				<p className="-mt-1 text-sm text-kumo-danger">{t`This field is required`}</p>
 			)}

--- a/packages/admin/src/components/ImageFieldRenderer.tsx
+++ b/packages/admin/src/components/ImageFieldRenderer.tsx
@@ -407,7 +407,7 @@ export function ImageFieldRenderer({
 				)}
 			</div>
 			<div className="flex min-w-0 flex-col justify-center gap-3 px-4 py-3">
-				<div className="grid min-w-0 gap-1">
+				<div className="grid min-w-0 gap-1" style={{ transform: "translateY(2px)" }}>
 					<Text as="p" bold truncate>
 						{selectedFilename}
 					</Text>

--- a/packages/admin/src/components/ImageFieldRenderer.tsx
+++ b/packages/admin/src/components/ImageFieldRenderer.tsx
@@ -252,7 +252,14 @@ export function ImageFieldRenderer({
 		darkValue?.id && canonicalMediaProviderId(darkValue.provider) === "local",
 	);
 	const primaryActions = (
-		<div className="flex flex-wrap items-center gap-2">
+		<div
+			className={
+				isFeatured
+					? "-m-0.5 flex w-full min-w-0 items-center gap-2 overflow-x-auto overscroll-x-contain p-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+					: "flex flex-wrap items-center gap-2"
+			}
+			style={isFeatured ? { scrollbarWidth: "none" } : undefined}
+		>
 			<Button
 				type="button"
 				size="sm"

--- a/packages/admin/src/components/ImageFieldRenderer.tsx
+++ b/packages/admin/src/components/ImageFieldRenderer.tsx
@@ -406,18 +406,23 @@ export function ImageFieldRenderer({
 					/>
 				)}
 			</div>
-			<div className="flex min-w-0 flex-col justify-center gap-3 px-4 py-3">
-				<div className="grid min-w-0 gap-1" style={{ transform: "translateY(2px)" }}>
-					<Text as="p" bold truncate>
-						{selectedFilename}
-					</Text>
-					{metadata && (
-						<Text as="p" variant="secondary" truncate>
-							<bdi dir="ltr">{metadata}</bdi>
+			<div className="flex min-w-0 flex-col justify-center px-4 py-3">
+				<div
+					className="flex w-full min-w-0 flex-col gap-3"
+					style={{ transform: "translateY(6px)" }}
+				>
+					<div className="grid min-w-0 gap-1">
+						<Text as="p" bold truncate>
+							{selectedFilename}
 						</Text>
-					)}
+						{metadata && (
+							<Text as="p" variant="secondary" truncate>
+								<bdi dir="ltr">{metadata}</bdi>
+							</Text>
+						)}
+					</div>
+					{primaryActions}
 				</div>
-				{primaryActions}
 			</div>
 		</LayerCard>
 	) : null;

--- a/packages/admin/src/components/ImageFieldRenderer.tsx
+++ b/packages/admin/src/components/ImageFieldRenderer.tsx
@@ -261,7 +261,7 @@ export function ImageFieldRenderer({
 				onClick={() => openPicker("image")}
 				disabled={assetEditor.isActive}
 			>
-				{t`Choose another`}
+				{t`Replace`}
 			</Button>
 			{canEditPrimaryAsset && (
 				<Button
@@ -328,9 +328,9 @@ export function ImageFieldRenderer({
 								icon={<ImageSquare />}
 								onClick={() => openPicker("darkVariant")}
 								disabled={assetEditor.isActive}
-								aria-label={t`Choose another dark mode image`}
+								aria-label={t`Replace dark mode image`}
 							>
-								{t`Choose another`}
+								{t`Replace`}
 							</Button>
 							{canEditDarkAsset && (
 								<Button
@@ -472,8 +472,21 @@ export function ImageFieldRenderer({
 				fieldId={fieldId}
 				title={
 					pickerTarget === "darkVariant"
-						? t`Select dark mode variant for ${label}`
-						: t`Select ${label}`
+						? darkDisplayUrl
+							? t`Replace dark mode variant for ${label}`
+							: t`Select dark mode variant for ${label}`
+						: displayUrl
+							? t`Replace ${label}`
+							: t`Select ${label}`
+				}
+				confirmLabel={
+					pickerTarget === "darkVariant"
+						? darkDisplayUrl
+							? t`Replace`
+							: undefined
+						: displayUrl
+							? t`Replace`
+							: undefined
 				}
 			/>
 			{assetEditor.dialog}

--- a/packages/admin/src/components/ImageFieldRenderer.tsx
+++ b/packages/admin/src/components/ImageFieldRenderer.tsx
@@ -378,9 +378,12 @@ export function ImageFieldRenderer({
 
 	const featuredCard = displayUrl ? (
 		<LayerCard className="grid w-full grid-cols-1 rounded-xl p-0 sm:grid-cols-[12rem_minmax(0,1fr)]">
-			<div className="m-2 aspect-[3/2] min-h-28 overflow-hidden rounded bg-kumo-tint ring ring-kumo-line">
+			<div
+				className="m-2 overflow-hidden rounded bg-kumo-tint ring ring-kumo-line"
+				style={{ aspectRatio: "16 / 9" }}
+			>
 				{imageBroken ? (
-					<div className="flex h-full min-h-28 items-center justify-center gap-2 text-kumo-subtle">
+					<div className="flex h-full items-center justify-center gap-2 text-kumo-subtle">
 						<ImageBroken className="h-5 w-5" aria-hidden="true" />
 						<Text as="span" variant="secondary">
 							{t`Image not found`}

--- a/packages/admin/src/components/ImageFieldRenderer.tsx
+++ b/packages/admin/src/components/ImageFieldRenderer.tsx
@@ -8,7 +8,7 @@
  * sub-fields) can reuse the same picker without a circular import.
  */
 
-import { Button, DropdownMenu, Label, LayerCard, Text } from "@cloudflare/kumo";
+import { Button, DropdownMenu, Label, LayerCard, Text, Tooltip } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
 	Image as ImageIcon,
@@ -313,32 +313,39 @@ export function ImageFieldRenderer({
 	);
 	const mobileFeaturedActions = (
 		<DropdownMenu open={mobileActionsOpen} onOpenChange={setMobileActionsOpen}>
-			<DropdownMenu.Trigger
+			<Tooltip
+				content={t`Image actions`}
+				side="top"
+				className="cursor-pointer"
 				render={
-					<Button
-						ref={mobileImageActionsRef}
-						type="button"
-						shape="square"
-						variant="ghost"
-						icon={<DotsThree aria-hidden="true" />}
-						loading={assetEditor.isOpening && pickerTarget === "image"}
-						disabled={assetEditor.isActive}
-						aria-label={t`Image actions`}
-						aria-haspopup="menu"
-						aria-expanded={mobileActionsOpen}
+					<DropdownMenu.Trigger
+						render={
+							<Button
+								ref={mobileImageActionsRef}
+								type="button"
+								shape="square"
+								variant="ghost"
+								icon={<DotsThree aria-hidden="true" />}
+								loading={assetEditor.isOpening && pickerTarget === "image"}
+								disabled={assetEditor.isActive}
+								aria-label={t`Image actions`}
+								aria-haspopup="menu"
+								aria-expanded={mobileActionsOpen}
+							/>
+						}
 					/>
 				}
 			/>
 			<DropdownMenu.Content align="end" className="min-w-40 sm:hidden">
 				<DropdownMenu.Item
-					icon={<ImageSquare aria-hidden="true" />}
+					icon={<ImageSquare className="me-1.5 size-4" aria-hidden="true" />}
 					onClick={() => openPicker("image")}
 				>
 					{t`Replace`}
 				</DropdownMenu.Item>
 				{canEditPrimaryAsset && (
 					<DropdownMenu.Item
-						icon={<PencilSimple aria-hidden="true" />}
+						icon={<PencilSimple className="me-1.5 size-4" aria-hidden="true" />}
 						onClick={() => {
 							setPickerTarget("image");
 							void assetEditor.openAssetEditor(objectValue!.id, mobileImageActionsRef.current);
@@ -348,7 +355,11 @@ export function ImageFieldRenderer({
 					</DropdownMenu.Item>
 				)}
 				<DropdownMenu.Separator />
-				<DropdownMenu.Item variant="danger" icon={<X aria-hidden="true" />} onClick={handleRemove}>
+				<DropdownMenu.Item
+					variant="danger"
+					icon={<X className="me-1.5 size-4" aria-hidden="true" />}
+					onClick={handleRemove}
+				>
 					{t`Remove`}
 				</DropdownMenu.Item>
 			</DropdownMenu.Content>

--- a/packages/admin/src/components/ImageFieldRenderer.tsx
+++ b/packages/admin/src/components/ImageFieldRenderer.tsx
@@ -373,7 +373,7 @@ export function ImageFieldRenderer({
 						type="button"
 						size="sm"
 						variant="secondary"
-						icon={<Moon />}
+						icon={<Moon aria-hidden="true" />}
 						onClick={() => openPicker("darkVariant")}
 						disabled={assetEditor.isActive}
 					>

--- a/packages/admin/src/components/ImageFieldRenderer.tsx
+++ b/packages/admin/src/components/ImageFieldRenderer.tsx
@@ -8,12 +8,13 @@
  * sub-fields) can reuse the same picker without a circular import.
  */
 
-import { Button, Label, LayerCard, Text } from "@cloudflare/kumo";
+import { Button, DropdownMenu, Label, LayerCard, Text } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
 	Image as ImageIcon,
 	ImageBroken,
 	ImageSquare,
+	DotsThree,
 	Moon,
 	PencilSimple,
 	X,
@@ -127,8 +128,10 @@ export function ImageFieldRenderer({
 	const { t } = useLingui();
 	const [pickerOpen, setPickerOpen] = React.useState(false);
 	const [pickerTarget, setPickerTarget] = React.useState<"image" | "darkVariant">("image");
+	const [mobileActionsOpen, setMobileActionsOpen] = React.useState(false);
 	const [imageBroken, setImageBroken] = React.useState(false);
 	const [darkImageBroken, setDarkImageBroken] = React.useState(false);
+	const mobileImageActionsRef = React.useRef<HTMLButtonElement>(null);
 	const [editedContentHashes, setEditedContentHashes] = React.useState<
 		Record<string, string | null | undefined>
 	>({});
@@ -201,6 +204,16 @@ export function ImageFieldRenderer({
 		setDarkImageBroken(false);
 	}, [darkDisplayUrl]);
 
+	React.useEffect(() => {
+		if (variant !== "featured") return;
+		const desktop = window.matchMedia("(min-width: 640px)");
+		const closeMobileActions = (event: MediaQueryListEvent) => {
+			if (event.matches) setMobileActionsOpen(false);
+		};
+		desktop.addEventListener("change", closeMobileActions);
+		return () => desktop.removeEventListener("change", closeMobileActions);
+	}, [variant]);
+
 	const openPicker = (target: "image" | "darkVariant") => {
 		setPickerTarget(target);
 		setPickerOpen(true);
@@ -255,7 +268,7 @@ export function ImageFieldRenderer({
 		<div
 			className={
 				isFeatured
-					? "-m-0.5 flex w-full min-w-0 items-center gap-2 overflow-x-auto overscroll-x-contain p-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+					? "-m-0.5 hidden w-full min-w-0 items-center gap-2 overflow-x-auto overscroll-x-contain p-0.5 [scrollbar-width:none] sm:flex [&::-webkit-scrollbar]:hidden"
 					: "flex flex-wrap items-center gap-2"
 			}
 			style={isFeatured ? { scrollbarWidth: "none" } : undefined}
@@ -297,6 +310,49 @@ export function ImageFieldRenderer({
 				{t`Remove`}
 			</Button>
 		</div>
+	);
+	const mobileFeaturedActions = (
+		<DropdownMenu open={mobileActionsOpen} onOpenChange={setMobileActionsOpen}>
+			<DropdownMenu.Trigger
+				render={
+					<Button
+						ref={mobileImageActionsRef}
+						type="button"
+						shape="square"
+						variant="ghost"
+						icon={<DotsThree aria-hidden="true" />}
+						loading={assetEditor.isOpening && pickerTarget === "image"}
+						disabled={assetEditor.isActive}
+						aria-label={t`Image actions`}
+						aria-haspopup="menu"
+						aria-expanded={mobileActionsOpen}
+					/>
+				}
+			/>
+			<DropdownMenu.Content align="end" className="min-w-40 sm:hidden">
+				<DropdownMenu.Item
+					icon={<ImageSquare aria-hidden="true" />}
+					onClick={() => openPicker("image")}
+				>
+					{t`Replace`}
+				</DropdownMenu.Item>
+				{canEditPrimaryAsset && (
+					<DropdownMenu.Item
+						icon={<PencilSimple aria-hidden="true" />}
+						onClick={() => {
+							setPickerTarget("image");
+							void assetEditor.openAssetEditor(objectValue!.id, mobileImageActionsRef.current);
+						}}
+					>
+						{t`Edit asset`}
+					</DropdownMenu.Item>
+				)}
+				<DropdownMenu.Separator />
+				<DropdownMenu.Item variant="danger" icon={<X aria-hidden="true" />} onClick={handleRemove}>
+					{t`Remove`}
+				</DropdownMenu.Item>
+			</DropdownMenu.Content>
+		</DropdownMenu>
 	);
 
 	const darkVariantSlot =
@@ -384,15 +440,15 @@ export function ImageFieldRenderer({
 		) : null;
 
 	const featuredCard = displayUrl ? (
-		<LayerCard className="grid w-full grid-cols-1 rounded-xl p-0 sm:grid-cols-[12rem_minmax(0,1fr)]">
+		<LayerCard className="grid w-full grid-cols-[5rem_minmax(0,1fr)_auto] items-center rounded-xl p-0 sm:grid-cols-[12rem_minmax(0,1fr)] sm:items-stretch">
 			<div
-				className="m-2 overflow-hidden rounded bg-kumo-tint ring ring-kumo-line"
+				className="emdash-featured-image-preview m-2 overflow-hidden rounded bg-kumo-tint ring ring-kumo-line"
 				style={{ aspectRatio: "16 / 9" }}
 			>
 				{imageBroken ? (
 					<div className="flex h-full items-center justify-center gap-2 text-kumo-subtle">
 						<ImageBroken className="h-5 w-5" aria-hidden="true" />
-						<Text as="span" variant="secondary">
+						<Text as="span" variant="secondary" DANGEROUS_className="sr-only sm:not-sr-only">
 							{t`Image not found`}
 						</Text>
 					</div>
@@ -406,11 +462,8 @@ export function ImageFieldRenderer({
 					/>
 				)}
 			</div>
-			<div className="flex min-w-0 flex-col justify-center px-4 py-3">
-				<div
-					className="flex w-full min-w-0 flex-col gap-3"
-					style={{ transform: "translateY(6px)" }}
-				>
+			<div className="flex min-w-0 flex-col justify-center px-2 py-2 sm:px-4 sm:py-3">
+				<div className="flex w-full min-w-0 flex-col gap-1.5 sm:translate-y-1.5 sm:gap-3">
 					<div className="grid min-w-0 gap-1">
 						<Text as="p" bold truncate>
 							{selectedFilename}
@@ -424,6 +477,7 @@ export function ImageFieldRenderer({
 					{primaryActions}
 				</div>
 			</div>
+			<div className="me-2 sm:hidden">{mobileFeaturedActions}</div>
 		</LayerCard>
 	) : null;
 

--- a/packages/admin/src/components/MediaDetailPanel.tsx
+++ b/packages/admin/src/components/MediaDetailPanel.tsx
@@ -140,7 +140,6 @@ export interface MediaDetailPanelProps {
 	open: boolean;
 	item: MediaItem;
 	embedded?: boolean;
-	backLabel?: string;
 	context?: "library" | "content";
 	providerName?: string;
 	canDelete?: boolean;
@@ -202,10 +201,7 @@ function MediaDetailSurface({
 }) {
 	if (embedded) {
 		return (
-			<div
-				className="flex h-full min-h-0 flex-col overflow-hidden"
-				data-testid="media-detail-workspace"
-			>
+			<div className="flex min-h-0 flex-col overflow-hidden" data-testid="media-detail-workspace">
 				{children}
 			</div>
 		);
@@ -228,7 +224,6 @@ export function MediaDetailPanel({
 	open,
 	item,
 	embedded = false,
-	backLabel,
 	context = "library",
 	providerName,
 	canDelete: canDeleteProp,
@@ -1106,26 +1101,11 @@ export function MediaDetailPanel({
 						style={embedded ? undefined : { padding: "1.25rem 2rem" }}
 						data-testid="media-detail-dialog-header"
 					>
-						<div className="flex min-w-0 flex-1 items-start gap-2">
-							{embedded && backLabel ? (
-								<Button
-									variant="ghost"
-									size="base"
-									className="-ms-2 shrink-0"
-									aria-label={backLabel}
-									icon={<ArrowLeft className="h-4 w-4 rtl:-scale-x-100" aria-hidden="true" />}
-									onClick={requestClose}
-									disabled={isBusy}
-								>
-									<span className="hidden sm:inline">{backLabel}</span>
-								</Button>
-							) : null}
-							<div className="min-w-0 flex-1">
-								<Dialog.Title className="truncate text-lg font-semibold leading-none">
-									{t`Media details`}
-								</Dialog.Title>
-								<p className="mt-1 truncate text-sm text-kumo-subtle">{item.filename}</p>
-							</div>
+						<div className="min-w-0 flex-1">
+							<Dialog.Title className="truncate text-lg font-semibold leading-none">
+								{t`Media details`}
+							</Dialog.Title>
+							<p className="mt-1 truncate text-sm text-kumo-subtle">{item.filename}</p>
 						</div>
 						<Button
 							variant="ghost"
@@ -1803,43 +1783,58 @@ export function MediaDetailPanel({
 						data-testid="media-detail-dialog-footer"
 					>
 						<div className="flex flex-wrap gap-2">
-							{canDelete && !cropFooterActive && (
+							{embedded ? (
 								<Button
-									variant="destructive"
-									icon={<Trash />}
-									onClick={handleDelete}
-									disabled={isBusy || mediaUnavailable}
+									variant="outline"
+									icon={<ArrowLeft className="h-4 w-4 rtl:-scale-x-100" aria-hidden="true" />}
+									onClick={requestClose}
+									disabled={isBusy}
 								>
-									{isDeleting ? t`Deleting...` : t`Delete`}
+									{t`Back`}
 								</Button>
-							)}
-							{canReplaceImage && activeTab === "details" ? (
+							) : (
 								<>
-									<Button
-										variant="outline"
-										icon={<ArrowsClockwise />}
-										onClick={openReplacementPicker}
-										disabled={replaceActionDisabled}
-									>
-										{t`Replace image`}
-									</Button>
-									<input
-										ref={replaceInputRef}
-										type="file"
-										accept={cropMime}
-										className="sr-only"
-										tabIndex={-1}
-										disabled={replaceActionDisabled}
-										aria-label={t`Choose replacement image`}
-										onChange={handleReplacementFile}
-									/>
+									{canDelete && !cropFooterActive ? (
+										<Button
+											variant="destructive"
+											icon={<Trash />}
+											onClick={handleDelete}
+											disabled={isBusy || mediaUnavailable}
+										>
+											{isDeleting ? t`Deleting...` : t`Delete`}
+										</Button>
+									) : null}
+									{canReplaceImage && activeTab === "details" ? (
+										<>
+											<Button
+												variant="outline"
+												icon={<ArrowsClockwise />}
+												onClick={openReplacementPicker}
+												disabled={replaceActionDisabled}
+											>
+												{t`Replace image`}
+											</Button>
+											<input
+												ref={replaceInputRef}
+												type="file"
+												accept={cropMime}
+												className="sr-only"
+												tabIndex={-1}
+												disabled={replaceActionDisabled}
+												aria-label={t`Choose replacement image`}
+												onChange={handleReplacementFile}
+											/>
+										</>
+									) : null}
 								</>
-							) : null}
+							)}
 						</div>
 						<div className="flex flex-wrap justify-end gap-2">
-							<Button variant="outline" onClick={requestClose} disabled={isBusy}>
-								{canEdit && (activeTab !== "used-in" || hasChanges) ? t`Cancel` : t`Close`}
-							</Button>
+							{!embedded ? (
+								<Button variant="outline" onClick={requestClose} disabled={isBusy}>
+									{canEdit && (activeTab !== "used-in" || hasChanges) ? t`Cancel` : t`Close`}
+								</Button>
+							) : null}
 							{cropFooterActive ? (
 								<>
 									{canReplaceOriginal ? (

--- a/packages/admin/src/components/MediaDetailPanel.tsx
+++ b/packages/admin/src/components/MediaDetailPanel.tsx
@@ -151,6 +151,7 @@ export interface MediaDetailPanelProps {
 	onUpdated?: () => void;
 	onItemRefreshed?: (item: LocalMediaItem) => void;
 	onCroppedCopyCreated?: (item: LocalMediaItem) => void;
+	onUnavailable?: (id: string) => void;
 	onDeleted?: () => void;
 }
 
@@ -173,6 +174,7 @@ export function MediaDetailPanel({
 	onUpdated,
 	onItemRefreshed,
 	onCroppedCopyCreated,
+	onUnavailable,
 	onDeleted,
 }: MediaDetailPanelProps) {
 	const { t } = useLingui();
@@ -186,6 +188,7 @@ export function MediaDetailPanel({
 	const closeFallbackTimerRef = React.useRef<number | null>(null);
 	const closeFinishedRef = React.useRef(false);
 	const cropPendingRef = React.useRef(false);
+	const unavailableReportedRef = React.useRef<string | null>(null);
 	const cropImageRef = React.useRef<HTMLImageElement | null>(null);
 	const dialogBodyRef = React.useRef<HTMLDivElement | null>(null);
 	const dialogResizeAnimationRef = React.useRef<Animation | null>(null);
@@ -271,6 +274,7 @@ export function MediaDetailPanel({
 		replacePendingRef.current = false;
 		replaceSelectionTokenRef.current += 1;
 		cropPendingRef.current = false;
+		unavailableReportedRef.current = null;
 		cropImageRef.current = null;
 		if (imageModeOverflowFrameRef.current !== null) {
 			window.cancelAnimationFrame(imageModeOverflowFrameRef.current);
@@ -688,9 +692,10 @@ export function MediaDetailPanel({
 			setShowCropConfirm(false);
 			setCropStatus(t`Original image cropped.`);
 		},
-		onError: (_error, action) => {
+		onError: (error, action) => {
 			setCropStatus("");
 			if (action === "replace") setShowCropConfirm(false);
+			if (error instanceof ApiResponseError && error.code === "NOT_FOUND") recoverMediaItem();
 		},
 		onSettled: () => {
 			cropPendingRef.current = false;
@@ -708,6 +713,11 @@ export function MediaDetailPanel({
 	const mediaUnavailable =
 		recoverMediaMutation.error instanceof ApiResponseError &&
 		recoverMediaMutation.error.code === "NOT_FOUND";
+	React.useEffect(() => {
+		if (!open || !mediaUnavailable || unavailableReportedRef.current === item.id) return;
+		unavailableReportedRef.current = item.id;
+		onUnavailable?.(item.id);
+	}, [item.id, mediaUnavailable, onUnavailable, open]);
 	const isBusy = isSaving || isDeleting || isRecovering || isReplacing || isCropping;
 	const cropFooterActive = activeTab === "edit-image" && imageEditMode === "crop" && canShowCrop;
 	const cropActionDisabled =

--- a/packages/admin/src/components/MediaDetailPanel.tsx
+++ b/packages/admin/src/components/MediaDetailPanel.tsx
@@ -1546,17 +1546,14 @@ export function MediaDetailPanel({
 											</Combobox.Content>
 										</Combobox>
 									) : (
-										<div className="space-y-1">
-											<p className="text-sm font-medium text-kumo-default">{t`Location`}</p>
-											<p
-												className="flex items-center gap-2 text-sm text-kumo-subtle"
-												aria-live="polite"
-											>
-												<MediaLocationIcon folderId={localItem.folderId} />
-												<span className="min-w-0 truncate" dir="auto">
-													{currentLocationName}
-												</span>
-											</p>
+										<div className="w-full space-y-2">
+											<span className="text-[14px] font-medium text-kumo-default">{t`Location`}</span>
+											<Input
+												aria-label={t`Location`}
+												value={currentLocationName}
+												disabled
+												className="w-full bg-kumo-tint text-kumo-subtle"
+											/>
 										</div>
 									))}
 

--- a/packages/admin/src/components/MediaDetailPanel.tsx
+++ b/packages/admin/src/components/MediaDetailPanel.tsx
@@ -201,7 +201,10 @@ function MediaDetailSurface({
 }) {
 	if (embedded) {
 		return (
-			<div className="flex min-h-0 flex-col overflow-hidden" data-testid="media-detail-workspace">
+			<div
+				className="flex h-full min-h-0 flex-col overflow-hidden"
+				data-testid="media-detail-workspace"
+			>
 				{children}
 			</div>
 		);

--- a/packages/admin/src/components/MediaDetailPanel.tsx
+++ b/packages/admin/src/components/MediaDetailPanel.tsx
@@ -138,6 +138,7 @@ interface MediaLocationOption {
 export interface MediaDetailPanelProps {
 	open: boolean;
 	item: MediaItem;
+	context?: "library" | "content";
 	providerName?: string;
 	canDelete?: boolean;
 	canMoveLocation?: boolean;
@@ -149,7 +150,7 @@ export interface MediaDetailPanelProps {
 	onClosed?: () => void;
 	onUpdated?: () => void;
 	onItemRefreshed?: (item: LocalMediaItem) => void;
-	onCroppedCopyCreated?: () => void;
+	onCroppedCopyCreated?: (item: LocalMediaItem) => void;
 	onDeleted?: () => void;
 }
 
@@ -159,6 +160,7 @@ export interface MediaDetailPanelProps {
 export function MediaDetailPanel({
 	open,
 	item,
+	context = "library",
 	providerName,
 	canDelete: canDeleteProp,
 	canMoveLocation: canMoveLocationProp,
@@ -199,10 +201,10 @@ export function MediaDetailPanel({
 	// Present when the item streams rather than resolving to a playable file.
 	const playback = metaPlayback(item.meta);
 	const canEditMetadata = !isProviderAsset && isImage;
-	const hasUsage = !isProviderAsset;
-	const canDelete = !isProviderAsset || Boolean(canDeleteProp);
+	const hasUsage = context === "library" && !isProviderAsset;
+	const canDelete = context === "library" && (!isProviderAsset || Boolean(canDeleteProp));
 	const localItem = isLocalMediaItem(item) ? item : null;
-	const canMoveLocation = Boolean(localItem && canMoveLocationProp);
+	const canMoveLocation = context === "library" && Boolean(localItem && canMoveLocationProp);
 	const canReplaceOriginal = canReplaceOriginalProp ?? canCropOriginal;
 	const cropMime = normalizeCropMime(item.mimeType);
 	const canShowCrop = Boolean(
@@ -665,7 +667,7 @@ export function MediaDetailPanel({
 		onSuccess: ({ action, item: croppedItem }) => {
 			void queryClient.invalidateQueries({ queryKey: ["media"] });
 			if (action === "duplicate") {
-				onCroppedCopyCreated?.();
+				onCroppedCopyCreated?.(croppedItem);
 				onUpdated?.();
 				setCropAspectMode("original");
 				setCropSelection(undefined);

--- a/packages/admin/src/components/MediaDetailPanel.tsx
+++ b/packages/admin/src/components/MediaDetailPanel.tsx
@@ -21,6 +21,7 @@ import {
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
+	ArrowLeft,
 	ArrowCounterClockwise,
 	ArrowsClockwise,
 	X,
@@ -138,6 +139,8 @@ interface MediaLocationOption {
 export interface MediaDetailPanelProps {
 	open: boolean;
 	item: MediaItem;
+	embedded?: boolean;
+	backLabel?: string;
 	context?: "library" | "content";
 	providerName?: string;
 	canDelete?: boolean;
@@ -145,8 +148,10 @@ export interface MediaDetailPanelProps {
 	canReplaceOriginal?: boolean;
 	canCropOriginal?: boolean;
 	canDuplicateCrop?: boolean;
+	requestExitRef?: React.MutableRefObject<(() => void) | null>;
 	restoreFocusTargetRef?: React.RefObject<HTMLElement | null>;
 	onClose: () => void;
+	onExit?: () => void;
 	onClosed?: () => void;
 	onUpdated?: () => void;
 	onItemRefreshed?: (item: LocalMediaItem) => void;
@@ -155,12 +160,75 @@ export interface MediaDetailPanelProps {
 	onDeleted?: () => void;
 }
 
+interface MediaDetailRootProps {
+	embedded: boolean;
+	open: boolean;
+	isConfirmOpen: boolean;
+	onRequestClose: () => void;
+	onClosed: () => void;
+	children: React.ReactNode;
+}
+
+function MediaDetailRoot({
+	embedded,
+	open,
+	isConfirmOpen,
+	onRequestClose,
+	onClosed,
+	children,
+}: MediaDetailRootProps) {
+	if (embedded) return <>{children}</>;
+	return (
+		<Dialog.Root
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen && !isConfirmOpen) onRequestClose();
+			}}
+			onOpenChangeComplete={(nextOpen) => {
+				if (!nextOpen) onClosed();
+			}}
+		>
+			{children}
+		</Dialog.Root>
+	);
+}
+
+function MediaDetailSurface({
+	embedded,
+	children,
+}: {
+	embedded: boolean;
+	children: React.ReactNode;
+}) {
+	if (embedded) {
+		return (
+			<div
+				className="flex h-full min-h-0 flex-col overflow-hidden"
+				data-testid="media-detail-workspace"
+			>
+				{children}
+			</div>
+		);
+	}
+	return (
+		<Dialog
+			size="xl"
+			className="min-w-0 flex flex-col overflow-hidden p-0"
+			style={{ width: "min(94vw, 68rem)", maxHeight: "min(88dvh, 43.5rem)" }}
+		>
+			{children}
+		</Dialog>
+	);
+}
+
 /**
  * Centered dialog for viewing and editing media metadata.
  */
 export function MediaDetailPanel({
 	open,
 	item,
+	embedded = false,
+	backLabel,
 	context = "library",
 	providerName,
 	canDelete: canDeleteProp,
@@ -168,8 +236,10 @@ export function MediaDetailPanel({
 	canReplaceOriginal: canReplaceOriginalProp,
 	canCropOriginal = false,
 	canDuplicateCrop = false,
+	requestExitRef,
 	restoreFocusTargetRef,
 	onClose,
+	onExit,
 	onClosed,
 	onUpdated,
 	onItemRefreshed,
@@ -257,6 +327,7 @@ export function MediaDetailPanel({
 	const [replacementImage, setReplacementImage] = React.useState<ReplacementImage | null>(null);
 	const [replaceSelectionError, setReplaceSelectionError] = React.useState("");
 	const [replaceStatus, setReplaceStatus] = React.useState("");
+	const discardActionRef = React.useRef<"close" | "exit">("close");
 	const [pendingUsageEntry, setPendingUsageEntry] = React.useState<MediaUsageEntryDetail | null>(
 		null,
 	);
@@ -307,6 +378,7 @@ export function MediaDetailPanel({
 		setReplacementImage(null);
 		setReplaceSelectionError("");
 		setReplaceStatus("");
+		discardActionRef.current = "close";
 		setPendingUsageEntry(null);
 	}, [item.id, localItem?.folderId, open]);
 
@@ -389,14 +461,26 @@ export function MediaDetailPanel({
 		}
 	}, [onClosed, restoreFocusTargetRef]);
 
-	const closeDialog = React.useCallback(() => {
-		replaceSelectionTokenRef.current += 1;
-		onClose();
-		if (closeFallbackTimerRef.current !== null) {
-			window.clearTimeout(closeFallbackTimerRef.current);
-		}
-		closeFallbackTimerRef.current = window.setTimeout(finishClose, CLOSE_FALLBACK_MS);
-	}, [finishClose, onClose]);
+	const closeWith = React.useCallback(
+		(callback: () => void) => {
+			replaceSelectionTokenRef.current += 1;
+			callback();
+			if (embedded) {
+				finishClose();
+				return;
+			}
+			if (closeFallbackTimerRef.current !== null) {
+				window.clearTimeout(closeFallbackTimerRef.current);
+			}
+			closeFallbackTimerRef.current = window.setTimeout(finishClose, CLOSE_FALLBACK_MS);
+		},
+		[embedded, finishClose],
+	);
+	const closeDialog = React.useCallback(() => closeWith(onClose), [closeWith, onClose]);
+	const exitDialog = React.useCallback(
+		() => closeWith(onExit ?? onClose),
+		[closeWith, onClose, onExit],
+	);
 
 	const originalFocalPoint = normalizeMediaFocalPoint(item);
 	const focalPointChanged =
@@ -743,6 +827,7 @@ export function MediaDetailPanel({
 	const requestClose = React.useCallback(() => {
 		if (isBusy) return;
 		if (isConfirmOpen) return;
+		discardActionRef.current = "close";
 		setPendingUsageEntry(null);
 		if (hasChanges) {
 			setShowDiscardConfirm(true);
@@ -750,6 +835,24 @@ export function MediaDetailPanel({
 		}
 		closeDialog();
 	}, [closeDialog, hasChanges, isBusy, isConfirmOpen]);
+	const requestExit = React.useCallback(() => {
+		if (isBusy) return;
+		if (isConfirmOpen) return;
+		discardActionRef.current = "exit";
+		setPendingUsageEntry(null);
+		if (hasChanges) {
+			setShowDiscardConfirm(true);
+			return;
+		}
+		exitDialog();
+	}, [exitDialog, hasChanges, isBusy, isConfirmOpen]);
+	React.useLayoutEffect(() => {
+		if (!requestExitRef) return;
+		requestExitRef.current = requestExit;
+		return () => {
+			if (requestExitRef.current === requestExit) requestExitRef.current = null;
+		};
+	}, [requestExit, requestExitRef]);
 
 	const handleSave = () => {
 		if (!canEdit || !hasChanges || isBusy || mediaUnavailable || savePendingRef.current) return;
@@ -943,7 +1046,8 @@ export function MediaDetailPanel({
 		const usageEntry = pendingUsageEntry;
 		setShowDiscardConfirm(false);
 		setPendingUsageEntry(null);
-		closeDialog();
+		if (usageEntry || discardActionRef.current === "close") closeDialog();
+		else exitDialog();
 		if (usageEntry) {
 			void navigate({
 				to: "/content/$collection/$id",
@@ -965,6 +1069,7 @@ export function MediaDetailPanel({
 		if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
 
 		event.preventDefault();
+		discardActionRef.current = "close";
 		setPendingUsageEntry(entry);
 		setShowDiscardConfirm(true);
 	};
@@ -988,37 +1093,45 @@ export function MediaDetailPanel({
 
 	return (
 		<>
-			<Dialog.Root
+			<MediaDetailRoot
+				embedded={embedded}
 				open={open}
-				onOpenChange={(nextOpen) => {
-					if (!nextOpen && !isConfirmOpen) requestClose();
-				}}
-				onOpenChangeComplete={(nextOpen) => {
-					if (nextOpen) return;
-					finishClose();
-				}}
+				isConfirmOpen={isConfirmOpen}
+				onRequestClose={requestClose}
+				onClosed={finishClose}
 			>
-				<Dialog
-					size="xl"
-					className="min-w-0 flex flex-col overflow-hidden p-0"
-					style={{ width: "min(94vw, 68rem)", maxHeight: "min(88dvh, 43.5rem)" }}
-				>
+				<MediaDetailSurface embedded={embedded}>
 					<div
-						className="flex shrink-0 items-start justify-between gap-4 border-b border-kumo-line"
-						style={{ padding: "1.25rem 2rem" }}
+						className={`flex shrink-0 items-start justify-between gap-4 border-b border-kumo-line ${embedded ? "px-5 py-4 sm:px-7" : ""}`}
+						style={embedded ? undefined : { padding: "1.25rem 2rem" }}
 						data-testid="media-detail-dialog-header"
 					>
-						<div className="min-w-0 flex-1">
-							<Dialog.Title className="truncate text-lg font-semibold leading-none">
-								{t`Media details`}
-							</Dialog.Title>
-							<p className="mt-1 truncate text-sm text-kumo-subtle">{item.filename}</p>
+						<div className="flex min-w-0 flex-1 items-start gap-2">
+							{embedded && backLabel ? (
+								<Button
+									variant="ghost"
+									size="base"
+									className="-ms-2 shrink-0"
+									aria-label={backLabel}
+									icon={<ArrowLeft className="h-4 w-4 rtl:-scale-x-100" aria-hidden="true" />}
+									onClick={requestClose}
+									disabled={isBusy}
+								>
+									<span className="hidden sm:inline">{backLabel}</span>
+								</Button>
+							) : null}
+							<div className="min-w-0 flex-1">
+								<Dialog.Title className="truncate text-lg font-semibold leading-none">
+									{t`Media details`}
+								</Dialog.Title>
+								<p className="mt-1 truncate text-sm text-kumo-subtle">{item.filename}</p>
+							</div>
 						</div>
 						<Button
 							variant="ghost"
 							shape="square"
 							aria-label={t`Close`}
-							onClick={requestClose}
+							onClick={embedded ? requestExit : requestClose}
 							disabled={isBusy}
 						>
 							<X className="h-4 w-4" aria-hidden="true" />
@@ -1760,8 +1873,8 @@ export function MediaDetailPanel({
 							) : null}
 						</div>
 					</div>
-				</Dialog>
-			</Dialog.Root>
+				</MediaDetailSurface>
+			</MediaDetailRoot>
 
 			<ConfirmDialog
 				open={showDiscardConfirm}

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -246,20 +246,15 @@ export function MediaPickerModal({
 	const [providerDimensions, setProviderDimensions] = React.useState<
 		Record<string, { width: number; height: number }>
 	>({});
-	const [browseOpen, setBrowseOpen] = React.useState(open);
 	const [assetOpen, setAssetOpen] = React.useState(false);
 	const [assetItem, setAssetItem] = React.useState<MediaItem>(EMPTY_DETAIL_ITEM);
 	const fileInputRef = React.useRef<HTMLInputElement>(null);
 	const editAssetButtonRef = React.useRef<HTMLButtonElement>(null);
+	const mediaDetailPanelRef = React.useRef<(() => void) | null>(null);
 	const updatedDimensionsRef = React.useRef(new Set<string>());
 	const urlProbeIdRef = React.useRef(0);
 	const uploadTargetsRef = React.useRef(new Map<number, string>());
 	const selectionOrderEditedRef = React.useRef(false);
-	const parentOpenRef = React.useRef(open);
-	const flowGenerationRef = React.useRef(0);
-	const transitionRef = React.useRef<
-		{ kind: "open-asset" | "return-browse"; generation: number } | undefined
-	>(undefined);
 	const restoreEditFocusRef = React.useRef(false);
 	const invalidateUrlProbe = React.useCallback(() => {
 		urlProbeIdRef.current += 1;
@@ -288,22 +283,16 @@ export function MediaPickerModal({
 	const uploadQueue = useMediaUploadQueue<UploadedMedia>({ upload: uploadFile });
 
 	React.useEffect(() => {
-		const wasOpen = parentOpenRef.current;
-		parentOpenRef.current = open;
-		if (!open) {
-			flowGenerationRef.current += 1;
-			transitionRef.current = undefined;
-			restoreEditFocusRef.current = false;
-			setBrowseOpen(false);
-			setAssetOpen(false);
-			return;
-		}
-		if (wasOpen) return;
-		flowGenerationRef.current += 1;
-		transitionRef.current = undefined;
+		if (open) return;
+		restoreEditFocusRef.current = false;
 		setAssetOpen(false);
-		setBrowseOpen(true);
 	}, [open]);
+
+	React.useEffect(() => {
+		if (!open || assetOpen || !restoreEditFocusRef.current) return;
+		restoreEditFocusRef.current = false;
+		editAssetButtonRef.current?.focus({ preventScroll: true });
+	}, [assetOpen, open]);
 
 	React.useEffect(() => {
 		if (!open) return;
@@ -773,31 +762,11 @@ export function MediaPickerModal({
 	const openAssetEditor = () => {
 		if (!editableSelection || uploadQueue.hasUnfinished) return;
 		setAssetItem(editableSelection);
-		transitionRef.current = {
-			kind: "open-asset",
-			generation: flowGenerationRef.current,
-		};
-		setBrowseOpen(false);
+		setAssetOpen(true);
 	};
 	const closeAssetEditor = () => {
-		transitionRef.current = {
-			kind: "return-browse",
-			generation: flowGenerationRef.current,
-		};
-		setAssetOpen(false);
-	};
-	const handleAssetClosed = () => {
-		const transition = transitionRef.current;
-		if (
-			!parentOpenRef.current ||
-			transition?.kind !== "return-browse" ||
-			transition.generation !== flowGenerationRef.current
-		) {
-			return;
-		}
-		transitionRef.current = undefined;
 		restoreEditFocusRef.current = true;
-		setBrowseOpen(true);
+		setAssetOpen(false);
 	};
 	const confirmText =
 		confirmLabel ??
@@ -902,56 +871,64 @@ export function MediaPickerModal({
 
 	const browseDialog = (
 		<Dialog.Root
-			open={open && browseOpen}
+			open={open}
 			onOpenChange={(nextOpen) => {
-				if (!nextOpen && transitionRef.current?.kind !== "open-asset") handleClose();
-			}}
-			onOpenChangeComplete={(nextOpen) => {
-				if (nextOpen) {
-					if (!restoreEditFocusRef.current) return;
-					restoreEditFocusRef.current = false;
-					editAssetButtonRef.current?.focus({ preventScroll: true });
+				if (nextOpen) return;
+				if (assetOpen && mediaDetailPanelRef.current) {
+					mediaDetailPanelRef.current();
 					return;
 				}
-				const transition = transitionRef.current;
-				if (
-					!parentOpenRef.current ||
-					transition?.kind !== "open-asset" ||
-					transition.generation !== flowGenerationRef.current
-				) {
-					return;
-				}
-				transitionRef.current = undefined;
-				setAssetOpen(true);
+				handleClose();
 			}}
 		>
 			<Dialog
 				size="xl"
 				className="flex h-[min(48rem,calc(100dvh-1rem))] w-[calc(100vw-2rem)] min-h-0 min-w-0 max-w-[48rem] flex-col overflow-hidden p-0 sm:w-[min(48rem,calc(100vw-2rem))]"
 			>
-				<header className="flex shrink-0 items-start justify-between gap-4 border-b border-kumo-line px-5 py-4 sm:px-7">
-					<div className="min-w-0">
-						<Dialog.Title className="text-lg font-semibold leading-6">{title}</Dialog.Title>
-						<Dialog.Description className="mt-1 text-sm leading-5 text-kumo-subtle">
-							{description}
-						</Dialog.Description>
-					</div>
-					<Dialog.Close
-						aria-label={t`Close`}
-						render={(props) => (
-							<Button
-								{...props}
-								variant="ghost"
-								shape="square"
-								size="base"
-								aria-label={t`Close`}
-								icon={<X aria-hidden="true" />}
-							/>
-						)}
+				{assetOpen ? (
+					<MediaDetailPanel
+						open={open}
+						item={assetItem}
+						embedded
+						backLabel={t`Back to library`}
+						context="content"
+						canCropOriginal={Boolean(editableSelection)}
+						canDuplicateCrop={(currentUser?.role ?? 0) >= ROLE_CONTRIBUTOR}
+						requestExitRef={mediaDetailPanelRef}
+						restoreFocusTargetRef={editAssetButtonRef}
+						onClose={closeAssetEditor}
+						onExit={handleClose}
+						onItemRefreshed={handleAssetRefreshed}
+						onCroppedCopyCreated={handleCroppedCopyCreated}
+						onUnavailable={handleAssetUnavailable}
 					/>
-				</header>
+				) : null}
+				{!assetOpen ? (
+					<header className="flex shrink-0 items-start justify-between gap-4 border-b border-kumo-line px-5 py-4 sm:px-7">
+						<div className="min-w-0">
+							<Dialog.Title className="text-lg font-semibold leading-6">{title}</Dialog.Title>
+							<Dialog.Description className="mt-1 text-sm leading-5 text-kumo-subtle">
+								{description}
+							</Dialog.Description>
+						</div>
+						<Dialog.Close
+							aria-label={t`Close`}
+							render={(props) => (
+								<Button
+									{...props}
+									variant="ghost"
+									shape="square"
+									size="base"
+									aria-label={t`Close`}
+									icon={<X aria-hidden="true" />}
+								/>
+							)}
+						/>
+					</header>
+				) : null}
 
 				<div
+					hidden={assetOpen}
 					className="flex min-h-0 flex-1 flex-col overflow-hidden"
 					onDragOver={(event) => {
 						if (!event.dataTransfer.types.includes("Files")) return;
@@ -1376,7 +1353,11 @@ export function MediaPickerModal({
 														const item =
 															activeSource === "local"
 																? (rawItem as MediaItem)
-																: toMediaItem({ key, providerId: activeSource, item: rawItem });
+																: toMediaItem({
+																		key,
+																		providerId: activeSource,
+																		item: rawItem,
+																	});
 														return (
 															<MediaBrowserItem
 																key={key}
@@ -1418,7 +1399,11 @@ export function MediaPickerModal({
 														const item =
 															activeSource === "local"
 																? (rawItem as MediaItem)
-																: toMediaItem({ key, providerId: activeSource, item: rawItem });
+																: toMediaItem({
+																		key,
+																		providerId: activeSource,
+																		item: rawItem,
+																	});
 														return (
 															<MediaBrowserItem
 																key={key}
@@ -1497,6 +1482,7 @@ export function MediaPickerModal({
 				</div>
 
 				<footer
+					hidden={assetOpen}
 					className="flex shrink-0 justify-end border-t border-kumo-line px-5 py-3 sm:px-7"
 					data-media-actions
 				>
@@ -1524,7 +1510,13 @@ export function MediaPickerModal({
 						</Button>
 					</div>
 				</footer>
-				<span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+				<span
+					hidden={assetOpen}
+					className="sr-only"
+					role="status"
+					aria-live="polite"
+					aria-atomic="true"
+				>
 					{uploadQueue.hasUnfinished
 						? plural(
 								uploadQueue.jobs.filter(
@@ -1543,24 +1535,7 @@ export function MediaPickerModal({
 		</Dialog.Root>
 	);
 
-	return (
-		<>
-			{browseDialog}
-			<MediaDetailPanel
-				open={open && assetOpen}
-				item={assetItem}
-				context="content"
-				canCropOriginal={Boolean(editableSelection)}
-				canDuplicateCrop={(currentUser?.role ?? 0) >= ROLE_CONTRIBUTOR}
-				restoreFocusTargetRef={editAssetButtonRef}
-				onClose={closeAssetEditor}
-				onClosed={handleAssetClosed}
-				onItemRefreshed={handleAssetRefreshed}
-				onCroppedCopyCreated={handleCroppedCopyCreated}
-				onUnavailable={handleAssetUnavailable}
-			/>
-		</>
-	);
+	return browseDialog;
 }
 
 export default MediaPickerModal;

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -883,14 +883,20 @@ export function MediaPickerModal({
 		>
 			<Dialog
 				size="xl"
-				className="flex h-[min(48rem,calc(100dvh-1rem))] w-[calc(100vw-2rem)] min-h-0 min-w-0 max-w-[48rem] flex-col overflow-hidden p-0 sm:w-[min(48rem,calc(100vw-2rem))]"
+				className={
+					assetOpen
+						? "min-w-0 flex flex-col overflow-hidden p-0"
+						: "flex h-[min(48rem,calc(100dvh-1rem))] w-[calc(100vw-2rem)] min-h-0 min-w-0 max-w-[48rem] flex-col overflow-hidden p-0 sm:w-[min(48rem,calc(100vw-2rem))]"
+				}
+				style={
+					assetOpen ? { width: "min(94vw, 68rem)", maxHeight: "min(88dvh, 43.5rem)" } : undefined
+				}
 			>
 				{assetOpen ? (
 					<MediaDetailPanel
 						open={open}
 						item={assetItem}
 						embedded
-						backLabel={t`Back to library`}
 						context="content"
 						canCropOriginal={Boolean(editableSelection)}
 						canDuplicateCrop={(currentUser?.role ?? 0) >= ROLE_CONTRIBUTOR}

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -33,6 +33,7 @@ import {
 	useQueryClient,
 } from "@tanstack/react-query";
 import * as React from "react";
+import { flushSync } from "react-dom";
 
 import {
 	ApiResponseError,
@@ -66,6 +67,8 @@ import { TableToolbar, TableToolbarSearch } from "./TableToolbar.js";
 
 const URL_SOURCE = "__url";
 const PICKER_PAGE_SIZE = 12;
+const WORKSPACE_RESIZE_DURATION_MS = 340;
+const WORKSPACE_RESIZE_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
 const ROLE_CONTRIBUTOR = 20;
 const ROLE_AUTHOR = 30;
 const ROLE_EDITOR = 40;
@@ -251,6 +254,8 @@ export function MediaPickerModal({
 	const fileInputRef = React.useRef<HTMLInputElement>(null);
 	const editAssetButtonRef = React.useRef<HTMLButtonElement>(null);
 	const mediaDetailPanelRef = React.useRef<(() => void) | null>(null);
+	const workspaceResizeAnimationRef = React.useRef<Animation | null>(null);
+	const workspaceResizeTimerRef = React.useRef<number | null>(null);
 	const updatedDimensionsRef = React.useRef(new Set<string>());
 	const urlProbeIdRef = React.useRef(0);
 	const uploadTargetsRef = React.useRef(new Map<number, string>());
@@ -284,9 +289,30 @@ export function MediaPickerModal({
 
 	React.useEffect(() => {
 		if (open) return;
+		workspaceResizeAnimationRef.current?.cancel();
+		workspaceResizeAnimationRef.current = null;
+		if (workspaceResizeTimerRef.current !== null) {
+			window.clearTimeout(workspaceResizeTimerRef.current);
+			workspaceResizeTimerRef.current = null;
+		}
+		const dialog = editAssetButtonRef.current?.closest<HTMLDivElement>('[role="dialog"]');
+		if (dialog) {
+			dialog.style.height = "";
+			dialog.style.maxHeight = "";
+		}
 		restoreEditFocusRef.current = false;
 		setAssetOpen(false);
 	}, [open]);
+
+	React.useEffect(
+		() => () => {
+			workspaceResizeAnimationRef.current?.cancel();
+			if (workspaceResizeTimerRef.current !== null) {
+				window.clearTimeout(workspaceResizeTimerRef.current);
+			}
+		},
+		[],
+	);
 
 	React.useEffect(() => {
 		if (!open || assetOpen || !restoreEditFocusRef.current) return;
@@ -759,14 +785,71 @@ export function MediaPickerModal({
 		},
 		[queryClient],
 	);
+	const transitionWorkspaceLayout = (nextAssetOpen: boolean) => {
+		const dialog = editAssetButtonRef.current?.closest<HTMLDivElement>('[role="dialog"]') ?? null;
+		const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+		if (!dialog || reduceMotion || typeof dialog.animate !== "function") {
+			setAssetOpen(nextAssetOpen);
+			return;
+		}
+
+		const startHeight = dialog.getBoundingClientRect().height;
+		workspaceResizeAnimationRef.current?.cancel();
+		workspaceResizeAnimationRef.current = null;
+		if (workspaceResizeTimerRef.current !== null) {
+			window.clearTimeout(workspaceResizeTimerRef.current);
+			workspaceResizeTimerRef.current = null;
+		}
+		dialog.style.height = `${startHeight}px`;
+		dialog.style.maxHeight = "none";
+		flushSync(() => setAssetOpen(nextAssetOpen));
+		dialog.style.maxHeight = "none";
+		dialog.style.height = "";
+		const naturalEndHeight = dialog.getBoundingClientRect().height;
+		const rootFontSize =
+			Number.parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+		const detailMaxHeight = Math.min(window.innerHeight * 0.88, rootFontSize * 43.5);
+		const endHeight = nextAssetOpen
+			? Math.min(naturalEndHeight, detailMaxHeight)
+			: naturalEndHeight;
+		const finalMaxHeight = nextAssetOpen ? "min(88dvh, 43.5rem)" : "";
+		if (Math.abs(endHeight - startHeight) < 1) {
+			dialog.style.maxHeight = finalMaxHeight;
+			return;
+		}
+
+		dialog.style.height = `${startHeight}px`;
+		const animation = dialog.animate(
+			[{ height: `${startHeight}px` }, { height: `${endHeight}px` }],
+			{
+				duration: WORKSPACE_RESIZE_DURATION_MS,
+				easing: WORKSPACE_RESIZE_EASING,
+				fill: "forwards",
+			},
+		);
+		workspaceResizeAnimationRef.current = animation;
+		const finish = () => {
+			if (workspaceResizeAnimationRef.current !== animation) return;
+			workspaceResizeAnimationRef.current = null;
+			if (workspaceResizeTimerRef.current !== null) {
+				window.clearTimeout(workspaceResizeTimerRef.current);
+				workspaceResizeTimerRef.current = null;
+			}
+			dialog.style.height = "";
+			dialog.style.maxHeight = finalMaxHeight;
+			animation.cancel();
+		};
+		animation.addEventListener("finish", finish, { once: true });
+		workspaceResizeTimerRef.current = window.setTimeout(finish, WORKSPACE_RESIZE_DURATION_MS + 100);
+	};
 	const openAssetEditor = () => {
 		if (!editableSelection || uploadQueue.hasUnfinished) return;
 		setAssetItem(editableSelection);
-		setAssetOpen(true);
+		transitionWorkspaceLayout(true);
 	};
 	const closeAssetEditor = () => {
 		restoreEditFocusRef.current = true;
-		setAssetOpen(false);
+		transitionWorkspaceLayout(false);
 	};
 	const confirmText =
 		confirmLabel ??
@@ -883,14 +966,8 @@ export function MediaPickerModal({
 		>
 			<Dialog
 				size="xl"
-				className={
-					assetOpen
-						? "min-w-0 flex flex-col overflow-hidden p-0"
-						: "flex h-[min(48rem,calc(100dvh-1rem))] w-[calc(100vw-2rem)] min-h-0 min-w-0 max-w-[48rem] flex-col overflow-hidden p-0 sm:w-[min(48rem,calc(100vw-2rem))]"
-				}
-				style={
-					assetOpen ? { width: "min(94vw, 68rem)", maxHeight: "min(88dvh, 43.5rem)" } : undefined
-				}
+				className={`flex w-[calc(100vw-2rem)] min-h-0 min-w-0 max-w-[48rem] flex-col overflow-hidden p-0 sm:w-[min(48rem,calc(100vw-2rem))] ${assetOpen ? "" : "h-[min(48rem,calc(100dvh-1rem))]"}`}
+				style={assetOpen ? { maxHeight: "min(88dvh, 43.5rem)" } : undefined}
 			>
 				{assetOpen ? (
 					<MediaDetailPanel

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -757,6 +757,19 @@ export function MediaPickerModal({
 		},
 		[assetItem.id, cacheLocalItem, multiple, queryClient],
 	);
+	const handleAssetUnavailable = React.useCallback(
+		(id: string) => {
+			setSelectedItems((current) =>
+				current.filter((selected) => selected.providerId !== "local" || selected.item.id !== id),
+			);
+			setPinnedItems((current) =>
+				current.filter((selected) => selected.providerId !== "local" || selected.item.id !== id),
+			);
+			queryClient.removeQueries({ queryKey: ["media", id], exact: true });
+			void queryClient.invalidateQueries({ queryKey: ["media"] });
+		},
+		[queryClient],
+	);
 	const openAssetEditor = () => {
 		if (!editableSelection || uploadQueue.hasUnfinished) return;
 		setAssetItem(editableSelection);
@@ -1544,6 +1557,7 @@ export function MediaPickerModal({
 				onClosed={handleAssetClosed}
 				onItemRefreshed={handleAssetRefreshed}
 				onCroppedCopyCreated={handleCroppedCopyCreated}
+				onUnavailable={handleAssetUnavailable}
 			/>
 		</>
 	);

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -20,6 +20,7 @@ import {
 	List,
 	LinkSimple,
 	Paperclip,
+	PencilSimple,
 	SquaresFour,
 	Upload,
 	X,
@@ -45,8 +46,10 @@ import {
 	uploadToProvider,
 	updateMedia,
 	type MediaItem,
+	type LocalMediaItem,
 	type MediaProviderItem,
 } from "../lib/api.js";
+import { useCurrentUser } from "../lib/api/current-user.js";
 import { useDebouncedValue } from "../lib/hooks.js";
 import { canonicalMediaProviderId, providerItemToMediaItem } from "../lib/media-utils.js";
 import { matchesMimeAllowlist, mimeFromUrl } from "../lib/mime-utils.js";
@@ -58,10 +61,23 @@ import {
 	mimeForMediaTypeFilter,
 } from "./media/MediaBrowserItems.js";
 import { useMediaUploadQueue } from "./media/useMediaUploadQueue.js";
+import { MediaDetailPanel } from "./MediaDetailPanel.js";
 import { TableToolbar, TableToolbarSearch } from "./TableToolbar.js";
 
 const URL_SOURCE = "__url";
 const PICKER_PAGE_SIZE = 12;
+const ROLE_CONTRIBUTOR = 20;
+const ROLE_AUTHOR = 30;
+const ROLE_EDITOR = 40;
+const EMPTY_DETAIL_ITEM: MediaItem = {
+	id: "",
+	filename: "",
+	mimeType: "application/octet-stream",
+	url: "",
+	size: 0,
+	createdAt: "",
+	provider: "picker-placeholder",
+};
 
 interface SelectedMedia {
 	key: string;
@@ -198,6 +214,7 @@ export function MediaPickerModal({
 }: MediaPickerModalProps) {
 	const { t } = useLingui();
 	const queryClient = useQueryClient();
+	const currentUser = useCurrentUser().data;
 	const isFileKind = mediaKind === "file";
 	const filters = React.useMemo(() => {
 		if (mimeTypeFilters !== undefined) {
@@ -229,11 +246,21 @@ export function MediaPickerModal({
 	const [providerDimensions, setProviderDimensions] = React.useState<
 		Record<string, { width: number; height: number }>
 	>({});
+	const [browseOpen, setBrowseOpen] = React.useState(open);
+	const [assetOpen, setAssetOpen] = React.useState(false);
+	const [assetItem, setAssetItem] = React.useState<MediaItem>(EMPTY_DETAIL_ITEM);
 	const fileInputRef = React.useRef<HTMLInputElement>(null);
+	const editAssetButtonRef = React.useRef<HTMLButtonElement>(null);
 	const updatedDimensionsRef = React.useRef(new Set<string>());
 	const urlProbeIdRef = React.useRef(0);
 	const uploadTargetsRef = React.useRef(new Map<number, string>());
 	const selectionOrderEditedRef = React.useRef(false);
+	const parentOpenRef = React.useRef(open);
+	const flowGenerationRef = React.useRef(0);
+	const transitionRef = React.useRef<
+		{ kind: "open-asset" | "return-browse"; generation: number } | undefined
+	>(undefined);
+	const restoreEditFocusRef = React.useRef(false);
 	const invalidateUrlProbe = React.useCallback(() => {
 		urlProbeIdRef.current += 1;
 		setIsProbing(false);
@@ -259,6 +286,24 @@ export function MediaPickerModal({
 		[fieldId],
 	);
 	const uploadQueue = useMediaUploadQueue<UploadedMedia>({ upload: uploadFile });
+
+	React.useEffect(() => {
+		const wasOpen = parentOpenRef.current;
+		parentOpenRef.current = open;
+		if (!open) {
+			flowGenerationRef.current += 1;
+			transitionRef.current = undefined;
+			restoreEditFocusRef.current = false;
+			setBrowseOpen(false);
+			setAssetOpen(false);
+			return;
+		}
+		if (wasOpen) return;
+		flowGenerationRef.current += 1;
+		transitionRef.current = undefined;
+		setAssetOpen(false);
+		setBrowseOpen(true);
+	}, [open]);
 
 	React.useEffect(() => {
 		if (!open) return;
@@ -637,6 +682,110 @@ export function MediaPickerModal({
 		setSelectedItems((current) => current.filter((item) => item.key !== selected.key));
 		setLiveMessage(t`Removed ${selected.item.filename} from selection.`);
 	};
+	const editableSelection = React.useMemo(() => {
+		if (selectedItems.length !== 1 || !currentUser) return null;
+		const selected = selectedItems[0]!;
+		if (selected.providerId !== "local" || !selected.item.mimeType.startsWith("image/")) {
+			return null;
+		}
+		const item = selected.item as LocalMediaItem;
+		const canEdit =
+			currentUser.role >= ROLE_EDITOR ||
+			(currentUser.role >= ROLE_AUTHOR && item.authorId === currentUser.id);
+		return canEdit ? item : null;
+	}, [currentUser, selectedItems]);
+	const replaceSelectedLocalItem = React.useCallback((item: LocalMediaItem) => {
+		setSelectedItems((current) =>
+			current.map((selected) =>
+				selected.providerId === "local" && selected.item.id === item.id
+					? { ...selected, item }
+					: selected,
+			),
+		);
+		setPinnedItems((current) =>
+			current.map((selected) =>
+				selected.providerId === "local" && selected.item.id === item.id
+					? { ...selected, item }
+					: selected,
+			),
+		);
+	}, []);
+	const cacheLocalItem = React.useCallback(
+		(item: LocalMediaItem) => {
+			queryClient.setQueryData(["media", item.id], item);
+			queryClient.setQueriesData<{ items: LocalMediaItem[] }>({ queryKey: ["media"] }, (current) =>
+				current && Array.isArray(current.items)
+					? {
+							...current,
+							items: current.items.map((entry) => (entry.id === item.id ? item : entry)),
+						}
+					: current,
+			);
+		},
+		[queryClient],
+	);
+	const handleAssetRefreshed = React.useCallback(
+		(item: LocalMediaItem) => {
+			setAssetItem(item);
+			replaceSelectedLocalItem(item);
+			cacheLocalItem(item);
+		},
+		[cacheLocalItem, replaceSelectedLocalItem],
+	);
+	const handleCroppedCopyCreated = React.useCallback(
+		(item: LocalMediaItem) => {
+			const selected: SelectedMedia = {
+				key: selectionKey("local", item),
+				providerId: "local",
+				item,
+			};
+			setAssetItem(item);
+			setPinnedItems((current) => appendUniqueSelections(current, [selected]));
+			setSelectedItems((current) => {
+				if (!multiple) return [selected];
+				const sourceId = assetItem.id;
+				const sourceIndex = current.findIndex(
+					(entry) => entry.providerId === "local" && entry.item.id === sourceId,
+				);
+				if (sourceIndex === -1) return appendUniqueSelections(current, [selected]);
+				const next = [...current];
+				next[sourceIndex] = selected;
+				return next;
+			});
+			cacheLocalItem(item);
+			void queryClient.invalidateQueries({ queryKey: ["media"] });
+		},
+		[assetItem.id, cacheLocalItem, multiple, queryClient],
+	);
+	const openAssetEditor = () => {
+		if (!editableSelection || uploadQueue.hasUnfinished) return;
+		setAssetItem(editableSelection);
+		transitionRef.current = {
+			kind: "open-asset",
+			generation: flowGenerationRef.current,
+		};
+		setBrowseOpen(false);
+	};
+	const closeAssetEditor = () => {
+		transitionRef.current = {
+			kind: "return-browse",
+			generation: flowGenerationRef.current,
+		};
+		setAssetOpen(false);
+	};
+	const handleAssetClosed = () => {
+		const transition = transitionRef.current;
+		if (
+			!parentOpenRef.current ||
+			transition?.kind !== "return-browse" ||
+			transition.generation !== flowGenerationRef.current
+		) {
+			return;
+		}
+		transitionRef.current = undefined;
+		restoreEditFocusRef.current = true;
+		setBrowseOpen(true);
+	};
 	const confirmText =
 		confirmLabel ??
 		(multiple
@@ -738,11 +887,29 @@ export function MediaPickerModal({
 			</section>
 		) : null;
 
-	return (
+	const browseDialog = (
 		<Dialog.Root
-			open={open}
+			open={open && browseOpen}
 			onOpenChange={(nextOpen) => {
-				if (!nextOpen) handleClose();
+				if (!nextOpen && transitionRef.current?.kind !== "open-asset") handleClose();
+			}}
+			onOpenChangeComplete={(nextOpen) => {
+				if (nextOpen) {
+					if (!restoreEditFocusRef.current) return;
+					restoreEditFocusRef.current = false;
+					editAssetButtonRef.current?.focus({ preventScroll: true });
+					return;
+				}
+				const transition = transitionRef.current;
+				if (
+					!parentOpenRef.current ||
+					transition?.kind !== "open-asset" ||
+					transition.generation !== flowGenerationRef.current
+				) {
+					return;
+				}
+				transitionRef.current = undefined;
+				setAssetOpen(true);
 			}}
 		>
 			<Dialog
@@ -1321,6 +1488,17 @@ export function MediaPickerModal({
 					data-media-actions
 				>
 					<div className="flex flex-wrap items-center justify-end gap-2">
+						{editableSelection && (
+							<Button
+								ref={editAssetButtonRef}
+								variant="outline"
+								onClick={openAssetEditor}
+								disabled={uploadQueue.hasUnfinished}
+								icon={<PencilSimple aria-hidden="true" />}
+							>
+								{t`Edit asset`}
+							</Button>
+						)}
 						<Button variant="outline" onClick={handleClose}>
 							{t`Cancel`}
 						</Button>
@@ -1350,6 +1528,24 @@ export function MediaPickerModal({
 				</span>
 			</Dialog>
 		</Dialog.Root>
+	);
+
+	return (
+		<>
+			{browseDialog}
+			<MediaDetailPanel
+				open={open && assetOpen}
+				item={assetItem}
+				context="content"
+				canCropOriginal={Boolean(editableSelection)}
+				canDuplicateCrop={(currentUser?.role ?? 0) >= ROLE_CONTRIBUTOR}
+				restoreFocusTargetRef={editAssetButtonRef}
+				onClose={closeAssetEditor}
+				onClosed={handleAssetClosed}
+				onItemRefreshed={handleAssetRefreshed}
+				onCroppedCopyCreated={handleCroppedCopyCreated}
+			/>
+		</>
 	);
 }
 

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -966,8 +966,11 @@ export function MediaPickerModal({
 		>
 			<Dialog
 				size="xl"
-				className={`flex w-[calc(100vw-2rem)] min-h-0 min-w-0 max-w-[48rem] flex-col overflow-hidden p-0 sm:w-[min(48rem,calc(100vw-2rem))] ${assetOpen ? "" : "h-[min(48rem,calc(100dvh-1rem))]"}`}
-				style={assetOpen ? { maxHeight: "min(88dvh, 43.5rem)" } : undefined}
+				className={`flex w-full min-h-0 min-w-0 max-w-[calc(100vw-2rem)] flex-col overflow-hidden p-0 ${assetOpen ? "" : "h-[min(48rem,calc(100dvh-1rem))]"}`}
+				style={{
+					width: "min(94vw, 68rem)",
+					maxHeight: assetOpen ? "min(88dvh, 43.5rem)" : undefined,
+				}}
 			>
 				{assetOpen ? (
 					<MediaDetailPanel

--- a/packages/admin/src/components/editor/GalleryDetailPanel.tsx
+++ b/packages/admin/src/components/editor/GalleryDetailPanel.tsx
@@ -444,7 +444,7 @@ function GalleryImageSettings({
 					onClick={() => setShowReplacePicker(true)}
 					disabled={assetEditor.isActive}
 				>
-					{t`Choose another`}
+					{t`Replace`}
 				</Button>
 				{canEditAsset && (
 					<Button
@@ -500,8 +500,8 @@ function GalleryImageSettings({
 					setShowReplacePicker(false);
 				}}
 				mimeTypeFilters={["image/"]}
-				title={t`Choose another image`}
-				confirmLabel={t`Choose another`}
+				title={t`Replace image`}
+				confirmLabel={t`Replace`}
 			/>
 			{assetEditor.dialog}
 			{assetEditor.error && (

--- a/packages/admin/src/components/editor/GalleryDetailPanel.tsx
+++ b/packages/admin/src/components/editor/GalleryDetailPanel.tsx
@@ -8,19 +8,33 @@
  */
 
 import { Button, Input, Label, Select } from "@cloudflare/kumo";
-import { DndContext, PointerSensor, closestCenter, useSensor, useSensors } from "@dnd-kit/core";
+import {
+	DndContext,
+	KeyboardSensor,
+	PointerSensor,
+	closestCenter,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
 import type { DragEndEvent } from "@dnd-kit/core";
-import { SortableContext, rectSortingStrategy, useSortable, arrayMove } from "@dnd-kit/sortable";
+import {
+	SortableContext,
+	arrayMove,
+	rectSortingStrategy,
+	sortableKeyboardCoordinates,
+	useSortable,
+} from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useLingui } from "@lingui/react/macro";
-import { X, Plus, Trash, ImageSquare } from "@phosphor-icons/react";
+import { X, Plus, Trash, ImageSquare, PencilSimple } from "@phosphor-icons/react";
 import * as React from "react";
 
 import type { MediaItem } from "../../lib/api";
-import { getMediaObjectPosition, metaString } from "../../lib/media-utils";
+import { canonicalMediaProviderId, metaString } from "../../lib/media-utils";
 import { cn } from "../../lib/utils";
+import { useMediaAssetEditor } from "../media/useMediaAssetEditor.js";
 import { MediaPickerModal } from "../MediaPickerModal";
-import { galleryImageUrl, type GalleryAttributes, type GalleryImage } from "./GalleryNode";
+import { GalleryPreviewImage, type GalleryAttributes, type GalleryImage } from "./GalleryNode";
 
 export interface GalleryDetailPanelProps {
 	attributes: GalleryAttributes;
@@ -35,27 +49,30 @@ function generateKey(): string {
 	return Math.random().toString(36).substring(2, 11);
 }
 
+function mediaItemAssetFields(item: MediaItem) {
+	return {
+		asset: {
+			_type: "reference" as const,
+			_ref: item.id,
+			url: item.url,
+			provider: item.provider && item.provider !== "local" ? item.provider : undefined,
+		},
+		width: item.width,
+		height: item.height,
+		focalX: item.focalX ?? undefined,
+		focalY: item.focalY ?? undefined,
+		blurhash: item.blurhash ?? metaString(item.meta, "blurhash"),
+		dominantColor: item.dominantColor ?? metaString(item.meta, "dominantColor"),
+	};
+}
+
 /** Map a picked MediaItem to the gallery's Portable Text image shape. */
 export function mediaItemToGalleryImage(item: MediaItem): GalleryImage {
 	return {
 		_type: "image",
 		_key: generateKey(),
-		asset: {
-			_type: "reference",
-			_ref: item.id,
-			url: item.url,
-			provider: item.provider && item.provider !== "local" ? item.provider : undefined,
-		},
 		alt: item.alt || "",
-		width: item.width,
-		height: item.height,
-		focalX: item.focalX ?? undefined,
-		focalY: item.focalY ?? undefined,
-		// Cache LQIP alongside dimensions so the gallery renders a placeholder
-		// without a runtime lookup. Fall back to `meta` for providers that
-		// stash it there — mirrors ImageFieldRenderer's handleSelect.
-		blurhash: item.blurhash ?? metaString(item.meta, "blurhash"),
-		dominantColor: item.dominantColor ?? metaString(item.meta, "dominantColor"),
+		...mediaItemAssetFields(item),
 	};
 }
 
@@ -70,8 +87,12 @@ export function GalleryDetailPanel({
 	// A distance-based activation constraint lets a plain pointerdown+pointerup
 	// (a click) pass through to the thumbnail button's onClick instead of the
 	// sensor immediately claiming the pointer and starting drag tracking.
-	const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+	const sensors = useSensors(
+		useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+	);
 	const [showMediaPicker, setShowMediaPicker] = React.useState(false);
+	const [assetEditorActive, setAssetEditorActive] = React.useState(false);
 	// `selectedImageKey` and `nodeKey` are transient UI state passed in via
 	// `attributes` when the gallery node view opens the sidebar (e.g. clicking
 	// an image in the canvas grid) — neither is ever persisted to node attrs.
@@ -113,6 +134,53 @@ export function GalleryDetailPanel({
 	const selectedImage = selectedKey
 		? (images.find((image) => image._key === selectedKey) ?? null)
 		: null;
+	const dragAccessibility = React.useMemo(
+		() => ({
+			announcements: {
+				onDragStart: ({ active }: { active: { id: string | number } }) => {
+					const index = images.findIndex((image) => image._key === active.id);
+					const label = images[index]?.alt || t`Image ${index + 1}`;
+					return t`Picked up ${label}.`;
+				},
+				onDragOver: ({
+					active,
+					over,
+				}: {
+					active: { id: string | number };
+					over: { id: string | number } | null;
+				}) => {
+					const oldIndex = images.findIndex((image) => image._key === active.id);
+					const newIndex = images.findIndex((image) => image._key === over?.id);
+					if (newIndex < 0) return "";
+					const label = images[oldIndex]?.alt || t`Image ${oldIndex + 1}`;
+					return t`Moving ${label} to position ${newIndex + 1} of ${images.length}.`;
+				},
+				onDragEnd: ({
+					active,
+					over,
+				}: {
+					active: { id: string | number };
+					over: { id: string | number } | null;
+				}) => {
+					const oldIndex = images.findIndex((image) => image._key === active.id);
+					const newIndex = images.findIndex((image) => image._key === over?.id);
+					const label = images[oldIndex]?.alt || t`Image ${oldIndex + 1}`;
+					return newIndex < 0
+						? t`Moving ${label} was cancelled.`
+						: t`${label} moved to position ${newIndex + 1} of ${images.length}.`;
+				},
+				onDragCancel: ({ active }: { active: { id: string | number } }) => {
+					const index = images.findIndex((image) => image._key === active.id);
+					const label = images[index]?.alt || t`Image ${index + 1}`;
+					return t`Moving ${label} was cancelled.`;
+				},
+			},
+			screenReaderInstructions: {
+				draggable: t`Press Space to pick up an image. Use the Arrow keys to move it, then press Space to drop it.`,
+			},
+		}),
+		[images, t],
+	);
 
 	const apply = (patch: Partial<GalleryAttributes>) => {
 		setGallery((prev) => ({ ...prev, ...patch }));
@@ -139,23 +207,15 @@ export function GalleryDetailPanel({
 		apply({
 			images: images.map((image) =>
 				image._key === key
-					? {
-							...image,
-							asset: {
-								_type: "reference",
-								_ref: item.id,
-								url: item.url,
-								provider: item.provider && item.provider !== "local" ? item.provider : undefined,
-							},
-							alt: item.alt || "",
-							width: item.width,
-							height: item.height,
-							focalX: item.focalX ?? undefined,
-							focalY: item.focalY ?? undefined,
-							blurhash: item.blurhash ?? metaString(item.meta, "blurhash"),
-							dominantColor: item.dominantColor ?? metaString(item.meta, "dominantColor"),
-						}
+					? { ...image, ...mediaItemAssetFields(item), alt: item.alt || "" }
 					: image,
+			),
+		});
+	};
+	const handleAssetChange = (key: string, item: MediaItem) => {
+		apply({
+			images: images.map((image) =>
+				image._key === key ? { ...image, ...mediaItemAssetFields(item) } : image,
 			),
 		});
 	};
@@ -200,6 +260,7 @@ export function GalleryDetailPanel({
 					size="sm"
 					icon={<Plus />}
 					onClick={() => setShowMediaPicker(true)}
+					disabled={assetEditorActive}
 				>
 					{t`Add Images`}
 				</Button>
@@ -208,7 +269,12 @@ export function GalleryDetailPanel({
 			{images.length === 0 ? (
 				<p className="text-sm text-kumo-subtle text-center py-4">{t`No images in this gallery yet.`}</p>
 			) : (
-				<DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+				<DndContext
+					sensors={sensors}
+					collisionDetection={closestCenter}
+					accessibility={dragAccessibility}
+					onDragEnd={handleDragEnd}
+				>
 					<SortableContext items={images.map((image) => image._key)} strategy={rectSortingStrategy}>
 						<div className="grid grid-cols-3 gap-2">
 							{images.map((image, index) => (
@@ -234,9 +300,11 @@ export function GalleryDetailPanel({
 					image={selectedImage}
 					onChange={(patch) => handleImageChange(selectedImage._key, patch)}
 					onReplace={(item) => handleReplace(selectedImage._key, item)}
+					onAssetChange={(item) => handleAssetChange(selectedImage._key, item)}
+					onAssetEditorActiveChange={setAssetEditorActive}
+					onRemove={() => handleRemove(selectedImage._key)}
 				/>
 			)}
-
 			<Button type="button" variant="destructive" className="w-full" onClick={onDelete}>
 				{t`Delete gallery`}
 			</Button>
@@ -304,19 +372,16 @@ function SortableGalleryThumb({
 				{...attributes}
 				{...listeners}
 			>
-				<img
-					src={galleryImageUrl(image)}
-					alt={image.alt || ""}
+				<GalleryPreviewImage
+					image={image}
 					className="emdash-media-transparency-grid h-full w-full object-cover"
-					style={{ objectPosition: getMediaObjectPosition(image) }}
-					draggable={false}
 				/>
 			</Button>
 			<Button
 				type="button"
 				variant="destructive"
 				shape="square"
-				className="absolute top-1 end-1 h-6 w-6 opacity-0 group-hover:opacity-100 focus:opacity-100"
+				className="absolute end-1 top-1 h-6 w-6 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100"
 				onClick={(e) => {
 					e.stopPropagation();
 					onRemove();
@@ -340,34 +405,71 @@ interface GalleryImageSettingsProps {
 	image: GalleryImage;
 	onChange: (patch: Partial<GalleryImage>) => void;
 	onReplace: (item: MediaItem) => void;
+	onAssetChange: (item: MediaItem) => void;
+	onAssetEditorActiveChange: (active: boolean) => void;
+	onRemove: () => void;
 }
 
-function GalleryImageSettings({ image, onChange, onReplace }: GalleryImageSettingsProps) {
+function GalleryImageSettings({
+	image,
+	onChange,
+	onReplace,
+	onAssetChange,
+	onAssetEditorActiveChange,
+	onRemove,
+}: GalleryImageSettingsProps) {
 	const { t } = useLingui();
 	const [showReplacePicker, setShowReplacePicker] = React.useState(false);
+	const assetEditor = useMediaAssetEditor(onAssetChange);
+	React.useEffect(() => {
+		onAssetEditorActiveChange(assetEditor.isActive);
+		return () => onAssetEditorActiveChange(false);
+	}, [assetEditor.isActive, onAssetEditorActiveChange]);
+	const canEditAsset =
+		Boolean(image.asset._ref) && canonicalMediaProviderId(image.asset.provider) === "local";
 
 	const hasOriginalSize = typeof image.width === "number" && typeof image.height === "number";
 
 	return (
 		<div className="border rounded-lg p-3 space-y-3">
-			<div className="emdash-media-transparency-grid group relative flex aspect-video items-center justify-center overflow-hidden rounded-lg">
-				<img
-					src={galleryImageUrl(image)}
-					alt={image.alt || ""}
-					className="max-h-full max-w-full object-contain"
-					draggable={false}
-				/>
-				<div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+			<div className="emdash-media-transparency-grid relative flex aspect-video items-center justify-center overflow-hidden rounded-lg">
+				<GalleryPreviewImage image={image} className="max-h-full max-w-full object-contain" />
+			</div>
+			<div className="flex flex-wrap items-center gap-2">
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					icon={<ImageSquare />}
+					onClick={() => setShowReplacePicker(true)}
+					disabled={assetEditor.isActive}
+				>
+					{t`Choose another`}
+				</Button>
+				{canEditAsset && (
 					<Button
 						type="button"
 						variant="outline"
 						size="sm"
-						icon={<ImageSquare />}
-						onClick={() => setShowReplacePicker(true)}
+						icon={<PencilSimple aria-hidden="true" />}
+						loading={assetEditor.isOpening}
+						onClick={(event) =>
+							void assetEditor.openAssetEditor(image.asset._ref, event.currentTarget)
+						}
 					>
-						{t`Replace image`}
+						{t`Edit asset`}
 					</Button>
-				</div>
+				)}
+				<Button
+					type="button"
+					variant="secondary-destructive"
+					size="sm"
+					icon={<Trash aria-hidden="true" />}
+					onClick={onRemove}
+					disabled={assetEditor.isActive}
+				>
+					{t`Remove`}
+				</Button>
 			</div>
 			{hasOriginalSize && (
 				<div className="flex items-center gap-2 text-sm">
@@ -398,9 +500,15 @@ function GalleryImageSettings({ image, onChange, onReplace }: GalleryImageSettin
 					setShowReplacePicker(false);
 				}}
 				mimeTypeFilters={["image/"]}
-				title={t`Replace image`}
-				confirmLabel={t`Replace image`}
+				title={t`Choose another image`}
+				confirmLabel={t`Choose another`}
 			/>
+			{assetEditor.dialog}
+			{assetEditor.error && (
+				<p role="alert" className="text-sm text-kumo-danger">
+					{assetEditor.error}
+				</p>
+			)}
 		</div>
 	);
 }

--- a/packages/admin/src/components/editor/GalleryDetailPanel.tsx
+++ b/packages/admin/src/components/editor/GalleryDetailPanel.tsx
@@ -389,7 +389,7 @@ function SortableGalleryThumb({
 				onPointerDown={(e) => e.stopPropagation()}
 				aria-label={t`Remove image ${index + 1}`}
 			>
-				<Trash className="h-3 w-3" />
+				<Trash className="h-3 w-3" aria-hidden="true" />
 			</Button>
 			<span
 				className="absolute bottom-1 start-1 text-[10px] bg-black/60 text-white rounded px-1"
@@ -440,7 +440,7 @@ function GalleryImageSettings({
 					type="button"
 					variant="outline"
 					size="sm"
-					icon={<ImageSquare />}
+					icon={<ImageSquare aria-hidden="true" />}
 					onClick={() => setShowReplacePicker(true)}
 					disabled={assetEditor.isActive}
 				>

--- a/packages/admin/src/components/editor/GalleryNode.tsx
+++ b/packages/admin/src/components/editor/GalleryNode.tsx
@@ -10,12 +10,18 @@
 import { Button } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { Images, Trash, SlidersHorizontal } from "@phosphor-icons/react";
+import { useQuery } from "@tanstack/react-query";
 import type { NodeViewProps } from "@tiptap/react";
 import { Node } from "@tiptap/react";
 import { ReactNodeViewRenderer, NodeViewWrapper } from "@tiptap/react";
 import * as React from "react";
 
-import { getMediaObjectPosition } from "../../lib/media-utils.js";
+import { fetchMediaItem } from "../../lib/api/media.js";
+import {
+	canonicalMediaProviderId,
+	getMediaObjectPosition,
+	getMediaPreviewUrl,
+} from "../../lib/media-utils.js";
 import { cn } from "../../lib/utils";
 
 /** One image inside a gallery block — mirrors the Portable Text shape. */
@@ -75,6 +81,33 @@ export function galleryImageUrl(image: GalleryImage): string {
 	if (image.asset.url) return image.asset.url;
 	if (image.asset._ref) return `/_emdash/api/media/file/${encodeURIComponent(image.asset._ref)}`;
 	return "";
+}
+
+export function GalleryPreviewImage({
+	image,
+	className,
+}: {
+	image: GalleryImage;
+	className: string;
+}) {
+	const mediaId =
+		canonicalMediaProviderId(image.asset.provider) === "local" && image.asset._ref
+			? image.asset._ref
+			: null;
+	const { data: currentMedia } = useQuery({
+		queryKey: mediaId ? ["media", mediaId] : ["media-preview-disabled", image.asset._ref],
+		queryFn: ({ signal }) => fetchMediaItem(mediaId!, { signal }),
+		enabled: false,
+	});
+	return (
+		<img
+			src={getMediaPreviewUrl(galleryImageUrl(image), currentMedia?.contentHash)}
+			alt={image.alt || ""}
+			className={className}
+			style={{ objectPosition: getMediaObjectPosition(image) }}
+			draggable={false}
+		/>
+	);
 }
 
 function GalleryNodeView({
@@ -180,12 +213,9 @@ function GalleryNodeView({
 								}}
 								aria-label={t`Edit image ${index + 1}`}
 							>
-								<img
-									src={galleryImageUrl(image)}
-									alt={image.alt || ""}
+								<GalleryPreviewImage
+									image={image}
 									className="w-full aspect-square object-cover rounded-md border"
-									style={{ objectPosition: getMediaObjectPosition(image) }}
-									draggable={false}
 								/>
 							</button>
 							{image.caption && (

--- a/packages/admin/src/components/editor/ImageDetailPanel.tsx
+++ b/packages/admin/src/components/editor/ImageDetailPanel.tsx
@@ -223,7 +223,7 @@ export function ImageDetailPanel({
 				onClick={() => setShowMediaPicker(true)}
 				disabled={assetEditor.isActive}
 			>
-				{t`Choose another`}
+				{t`Replace`}
 			</Button>
 			{canEditAsset && (
 				<Button
@@ -288,8 +288,8 @@ export function ImageDetailPanel({
 				onOpenChange={setShowMediaPicker}
 				onSelect={handleMediaSelect}
 				mimeTypeFilter="image/"
-				title={t`Choose another image`}
-				confirmLabel={t`Choose another`}
+				title={t`Replace image`}
+				confirmLabel={t`Replace`}
 			/>
 			{assetEditor.dialog}
 		</>

--- a/packages/admin/src/components/editor/ImageDetailPanel.tsx
+++ b/packages/admin/src/components/editor/ImageDetailPanel.tsx
@@ -13,6 +13,7 @@ import {
 	Ruler,
 	SlidersHorizontal,
 	ImageSquare,
+	PencilSimple,
 	LinkSimple,
 	LinkBreak,
 } from "@phosphor-icons/react";
@@ -20,8 +21,9 @@ import * as React from "react";
 
 import type { MediaItem } from "../../lib/api";
 import { useStableCallback } from "../../lib/hooks";
-import { canonicalMediaProviderId } from "../../lib/media-utils.js";
+import { canonicalMediaProviderId, metaString } from "../../lib/media-utils.js";
 import { ConfirmDialog } from "../ConfirmDialog";
+import { useMediaAssetEditor } from "../media/useMediaAssetEditor.js";
 import { MediaPickerModal } from "../MediaPickerModal";
 
 export interface ImageAttributes {
@@ -76,6 +78,38 @@ export function ImageDetailPanel({
 	const [caption, setCaption] = React.useState(attributes.caption ?? "");
 	const [title, setTitle] = React.useState(attributes.title ?? "");
 	const [showMediaPicker, setShowMediaPicker] = React.useState(false);
+	const [asset, setAsset] = React.useState(attributes);
+	const handleAssetItemChanged = React.useCallback(
+		(item: MediaItem) => {
+			setDisplayWidth((current) =>
+				attributes.displayWidth === undefined && current === asset.width ? item.width : current,
+			);
+			setDisplayHeight((current) =>
+				attributes.displayHeight === undefined && current === asset.height ? item.height : current,
+			);
+			setAsset((current) => ({
+				...current,
+				src: item.url,
+				mediaId: item.id,
+				provider: "local",
+				width: item.width,
+				height: item.height,
+				blurhash: item.blurhash ?? metaString(item.meta, "blurhash"),
+				dominantColor: item.dominantColor ?? metaString(item.meta, "dominantColor"),
+			}));
+			onUpdate({
+				src: item.url,
+				mediaId: item.id,
+				provider: "local",
+				width: item.width,
+				height: item.height,
+				blurhash: item.blurhash ?? metaString(item.meta, "blurhash"),
+				dominantColor: item.dominantColor ?? metaString(item.meta, "dominantColor"),
+			});
+		},
+		[asset.height, asset.width, attributes.displayHeight, attributes.displayWidth, onUpdate],
+	);
+	const assetEditor = useMediaAssetEditor(handleAssetItemChanged);
 
 	// Dimension state - default to display dimensions, fall back to original
 	const [displayWidth, setDisplayWidth] = React.useState<number | undefined>(
@@ -90,8 +124,7 @@ export function ImageDetailPanel({
 	);
 
 	// Calculate aspect ratio from original dimensions
-	const aspectRatio =
-		attributes.width && attributes.height ? attributes.width / attributes.height : undefined;
+	const aspectRatio = asset.width && asset.height ? asset.width / asset.height : undefined;
 
 	const handleWidthChange = (value: string) => {
 		const newWidth = value ? parseInt(value, 10) : undefined;
@@ -110,8 +143,8 @@ export function ImageDetailPanel({
 	};
 
 	const handleResetDimensions = () => {
-		setDisplayWidth(attributes.width);
-		setDisplayHeight(attributes.height);
+		setDisplayWidth(asset.width);
+		setDisplayHeight(asset.height);
 	};
 
 	const handleMediaSelect = (item: MediaItem) => {
@@ -134,8 +167,8 @@ export function ImageDetailPanel({
 
 	// Track if form has unsaved changes
 	const hasChanges = React.useMemo(() => {
-		const originalDisplayWidth = attributes.displayWidth ?? attributes.width;
-		const originalDisplayHeight = attributes.displayHeight ?? attributes.height;
+		const originalDisplayWidth = attributes.displayWidth ?? asset.width;
+		const originalDisplayHeight = attributes.displayHeight ?? asset.height;
 		return (
 			alt !== (attributes.alt ?? "") ||
 			caption !== (attributes.caption ?? "") ||
@@ -144,7 +177,17 @@ export function ImageDetailPanel({
 			displayHeight !== originalDisplayHeight ||
 			alignment !== attributes.alignment
 		);
-	}, [attributes, alt, caption, title, displayWidth, displayHeight, alignment]);
+	}, [
+		asset.height,
+		asset.width,
+		attributes,
+		alt,
+		caption,
+		title,
+		displayWidth,
+		displayHeight,
+		alignment,
+	]);
 
 	const handleSave = () => {
 		onUpdate({
@@ -168,6 +211,33 @@ export function ImageDetailPanel({
 	];
 
 	const [showDeleteConfirm, setShowDeleteConfirm] = React.useState(false);
+	const canEditAsset = Boolean(
+		asset.mediaId && canonicalMediaProviderId(asset.provider) === "local",
+	);
+	const imageActions = (
+		<div className="mt-3 flex flex-wrap items-center gap-2">
+			<Button
+				variant="secondary"
+				size="sm"
+				icon={<ImageSquare aria-hidden="true" />}
+				onClick={() => setShowMediaPicker(true)}
+				disabled={assetEditor.isActive}
+			>
+				{t`Choose another`}
+			</Button>
+			{canEditAsset && (
+				<Button
+					variant="secondary"
+					size="sm"
+					icon={<PencilSimple aria-hidden="true" />}
+					loading={assetEditor.isOpening}
+					onClick={(event) => void assetEditor.openAssetEditor(asset.mediaId!, event.currentTarget)}
+				>
+					{t`Edit asset`}
+				</Button>
+			)}
+		</div>
+	);
 
 	const handleDelete = () => {
 		setShowDeleteConfirm(true);
@@ -179,10 +249,15 @@ export function ImageDetailPanel({
 	// Handle keyboard shortcuts
 	React.useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
+			const saveShortcut = (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s";
+			if (showDeleteConfirm || showMediaPicker || assetEditor.isActive) {
+				if (saveShortcut) e.preventDefault();
+				return;
+			}
 			if (e.key === "Escape") {
 				stableOnClose();
 			}
-			if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+			if (saveShortcut) {
 				e.preventDefault();
 				stableHandleSave();
 			}
@@ -190,14 +265,14 @@ export function ImageDetailPanel({
 
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [stableOnClose, stableHandleSave]);
+	}, [assetEditor.isActive, showDeleteConfirm, showMediaPicker, stableOnClose, stableHandleSave]);
 
 	const dialogs = (
 		<>
 			<ConfirmDialog
 				open={showDeleteConfirm}
 				onClose={() => setShowDeleteConfirm(false)}
-				title={t`Remove Image?`}
+				title={t`Remove image?`}
 				description={t`Remove this image from the document?`}
 				confirmLabel={t`Remove`}
 				pendingLabel={t`Removing...`}
@@ -213,9 +288,10 @@ export function ImageDetailPanel({
 				onOpenChange={setShowMediaPicker}
 				onSelect={handleMediaSelect}
 				mimeTypeFilter="image/"
-				title={t`Replace image`}
-				confirmLabel={t`Replace image`}
+				title={t`Choose another image`}
+				confirmLabel={t`Choose another`}
 			/>
+			{assetEditor.dialog}
 		</>
 	);
 
@@ -236,42 +312,38 @@ export function ImageDetailPanel({
 
 				{/* Preview */}
 				<div className="p-4 border-b">
-					<div className="emdash-media-transparency-grid group relative flex aspect-video items-center justify-center overflow-hidden rounded-lg">
+					<div className="emdash-media-transparency-grid relative flex aspect-video items-center justify-center overflow-hidden rounded-lg">
 						<img
-							src={attributes.src}
+							src={asset.src}
 							alt={attributes.alt || ""}
 							className="max-h-full max-w-full object-contain"
 						/>
-						<div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-							<Button
-								variant="secondary"
-								size="sm"
-								icon={<ImageSquare />}
-								onClick={() => setShowMediaPicker(true)}
-							>
-								{t`Replace Image`}
-							</Button>
-						</div>
 					</div>
+					{imageActions}
+					{assetEditor.error && (
+						<p role="alert" className="mt-2 text-sm text-kumo-danger">
+							{assetEditor.error}
+						</p>
+					)}
 
 					{/* Original dimensions */}
-					{(attributes.width || attributes.height) && (
+					{(asset.width || asset.height) && (
 						<div className="flex items-center gap-2 text-sm mt-3">
 							<Ruler className="h-4 w-4 text-kumo-subtle" />
 							<span className="text-kumo-subtle">{t`Original:`}</span>
 							<span>
-								{attributes.width} × {attributes.height}
+								{asset.width} × {asset.height}
 							</span>
 						</div>
 					)}
 				</div>
 
 				{/* Display Size — shown for any image; migrated images may lack original dims */}
-				{attributes.src && (
+				{asset.src && (
 					<div className="p-4 border-b space-y-3">
 						<div className="flex items-center justify-between">
 							<Label>{t`Display Size`}</Label>
-							{attributes.width && attributes.height && (
+							{asset.width && asset.height && (
 								<Button
 									variant="ghost"
 									size="sm"
@@ -323,7 +395,7 @@ export function ImageDetailPanel({
 				)}
 
 				{/* Alignment */}
-				{attributes.src && (
+				{asset.src && (
 					<div className="p-4 border-b space-y-3">
 						<Label>{t`Alignment`}</Label>
 						<div className="flex flex-wrap gap-1">
@@ -370,15 +442,15 @@ export function ImageDetailPanel({
 					/>
 
 					{/* Source URL - only show for external images (no mediaId) */}
-					{!attributes.mediaId && attributes.src && (
+					{!asset.mediaId && asset.src && (
 						<div>
 							<Label>{t`Source`}</Label>
 							<div className="mt-1.5 flex gap-2">
-								<Input value={attributes.src} readOnly className="text-xs font-mono flex-1" />
+								<Input value={asset.src} readOnly className="text-xs font-mono flex-1" />
 								<LinkButton
 									variant="outline"
 									shape="square"
-									href={attributes.src}
+									href={asset.src}
 									external
 									title={t`Open in new tab`}
 									aria-label={t`Open in new tab`}
@@ -392,8 +464,13 @@ export function ImageDetailPanel({
 
 				{/* Actions */}
 				<div className="p-4 border-t flex items-center justify-between gap-2">
-					<Button variant="destructive" size="sm" onClick={handleDelete}>
-						{t`Remove Image`}
+					<Button
+						variant="destructive"
+						size="sm"
+						onClick={handleDelete}
+						disabled={assetEditor.isActive}
+					>
+						{t`Remove`}
 					</Button>
 					<Button size="sm" onClick={handleSave} disabled={!hasChanges}>
 						{t`Save`}
@@ -423,44 +500,40 @@ export function ImageDetailPanel({
 			<div className="flex-1 overflow-y-auto">
 				{/* Preview */}
 				<div className="p-4 border-b">
-					<div className="emdash-media-transparency-grid group relative flex aspect-video items-center justify-center overflow-hidden rounded-lg">
+					<div className="emdash-media-transparency-grid relative flex aspect-video items-center justify-center overflow-hidden rounded-lg">
 						<img
-							src={attributes.src}
+							src={asset.src}
 							alt={attributes.alt || ""}
 							className="max-h-full max-w-full object-contain"
 						/>
-						<div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-							<Button
-								variant="secondary"
-								size="sm"
-								icon={<ImageSquare />}
-								onClick={() => setShowMediaPicker(true)}
-							>
-								{t`Replace Image`}
-							</Button>
-						</div>
 					</div>
+					{imageActions}
+					{assetEditor.error && (
+						<p role="alert" className="mt-2 text-sm text-kumo-danger">
+							{assetEditor.error}
+						</p>
+					)}
 				</div>
 
 				{/* Image Info - original dimensions */}
-				{(attributes.width || attributes.height) && (
+				{(asset.width || asset.height) && (
 					<div className="p-4 border-b">
 						<div className="flex items-center gap-2 text-sm">
 							<Ruler className="h-4 w-4 text-kumo-subtle" />
 							<span className="text-kumo-subtle">{t`Original:`}</span>
 							<span>
-								{attributes.width} × {attributes.height}
+								{asset.width} × {asset.height}
 							</span>
 						</div>
 					</div>
 				)}
 
 				{/* Display Size — shown for any image; migrated images may lack original dims */}
-				{attributes.src && (
+				{asset.src && (
 					<div className="p-4 border-b space-y-3">
 						<div className="flex items-center justify-between">
 							<Label>{t`Display Size`}</Label>
-							{attributes.width && attributes.height && (
+							{asset.width && asset.height && (
 								<Button
 									variant="ghost"
 									size="sm"
@@ -512,7 +585,7 @@ export function ImageDetailPanel({
 				)}
 
 				{/* Alignment */}
-				{attributes.src && (
+				{asset.src && (
 					<div className="p-4 border-b space-y-3">
 						<Label>{t`Alignment`}</Label>
 						<div className="flex flex-wrap gap-1">
@@ -559,15 +632,15 @@ export function ImageDetailPanel({
 					/>
 
 					{/* Source URL - only show for external images (no mediaId) */}
-					{!attributes.mediaId && attributes.src && (
+					{!asset.mediaId && asset.src && (
 						<div>
 							<Label>{t`Source`}</Label>
 							<div className="mt-1.5 flex gap-2">
-								<Input value={attributes.src} readOnly className="text-xs font-mono flex-1" />
+								<Input value={asset.src} readOnly className="text-xs font-mono flex-1" />
 								<LinkButton
 									variant="outline"
 									shape="square"
-									href={attributes.src}
+									href={asset.src}
 									external
 									title={t`Open in new tab`}
 									aria-label={t`Open in new tab`}
@@ -582,8 +655,13 @@ export function ImageDetailPanel({
 
 			{/* Footer */}
 			<div className="p-4 border-t flex items-center justify-between gap-2">
-				<Button variant="destructive" size="sm" onClick={handleDelete}>
-					{t`Remove Image`}
+				<Button
+					variant="destructive"
+					size="sm"
+					onClick={handleDelete}
+					disabled={assetEditor.isActive}
+				>
+					{t`Remove`}
 				</Button>
 				<div className="flex gap-2">
 					<Button variant="outline" size="sm" onClick={onClose}>

--- a/packages/admin/src/components/editor/ImageDetailPanel.tsx
+++ b/packages/admin/src/components/editor/ImageDetailPanel.tsx
@@ -49,8 +49,13 @@ export interface ImageAttributes {
 	alignment?: "left" | "center" | "right" | "wide" | "full";
 }
 
+export interface ImagePanelAttributes extends ImageAttributes {
+	/** Transient identity for the image node that opened the sidebar. */
+	nodeKey?: object;
+}
+
 export interface ImageDetailPanelProps {
-	attributes: ImageAttributes;
+	attributes: ImagePanelAttributes;
 	onUpdate: (attrs: Partial<ImageAttributes>) => void;
 	onReplace: (attrs: ImageAttributes) => void;
 	onDelete: () => void;
@@ -122,6 +127,19 @@ export function ImageDetailPanel({
 	const [alignment, setAlignment] = React.useState<ImageAttributes["alignment"]>(
 		attributes.alignment,
 	);
+	const nodeKey = attributes.nodeKey;
+
+	React.useEffect(() => {
+		setAlt(attributes.alt ?? "");
+		setCaption(attributes.caption ?? "");
+		setTitle(attributes.title ?? "");
+		setAsset(attributes);
+		setDisplayWidth(attributes.displayWidth ?? attributes.width);
+		setDisplayHeight(attributes.displayHeight ?? attributes.height);
+		setLockAspectRatio(true);
+		setAlignment(attributes.alignment);
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- the node token identifies a new attribute snapshot
+	}, [nodeKey]);
 
 	// Calculate aspect ratio from original dimensions
 	const aspectRatio = asset.width && asset.height ? asset.width / asset.height : undefined;

--- a/packages/admin/src/components/editor/ImageNode.tsx
+++ b/packages/admin/src/components/editor/ImageNode.tsx
@@ -21,7 +21,7 @@ import * as React from "react";
 import { fetchMediaItem } from "../../lib/api/media.js";
 import { canonicalMediaProviderId, getMediaPreviewUrl } from "../../lib/media-utils.js";
 import { cn } from "../../lib/utils";
-import type { ImageAttributes } from "./ImageDetailPanel";
+import type { ImageAttributes, ImagePanelAttributes } from "./ImageDetailPanel";
 
 // Extend the Commands interface to include setImage
 declare module "@tiptap/react" {
@@ -77,6 +77,7 @@ function ImageNodeView({
 
 	/** Whether this node currently has its sidebar panel open */
 	const sidebarOpenRef = React.useRef(false);
+	const nodeKeyRef = React.useRef({});
 
 	const handleSaveAlt = () => {
 		updateAttributes({ alt: altText });
@@ -106,7 +107,8 @@ function ImageNodeView({
 		}
 	};
 
-	const getImageAttrs = (): ImageAttributes => ({
+	const getImageAttrs = (): ImagePanelAttributes => ({
+		nodeKey: nodeKeyRef.current,
 		src: node.attrs.src,
 		alt: node.attrs.alt,
 		title: node.attrs.title,
@@ -127,7 +129,7 @@ function ImageNodeView({
 		const onOpen = storage?.onOpenBlockSidebar as
 			| ((panel: {
 					type: "image";
-					attrs: ImageAttributes;
+					attrs: ImagePanelAttributes;
 					onUpdate: (attrs: Partial<ImageAttributes>) => void;
 					onReplace: (attrs: ImageAttributes) => void;
 					onDelete: () => void;
@@ -329,7 +331,7 @@ export const ImageExtension = Node.create({
 			onOpenBlockSidebar: null as
 				| ((panel: {
 						type: "image";
-						attrs: import("./ImageDetailPanel").ImageAttributes;
+						attrs: import("./ImageDetailPanel").ImagePanelAttributes;
 						onUpdate: (attrs: Partial<import("./ImageDetailPanel").ImageAttributes>) => void;
 						onReplace: (attrs: import("./ImageDetailPanel").ImageAttributes) => void;
 						onDelete: () => void;

--- a/packages/admin/src/components/media/useMediaAssetEditor.tsx
+++ b/packages/admin/src/components/media/useMediaAssetEditor.tsx
@@ -1,0 +1,111 @@
+import { useLingui } from "@lingui/react/macro";
+import { useQueryClient } from "@tanstack/react-query";
+import * as React from "react";
+
+import {
+	ApiResponseError,
+	fetchMediaItem,
+	type LocalMediaItem,
+	type MediaItem,
+} from "../../lib/api.js";
+import { useCurrentUser } from "../../lib/api/current-user.js";
+import { MediaDetailPanel } from "../MediaDetailPanel.js";
+
+const ROLE_AUTHOR = 30;
+const ROLE_EDITOR = 40;
+const EMPTY_ITEM: MediaItem = {
+	id: "",
+	filename: "",
+	mimeType: "application/octet-stream",
+	url: "",
+	size: 0,
+	createdAt: "",
+	provider: "content-placeholder",
+};
+
+export function useMediaAssetEditor(onItemChanged: (item: LocalMediaItem) => void) {
+	const { t } = useLingui();
+	const queryClient = useQueryClient();
+	const currentUserQuery = useCurrentUser();
+	const [item, setItem] = React.useState<LocalMediaItem | null>(null);
+	const [open, setOpen] = React.useState(false);
+	const [isOpening, setIsOpening] = React.useState(false);
+	const [error, setError] = React.useState<string | null>(null);
+	const requestRef = React.useRef<AbortController | null>(null);
+	const triggerRef = React.useRef<HTMLElement | null>(null);
+
+	React.useEffect(
+		() => () => {
+			requestRef.current?.abort();
+			requestRef.current = null;
+		},
+		[],
+	);
+
+	const openAssetEditor = async (mediaId: string, trigger?: HTMLElement | null) => {
+		requestRef.current?.abort();
+		const request = new AbortController();
+		requestRef.current = request;
+		triggerRef.current = trigger ?? null;
+		setError(null);
+		setIsOpening(true);
+		try {
+			const [fetchedMedia, userResult] = await Promise.all([
+				fetchMediaItem(mediaId, { signal: request.signal }),
+				currentUserQuery.data ? Promise.resolve(currentUserQuery) : currentUserQuery.refetch(),
+			]);
+			if (request.signal.aborted) return;
+			const media = fetchedMedia.url
+				? fetchedMedia
+				: {
+						...fetchedMedia,
+						url: `/_emdash/api/media/file/${encodeURIComponent(fetchedMedia.storageKey)}`,
+					};
+			const user = userResult.data;
+			const canEdit =
+				user &&
+				(user.role >= ROLE_EDITOR || (user.role >= ROLE_AUTHOR && media.authorId === user.id));
+			if (!media.mimeType.startsWith("image/") || !canEdit) {
+				setError(t`You do not have permission to edit this asset.`);
+				return;
+			}
+			setItem(media);
+			setOpen(true);
+		} catch (cause) {
+			if (request.signal.aborted) return;
+			if (cause instanceof ApiResponseError && (cause.status === 401 || cause.status === 403)) {
+				void queryClient.resetQueries({ queryKey: ["currentUser"], exact: true });
+				setError(t`You do not have permission to edit this asset.`);
+			} else if (cause instanceof ApiResponseError && cause.code === "NOT_FOUND") {
+				setError(t`This media item no longer exists.`);
+			} else {
+				setError(t`This media item could not be loaded. Try again.`);
+			}
+		} finally {
+			if (requestRef.current === request) setIsOpening(false);
+		}
+	};
+
+	const handleItemChanged = (nextItem: LocalMediaItem) => {
+		setItem(nextItem);
+		queryClient.setQueryData(["media", nextItem.id], nextItem);
+		onItemChanged(nextItem);
+	};
+
+	const dialog = (
+		<MediaDetailPanel
+			open={open && item !== null}
+			item={item ?? EMPTY_ITEM}
+			context="content"
+			canCropOriginal
+			canDuplicateCrop
+			restoreFocusTargetRef={triggerRef}
+			onClose={() => setOpen(false)}
+			onClosed={() => triggerRef.current?.focus({ preventScroll: true })}
+			onItemRefreshed={handleItemChanged}
+			onCroppedCopyCreated={handleItemChanged}
+		/>
+	);
+
+	return { dialog, error, isActive: open || isOpening, isOpening, openAssetEditor };
+}

--- a/packages/admin/src/lib/api/media.ts
+++ b/packages/admin/src/lib/api/media.ts
@@ -357,14 +357,14 @@ async function confirmUpload(
 	mediaId: string,
 	metadata?: { width?: number; height?: number; size?: number },
 	options?: MediaUploadOptions,
-): Promise<MediaItem> {
+): Promise<LocalMediaItem> {
 	const response = await apiFetch(`${API_BASE}/media/${mediaId}/confirm`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(metadata || {}),
 		signal: options?.signal,
 	});
-	const data = await parseApiResponse<{ item: MediaItem }>(
+	const data = await parseApiResponse<{ item: LocalMediaItem }>(
 		response,
 		i18n._(msg`Failed to confirm upload`),
 	);
@@ -438,7 +438,7 @@ export async function getImageDimensions(
 /**
  * Upload media file via direct upload (legacy/local storage)
  */
-async function uploadMediaDirect(file: File, opts?: UploadMediaOptions): Promise<MediaItem> {
+async function uploadMediaDirect(file: File, opts?: UploadMediaOptions): Promise<LocalMediaItem> {
 	// Get image dimensions before upload
 	const dimensions = await getImageDimensions(file, opts);
 
@@ -458,7 +458,7 @@ async function uploadMediaDirect(file: File, opts?: UploadMediaOptions): Promise
 		body: formData,
 		signal: opts?.signal,
 	});
-	const data = await parseApiResponse<{ item: MediaItem }>(
+	const data = await parseApiResponse<{ item: LocalMediaItem }>(
 		response,
 		i18n._(msg`Failed to upload media`),
 	);
@@ -471,7 +471,7 @@ async function uploadMediaDirect(file: File, opts?: UploadMediaOptions): Promise
  * Tries signed URL upload first (for S3/R2 storage), falls back to direct upload
  * (for local storage) if signed URLs are not supported.
  */
-export async function uploadMedia(file: File, opts?: UploadMediaOptions): Promise<MediaItem> {
+export async function uploadMedia(file: File, opts?: UploadMediaOptions): Promise<LocalMediaItem> {
 	opts?.signal?.throwIfAborted();
 	// Try to get a signed upload URL
 	const uploadInfo = await getUploadUrl(file, opts);

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -115,6 +115,12 @@ body {
 	background-size: 20px 20px;
 }
 
+@media (max-width: 639px) {
+	.emdash-featured-image-preview {
+		aspect-ratio: 4 / 3 !important;
+	}
+}
+
 /*
  * Mirrors the pre-React EmDash boot loader exactly. Keep these values in sync
  * with packages/core/src/astro/routes/admin.astro so the two loading stages do

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -693,9 +693,7 @@ describe("ContentEditor", () => {
 
 			// Filename should be visible
 			await expect.element(screen.getByText("report.pdf")).toBeInTheDocument();
-			await expect
-				.element(screen.getByRole("button", { name: "Choose another" }))
-				.toBeInTheDocument();
+			await expect.element(screen.getByRole("button", { name: "Replace" })).toBeInTheDocument();
 			await expect
 				.element(screen.getByRole("button", { name: "Remove Attachment" }))
 				.toHaveTextContent("Remove");

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -398,9 +398,7 @@ describe("ContentEditor", () => {
 				await expect
 					.element(screen.getByRole("navigation", { name: "Settings" }))
 					.toBeInTheDocument();
-				await expect
-					.element(screen.getByRole("button", { name: "Remove Image" }))
-					.toBeInTheDocument();
+				await expect.element(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
 
 				// Closing the block panel restores the sheet's prior (closed) state.
 				close();
@@ -443,9 +441,7 @@ describe("ContentEditor", () => {
 				await expect
 					.element(screen.getByRole("navigation", { name: "Settings" }))
 					.toBeInTheDocument();
-				await expect
-					.element(screen.getByRole("button", { name: "Remove Image" }))
-					.toBeInTheDocument();
+				await expect.element(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
 			} finally {
 				media.restore();
 			}
@@ -469,9 +465,7 @@ describe("ContentEditor", () => {
 				await expect
 					.element(screen.getByRole("navigation", { name: "Settings" }))
 					.not.toBeInTheDocument();
-				await expect
-					.element(screen.getByRole("button", { name: "Remove Image" }))
-					.toBeInTheDocument();
+				await expect.element(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
 			} finally {
 				media.restore();
 			}
@@ -699,8 +693,12 @@ describe("ContentEditor", () => {
 
 			// Filename should be visible
 			await expect.element(screen.getByText("report.pdf")).toBeInTheDocument();
-			// Change button present (picker is wired up)
-			await expect.element(screen.getByRole("button", { name: "Change" })).toBeInTheDocument();
+			await expect
+				.element(screen.getByRole("button", { name: "Choose another" }))
+				.toBeInTheDocument();
+			await expect
+				.element(screen.getByRole("button", { name: "Remove Attachment" }))
+				.toHaveTextContent("Remove");
 		});
 
 		it("renders 0-byte file size instead of hiding it", async () => {

--- a/packages/admin/tests/components/ImageDetailPanel.test.tsx
+++ b/packages/admin/tests/components/ImageDetailPanel.test.tsx
@@ -144,7 +144,7 @@ describe("ImageDetailPanel replacement", () => {
 			/>,
 		);
 
-		await screen.getByRole("button", { name: "Choose another" }).click();
+		await screen.getByRole("button", { name: "Replace" }).click();
 		await screen.getByRole("button", { name: action }).click();
 
 		expect(onReplace).toHaveBeenCalledWith(expect.objectContaining({ provider: expectedProvider }));
@@ -173,7 +173,7 @@ describe("ImageDetailPanel replacement", () => {
 			/>,
 		);
 
-		await expect.element(screen.getByRole("button", { name: "Choose another" })).toBeVisible();
+		await expect.element(screen.getByRole("button", { name: "Replace" })).toBeVisible();
 		await expect.element(screen.getByRole("button", { name: "Edit asset" })).toBeVisible();
 		await expect.element(screen.getByRole("button", { name: "Remove" })).toBeVisible();
 		expect(fetchMediaItem).not.toHaveBeenCalled();
@@ -311,7 +311,7 @@ describe("ImageDetailPanel replacement", () => {
 
 		await screen.getByRole("button", { name: "Edit asset" }).click();
 
-		await expect.element(screen.getByRole("button", { name: "Choose another" })).toBeDisabled();
+		await expect.element(screen.getByRole("button", { name: "Replace" })).toBeDisabled();
 		await expect.element(screen.getByRole("button", { name: "Remove" })).toBeDisabled();
 		resolveItem({
 			id: "old-image",

--- a/packages/admin/tests/components/ImageDetailPanel.test.tsx
+++ b/packages/admin/tests/components/ImageDetailPanel.test.tsx
@@ -1,9 +1,77 @@
 import * as React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ImageDetailPanel } from "../../src/components/editor/ImageDetailPanel.js";
-import type { MediaItem } from "../../src/lib/api/media.js";
+import { ApiResponseError, fetchMediaItem } from "../../src/lib/api";
+import type { LocalMediaItem, MediaItem } from "../../src/lib/api/media.js";
 import { render } from "../utils/render.js";
+
+vi.mock("../../src/lib/api", async () => {
+	const actual = await vi.importActual("../../src/lib/api");
+	return {
+		...actual,
+		fetchMediaItem: vi.fn().mockResolvedValue({
+			id: "old-image",
+			filename: "old.jpg",
+			mimeType: "image/jpeg",
+			url: "/_emdash/api/media/file/old.jpg",
+			storageKey: "old.jpg",
+			size: 100,
+			status: "ready",
+			authorId: "editor-1",
+			folderId: null,
+			createdAt: "2026-08-16T00:00:00.000Z",
+		}),
+	};
+});
+
+vi.mock("../../src/lib/api/current-user.js", () => ({
+	useCurrentUser: () => ({ data: { id: "editor-1", role: 40 } }),
+}));
+
+vi.mock("../../src/components/MediaDetailPanel.js", () => ({
+	MediaDetailPanel: ({
+		open,
+		item,
+		onClose,
+		onClosed,
+		onCroppedCopyCreated,
+	}: {
+		open: boolean;
+		item: LocalMediaItem;
+		onClose: () => void;
+		onClosed?: () => void;
+		onCroppedCopyCreated?: (item: LocalMediaItem) => void;
+	}) =>
+		open ? (
+			<button
+				type="button"
+				data-item-url={item.url}
+				onClick={() => {
+					onCroppedCopyCreated?.({
+						id: "cropped-image",
+						filename: "cropped.jpg",
+						mimeType: "image/jpeg",
+						url: "/_emdash/api/media/file/cropped.jpg",
+						storageKey: "cropped.jpg",
+						size: 100,
+						width: 640,
+						height: 480,
+						blurhash: "new-hash",
+						dominantColor: "#123456",
+						status: "ready",
+						authorId: "editor-1",
+						folderId: null,
+						createdAt: "2026-08-17T00:00:00.000Z",
+					});
+					onClose();
+					onClosed?.();
+				}}
+			>
+				Use cropped asset
+			</button>
+		) : null,
+}));
 
 const replacements: Record<string, MediaItem> = {
 	"Choose local image": {
@@ -40,6 +108,22 @@ vi.mock("../../src/components/MediaPickerModal.js", () => ({
 }));
 
 describe("ImageDetailPanel replacement", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(fetchMediaItem).mockResolvedValue({
+			id: "old-image",
+			filename: "old.jpg",
+			mimeType: "image/jpeg",
+			url: "/_emdash/api/media/file/old.jpg",
+			storageKey: "old.jpg",
+			size: 100,
+			status: "ready",
+			authorId: "editor-1",
+			folderId: null,
+			createdAt: "2026-08-16T00:00:00.000Z",
+		});
+	});
+
 	it.each([
 		{ action: "Choose local image", expectedProvider: "local" },
 		{ action: "Choose provider image", expectedProvider: "cloudflare-images" },
@@ -60,9 +144,219 @@ describe("ImageDetailPanel replacement", () => {
 			/>,
 		);
 
-		await screen.getByRole("button", { name: "Replace Image" }).click();
+		await screen.getByRole("button", { name: "Choose another" }).click();
 		await screen.getByRole("button", { name: action }).click();
 
 		expect(onReplace).toHaveBeenCalledWith(expect.objectContaining({ provider: expectedProvider }));
+	});
+
+	it("preserves per-use image settings when a cropped copy replaces the asset", async () => {
+		const onUpdate = vi.fn();
+		const screen = await render(
+			<ImageDetailPanel
+				attributes={{
+					src: "/_emdash/api/media/file/old.jpg",
+					provider: "local",
+					mediaId: "old-image",
+					alt: "Usage alt",
+					caption: "Usage caption",
+					title: "Usage title",
+					displayWidth: 320,
+					displayHeight: 240,
+					alignment: "wide",
+				}}
+				onUpdate={onUpdate}
+				onReplace={vi.fn()}
+				onDelete={vi.fn()}
+				onClose={vi.fn()}
+				inline
+			/>,
+		);
+
+		await expect.element(screen.getByRole("button", { name: "Choose another" })).toBeVisible();
+		await expect.element(screen.getByRole("button", { name: "Edit asset" })).toBeVisible();
+		await expect.element(screen.getByRole("button", { name: "Remove" })).toBeVisible();
+		expect(fetchMediaItem).not.toHaveBeenCalled();
+		await screen.getByRole("button", { name: "Edit asset" }).click();
+		await vi.waitFor(() =>
+			expect(fetchMediaItem).toHaveBeenCalledWith("old-image", {
+				signal: expect.any(AbortSignal),
+			}),
+		);
+		await screen.getByRole("button", { name: "Use cropped asset" }).click();
+
+		expect(onUpdate).toHaveBeenCalledWith({
+			src: "/_emdash/api/media/file/cropped.jpg",
+			mediaId: "cropped-image",
+			provider: "local",
+			width: 640,
+			height: 480,
+			blurhash: "new-hash",
+			dominantColor: "#123456",
+		});
+	});
+
+	it("keeps the usage unchanged when the current asset no longer exists", async () => {
+		vi.mocked(fetchMediaItem).mockRejectedValueOnce(
+			new ApiResponseError(404, "NOT_FOUND", "Missing"),
+		);
+		const onUpdate = vi.fn();
+		const screen = await render(
+			<ImageDetailPanel
+				attributes={{
+					src: "/_emdash/api/media/file/old.jpg",
+					provider: "local",
+					mediaId: "old-image",
+					alt: "Usage alt",
+				}}
+				onUpdate={onUpdate}
+				onReplace={vi.fn()}
+				onDelete={vi.fn()}
+				onClose={vi.fn()}
+				inline
+			/>,
+		);
+
+		await screen.getByRole("button", { name: "Edit asset" }).click();
+
+		await expect
+			.element(screen.getByRole("alert"))
+			.toHaveTextContent("This media item no longer exists.");
+		expect(onUpdate).not.toHaveBeenCalled();
+	});
+
+	it("builds a local preview URL when the item response omits one", async () => {
+		vi.mocked(fetchMediaItem).mockResolvedValueOnce({
+			id: "old-image",
+			filename: "old.jpg",
+			mimeType: "image/jpeg",
+			storageKey: "folder/old image.jpg",
+			size: 100,
+			status: "ready",
+			authorId: "editor-1",
+			folderId: null,
+			createdAt: "2026-08-16T00:00:00.000Z",
+		} as LocalMediaItem);
+		const screen = await render(
+			<ImageDetailPanel
+				attributes={{
+					src: "/_emdash/api/media/file/old.jpg",
+					provider: "local",
+					mediaId: "old-image",
+				}}
+				onUpdate={vi.fn()}
+				onReplace={vi.fn()}
+				onDelete={vi.fn()}
+				onClose={vi.fn()}
+				inline
+			/>,
+		);
+
+		await screen.getByRole("button", { name: "Edit asset" }).click();
+
+		await expect
+			.element(screen.getByRole("button", { name: "Use cropped asset" }))
+			.toHaveAttribute("data-item-url", "/_emdash/api/media/file/folder%2Fold%20image.jpg");
+	});
+
+	it("does not close or save the usage behind an open asset dialog", async () => {
+		const onUpdate = vi.fn();
+		const onClose = vi.fn();
+		const screen = await render(
+			<ImageDetailPanel
+				attributes={{
+					src: "/_emdash/api/media/file/old.jpg",
+					provider: "local",
+					mediaId: "old-image",
+					alt: "Usage alt",
+				}}
+				onUpdate={onUpdate}
+				onReplace={vi.fn()}
+				onDelete={vi.fn()}
+				onClose={onClose}
+				inline
+			/>,
+		);
+
+		await screen.getByRole("button", { name: "Edit asset" }).click();
+		await expect.element(screen.getByRole("button", { name: "Use cropped asset" })).toBeVisible();
+		window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+		const saveEvent = new KeyboardEvent("keydown", { key: "s", ctrlKey: true, cancelable: true });
+		window.dispatchEvent(saveEvent);
+
+		expect(onClose).not.toHaveBeenCalled();
+		expect(onUpdate).not.toHaveBeenCalled();
+		expect(saveEvent.defaultPrevented).toBe(true);
+	});
+
+	it("blocks a second media action while the current asset is loading", async () => {
+		let resolveItem!: (item: LocalMediaItem) => void;
+		vi.mocked(fetchMediaItem).mockImplementationOnce(
+			() => new Promise<LocalMediaItem>((resolve) => (resolveItem = resolve)),
+		);
+		const screen = await render(
+			<ImageDetailPanel
+				attributes={{
+					src: "/_emdash/api/media/file/old.jpg",
+					provider: "local",
+					mediaId: "old-image",
+				}}
+				onUpdate={vi.fn()}
+				onReplace={vi.fn()}
+				onDelete={vi.fn()}
+				onClose={vi.fn()}
+				inline
+			/>,
+		);
+
+		await screen.getByRole("button", { name: "Edit asset" }).click();
+
+		await expect.element(screen.getByRole("button", { name: "Choose another" })).toBeDisabled();
+		await expect.element(screen.getByRole("button", { name: "Remove" })).toBeDisabled();
+		resolveItem({
+			id: "old-image",
+			filename: "old.jpg",
+			mimeType: "image/jpeg",
+			url: "/_emdash/api/media/file/old.jpg",
+			storageKey: "old.jpg",
+			size: 100,
+			status: "ready",
+			authorId: "editor-1",
+			folderId: null,
+			createdAt: "2026-08-16T00:00:00.000Z",
+		});
+	});
+
+	it("keeps implicit display dimensions aligned with the cropped asset", async () => {
+		const screen = await render(
+			<ImageDetailPanel
+				attributes={{
+					src: "/_emdash/api/media/file/old.jpg",
+					provider: "local",
+					mediaId: "old-image",
+					width: 1200,
+					height: 800,
+				}}
+				onUpdate={vi.fn()}
+				onReplace={vi.fn()}
+				onDelete={vi.fn()}
+				onClose={vi.fn()}
+				inline
+			/>,
+		);
+
+		await screen.getByRole("button", { name: "Edit asset" }).click();
+		await screen.getByRole("button", { name: "Use cropped asset" }).click();
+
+		await expect.element(screen.getByLabelText("Width")).toHaveValue(640);
+		await expect.element(screen.getByLabelText("Height")).toHaveValue(480);
+		await expect.element(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+
+		await screen.getByRole("button", { name: "Edit asset" }).click();
+		await vi.waitFor(() =>
+			expect(fetchMediaItem).toHaveBeenLastCalledWith("cropped-image", {
+				signal: expect.any(AbortSignal),
+			}),
+		);
 	});
 });

--- a/packages/admin/tests/components/ImageDetailPanel.test.tsx
+++ b/packages/admin/tests/components/ImageDetailPanel.test.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ImageDetailPanel } from "../../src/components/editor/ImageDetailPanel.js";
+import {
+	ImageDetailPanel,
+	type ImagePanelAttributes,
+} from "../../src/components/editor/ImageDetailPanel.js";
 import { ApiResponseError, fetchMediaItem } from "../../src/lib/api";
 import type { LocalMediaItem, MediaItem } from "../../src/lib/api/media.js";
 import { render } from "../utils/render.js";
@@ -358,5 +361,102 @@ describe("ImageDetailPanel replacement", () => {
 				signal: expect.any(AbortSignal),
 			}),
 		);
+	});
+
+	it("resyncs the complete form when the sidebar switches image nodes", async () => {
+		const firstNode = {};
+		const secondNode = {};
+		const thirdNode = {};
+		const onSecondUpdate = vi.fn();
+		const onThirdUpdate = vi.fn();
+		const panel = (attributes: ImagePanelAttributes, onUpdate = vi.fn()) => (
+			<ImageDetailPanel
+				attributes={attributes}
+				onUpdate={onUpdate}
+				onReplace={vi.fn()}
+				onDelete={vi.fn()}
+				onClose={vi.fn()}
+				inline
+			/>
+		);
+		const screen = await render(
+			panel({
+				nodeKey: firstNode,
+				src: "/_emdash/api/media/file/first.jpg",
+				mediaId: "first-image",
+				provider: "local",
+				width: 1200,
+				height: 800,
+				alt: "First alt",
+				caption: "First caption",
+				title: "First title",
+				displayWidth: 600,
+				displayHeight: 400,
+				alignment: "wide",
+			}),
+		);
+
+		await screen.rerender(
+			panel(
+				{
+					nodeKey: secondNode,
+					src: "/_emdash/api/media/file/second.jpg",
+					mediaId: "second-image",
+					provider: "local",
+					width: 900,
+					height: 600,
+					alt: "Second alt",
+					caption: "Second caption",
+					title: "Second title",
+					displayWidth: 450,
+					displayHeight: 300,
+					alignment: "center",
+				},
+				onSecondUpdate,
+			),
+		);
+
+		await expect
+			.element(screen.getByRole("img", { name: "Second alt" }))
+			.toHaveAttribute("src", "/_emdash/api/media/file/second.jpg");
+		await expect.element(screen.getByLabelText("Alt Text")).toHaveValue("Second alt");
+		await expect.element(screen.getByLabelText("Caption")).toHaveValue("Second caption");
+		await expect.element(screen.getByLabelText("Title (Tooltip)")).toHaveValue("Second title");
+		await expect.element(screen.getByLabelText("Width")).toHaveValue(450);
+		await expect.element(screen.getByLabelText("Height")).toHaveValue(300);
+
+		await screen.rerender(
+			panel(
+				{
+					nodeKey: thirdNode,
+					src: "/_emdash/api/media/file/second.jpg",
+					mediaId: "second-image",
+					provider: "local",
+					width: 900,
+					height: 600,
+					alt: "Third alt",
+					caption: "Third caption",
+					title: "Third title",
+					displayWidth: 300,
+					displayHeight: 200,
+					alignment: "full",
+				},
+				onThirdUpdate,
+			),
+		);
+
+		await expect.element(screen.getByLabelText("Alt Text")).toHaveValue("Third alt");
+		await screen.getByLabelText("Alt Text").fill("Updated third alt");
+		await screen.getByRole("button", { name: "Save" }).click();
+
+		expect(onSecondUpdate).not.toHaveBeenCalled();
+		expect(onThirdUpdate).toHaveBeenCalledWith({
+			alt: "Updated third alt",
+			caption: "Third caption",
+			title: "Third title",
+			displayWidth: 300,
+			displayHeight: 200,
+			alignment: "full",
+		});
 	});
 });

--- a/packages/admin/tests/components/ImageFieldRenderer.test.tsx
+++ b/packages/admin/tests/components/ImageFieldRenderer.test.tsx
@@ -58,6 +58,81 @@ vi.mock("../../src/components/MediaPickerModal", () => ({
 		) : null,
 }));
 
+vi.mock("../../src/lib/api/current-user.js", () => ({
+	useCurrentUser: () => ({ data: { id: "editor-1", role: 40 } }),
+}));
+
+vi.mock("../../src/components/MediaDetailPanel.js", () => ({
+	MediaDetailPanel: ({
+		open,
+		onClose,
+		onClosed,
+		onItemRefreshed,
+		onCroppedCopyCreated,
+	}: {
+		open: boolean;
+		onClose: () => void;
+		onClosed?: () => void;
+		onItemRefreshed?: (item: LocalMediaItem) => void;
+		onCroppedCopyCreated?: (item: LocalMediaItem) => void;
+	}) =>
+		open ? (
+			<>
+				<button
+					type="button"
+					onClick={() =>
+						onItemRefreshed?.({
+							id: "featured-image",
+							filename: "notes-on-simplicity.jpg",
+							mimeType: "image/jpeg",
+							url: "/_emdash/api/media/file/featured-image.jpg",
+							storageKey: "featured-image.jpg",
+							size: 30_000,
+							width: 1200,
+							height: 800,
+							contentHash: "sha256:replaced-original",
+							status: "ready",
+							authorId: "editor-1",
+							folderId: null,
+							createdAt: "2026-01-01T00:00:00.000Z",
+						})
+					}
+				>
+					Refresh original asset
+				</button>
+				<button
+					type="button"
+					onClick={() => {
+						onCroppedCopyCreated?.({
+							id: "cropped-image",
+							filename: "cropped.webp",
+							mimeType: "image/webp",
+							url: "/_emdash/api/media/file/cropped.webp",
+							storageKey: "cropped.webp",
+							size: 24_000,
+							width: 900,
+							height: 600,
+							contentHash: "sha256:cropped-copy",
+							alt: "Cropped asset alt",
+							focalX: 0.4,
+							focalY: 0.6,
+							blurhash: "cropped-hash",
+							dominantColor: "#aabbcc",
+							status: "ready",
+							authorId: "editor-1",
+							folderId: null,
+							createdAt: "2026-01-02T00:00:00.000Z",
+						});
+						onClose();
+						onClosed?.();
+					}}
+				>
+					Use cropped asset
+				</button>
+			</>
+		) : null,
+}));
+
 const selectedImage: ImageFieldValue = {
 	id: "featured-image",
 	provider: "local",
@@ -104,9 +179,10 @@ describe("ImageFieldRenderer", () => {
 		const metadata = screen.getByText("1200 × 800 · image/jpeg");
 		await expect.element(metadata).toBeVisible();
 		expect(metadata.element()).toHaveAttribute("dir", "ltr");
-		const replaceButton = screen.getByRole("button", { name: "Replace" });
-		await expect.element(replaceButton).toBeVisible();
-		expect(replaceButton.element().querySelector("svg")).not.toBeNull();
+		const chooseAnotherButton = screen.getByRole("button", { name: "Choose another" });
+		await expect.element(chooseAnotherButton).toBeVisible();
+		expect(chooseAnotherButton.element().querySelector("svg")).not.toBeNull();
+		await expect.element(screen.getByRole("button", { name: "Edit asset" })).toBeVisible();
 		const removeButton = screen.getByRole("button", { name: "Remove image" });
 		await expect.element(removeButton).toBeVisible();
 		expect(removeButton.element()).toHaveTextContent("Remove");
@@ -251,7 +327,7 @@ describe("ImageFieldRenderer", () => {
 			/>,
 		);
 
-		await screen.getByRole("button", { name: "Replace" }).click();
+		await screen.getByRole("button", { name: "Choose another" }).click();
 		await screen.getByRole("button", { name: "Choose replacement" }).click();
 
 		expect(onChange).toHaveBeenCalledWith(
@@ -278,7 +354,7 @@ describe("ImageFieldRenderer", () => {
 			/>,
 		);
 
-		await screen.getByRole("button", { name: "Replace" }).click();
+		await screen.getByRole("button", { name: "Choose another" }).click();
 		await screen.getByRole("button", { name: "Choose external URL" }).click();
 
 		expect(onChange).toHaveBeenCalledWith(
@@ -322,7 +398,8 @@ describe("ImageFieldRenderer", () => {
 
 		await expect.element(screen.getByText("Image not found")).toBeVisible();
 		await expect.element(screen.getByText("notes-on-simplicity.jpg")).toBeVisible();
-		await expect.element(screen.getByRole("button", { name: "Replace" })).toBeVisible();
+		await expect.element(screen.getByRole("button", { name: "Choose another" })).toBeVisible();
+		await expect.element(screen.getByRole("button", { name: "Edit asset" })).toBeVisible();
 		await expect.element(screen.getByRole("button", { name: "Remove image" })).toBeVisible();
 	});
 
@@ -472,7 +549,7 @@ describe("ImageFieldRenderer", () => {
 			/>,
 		);
 
-		await screen.getByRole("button", { name: "Change", exact: true }).click();
+		await screen.getByRole("button", { name: "Choose another", exact: true }).click();
 		await screen.getByRole("button", { name: "Choose replacement" }).click();
 
 		expect(onChange).toHaveBeenCalledWith(
@@ -487,5 +564,120 @@ describe("ImageFieldRenderer", () => {
 
 		expect(screen.getByText("notes-on-simplicity.jpg").query()).toBeNull();
 		expect(screen.getByText("1200 × 800 · image/jpeg").query()).toBeNull();
+	});
+
+	it("uses a cropped copy for the field without dropping its dark mode variant", async () => {
+		const darkVariant: ImageFieldValue = { id: "dark-image", provider: "local" };
+		const onChange = vi.fn();
+		const screen = await render(
+			<ImageFieldRenderer
+				label="Featured image"
+				value={{ ...selectedImage, darkVariant }}
+				onChange={onChange}
+				variant="featured"
+			/>,
+		);
+
+		await screen.getByRole("button", { name: "Edit asset" }).click();
+		await screen.getByRole("button", { name: "Use cropped asset" }).click();
+
+		expect(onChange).toHaveBeenCalledWith({
+			id: "cropped-image",
+			provider: "local",
+			src: undefined,
+			previewUrl: undefined,
+			alt: "Cropped asset alt",
+			width: 900,
+			height: 600,
+			focalX: 0.4,
+			focalY: 0.6,
+			filename: "cropped.webp",
+			mimeType: "image/webp",
+			blurhash: "cropped-hash",
+			dominantColor: "#aabbcc",
+			meta: { storageKey: "cropped.webp" },
+			darkVariant,
+		});
+	});
+
+	it("refreshes a custom field preview from the edited item without persisting its content hash", async () => {
+		let persistedValue: ImageFieldValue | null | undefined;
+		function Harness() {
+			const [value, setValue] = React.useState<ImageFieldValue | null>(selectedImage);
+			return (
+				<ImageFieldRenderer
+					label="Image"
+					value={value ?? undefined}
+					onChange={(next) => {
+						persistedValue = next;
+						setValue(next);
+					}}
+				/>
+			);
+		}
+		const screen = await render(<Harness />);
+		const sources: string[] = [];
+		const observer = new MutationObserver(() => {
+			for (const image of screen.container.querySelectorAll("img")) sources.push(image.src);
+		});
+		observer.observe(screen.container, {
+			attributes: true,
+			attributeFilter: ["src"],
+			childList: true,
+			subtree: true,
+		});
+
+		await screen.getByRole("button", { name: "Edit asset" }).click();
+		await screen.getByRole("button", { name: "Use cropped asset" }).click();
+
+		await vi.waitFor(() => {
+			expect(
+				sources.some((source) =>
+					source.endsWith(
+						"/_emdash/api/media/file/cropped.webp?_emdash_media=sha256%3Acropped-copy",
+					),
+				),
+			).toBe(true);
+		});
+		observer.disconnect();
+		expect(persistedValue).not.toHaveProperty("contentHash");
+	});
+
+	it("refreshes both previews when light and dark variants share one replaced asset", async () => {
+		function Harness() {
+			const [value, setValue] = React.useState<ImageFieldValue>({
+				...selectedImage,
+				darkVariant: { ...selectedImage },
+			});
+			return (
+				<ImageFieldRenderer
+					label="Image"
+					value={value}
+					onChange={(next) => next && setValue(next)}
+					darkVariant
+				/>
+			);
+		}
+		const screen = await render(<Harness />);
+		const refreshedSource =
+			"/_emdash/api/media/file/featured-image.jpg?_emdash_media=sha256%3Areplaced-original";
+		const sources: string[] = [];
+		const observer = new MutationObserver(() => {
+			for (const image of screen.container.querySelectorAll("img")) sources.push(image.src);
+		});
+		observer.observe(screen.container, {
+			attributes: true,
+			attributeFilter: ["src"],
+			childList: true,
+			subtree: true,
+		});
+
+		await screen.getByRole("button", { name: "Edit asset" }).click();
+		await screen.getByRole("button", { name: "Refresh original asset" }).click();
+
+		await vi.waitFor(() => {
+			expect(sources.filter((source) => source.endsWith(refreshedSource))).toHaveLength(2);
+		});
+		observer.disconnect();
 	});
 });

--- a/packages/admin/tests/components/ImageFieldRenderer.test.tsx
+++ b/packages/admin/tests/components/ImageFieldRenderer.test.tsx
@@ -190,6 +190,7 @@ describe("ImageFieldRenderer", () => {
 		const image = screen.container.querySelector("img");
 		expect(image).toHaveAttribute("src", "/_emdash/api/media/file/featured-image.jpg");
 		expect(image?.style.objectPosition).toBe("25% 75%");
+		expect(getComputedStyle(image!.parentElement!).aspectRatio).toBe("16 / 9");
 	});
 
 	it("refreshes a featured local preview from the current media item", async () => {

--- a/packages/admin/tests/components/ImageFieldRenderer.test.tsx
+++ b/packages/admin/tests/components/ImageFieldRenderer.test.tsx
@@ -179,7 +179,7 @@ describe("ImageFieldRenderer", () => {
 		const metadata = screen.getByText("1200 × 800 · image/jpeg");
 		await expect.element(metadata).toBeVisible();
 		expect(metadata.element()).toHaveAttribute("dir", "ltr");
-		const chooseAnotherButton = screen.getByRole("button", { name: "Choose another" });
+		const chooseAnotherButton = screen.getByRole("button", { name: "Replace" });
 		await expect.element(chooseAnotherButton).toBeVisible();
 		expect(chooseAnotherButton.element().querySelector("svg")).not.toBeNull();
 		await expect.element(screen.getByRole("button", { name: "Edit asset" })).toBeVisible();
@@ -327,7 +327,7 @@ describe("ImageFieldRenderer", () => {
 			/>,
 		);
 
-		await screen.getByRole("button", { name: "Choose another" }).click();
+		await screen.getByRole("button", { name: "Replace" }).click();
 		await screen.getByRole("button", { name: "Choose replacement" }).click();
 
 		expect(onChange).toHaveBeenCalledWith(
@@ -354,7 +354,7 @@ describe("ImageFieldRenderer", () => {
 			/>,
 		);
 
-		await screen.getByRole("button", { name: "Choose another" }).click();
+		await screen.getByRole("button", { name: "Replace" }).click();
 		await screen.getByRole("button", { name: "Choose external URL" }).click();
 
 		expect(onChange).toHaveBeenCalledWith(
@@ -398,7 +398,7 @@ describe("ImageFieldRenderer", () => {
 
 		await expect.element(screen.getByText("Image not found")).toBeVisible();
 		await expect.element(screen.getByText("notes-on-simplicity.jpg")).toBeVisible();
-		await expect.element(screen.getByRole("button", { name: "Choose another" })).toBeVisible();
+		await expect.element(screen.getByRole("button", { name: "Replace" })).toBeVisible();
 		await expect.element(screen.getByRole("button", { name: "Edit asset" })).toBeVisible();
 		await expect.element(screen.getByRole("button", { name: "Remove image" })).toBeVisible();
 	});
@@ -549,7 +549,7 @@ describe("ImageFieldRenderer", () => {
 			/>,
 		);
 
-		await screen.getByRole("button", { name: "Choose another", exact: true }).click();
+		await screen.getByRole("button", { name: "Replace", exact: true }).click();
 		await screen.getByRole("button", { name: "Choose replacement" }).click();
 
 		expect(onChange).toHaveBeenCalledWith(

--- a/packages/admin/tests/components/ImageFieldRenderer.test.tsx
+++ b/packages/admin/tests/components/ImageFieldRenderer.test.tsx
@@ -368,6 +368,29 @@ describe("ImageFieldRenderer", () => {
 		expect(onChange.mock.calls[0]?.[0].previewUrl).toBeUndefined();
 	});
 
+	it("does not offer asset editing in mobile actions for an external featured image", async () => {
+		const screen = await render(
+			<ImageFieldRenderer
+				label="Featured image"
+				value={{
+					id: "",
+					provider: "external",
+					src: "https://media.example/external.jpg",
+					filename: "external.jpg",
+					mimeType: "image/jpeg",
+				}}
+				onChange={vi.fn()}
+				variant="featured"
+			/>,
+		);
+
+		await screen.getByRole("button", { name: "Image actions" }).click();
+
+		await expect.element(screen.getByRole("menuitem", { name: "Replace" })).toBeVisible();
+		expect(screen.getByRole("menuitem", { name: "Edit asset" }).query()).toBeNull();
+		await expect.element(screen.getByRole("menuitem", { name: "Remove" })).toBeVisible();
+	});
+
 	it("removes the featured image immediately", async () => {
 		const onChange = vi.fn();
 		const screen = await render(

--- a/packages/admin/tests/components/MediaDetailPanel.test.tsx
+++ b/packages/admin/tests/components/MediaDetailPanel.test.tsx
@@ -1079,6 +1079,33 @@ describe("MediaDetailPanel", () => {
 		expect(cropSelectionStyle(screen)).toBe(draftStyle);
 	});
 
+	it("reports when the image is deleted while replacing the original", async () => {
+		vi.mocked(replaceMediaImage).mockRejectedValueOnce(
+			new ApiResponseError(404, "NOT_FOUND", "Media item not found"),
+		);
+		vi.mocked(fetchMediaItem).mockRejectedValueOnce(
+			new ApiResponseError(404, "NOT_FOUND", "Media item not found"),
+		);
+		const onUnavailable = vi.fn();
+		const screen = await renderPanel({
+			item: makeLocalItem({ url: TEST_IMAGE_URL }),
+			canCropOriginal: true,
+			onUnavailable,
+		});
+		await openCropEditor(screen);
+		await resizeCrop(screen);
+
+		screen.getByRole("button", { name: "Replace original" }).element().click();
+		const confirmation = screen.getByRole("alertdialog", { name: "Replace original image?" });
+		await expect.element(confirmation).toBeVisible();
+		confirmation.getByRole("button", { name: "Replace original" }).element().click();
+
+		await vi.waitFor(() => {
+			expect(fetchMediaItem).toHaveBeenCalledWith("media-1");
+			expect(onUnavailable).toHaveBeenCalledWith("media-1");
+		});
+	});
+
 	it("explains that cropped WebP output is static", async () => {
 		const screen = await renderPanel({
 			item: makeLocalItem({
@@ -1749,7 +1776,12 @@ describe("MediaDetailPanel", () => {
 		vi.mocked(fetchMediaItem).mockRejectedValueOnce(
 			new ApiResponseError(404, "NOT_FOUND", "Media item not found"),
 		);
-		const screen = await renderPanel({ item: makeLocalItem(), canMoveLocation: true });
+		const onUnavailable = vi.fn();
+		const screen = await renderPanel({
+			item: makeLocalItem(),
+			canMoveLocation: true,
+			onUnavailable,
+		});
 
 		screen.getByRole("combobox", { name: "Location" }).element().click();
 		await expect.element(screen.getByRole("option", { name: "Main library" })).toBeInTheDocument();
@@ -1764,6 +1796,7 @@ describe("MediaDetailPanel", () => {
 				.query(),
 		).toBeNull();
 		await expect.element(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+		expect(onUnavailable).toHaveBeenCalledWith("media-1");
 	});
 
 	it("does not blame the folder when missing-item recovery cannot confirm the state", async () => {

--- a/packages/admin/tests/components/MediaDetailPanel.test.tsx
+++ b/packages/admin/tests/components/MediaDetailPanel.test.tsx
@@ -222,7 +222,6 @@ function renderEmbeddedPanel(props: Partial<React.ComponentProps<typeof MediaDet
 		open: true,
 		item: makeImageItem(),
 		embedded: true,
-		backLabel: "Back to library",
 		onClose: vi.fn(),
 		onDeleted: vi.fn(),
 		...props,
@@ -1947,12 +1946,18 @@ describe("MediaDetailPanel", () => {
 		expect(onClose).toHaveBeenCalled();
 	});
 
-	it("uses Back to return from embedded details without closing the workspace", async () => {
+	it("places a compact Back action in the embedded footer", async () => {
 		const onClose = vi.fn();
 		const onExit = vi.fn();
 		const screen = await renderEmbeddedPanel({ onClose, onExit });
+		const header = screen.getByTestId("media-detail-dialog-header").element();
+		const footer = screen.getByTestId("media-detail-dialog-footer").element();
+		const back = screen.getByRole("button", { name: "Back" });
 
-		screen.getByRole("button", { name: "Back to library" }).element().click();
+		expect(header).not.toContainElement(back.element());
+		expect(footer).toContainElement(back.element());
+		expect(screen.getByRole("button", { name: "Cancel" }).query()).toBeNull();
+		back.element().click();
 
 		expect(onClose).toHaveBeenCalledTimes(1);
 		expect(onExit).not.toHaveBeenCalled();

--- a/packages/admin/tests/components/MediaDetailPanel.test.tsx
+++ b/packages/admin/tests/components/MediaDetailPanel.test.tsx
@@ -993,7 +993,10 @@ describe("MediaDetailPanel", () => {
 		expect(screen.getByRole("tab", { name: "Used in" }).query()).toBeNull();
 		expect(screen.getByRole("button", { name: "Delete" }).query()).toBeNull();
 		expect(screen.getByRole("combobox", { name: "Location" }).query()).toBeNull();
-		await expect.element(screen.getByText("Product photos")).toBeVisible();
+		await expect
+			.element(screen.getByRole("textbox", { name: "Location" }))
+			.toHaveValue("Product photos");
+		await expect.element(screen.getByRole("textbox", { name: "Location" })).toBeDisabled();
 	});
 
 	it("confirms and replaces the original while keeping the dialog open", async () => {
@@ -1691,13 +1694,9 @@ describe("MediaDetailPanel", () => {
 	it("shows a read-only Location when the user cannot move the item", async () => {
 		const screen = await renderPanel({ item: makeLocalItem(), canMoveLocation: false });
 
-		await expect.element(screen.getByText("Location")).toBeInTheDocument();
-		const currentLocation = screen.getByText("Product photos");
-		await expect.element(currentLocation).toBeInTheDocument();
-		expect(currentLocation.element()).toHaveAttribute("dir", "auto");
-		expect(
-			currentLocation.element().parentElement?.querySelector('[data-testid="media-location-icon"]'),
-		).not.toBeNull();
+		const currentLocation = screen.getByRole("textbox", { name: "Location" });
+		await expect.element(currentLocation).toHaveValue("Product photos");
+		await expect.element(currentLocation).toBeDisabled();
 		expect(screen.getByRole("combobox", { name: "Location" }).query()).toBeNull();
 		expect(fetchMediaFolders).not.toHaveBeenCalled();
 	});

--- a/packages/admin/tests/components/MediaDetailPanel.test.tsx
+++ b/packages/admin/tests/components/MediaDetailPanel.test.tsx
@@ -1,3 +1,4 @@
+import { Dialog } from "@cloudflare/kumo";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -212,6 +213,27 @@ function renderPanel(props: Partial<React.ComponentProps<typeof MediaDetailPanel
 	return render(
 		<QueryWrapper>
 			<MediaDetailPanel {...defaultProps} />
+		</QueryWrapper>,
+	);
+}
+
+function renderEmbeddedPanel(props: Partial<React.ComponentProps<typeof MediaDetailPanel>> = {}) {
+	const defaultProps: React.ComponentProps<typeof MediaDetailPanel> = {
+		open: true,
+		item: makeImageItem(),
+		embedded: true,
+		backLabel: "Back to library",
+		onClose: vi.fn(),
+		onDeleted: vi.fn(),
+		...props,
+	};
+	return render(
+		<QueryWrapper>
+			<Dialog.Root open>
+				<Dialog>
+					<MediaDetailPanel {...defaultProps} />
+				</Dialog>
+			</Dialog.Root>
 		</QueryWrapper>,
 	);
 }
@@ -1923,6 +1945,36 @@ describe("MediaDetailPanel", () => {
 		screen.getByRole("button", { name: "Close" }).element().click();
 
 		expect(onClose).toHaveBeenCalled();
+	});
+
+	it("uses Back to return from embedded details without closing the workspace", async () => {
+		const onClose = vi.fn();
+		const onExit = vi.fn();
+		const screen = await renderEmbeddedPanel({ onClose, onExit });
+
+		screen.getByRole("button", { name: "Back to library" }).element().click();
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+		expect(onExit).not.toHaveBeenCalled();
+		expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(1);
+	});
+
+	it("confirms dirty changes before closing an embedded workspace", async () => {
+		const onClose = vi.fn();
+		const onExit = vi.fn();
+		const item = makeImageItem({ alt: "Original" });
+		const screen = await renderEmbeddedPanel({ item, onClose, onExit });
+
+		await screen.getByLabelText("Alt Text").fill("Changed alt");
+		screen.getByRole("button", { name: "Close" }).element().click();
+
+		await expect.element(screen.getByText("Discard changes?")).toBeInTheDocument();
+		expect(onClose).not.toHaveBeenCalled();
+		expect(onExit).not.toHaveBeenCalled();
+
+		screen.getByRole("button", { name: "Discard" }).element().click();
+		expect(onExit).toHaveBeenCalledTimes(1);
+		expect(onClose).not.toHaveBeenCalled();
 	});
 
 	it("close button opens discard confirmation when dirty", async () => {

--- a/packages/admin/tests/components/MediaDetailPanel.test.tsx
+++ b/packages/admin/tests/components/MediaDetailPanel.test.tsx
@@ -950,11 +950,29 @@ describe("MediaDetailPanel", () => {
 				expect.objectContaining({ name: "photo-80x80.jpg", type: "image/jpeg" }),
 				{ deduplicate: false, ensureUniqueFilename: true, folderId: "folder-1" },
 			);
-			expect(onCroppedCopyCreated).toHaveBeenCalledTimes(1);
+			expect(onCroppedCopyCreated).toHaveBeenCalledWith(duplicate);
 		});
 		expect(onClose).toHaveBeenCalledTimes(1);
 		expect(replaceMediaImage).not.toHaveBeenCalled();
 		expect(onItemRefreshed).not.toHaveBeenCalled();
+	});
+
+	it("keeps asset-management controls out of content workflows", async () => {
+		const screen = await renderPanel({
+			item: makeLocalItem(),
+			context: "content",
+			canDelete: true,
+			canMoveLocation: true,
+			canCropOriginal: true,
+			canDuplicateCrop: true,
+		});
+
+		await expect.element(screen.getByRole("tab", { name: "Details" })).toBeVisible();
+		await expect.element(screen.getByRole("tab", { name: "Edit image" })).toBeVisible();
+		expect(screen.getByRole("tab", { name: "Used in" }).query()).toBeNull();
+		expect(screen.getByRole("button", { name: "Delete" }).query()).toBeNull();
+		expect(screen.getByRole("combobox", { name: "Location" }).query()).toBeNull();
+		await expect.element(screen.getByText("Product photos")).toBeVisible();
 	});
 
 	it("confirms and replaces the original while keeping the dialog open", async () => {

--- a/packages/admin/tests/components/MediaPickerModal.test.tsx
+++ b/packages/admin/tests/components/MediaPickerModal.test.tsx
@@ -73,7 +73,9 @@ vi.mock("../../src/components/MediaDetailPanel", () => ({
 		open,
 		item,
 		context,
+		embedded,
 		onClose,
+		onExit,
 		onClosed,
 		onItemRefreshed,
 		onCroppedCopyCreated,
@@ -82,14 +84,21 @@ vi.mock("../../src/components/MediaDetailPanel", () => ({
 		open: boolean;
 		item: { filename: string };
 		context?: string;
+		embedded?: boolean;
 		onClose: () => void;
+		onExit?: () => void;
 		onClosed?: () => void;
 		onItemRefreshed?: (item: unknown) => void;
 		onCroppedCopyCreated?: (item: unknown) => void;
 		onUnavailable?: (id: string) => void;
 	}) =>
 		open ? (
-			<div role="dialog" aria-label="Asset details" data-context={context}>
+			<div
+				role={embedded ? "region" : "dialog"}
+				aria-label="Asset details"
+				data-context={context}
+				data-embedded={embedded || undefined}
+			>
 				<span>{item.filename}</span>
 				<button
 					type="button"
@@ -98,7 +107,16 @@ vi.mock("../../src/components/MediaDetailPanel", () => ({
 						onClosed?.();
 					}}
 				>
-					Close asset details
+					Back to library
+				</button>
+				<button
+					type="button"
+					onClick={() => {
+						(onExit ?? onClose)();
+						onClosed?.();
+					}}
+				>
+					Close workspace
 				</button>
 				<button
 					type="button"
@@ -269,6 +287,7 @@ describe("MediaPickerModal", () => {
 
 		it("edits a selected local image and returns to the preserved picker state", async () => {
 			const screen = await renderModal();
+			const workspace = screen.getByRole("dialog", { name: "Select image" }).element();
 			const item = screen.getByRole("button", { name: "photo.jpg" });
 			await expect.element(item).toBeVisible();
 			item.element().click();
@@ -277,17 +296,37 @@ describe("MediaPickerModal", () => {
 			await expect.element(editAsset).toBeEnabled();
 			editAsset.element().click();
 
-			const details = screen.getByRole("dialog", { name: "Asset details" });
+			const details = screen.getByRole("region", { name: "Asset details" });
 			await expect.element(details).toBeVisible();
 			expect(details.element()).toHaveAttribute("data-context", "content");
-			expect(screen.getByRole("dialog", { name: "Select image" }).query()).toBeNull();
+			expect(details.element()).toHaveAttribute("data-embedded", "true");
+			expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(1);
+			expect(document.querySelector('[role="dialog"]')).toBe(workspace);
+			expect(screen.getByRole("button", { name: "Select" }).query()).toBeNull();
 
-			screen.getByRole("button", { name: "Close asset details" }).element().click();
+			screen.getByRole("button", { name: "Back to library" }).element().click();
 
 			const returnedItem = screen.getByRole("button", { name: "photo.jpg" });
 			await expect.element(returnedItem).toBeVisible();
 			await expect.element(returnedItem).toHaveAttribute("aria-pressed", "true");
 			await expect.element(screen.getByRole("button", { name: "Edit asset" })).toHaveFocus();
+		});
+
+		it("closes the complete workspace from asset details without returning to browse", async () => {
+			const onOpenChange = vi.fn();
+			const screen = await renderModal({ onOpenChange });
+			const item = screen.getByRole("button", { name: "photo.jpg" });
+			await expect.element(item).toBeVisible();
+			item.element().click();
+			const editAsset = screen.getByRole("button", { name: "Edit asset" });
+			await expect.element(editAsset).toBeEnabled();
+			editAsset.element().click();
+			await expect.element(screen.getByRole("button", { name: "Close workspace" })).toBeVisible();
+
+			screen.getByRole("button", { name: "Close workspace" }).element().click();
+
+			expect(onOpenChange).toHaveBeenCalledWith(false);
+			expect(screen.getByRole("button", { name: "photo.jpg" }).query()).toBeNull();
 		});
 
 		it("does not reopen either dialog when the parent closes during the handoff", async () => {
@@ -350,7 +389,7 @@ describe("MediaPickerModal", () => {
 				.element(screen.getByRole("button", { name: "Save updated asset" }))
 				.toBeVisible();
 			screen.getByRole("button", { name: "Save updated asset" }).element().click();
-			screen.getByRole("button", { name: "Close asset details" }).element().click();
+			screen.getByRole("button", { name: "Back to library" }).element().click();
 
 			await expect.element(screen.getByRole("button", { name: "Select" })).toBeEnabled();
 			screen.getByRole("button", { name: "Select" }).element().click();

--- a/packages/admin/tests/components/MediaPickerModal.test.tsx
+++ b/packages/admin/tests/components/MediaPickerModal.test.tsx
@@ -107,7 +107,7 @@ vi.mock("../../src/components/MediaDetailPanel", () => ({
 						onClosed?.();
 					}}
 				>
-					Back to library
+					Back
 				</button>
 				<button
 					type="button"
@@ -304,7 +304,7 @@ describe("MediaPickerModal", () => {
 			expect(document.querySelector('[role="dialog"]')).toBe(workspace);
 			expect(screen.getByRole("button", { name: "Select" }).query()).toBeNull();
 
-			screen.getByRole("button", { name: "Back to library" }).element().click();
+			screen.getByRole("button", { name: "Back" }).element().click();
 
 			const returnedItem = screen.getByRole("button", { name: "photo.jpg" });
 			await expect.element(returnedItem).toBeVisible();
@@ -389,7 +389,7 @@ describe("MediaPickerModal", () => {
 				.element(screen.getByRole("button", { name: "Save updated asset" }))
 				.toBeVisible();
 			screen.getByRole("button", { name: "Save updated asset" }).element().click();
-			screen.getByRole("button", { name: "Back to library" }).element().click();
+			screen.getByRole("button", { name: "Back" }).element().click();
 
 			await expect.element(screen.getByRole("button", { name: "Select" })).toBeEnabled();
 			screen.getByRole("button", { name: "Select" }).element().click();

--- a/packages/admin/tests/components/MediaPickerModal.test.tsx
+++ b/packages/admin/tests/components/MediaPickerModal.test.tsx
@@ -77,6 +77,7 @@ vi.mock("../../src/components/MediaDetailPanel", () => ({
 		onClosed,
 		onItemRefreshed,
 		onCroppedCopyCreated,
+		onUnavailable,
 	}: {
 		open: boolean;
 		item: { filename: string };
@@ -85,6 +86,7 @@ vi.mock("../../src/components/MediaDetailPanel", () => ({
 		onClosed?: () => void;
 		onItemRefreshed?: (item: unknown) => void;
 		onCroppedCopyCreated?: (item: unknown) => void;
+		onUnavailable?: (id: string) => void;
 	}) =>
 		open ? (
 			<div role="dialog" aria-label="Asset details" data-context={context}>
@@ -143,6 +145,16 @@ vi.mock("../../src/components/MediaDetailPanel", () => ({
 					}}
 				>
 					Create cropped copy
+				</button>
+				<button
+					type="button"
+					onClick={() => {
+						onUnavailable?.("m1");
+						onClose();
+						onClosed?.();
+					}}
+				>
+					Report asset missing
 				</button>
 			</div>
 		) : null,
@@ -356,6 +368,26 @@ describe("MediaPickerModal", () => {
 
 			await expect.element(item).toHaveAttribute("aria-pressed", "true");
 			expect(screen.getByRole("button", { name: "Edit asset" }).query()).toBeNull();
+		});
+
+		it("removes a missing edited asset from the picker selection", async () => {
+			const screen = await renderModal();
+			const item = screen.getByRole("button", { name: "photo.jpg" });
+			await expect.element(item).toBeVisible();
+			item.element().click();
+			const editAsset = screen.getByRole("button", { name: "Edit asset" });
+			await expect.element(editAsset).toBeEnabled();
+			editAsset.element().click();
+			await expect
+				.element(screen.getByRole("button", { name: "Report asset missing" }))
+				.toBeVisible();
+
+			screen.getByRole("button", { name: "Report asset missing" }).element().click();
+
+			await expect.element(screen.getByRole("button", { name: "Select" })).toBeDisabled();
+			await expect
+				.element(screen.getByRole("button", { name: "photo.jpg" }))
+				.toHaveAttribute("aria-pressed", "false");
 		});
 	});
 

--- a/packages/admin/tests/components/MediaPickerModal.test.tsx
+++ b/packages/admin/tests/components/MediaPickerModal.test.tsx
@@ -13,6 +13,9 @@ import { render } from "../utils/render.tsx";
 // matches the hidden file `<input aria-label="Upload file">` and trips
 // playwright's strict-mode "resolved to N elements" guard.
 const UPLOAD_BUTTON_REGEX = /^Upload files$/;
+const pickerTestState = vi.hoisted(() => ({
+	currentUser: { id: "user-1", role: 40 },
+}));
 
 vi.mock("../../src/lib/api", async () => {
 	const actual = await vi.importActual("../../src/lib/api");
@@ -30,6 +33,10 @@ vi.mock("../../src/lib/api", async () => {
 					height: 600,
 					focalX: 0.2,
 					focalY: 0.8,
+					storageKey: "photo.jpg",
+					status: "ready",
+					authorId: "user-1",
+					folderId: null,
 					createdAt: "2024-01-01",
 				},
 				{
@@ -56,6 +63,90 @@ vi.mock("../../src/lib/api", async () => {
 		updateMedia: vi.fn().mockResolvedValue({}),
 	};
 });
+
+vi.mock("../../src/lib/api/current-user.js", () => ({
+	useCurrentUser: () => ({ data: pickerTestState.currentUser }),
+}));
+
+vi.mock("../../src/components/MediaDetailPanel", () => ({
+	MediaDetailPanel: ({
+		open,
+		item,
+		context,
+		onClose,
+		onClosed,
+		onItemRefreshed,
+		onCroppedCopyCreated,
+	}: {
+		open: boolean;
+		item: { filename: string };
+		context?: string;
+		onClose: () => void;
+		onClosed?: () => void;
+		onItemRefreshed?: (item: unknown) => void;
+		onCroppedCopyCreated?: (item: unknown) => void;
+	}) =>
+		open ? (
+			<div role="dialog" aria-label="Asset details" data-context={context}>
+				<span>{item.filename}</span>
+				<button
+					type="button"
+					onClick={() => {
+						onClose();
+						onClosed?.();
+					}}
+				>
+					Close asset details
+				</button>
+				<button
+					type="button"
+					onClick={() =>
+						onItemRefreshed?.({
+							id: "m1",
+							filename: "photo.jpg",
+							mimeType: "image/jpeg",
+							url: "/media/photo.jpg",
+							storageKey: "photo.jpg",
+							size: 700,
+							width: 320,
+							height: 240,
+							focalX: 0.5,
+							focalY: 0.4,
+							status: "ready",
+							authorId: "user-1",
+							folderId: null,
+							createdAt: "2024-01-01",
+						})
+					}
+				>
+					Save updated asset
+				</button>
+				<button
+					type="button"
+					onClick={() => {
+						onCroppedCopyCreated?.({
+							id: "media-copy",
+							filename: "photo-cropped.jpg",
+							mimeType: "image/jpeg",
+							url: "/media/photo-cropped.jpg",
+							storageKey: "photo-cropped.jpg",
+							size: 800,
+							width: 400,
+							height: 300,
+							status: "ready",
+							authorId: "user-1",
+							folderId: null,
+							createdAt: "2024-01-03",
+						});
+						onClose();
+						onClosed?.();
+					}}
+				>
+					Create cropped copy
+				</button>
+			</div>
+		) : null,
+}));
 
 function QueryWrapper({ children }: { children: React.ReactNode }) {
 	const qc = new QueryClient({
@@ -85,6 +176,7 @@ async function openUrlSource(screen: Awaited<ReturnType<typeof renderModal>>) {
 describe("MediaPickerModal", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		pickerTestState.currentUser = { id: "user-1", role: 40 };
 	});
 	afterEach(() => vi.unstubAllGlobals());
 
@@ -161,6 +253,109 @@ describe("MediaPickerModal", () => {
 			expect(onSelect).toHaveBeenCalledWith(
 				expect.objectContaining({ id: "m1", filename: "photo.jpg" }),
 			);
+		});
+
+		it("edits a selected local image and returns to the preserved picker state", async () => {
+			const screen = await renderModal();
+			const item = screen.getByRole("button", { name: "photo.jpg" });
+			await expect.element(item).toBeVisible();
+			item.element().click();
+
+			const editAsset = screen.getByRole("button", { name: "Edit asset" });
+			await expect.element(editAsset).toBeEnabled();
+			editAsset.element().click();
+
+			const details = screen.getByRole("dialog", { name: "Asset details" });
+			await expect.element(details).toBeVisible();
+			expect(details.element()).toHaveAttribute("data-context", "content");
+			expect(screen.getByRole("dialog", { name: "Select image" }).query()).toBeNull();
+
+			screen.getByRole("button", { name: "Close asset details" }).element().click();
+
+			const returnedItem = screen.getByRole("button", { name: "photo.jpg" });
+			await expect.element(returnedItem).toBeVisible();
+			await expect.element(returnedItem).toHaveAttribute("aria-pressed", "true");
+			await expect.element(screen.getByRole("button", { name: "Edit asset" })).toHaveFocus();
+		});
+
+		it("does not reopen either dialog when the parent closes during the handoff", async () => {
+			const onOpenChange = vi.fn();
+			const screen = await renderModal({ onOpenChange });
+			const item = screen.getByRole("button", { name: "photo.jpg" });
+			await expect.element(item).toBeVisible();
+			item.element().click();
+			const editAsset = screen.getByRole("button", { name: "Edit asset" });
+			await expect.element(editAsset).toBeEnabled();
+			editAsset.element().click();
+
+			await screen.rerender(
+				<QueryWrapper>
+					<MediaPickerModal open={false} onOpenChange={onOpenChange} onSelect={vi.fn()} />
+				</QueryWrapper>,
+			);
+
+			await new Promise((resolve) => window.setTimeout(resolve, 250));
+			expect(screen.getByRole("dialog", { name: "Asset details" }).query()).toBeNull();
+			expect(screen.getByRole("dialog", { name: "Select image" }).query()).toBeNull();
+			expect(onOpenChange).not.toHaveBeenCalled();
+		});
+
+		it("returns from asset editing with a cropped copy selected", async () => {
+			const onSelect = vi.fn();
+			const screen = await renderModal({ onSelect });
+			const item = screen.getByRole("button", { name: "photo.jpg" });
+			await expect.element(item).toBeVisible();
+			item.element().click();
+			const editAsset = screen.getByRole("button", { name: "Edit asset" });
+			await expect.element(editAsset).toBeEnabled();
+			editAsset.element().click();
+			await expect
+				.element(screen.getByRole("button", { name: "Create cropped copy" }))
+				.toBeVisible();
+
+			screen.getByRole("button", { name: "Create cropped copy" }).element().click();
+
+			const copy = screen.getByRole("button", { name: "photo-cropped.jpg" });
+			await expect.element(copy).toBeVisible();
+			await expect.element(copy).toHaveAttribute("aria-pressed", "true");
+			screen.getByRole("button", { name: "Select" }).element().click();
+			expect(onSelect).toHaveBeenCalledWith(
+				expect.objectContaining({ id: "media-copy", filename: "photo-cropped.jpg" }),
+			);
+		});
+
+		it("confirms the refreshed local item after editing its asset metadata", async () => {
+			const onSelect = vi.fn();
+			const screen = await renderModal({ onSelect });
+			const item = screen.getByRole("button", { name: "photo.jpg" });
+			await expect.element(item).toBeVisible();
+			item.element().click();
+			const editAsset = screen.getByRole("button", { name: "Edit asset" });
+			await expect.element(editAsset).toBeEnabled();
+			editAsset.element().click();
+
+			await expect
+				.element(screen.getByRole("button", { name: "Save updated asset" }))
+				.toBeVisible();
+			screen.getByRole("button", { name: "Save updated asset" }).element().click();
+			screen.getByRole("button", { name: "Close asset details" }).element().click();
+
+			await expect.element(screen.getByRole("button", { name: "Select" })).toBeEnabled();
+			screen.getByRole("button", { name: "Select" }).element().click();
+			expect(onSelect).toHaveBeenCalledWith(
+				expect.objectContaining({ id: "m1", width: 320, height: 240, focalX: 0.5, focalY: 0.4 }),
+			);
+		});
+
+		it("does not offer asset editing to an author who does not own the image", async () => {
+			pickerTestState.currentUser = { id: "other-user", role: 30 };
+			const screen = await renderModal();
+			const item = screen.getByRole("button", { name: "photo.jpg" });
+			await expect.element(item).toBeVisible();
+			item.element().click();
+
+			await expect.element(item).toHaveAttribute("aria-pressed", "true");
+			expect(screen.getByRole("button", { name: "Edit asset" }).query()).toBeNull();
 		});
 	});
 

--- a/packages/admin/tests/gallery-detail-panel.test.tsx
+++ b/packages/admin/tests/gallery-detail-panel.test.tsx
@@ -23,11 +23,96 @@ vi.mock("../src/lib/api", async () => {
 		fetchMediaList: vi.fn().mockResolvedValue({ items: [] }),
 		fetchMediaProviders: vi.fn().mockResolvedValue([]),
 		fetchProviderMedia: vi.fn().mockResolvedValue({ items: [] }),
+		fetchMediaItem: vi.fn().mockResolvedValue({
+			id: "m2",
+			filename: "m2.jpg",
+			mimeType: "image/jpeg",
+			url: "/media/m2.jpg",
+			storageKey: "m2.jpg",
+			size: 100,
+			status: "ready",
+			authorId: "editor-1",
+			folderId: null,
+			createdAt: "2026-01-01T00:00:00.000Z",
+		}),
 		uploadMedia: vi.fn().mockResolvedValue({}),
 		uploadToProvider: vi.fn().mockResolvedValue({}),
 		updateMedia: vi.fn().mockResolvedValue({}),
 	};
 });
+
+vi.mock("../src/lib/api/current-user.js", () => ({
+	useCurrentUser: () => ({ data: { id: "editor-1", role: 40 } }),
+}));
+
+vi.mock("../src/components/MediaDetailPanel.js", () => ({
+	MediaDetailPanel: ({
+		open,
+		onClose,
+		onClosed,
+		onItemRefreshed,
+		onCroppedCopyCreated,
+	}: {
+		open: boolean;
+		onClose: () => void;
+		onClosed?: () => void;
+		onItemRefreshed?: (item: unknown) => void;
+		onCroppedCopyCreated?: (item: unknown) => void;
+	}) =>
+		open ? (
+			<>
+				<button
+					type="button"
+					onClick={() =>
+						onItemRefreshed?.({
+							id: "m2",
+							filename: "m2.jpg",
+							mimeType: "image/jpeg",
+							url: "/_emdash/api/media/file/m2.jpg",
+							storageKey: "m2.jpg",
+							size: 70,
+							width: 600,
+							height: 400,
+							contentHash: "sha256:replaced-gallery",
+							status: "ready",
+							authorId: "editor-1",
+							folderId: null,
+							createdAt: "2026-01-01T00:00:00.000Z",
+						})
+					}
+				>
+					Refresh gallery asset
+				</button>
+				<button
+					type="button"
+					onClick={() => {
+						onCroppedCopyCreated?.({
+							id: "m2-cropped",
+							filename: "m2-cropped.jpg",
+							mimeType: "image/jpeg",
+							url: "/media/m2-cropped.jpg",
+							storageKey: "m2-cropped.jpg",
+							size: 80,
+							width: 640,
+							height: 480,
+							focalX: 0.4,
+							focalY: 0.6,
+							blurhash: "cropped-hash",
+							dominantColor: "#123456",
+							status: "ready",
+							authorId: "editor-1",
+							folderId: null,
+							createdAt: "2026-01-02T00:00:00.000Z",
+						});
+						onClose();
+						onClosed?.();
+					}}
+				>
+					Use cropped gallery asset
+				</button>
+			</>
+		) : null,
+}));
 
 function QueryWrapper({ children }: { children: React.ReactNode }) {
 	const qc = new QueryClient({
@@ -223,5 +308,136 @@ describe("GalleryDetailPanel", () => {
 		await expect.element(screen.getByRole("img", { name: "Other Image" })).toBeInTheDocument();
 		expect(screen.getByRole("img", { name: "Image One" }).query()).toBeNull();
 		expect(screen.getByRole("img", { name: "Image Three" }).query()).toBeNull();
+	});
+
+	it("reorders gallery images with the keyboard and announces the new position", async () => {
+		const onUpdate = vi.fn();
+		const screen = await renderPanel({
+			attributes: { images: threeImages(), columns: 3, nodeKey: "10" },
+			onUpdate,
+		});
+		const first = screen.getByRole("button", { name: "Image One" });
+		first.element().focus();
+
+		first
+			.element()
+			.dispatchEvent(
+				new KeyboardEvent("keydown", { key: " ", code: "Space", bubbles: true, cancelable: true }),
+			);
+		await expect.element(first).toHaveAttribute("aria-pressed", "true");
+		await new Promise((resolve) => window.setTimeout(resolve, 50));
+		document.dispatchEvent(
+			new KeyboardEvent("keydown", {
+				key: "ArrowDown",
+				code: "ArrowDown",
+				bubbles: true,
+				cancelable: true,
+			}),
+		);
+		await new Promise((resolve) => window.setTimeout(resolve, 50));
+		await expect
+			.element(screen.getByText("Moving Image One to position 2 of 3."))
+			.toBeInTheDocument();
+		document.dispatchEvent(
+			new KeyboardEvent("keydown", { key: " ", code: "Space", bubbles: true, cancelable: true }),
+		);
+
+		await vi.waitFor(() => expect(onUpdate).toHaveBeenCalled());
+		const images = onUpdate.mock.calls.at(-1)?.[0].images as GalleryImage[];
+		expect(images.map((image) => image._key)).toEqual(["img2", "img1", "img3"]);
+		await expect
+			.element(screen.getByText("Image One moved to position 2 of 3."))
+			.toBeInTheDocument();
+	});
+
+	it("uses a cropped copy without changing the gallery slot metadata or order", async () => {
+		const onUpdate = vi.fn();
+		const images = threeImages();
+		images[1] = { ...images[1]!, alt: "Usage alt", caption: "Usage caption" };
+		const screen = await renderPanel({
+			attributes: { images, columns: 3, nodeKey: "10", selectedImageKey: "img2" },
+			onUpdate,
+		});
+
+		await expect.element(screen.getByRole("button", { name: "Choose another" })).toBeVisible();
+		await expect.element(screen.getByRole("button", { name: "Edit asset" })).toBeVisible();
+		await expect.element(screen.getByRole("button", { name: "Remove", exact: true })).toBeVisible();
+		await screen.getByRole("button", { name: "Edit asset" }).click();
+		await screen.getByRole("button", { name: "Use cropped gallery asset" }).click();
+
+		await vi.waitFor(() => expect(onUpdate).toHaveBeenCalled());
+		const patched = onUpdate.mock.calls.at(-1)?.[0].images as GalleryImage[];
+		expect(patched.map((image) => image._key)).toEqual(["img1", "img2", "img3"]);
+		expect(patched[1]).toEqual({
+			...images[1],
+			asset: { _type: "reference", _ref: "m2-cropped", url: "/media/m2-cropped.jpg" },
+			width: 640,
+			height: 480,
+			focalX: 0.4,
+			focalY: 0.6,
+			blurhash: "cropped-hash",
+			dominantColor: "#123456",
+		});
+	});
+
+	it("refreshes every admin preview of a replaced gallery asset without another load request", async () => {
+		const api = await import("../src/lib/api");
+		const images = threeImages();
+		images[1] = {
+			...images[1]!,
+			asset: {
+				...images[1]!.asset,
+				url: "/_emdash/api/media/file/m2.jpg",
+			},
+			alt: "Usage alt",
+		};
+		const screen = await renderPanel({
+			attributes: { images, columns: 3, nodeKey: "10", selectedImageKey: "img2" },
+		});
+		expect(api.fetchMediaItem).not.toHaveBeenCalled();
+
+		await screen.getByRole("button", { name: "Edit asset" }).click();
+		await screen.getByRole("button", { name: "Refresh gallery asset" }).click();
+
+		await vi.waitFor(() => {
+			expect(
+				screen.container.querySelectorAll(
+					'img[src="/_emdash/api/media/file/m2.jpg?_emdash_media=sha256%3Areplaced-gallery"]',
+				),
+			).toHaveLength(2);
+		});
+		expect(api.fetchMediaItem).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not open the add picker while an asset edit is loading", async () => {
+		const api = await import("../src/lib/api");
+		let resolveItem!: (item: Awaited<ReturnType<typeof api.fetchMediaItem>>) => void;
+		vi.mocked(api.fetchMediaItem).mockImplementationOnce(
+			() => new Promise((resolve) => (resolveItem = resolve)),
+		);
+		const screen = await renderPanel({
+			attributes: {
+				images: threeImages(),
+				columns: 3,
+				nodeKey: "10",
+				selectedImageKey: "img2",
+			},
+		});
+
+		await screen.getByRole("button", { name: "Edit asset" }).click();
+
+		await expect.element(screen.getByRole("button", { name: "Add Images" })).toBeDisabled();
+		resolveItem({
+			id: "m2",
+			filename: "m2.jpg",
+			mimeType: "image/jpeg",
+			url: "/media/m2.jpg",
+			storageKey: "m2.jpg",
+			size: 100,
+			status: "ready",
+			authorId: "editor-1",
+			folderId: null,
+			createdAt: "2026-01-01T00:00:00.000Z",
+		});
 	});
 });

--- a/packages/admin/tests/gallery-detail-panel.test.tsx
+++ b/packages/admin/tests/gallery-detail-panel.test.tsx
@@ -359,7 +359,7 @@ describe("GalleryDetailPanel", () => {
 			onUpdate,
 		});
 
-		await expect.element(screen.getByRole("button", { name: "Choose another" })).toBeVisible();
+		await expect.element(screen.getByRole("button", { name: "Replace" })).toBeVisible();
 		await expect.element(screen.getByRole("button", { name: "Edit asset" })).toBeVisible();
 		await expect.element(screen.getByRole("button", { name: "Remove", exact: true })).toBeVisible();
 		await screen.getByRole("button", { name: "Edit asset" }).click();


### PR DESCRIPTION
## What does this PR do?

Adds in-context Media Library asset editing to admin image workflows:

- opens media details from featured image fields, Portable Text images, and gallery images without leaving the editor;
- keeps browsing and editing inside one consistently sized media workspace;
- supports metadata and focal-point updates, cropped copies, and original-image replacement;
- refreshes edited previews while preserving per-use alt text, captions, layout, and display dimensions; and
- adds accessible keyboard reordering for gallery images.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5) with GPT-5.6 Terra used for iterative second-opinion review

## Screenshots / test output

Verified on rebased commit `f55ad62f7`:

- `pnpm lint:json` — 0 diagnostics
- `pnpm lint:quick`
- `pnpm typecheck`
- `pnpm format`
- 249 focused admin tests covering the media workspace, picker, image fields, rich-text images, galleries, and content editor
