### PR TITLE
Handle maintainer reviews on bot pull requests

### DIFF
--- a/infra/emdash-bot/.flue/lib/github.ts
+++ b/infra/emdash-bot/.flue/lib/github.ts
@@ -572,3 +572,44 @@ export async function hasIssueCommentMarker(
 		if (comments.length < 100) return false;
 	}
 }
+
+export async function getPullRequestReviewComments(
+	token: string,
+	ctx: RepoContext,
+	prNumber: number,
+	reviewId: number,
+	signal?: AbortSignal,
+): Promise<string[]> {
+	const result: string[] = [];
+	for (let page = 1; ; page += 1) {
+		const res = await githubFetch(
+			`${GITHUB_API}/repos/${ctx.owner}/${ctx.repo}/pulls/${prNumber}/reviews/${reviewId}/comments?per_page=100&page=${page}`,
+			{ headers: authHeaders(token), signal },
+		);
+		if (!res.ok)
+			throw new Error(`getPullRequestReviewComments failed: ${res.status} ${await res.text()}`);
+		const comments = await res.json<
+			Array<{
+				body?: string | null;
+				path?: string;
+				line?: number | null;
+				original_line?: number | null;
+				diff_hunk?: string;
+			}>
+		>();
+		for (const comment of comments) {
+			if (!comment.body?.trim()) continue;
+			const line = comment.line ?? comment.original_line;
+			result.push(
+				[
+					`File: ${comment.path ?? "unknown"}${line ? `:${line}` : ""}`,
+					comment.diff_hunk ?? "",
+					comment.body,
+				]
+					.filter(Boolean)
+					.join("\n\n"),
+			);
+		}
+		if (comments.length < 100) return result;
+	}
+}

--- a/infra/emdash-bot/.flue/lib/machine.json
+++ b/infra/emdash-bot/.flue/lib/machine.json
@@ -111,6 +111,7 @@
 				"confirm",
 				"reject",
 				"retry",
+				"revise",
 				"take_over"
 			]
 		},
@@ -177,6 +178,7 @@
 				"implement",
 				"repro",
 				"investigate",
+				"revise",
 				"decline"
 			]
 		},
@@ -478,12 +480,6 @@
 				"system"
 			]
 		},
-		"pr.changes_requested": {
-			"description": "A reviewer requested changes (review sub-state).",
-			"actors": [
-				"system"
-			]
-		},
 		"pr.approved": {
 			"description": "A reviewer approved the PR (review sub-state).",
 			"actors": [
@@ -687,12 +683,6 @@
 		{
 			"from": "in_review",
 			"event": "pr.approved",
-			"to": "in_review",
-			"note": "review sub-state only"
-		},
-		{
-			"from": "in_review",
-			"event": "pr.changes_requested",
 			"to": "in_review",
 			"note": "review sub-state only"
 		},

--- a/infra/emdash-bot/.flue/lib/machine.json
+++ b/infra/emdash-bot/.flue/lib/machine.json
@@ -436,6 +436,12 @@
 				"system"
 			]
 		},
+		"agent.revised": {
+			"description": "Review feedback is addressed and the PR branch is updated.",
+			"actors": [
+				"system"
+			]
+		},
 		"agent.fix_ready": {
 			"description": "A candidate change is published on bot/fix-<n>.",
 			"actors": [
@@ -594,6 +600,11 @@
 		},
 		{
 			"from": "working",
+			"event": "agent.revised",
+			"to": "in_review"
+		},
+		{
+			"from": "working",
 			"event": "agent.failed",
 			"to": "failed"
 		},
@@ -654,6 +665,18 @@
 			"from": "awaiting_feedback",
 			"event": "take_over",
 			"to": "human_owned"
+		},
+		{
+			"from": "failed",
+			"event": "revise",
+			"to": "working",
+			"action": "investigate.revise"
+		},
+		{
+			"from": "awaiting_feedback",
+			"event": "revise",
+			"to": "working",
+			"action": "investigate.revise"
 		},
 		{
 			"from": "in_review",

--- a/infra/emdash-bot/.flue/lib/machine.ts
+++ b/infra/emdash-bot/.flue/lib/machine.ts
@@ -200,7 +200,7 @@ export const STATES: Record<StateId, StateMeta> = {
 		description:
 			"A fix is staged on bot/fix-<n>; waiting for the reporter or a maintainer to confirm or reject.",
 		terminal: false,
-		offeredCommands: ["confirm", "reject", "retry", "take_over"],
+		offeredCommands: ["confirm", "reject", "retry", "revise", "take_over"],
 	},
 	in_review: {
 		label: "bot:in-review",
@@ -251,7 +251,7 @@ export const STATES: Record<StateId, StateMeta> = {
 		boardColumn: "Failed",
 		description: "An agent run errored or produced no usable result. Retryable -- not a dead end.",
 		terminal: false,
-		offeredCommands: ["resume", "retry", "implement", "repro", "investigate", "decline"],
+		offeredCommands: ["resume", "retry", "implement", "repro", "investigate", "revise", "decline"],
 	},
 
 	// -----------------------------------------------------------------------
@@ -398,12 +398,7 @@ export type AgentEvent =
 	| "agent.failed"; // nonzero exit / no result file
 
 // GitHub PR lifecycle events that propagate onto the anchoring issue.
-export type PrEvent =
-	| "pr.opened"
-	| "pr.merged"
-	| "pr.closed"
-	| "pr.changes_requested"
-	| "pr.approved";
+export type PrEvent = "pr.opened" | "pr.merged" | "pr.closed" | "pr.approved";
 
 // Preview-deploy lifecycle events, emitted by the preview-build pipeline.
 export type PreviewEvent =
@@ -577,10 +572,6 @@ export const EVENTS: Record<EventId, EventMeta> = {
 		description: "The bot PR was closed without merging.",
 		actors: ["system"],
 	},
-	"pr.changes_requested": {
-		description: "A reviewer requested changes (review sub-state).",
-		actors: ["system"],
-	},
 	"pr.approved": {
 		description: "A reviewer approved the PR (review sub-state).",
 		actors: ["system"],
@@ -719,12 +710,6 @@ export const TRANSITIONS: Transition[] = [
 		note: "idempotent; sets review sub-state",
 	},
 	{ from: "in_review", event: "pr.approved", to: "in_review", note: "review sub-state only" },
-	{
-		from: "in_review",
-		event: "pr.changes_requested",
-		to: "in_review",
-		note: "review sub-state only",
-	},
 	{
 		from: "in_review",
 		event: "revise",

--- a/infra/emdash-bot/.flue/lib/machine.ts
+++ b/infra/emdash-bot/.flue/lib/machine.ts
@@ -392,6 +392,7 @@ export type AgentEvent =
 	| "agent.by_design" // verdict === "intended-behavior"
 	| "agent.reproduced" // reproduced && !fixed
 	| "agent.diagnosed" // root cause found, no confirming reproduction
+	| "agent.revised"
 	| "agent.fix_ready" // reproduced && fixed
 	| "agent.needs_info" // reproduced/unclear but blocked on reporter-only info
 	| "agent.failed"; // nonzero exit / no result file
@@ -550,6 +551,10 @@ export const EVENTS: Record<EventId, EventMeta> = {
 		description: "Root cause identified without a confirming reproduction.",
 		actors: ["system"],
 	},
+	"agent.revised": {
+		description: "Review feedback is addressed and the PR branch is updated.",
+		actors: ["system"],
+	},
 	"agent.fix_ready": {
 		description: "A candidate change is published on bot/fix-<n>.",
 		actors: ["system"],
@@ -681,6 +686,7 @@ export const TRANSITIONS: Transition[] = [
 		to: "awaiting_feedback",
 		note: "executor pushes bot/fix-<n>; orchestrator asks the reporter to confirm. PR opens on confirm, not here.",
 	},
+	{ from: "working", event: "agent.revised", to: "in_review" },
 	{ from: "working", event: "agent.failed", to: "failed" },
 
 	// --- blocked: every reason accepts the same overrides (kills the sinks) ---
@@ -704,6 +710,8 @@ export const TRANSITIONS: Transition[] = [
 	{ from: "awaiting_feedback", event: "take_over", to: "human_owned" },
 
 	// --- in review (the PR bridge) ---
+	{ from: "failed", event: "revise", to: "working", action: "investigate.revise" },
+	{ from: "awaiting_feedback", event: "revise", to: "working", action: "investigate.revise" },
 	{
 		from: "in_review",
 		event: "pr.opened",

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -147,6 +147,8 @@ export interface NormalizedEvent {
 	readonly classifyText?: string | null;
 	/** Exact human comment that caused this event, retained for agent context. */
 	readonly triggeringComment?: TriggeringComment;
+	readonly pullRequestNumber?: number;
+	readonly reviewId?: number;
 	/** True only on a bot-authored PR (enables the in_review default). */
 	readonly allowDefault?: boolean;
 	/** Webhook delivery id; the DO dedupes by this. */
@@ -383,6 +385,7 @@ interface PendingSideEffect {
 	readonly addLabels: readonly string[];
 	readonly removeLabels: readonly string[];
 	readonly commentBody: string;
+	readonly commentTargetNumber?: number;
 	readonly commentMarker: string;
 	readonly commentMayExist: boolean;
 	/** Post the comment before flipping labels (fix-loop ask ordering). */
@@ -833,7 +836,10 @@ export class OrchestratorDO extends DurableObject<Env> {
 				? { ...existing, body, pending: true }
 				: {
 						runId: input.runId,
-						anchorNumber,
+						anchorNumber:
+							run.mode === "revise"
+								? ((await transaction.get<number>(STORAGE.prNumber)) ?? anchorNumber)
+								: anchorNumber,
 						marker,
 						body,
 						commentId: null,
@@ -896,7 +902,10 @@ export class OrchestratorDO extends DurableObject<Env> {
 					? { ...existing, body, pending: true }
 					: {
 							runId: input.runId,
-							anchorNumber,
+							anchorNumber:
+								run.mode === "revise"
+									? ((await transaction.get<number>(STORAGE.prNumber)) ?? anchorNumber)
+									: anchorNumber,
 							marker,
 							body,
 							commentId: null,
@@ -961,7 +970,10 @@ export class OrchestratorDO extends DurableObject<Env> {
 				? { ...existing, body, pending: true }
 				: {
 						runId: input.runId,
-						anchorNumber,
+						anchorNumber:
+							run.mode === "revise"
+								? ((await transaction.get<number>(STORAGE.prNumber)) ?? anchorNumber)
+								: anchorNumber,
 						marker,
 						body,
 						commentId: null,
@@ -1022,12 +1034,19 @@ export class OrchestratorDO extends DurableObject<Env> {
 			await this.persistSuccessfulDiagnosis(input.runId, currentRunMode, input.result);
 		}
 
-		const event = outcomeFromResult({
+		let event = outcomeFromResult({
 			ok: input.ok,
 			result: input.result,
 			pushed: input.pushed,
 			mode: currentRunMode,
 		});
+		if (
+			event === "agent.fix_ready" &&
+			currentRunMode === "revise" &&
+			(await this.ctx.storage.get<number>(STORAGE.prNumber))
+		) {
+			event = "agent.revised";
+		}
 		const resumedAttempt = savedRun?.runId === input.runId || (run?.attempt ?? 1) > 1;
 		if (event === "agent.failed" && resumedAttempt && currentRunMode && currentAgentId && state) {
 			await this.ctx.storage.put<ResumableRunCheckpoint>(STORAGE.resumableRun, {
@@ -1327,7 +1346,19 @@ export class OrchestratorDO extends DurableObject<Env> {
 
 	private async processInboxHead(): Promise<boolean> {
 		const inbox = (await this.ctx.storage.get<InboxEntry[]>(STORAGE.inbox)) ?? [];
-		const entry = inbox[0];
+		const [state, runId] = await Promise.all([
+			this.ctx.storage.get<StateId>(STORAGE.state),
+			this.ctx.storage.get<string>(STORAGE.currentRunId),
+		]);
+		const entry = inbox.find(
+			(candidate) =>
+				!(
+					state === "working" &&
+					runId &&
+					candidate.input.event === "revise" &&
+					candidate.input.pullRequestNumber
+				),
+		);
 		if (!entry) return false;
 
 		try {
@@ -1337,9 +1368,14 @@ export class OrchestratorDO extends DurableObject<Env> {
 			const attempts = (entry.attempts ?? 0) + 1;
 			await this.ctx.storage.transaction(async (transaction) => {
 				const current = (await transaction.get<InboxEntry[]>(STORAGE.inbox)) ?? [];
-				if (current[0]?.id !== entry.id) return;
+				if (!current.some((candidate) => candidate.id === entry.id)) return;
 				if (attempts < CLASSIFIER_MAX_ATTEMPTS) {
-					await transaction.put(STORAGE.inbox, [{ ...entry, attempts }, ...current.slice(1)]);
+					await transaction.put(
+						STORAGE.inbox,
+						current.map((candidate) =>
+							candidate.id === entry.id ? { ...entry, attempts } : candidate,
+						),
+					);
 					return;
 				}
 				if (entry.input.deliveryId) {
@@ -1352,7 +1388,11 @@ export class OrchestratorDO extends DurableObject<Env> {
 					}
 				}
 				if (current.length === 1) await transaction.delete(STORAGE.inbox);
-				else await transaction.put(STORAGE.inbox, current.slice(1));
+				else
+					await transaction.put(
+						STORAGE.inbox,
+						current.filter((candidate) => candidate.id !== entry.id),
+					);
 			});
 			if (attempts >= CLASSIFIER_MAX_ATTEMPTS) {
 				console.error("[orchestrator] discarded classifier entry after retry limit", {
@@ -1365,9 +1405,13 @@ export class OrchestratorDO extends DurableObject<Env> {
 		}
 		await this.ctx.storage.transaction(async (transaction) => {
 			const current = (await transaction.get<InboxEntry[]>(STORAGE.inbox)) ?? [];
-			if (current[0]?.id !== entry.id) return;
+			if (!current.some((candidate) => candidate.id === entry.id)) return;
 			if (current.length === 1) await transaction.delete(STORAGE.inbox);
-			else await transaction.put(STORAGE.inbox, current.slice(1));
+			else
+				await transaction.put(
+					STORAGE.inbox,
+					current.filter((candidate) => candidate.id !== entry.id),
+				);
 		});
 		return true;
 	}
@@ -2454,7 +2498,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 			exists = await hasIssueCommentMarker(
 				token,
 				repo,
-				pending.anchorNumber,
+				pending.commentTargetNumber ?? pending.anchorNumber,
 				pending.commentMarker,
 			);
 		} else {
@@ -2465,7 +2509,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 			await postIssueComment(
 				token,
 				repo,
-				pending.anchorNumber,
+				pending.commentTargetNumber ?? pending.anchorNumber,
 				`${pending.commentBody}\n\n${pending.commentMarker}`,
 			);
 		}
@@ -2577,6 +2621,8 @@ export class OrchestratorDO extends DurableObject<Env> {
 				const kind = parseKind(kindLabel.slice("bot:".length));
 				if (kind) puts.push(transaction.put(STORAGE.kind, kind));
 			}
+			if (input.pullRequestNumber)
+				puts.push(transaction.put(STORAGE.prNumber, input.pullRequestNumber));
 			if (preparedInvestigation) {
 				const run = startRunLifecycle({
 					runId: preparedInvestigation.runId,
@@ -2644,6 +2690,11 @@ export class OrchestratorDO extends DurableObject<Env> {
 			}
 			const anchorNumber =
 				input.anchorNumber ?? (await transaction.get<number>(STORAGE.anchorNumber));
+			const commentTargetNumber =
+				input.pullRequestNumber ??
+				((await transaction.get<InvestigationMode>(STORAGE.currentRunMode)) === "revise"
+					? await transaction.get<number>(STORAGE.prNumber)
+					: undefined);
 			const effectRunId =
 				preparedInvestigation?.runId ?? preparedResume?.checkpoint.runId ?? input.settlesRunId;
 			const effectDeliveryId = input.settlesDeliveryId ?? input.deliveryId;
@@ -2661,6 +2712,7 @@ export class OrchestratorDO extends DurableObject<Env> {
 							anchorNumber,
 							addLabels: decision.addLabels,
 							removeLabels: decision.removeLabels,
+							...(commentTargetNumber ? { commentTargetNumber } : {}),
 							commentBody:
 								input.commentBodyOverride ??
 								renderComment(

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -2688,6 +2688,19 @@ export class OrchestratorDO extends DurableObject<Env> {
 						: []),
 				);
 			}
+			if (decision.event === "pr.closed" || decision.event === "pr.merged") {
+				const inbox = (await transaction.get<InboxEntry[]>(STORAGE.inbox)) ?? [];
+				const kept = inbox.filter(
+					(candidate) => !(candidate.input.event === "revise" && candidate.input.pullRequestNumber),
+				);
+				if (kept.length !== inbox.length) {
+					puts.push(
+						kept.length === 0
+							? transaction.delete(STORAGE.inbox)
+							: transaction.put(STORAGE.inbox, kept),
+					);
+				}
+			}
 			const anchorNumber =
 				input.anchorNumber ?? (await transaction.get<number>(STORAGE.anchorNumber));
 			const commentTargetNumber =

--- a/infra/emdash-bot/.flue/lib/webhook.ts
+++ b/infra/emdash-bot/.flue/lib/webhook.ts
@@ -167,7 +167,13 @@ export interface PullRequestEvent {
 
 export interface PullRequestReviewEvent {
 	action?: string;
-	review?: { body?: string | null; state?: string; user?: User; author_association?: string };
+	review?: {
+		id?: number;
+		body?: string | null;
+		state?: string;
+		user?: User;
+		author_association?: string;
+	};
 	pull_request?: PullRequest;
 	sender?: User;
 }
@@ -325,7 +331,11 @@ function normalizeIssueComment(
 	}
 	const dispatch = (normalized: Omit<NormalizedEvent, "anchorNumber">): NormalizeResult =>
 		isPullRequest
-			? { kind: "pull_request", pullRequestNumber: number, event: normalized }
+			? {
+					kind: "pull_request",
+					pullRequestNumber: number,
+					event: { ...normalized, pullRequestNumber: number },
+				}
 			: dispatchFor(number, normalized);
 
 	// Three-way grammar (mirrors router.resolveComment):
@@ -407,6 +417,7 @@ function normalizePullRequest(
 
 	return dispatchFor(issueNumber, {
 		event: machineEvent,
+		pullRequestNumber: readNumber(pr?.number),
 		arg: null,
 		actor: "system",
 		labels: collectLabels(pr?.labels),
@@ -415,38 +426,51 @@ function normalizePullRequest(
 	});
 }
 
-/**
- * PR review submissions. `pr.*` events are machine-defined as
- * actors:["system"] (they represent "GitHub reported a review state change",
- * not "system pressed approve"), so we pass actor: "system" regardless of
- * who submitted on GitHub.
- */
 function normalizePullRequestReview(
 	event: Record<string, unknown> | undefined,
 	deliveryId?: string,
 ): NormalizeResult {
 	const action = readString(event?.action);
-	if (action !== "submitted") {
+	if (action !== "submitted")
 		return { kind: "skip", reason: `pull_request_review.${action} not handled` };
-	}
 	const pr = asRecord(event?.pull_request);
 	const issueNumber = botFixIssueNumber(pr);
-	if (issueNumber === null) {
-		return { kind: "skip", reason: "pull_request_review is not on an emdashbot fix PR" };
+	const pullRequestNumber = readNumber(pr?.number);
+	if (issueNumber === null || !pullRequestNumber || pr?.state === "closed") {
+		return { kind: "skip", reason: "pull_request_review is not on an open emdashbot fix PR" };
 	}
-
-	const reviewState = (readString(asRecord(event?.review)?.state) ?? "").toLowerCase();
-	let machineEvent: NormalizedEvent["event"];
-	if (reviewState === "approved") machineEvent = "pr.approved";
-	else if (reviewState === "changes_requested") machineEvent = "pr.changes_requested";
-	else return { kind: "skip", reason: `review state "${reviewState}" not actionable` };
-
+	const review = asRecord(event?.review);
+	const authorLogin = readString(asRecord(review?.user)?.login) ?? null;
+	const authorAssociation = readString(review?.author_association) ?? null;
+	const actor = classifyActor({ senderLogin: authorLogin, authorAssociation });
+	if (actor !== "maintainer") return { kind: "skip", reason: "review author is not a maintainer" };
+	const state = (readString(review?.state) ?? "").toLowerCase();
+	if (state === "approved") {
+		return dispatchFor(issueNumber, {
+			event: "pr.approved",
+			arg: null,
+			actor: "system",
+			pullRequestNumber,
+			labels: collectLabels(pr?.labels),
+			needsClassify: false,
+			...(deliveryId ? { deliveryId } : {}),
+		});
+	}
+	if (state !== "changes_requested" && state !== "commented") {
+		return { kind: "skip", reason: `review state "${state}" not actionable` };
+	}
+	const reviewId = readNumber(review?.id);
+	if (!reviewId) return { kind: "skip", reason: "submitted review missing review.id" };
+	const body = readString(review?.body) ?? "";
 	return dispatchFor(issueNumber, {
-		event: machineEvent,
-		arg: null,
-		actor: "system",
+		event: "revise",
+		arg: body,
+		actor,
+		pullRequestNumber,
+		reviewId,
 		labels: collectLabels(pr?.labels),
 		needsClassify: false,
+		triggeringComment: { body, authorLogin, authorAssociation, actor },
 		...(deliveryId ? { deliveryId } : {}),
 	});
 }
@@ -487,7 +511,9 @@ function normalizePullRequestReviewComment(
 	const labels = collectLabels(pr?.labels);
 	const triggeringComment = {
 		id: readNumber(comment?.id) ?? null,
-		body,
+		body: [readString(comment?.path), readString(comment?.diff_hunk), body]
+			.filter(Boolean)
+			.join("\n\n"),
 		authorLogin: senderLogin,
 		authorAssociation,
 		actor,
@@ -501,6 +527,7 @@ function normalizePullRequestReviewComment(
 			actor,
 			labels,
 			needsClassify: false,
+			pullRequestNumber: readNumber(pr?.number),
 			triggeringComment,
 			...(deliveryId ? { deliveryId } : {}),
 		});
@@ -512,6 +539,7 @@ function normalizePullRequestReviewComment(
 			actor,
 			labels,
 			needsClassify: false,
+			pullRequestNumber: readNumber(pr?.number),
 			triggeringComment,
 			...(deliveryId ? { deliveryId } : {}),
 		});
@@ -522,6 +550,7 @@ function normalizePullRequestReviewComment(
 		actor,
 		labels,
 		needsClassify: false,
+		pullRequestNumber: readNumber(pr?.number),
 		triggeringComment,
 		...(deliveryId ? { deliveryId } : {}),
 	});

--- a/infra/emdash-bot/.flue/routes.ts
+++ b/infra/emdash-bot/.flue/routes.ts
@@ -9,6 +9,7 @@ import dashboardHtml from "./dashboard.html?raw";
 import { getDashboardPayload } from "./lib/dashboard.js";
 import {
 	getPullRequestHeadBranch,
+	getPullRequestReviewComments,
 	mintInstallationToken,
 	readAppCreds,
 	readRepoContext,
@@ -127,6 +128,43 @@ export function registerCoreRoutes(app: Hono<{ Bindings: Env }>): Hono<{ Binding
 				return c.text("pull request lookup failed", 503);
 			}
 		}
+		if (result.kind === "dispatch" && result.event.reviewId && result.event.pullRequestNumber) {
+			const creds = readAppCreds(c.env);
+			const repo = readRepoContext(c.env);
+			if (!creds || !repo) return c.text("GitHub integration not configured", 503);
+			try {
+				const signal = AbortSignal.timeout(WEBHOOK_GITHUB_LOOKUP_TIMEOUT_MS);
+				const token = await mintInstallationToken(creds, signal);
+				const comments = await getPullRequestReviewComments(
+					token,
+					repo,
+					result.event.pullRequestNumber,
+					result.event.reviewId,
+					signal,
+				);
+				const body = [result.event.triggeringComment?.body.trim(), ...comments]
+					.filter(Boolean)
+					.join("\n\n");
+				if (!body) return c.text("skipped: review has no feedback", 202);
+				result = {
+					...result,
+					event: {
+						...result.event,
+						arg: body,
+						...(result.event.triggeringComment
+							? { triggeringComment: { ...result.event.triggeringComment, body } }
+							: {}),
+					},
+				};
+			} catch (error) {
+				console.error("[webhook] review comments lookup failed", {
+					delivery: deliveryId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				return c.text("review comments lookup failed", 503);
+			}
+		}
+
 		if (result.kind === "skip") {
 			console.log("[webhook] skip", {
 				event: eventType,

--- a/infra/emdash-bot/BOT_STATE_MACHINE.md
+++ b/infra/emdash-bot/BOT_STATE_MACHINE.md
@@ -69,6 +69,7 @@ Entry state: `unmanaged`. Kinds: `bug`, `enhancement`, `task`.
 | `agent.by_design` | agent result | system | — | Agent verified the behaviour as intended. |
 | `agent.reproduced` | agent result | system | — | Reproduced, but the fix needs a human decision. |
 | `agent.diagnosed` | agent result | system | — | Root cause identified without a confirming reproduction. |
+| `agent.revised` | agent result | system | — | Review feedback is addressed and the PR branch is updated. |
 | `agent.fix_ready` | agent result | system | — | A candidate change is published on bot/fix-<n>. |
 | `agent.needs_info` | agent result | system | — | Investigation is blocked on information only the reporter can supply. |
 | `agent.failed` | agent result | system | — | Agent run errored or produced no usable result. |
@@ -100,6 +101,7 @@ Entry state: `unmanaged`. Kinds: `bug`, `enhancement`, `task`.
 | `working` | `agent.diagnosed` | `diagnosed` | — |
 | `working` | `agent.needs_info` | `needs_info` | — |
 | `working` | `agent.fix_ready` | `awaiting_feedback` | — |
+| `working` | `agent.revised` | `in_review` | — |
 | `working` | `agent.failed` | `failed` | — |
 | `blocked` | `fix` | `fixing` | `investigate.implement` |
 | `blocked` | `implement` | `fixing` | `investigate.implement` |
@@ -111,6 +113,8 @@ Entry state: `unmanaged`. Kinds: `bug`, `enhancement`, `task`.
 | `awaiting_feedback` | `reject` | `working` | `investigate.revise` |
 | `awaiting_feedback` | `retry` | `working` | `investigate.repro` |
 | `awaiting_feedback` | `take_over` | `human_owned` | — |
+| `failed` | `revise` | `working` | `investigate.revise` |
+| `awaiting_feedback` | `revise` | `working` | `investigate.revise` |
 | `in_review` | `pr.opened` | `in_review` | — |
 | `in_review` | `pr.approved` | `in_review` | — |
 | `in_review` | `pr.changes_requested` | `in_review` | — |
@@ -207,6 +211,7 @@ stateDiagram-v2
     working --> diagnosed: agent.diagnosed
     working --> needs_info: agent.needs_info
     working --> awaiting_feedback: agent.fix_ready
+    working --> in_review: agent.revised
     working --> failed: agent.failed
     blocked --> fixing: fix / investigate.implement
     blocked --> fixing: implement / investigate.implement
@@ -218,6 +223,8 @@ stateDiagram-v2
     awaiting_feedback --> working: reject / investigate.revise
     awaiting_feedback --> working: retry / investigate.repro
     awaiting_feedback --> human_owned: take_over
+    failed --> working: revise / investigate.revise
+    awaiting_feedback --> working: revise / investigate.revise
     in_review --> in_review: pr.opened
     in_review --> in_review: pr.approved
     in_review --> in_review: pr.changes_requested

--- a/infra/emdash-bot/BOT_STATE_MACHINE.md
+++ b/infra/emdash-bot/BOT_STATE_MACHINE.md
@@ -29,12 +29,12 @@ Entry state: `unmanaged`. Kinds: `bug`, `enhancement`, `task`.
 | `triage` | `intake` | `bot:triage` | Triage | no | no | `investigate`, `repro`, `fix`, `implement`, `decline` |
 | `working` | `evidence` | `bot:working` | Working | no | yes | `status` |
 | `blocked` | `candidate` | `bot:blocked` | Blocked | no | no | `investigate`, `fix`, `implement`, `repro`, `retry`, `decline`, `take_over` |
-| `awaiting_feedback` | `confirmation` | `bot:awaiting-feedback` | Awaiting feedback | no | no | `confirm`, `reject`, `retry`, `take_over` |
+| `awaiting_feedback` | `confirmation` | `bot:awaiting-feedback` | Awaiting feedback | no | no | `confirm`, `reject`, `retry`, `revise`, `take_over` |
 | `in_review` | `review` | `bot:in-review` | In review | no | no | `revise`, `decline`, `take_over` |
 | `human_owned` | `review` | `bot:human-owned` | Human owned | no | no | `hand_back` |
 | `done` | `complete` | `bot:done` | Done | yes | no | `reopen` |
 | `declined` | `complete` | `bot:declined` | Declined | yes | no | `reopen` |
-| `failed` | `candidate` | `bot:failed` | Failed | no | no | `resume`, `retry`, `implement`, `repro`, `investigate`, `decline` |
+| `failed` | `candidate` | `bot:failed` | Failed | no | no | `resume`, `retry`, `implement`, `repro`, `investigate`, `revise`, `decline` |
 | `investigating` | `evidence` | `bot:investigating` | Investigating | no | yes | `status` |
 | `reproduced` | `verdict` | `bot:reproduced` | Reproduced | no | no | `fix`, `implement`, `investigate`, `decline`, `take_over` |
 | `diagnosed` | `verdict` | `bot:diagnosed` | Diagnosed | no | no | `fix`, `implement`, `investigate`, `decline`, `take_over` |
@@ -76,7 +76,6 @@ Entry state: `unmanaged`. Kinds: `bug`, `enhancement`, `task`.
 | `pr.opened` | pr lifecycle | system | — | A bot PR was opened for this item. |
 | `pr.merged` | pr lifecycle | system | — | The bot PR was merged. |
 | `pr.closed` | pr lifecycle | system | — | The bot PR was closed without merging. |
-| `pr.changes_requested` | pr lifecycle | system | — | A reviewer requested changes (review sub-state). |
 | `pr.approved` | pr lifecycle | system | — | A reviewer approved the PR (review sub-state). |
 | `preview.ready` | preview | system | — | The preview deploy for the candidate change is live; link ready to post. |
 | `preview.failed` | preview | system | — | The preview deploy failed to build. |
@@ -117,7 +116,6 @@ Entry state: `unmanaged`. Kinds: `bug`, `enhancement`, `task`.
 | `awaiting_feedback` | `revise` | `working` | `investigate.revise` |
 | `in_review` | `pr.opened` | `in_review` | — |
 | `in_review` | `pr.approved` | `in_review` | — |
-| `in_review` | `pr.changes_requested` | `in_review` | — |
 | `in_review` | `revise` | `working` | `investigate.revise` |
 | `in_review` | `pr.merged` | `done` | — |
 | `working` | `pr.merged` | `done` | — |
@@ -227,7 +225,6 @@ stateDiagram-v2
     awaiting_feedback --> working: revise / investigate.revise
     in_review --> in_review: pr.opened
     in_review --> in_review: pr.approved
-    in_review --> in_review: pr.changes_requested
     in_review --> working: revise / investigate.revise
     in_review --> done: pr.merged
     working --> done: pr.merged

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -65,6 +65,144 @@ describe("OrchestratorDO (workers-pool)", () => {
 		vi.unstubAllGlobals();
 	});
 
+	test("review revisions publish progress and completion on the PR and remain reviewable", async () => {
+		const requests: Array<{ method: string; url: string; body: string }> = [];
+		testEnv.GITHUB_APP_PRIVATE_KEY = "test-key-present";
+		vi.stubGlobal("fetch", (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			const method = init?.method ?? "GET";
+			requests.push({ method, url, body: typeof init?.body === "string" ? init.body : "" });
+			return Promise.resolve(
+				new Response(
+					JSON.stringify(method === "POST" && url.endsWith("/comments") ? { id: 776 } : {}),
+					{ status: 200 },
+				),
+			);
+		});
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugSetTokenCache("cached-token", Date.now() + 60 * 60 * 1000);
+		await runInDurableObject(stub, async (_instance, state) => {
+			await state.storage.put({
+				"o:anchorNumber": 42,
+				"o:prNumber": 99,
+				"o:state": "working",
+				"o:kind": "bug",
+			});
+		});
+		await stub.debugSetStaleRun("review-run", Date.now(), "investigate-review", "revise");
+		await stub.prepareWorkPlanComment({ runId: "review-run", summary: "Address adapter review" });
+		await stub.updateWorkPlan({
+			runId: "review-run",
+			summary: "Address adapter review",
+			steps: [{ id: "fix", title: "Test and fix the adapter", status: "completed" }],
+		});
+		await stub.applyAgentResult({
+			runId: "review-run",
+			result: { fixed: true, summary: "Covered the adapter case." },
+			pushed: true,
+			ok: true,
+		});
+		const posts = requests.filter(
+			(request) => request.method === "POST" && request.url.endsWith("/comments"),
+		);
+		expect(posts).toHaveLength(1);
+		expect(posts[0]?.url).toContain("/issues/99/comments");
+		expect(posts[0]?.body).toContain("Preparing workspace");
+		expect(requests.findLast((request) => request.method === "PATCH")?.body).toContain(
+			"Covered the adapter case.",
+		);
+		expect((await stub.getPersistedState()).state).toBe("in_review");
+	});
+
+	test("queues review feedback during a revision while allowing a PR close through", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await runInDurableObject(stub, async (_instance, state) => {
+			await state.storage.put({
+				"o:anchorNumber": 42,
+				"o:prNumber": 99,
+				"o:state": "working",
+				"o:kind": "bug",
+			});
+		});
+		await stub.debugSetStaleRun("review-run", Date.now(), "investigate-review", "revise");
+		await stub.enqueue(
+			makeEvent({
+				event: "revise",
+				arg: "Also cover null",
+				anchorNumber: 42,
+				pullRequestNumber: 99,
+				deliveryId: "another-review",
+			}),
+		);
+		await stub.tick();
+		expect(await stub.getInboxDepth()).toBe(1);
+		await stub.enqueue(
+			makeEvent({
+				event: "pr.closed",
+				arg: null,
+				actor: "system",
+				anchorNumber: 42,
+				deliveryId: "closed-pr",
+			}),
+		);
+		await stub.tick();
+		expect((await stub.getPersistedState()).state).toBe("blocked");
+	});
+
+	test.each([true, false])(
+		"processes queued feedback after the revision settles (success=%s)",
+		async (ok) => {
+			const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+			await runInDurableObject(stub, async (_instance, state) => {
+				await state.storage.put({
+					"o:anchorNumber": 42,
+					"o:prNumber": 99,
+					"o:state": "working",
+					"o:kind": "bug",
+				});
+			});
+			await stub.debugSetStaleRun("review-run", Date.now(), "investigate-review", "revise");
+			await stub.enqueue(
+				makeEvent({
+					event: "revise",
+					arg: "Also cover null",
+					anchorNumber: 42,
+					pullRequestNumber: 99,
+					deliveryId: "another-review",
+				}),
+			);
+			await stub.tick();
+			expect(await stub.getInboxDepth()).toBe(1);
+			await stub.applyAgentResult({
+				runId: "review-run",
+				result: { fixed: ok, summary: "Review outcome" },
+				pushed: ok,
+				ok,
+			});
+			await stub.tick();
+			expect(await stub.getInboxDepth()).toBe(0);
+			expect((await stub.getPersistedState()).state).toBe("working");
+			expect(
+				await stub.enqueue(makeEvent({ event: "revise", deliveryId: "another-review" })),
+			).toMatchObject({ kind: "duplicate" });
+		},
+	);
+
+	test("a revision before a PR exists still asks for reporter confirmation", async () => {
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await runInDurableObject(stub, async (_instance, state) => {
+			await state.storage.put({ "o:anchorNumber": 42, "o:state": "working", "o:kind": "bug" });
+		});
+		await stub.debugSetStaleRun("review-run", Date.now(), "investigate-review", "revise");
+		await stub.applyAgentResult({
+			runId: "review-run",
+			result: { fixed: true },
+			pushed: true,
+			ok: true,
+		});
+		expect((await stub.getPersistedState()).state).toBe("awaiting_feedback");
+	});
+
 	test("fresh instance starts with no persisted state", async () => {
 		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
 		const state = await stub.getPersistedState();

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -114,40 +114,55 @@ describe("OrchestratorDO (workers-pool)", () => {
 		expect((await stub.getPersistedState()).state).toBe("in_review");
 	});
 
-	test("queues review feedback during a revision while allowing a PR close through", async () => {
-		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
-		await runInDurableObject(stub, async (_instance, state) => {
-			await state.storage.put({
-				"o:anchorNumber": 42,
-				"o:prNumber": 99,
-				"o:state": "working",
-				"o:kind": "bug",
+	test.each([
+		["pr.closed", "blocked"],
+		["pr.merged", "done"],
+	] as const)(
+		"queues review feedback during a revision, then discards it when %s arrives",
+		async (event, expectedState) => {
+			const calls: string[] = [];
+			const comments: string[] = [];
+			testEnv.GITHUB_APP_PRIVATE_KEY = "test-key-present";
+			vi.stubGlobal("fetch", githubCallRecorder(calls, 201, comments));
+			const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+			await stub.debugSetTokenCache("cached-token", Date.now() + 60 * 60 * 1000);
+			await runInDurableObject(stub, async (_instance, state) => {
+				await state.storage.put({
+					"o:anchorNumber": 42,
+					"o:prNumber": 99,
+					"o:state": "working",
+					"o:kind": "bug",
+				});
 			});
-		});
-		await stub.debugSetStaleRun("review-run", Date.now(), "investigate-review", "revise");
-		await stub.enqueue(
-			makeEvent({
-				event: "revise",
-				arg: "Also cover null",
-				anchorNumber: 42,
-				pullRequestNumber: 99,
-				deliveryId: "another-review",
-			}),
-		);
-		await stub.tick();
-		expect(await stub.getInboxDepth()).toBe(1);
-		await stub.enqueue(
-			makeEvent({
-				event: "pr.closed",
-				arg: null,
-				actor: "system",
-				anchorNumber: 42,
-				deliveryId: "closed-pr",
-			}),
-		);
-		await stub.tick();
-		expect((await stub.getPersistedState()).state).toBe("blocked");
-	});
+			await stub.debugSetStaleRun("review-run", Date.now(), "investigate-review", "revise");
+			await stub.enqueue(
+				makeEvent({
+					event: "revise",
+					arg: "Also cover null",
+					anchorNumber: 42,
+					pullRequestNumber: 99,
+					deliveryId: "another-review",
+					dryRun: false,
+				}),
+			);
+			await stub.tick();
+			expect(await stub.getInboxDepth()).toBe(1);
+			await stub.enqueue(
+				makeEvent({
+					event,
+					arg: null,
+					actor: "system",
+					anchorNumber: 42,
+					deliveryId: "closed-pr",
+					dryRun: false,
+				}),
+			);
+			await stub.tick();
+			expect((await stub.getPersistedState()).state).toBe(expectedState);
+			expect(await stub.getInboxDepth()).toBe(0);
+			expect(comments.some((comment) => comment.includes("isn't available"))).toBe(false);
+		},
+	);
 
 	test.each([true, false])(
 		"processes queued feedback after the revision settles (success=%s)",

--- a/infra/emdash-bot/tests/integration/webhook.test.ts
+++ b/infra/emdash-bot/tests/integration/webhook.test.ts
@@ -6,6 +6,7 @@
 // pool provides via wrangler.test.jsonc / vitest.workers.config.ts. We use
 // the same secret to sign synthetic payloads.
 
+import { runInDurableObject } from "cloudflare:test";
 import { env, exports } from "cloudflare:workers";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
@@ -294,6 +295,133 @@ describe("POST /webhook/github (workers-pool)", () => {
 		expect(res.status).toBe(202);
 		expect(await res.text()).toMatch(/skipped/);
 	});
+
+	test("submitted review batches its body and inline comments before admission", async () => {
+		const issueNumber = uniqueIssueNumber();
+		const pullRequestNumber = uniqueIssueNumber();
+		testEnv.GITHUB_APP_PRIVATE_KEY = await generatedPrivateKeyPem();
+		vi.stubGlobal("fetch", (input: Parameters<typeof fetch>[0]) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			return Promise.resolve(
+				new Response(
+					JSON.stringify(
+						url.includes("/access_tokens")
+							? { token: "installation-token" }
+							: [
+									{
+										body: "Handle null too",
+										path: "src/adapter.ts",
+										line: 42,
+										diff_hunk: "@@ -1 +1 @@\n+read()",
+									},
+								],
+					),
+					{ status: 200 },
+				),
+			);
+		});
+		const request = {
+			eventType: "pull_request_review",
+			delivery: `review-${issueNumber}`,
+			payload: {
+				action: "submitted",
+				pull_request: {
+					number: pullRequestNumber,
+					user: { login: "emdashbot[bot]" },
+					head: { ref: `bot/fix-${issueNumber}` },
+				},
+				review: {
+					id: 77,
+					state: "changes_requested",
+					body: "Cover the adapter case",
+					author_association: "MEMBER",
+					user: { login: "alice" },
+				},
+			},
+		};
+		const stub = testEnv.Orchestrator.getByName(`issue-${issueNumber}`);
+		await runInDurableObject(stub, async (_instance, state) => {
+			await state.storage.put({
+				"o:anchorNumber": issueNumber,
+				"o:prNumber": pullRequestNumber,
+				"o:state": "working",
+				"o:kind": "bug",
+			});
+		});
+		await stub.debugSetStaleRun("active-review", Date.now(), "investigate-review", "revise");
+		const admitted = await postWebhook(request);
+		expect(admitted.status).toBe(202);
+		expect(await admitted.json()).toMatchObject({ admission: { kind: "admitted" } });
+		expect(await (await postWebhook(request)).json()).toMatchObject({
+			admission: { kind: "duplicate" },
+		});
+		expect(await stub.getInboxDepth()).toBe(1);
+		await runInDurableObject(stub, async (_instance, state) => {
+			const inbox =
+				await state.storage.get<
+					Array<{ input: { arg: string; triggeringComment: { body: string; actor: string } } }>
+				>("o:inbox");
+			expect(inbox?.[0]?.input.arg).toContain("Cover the adapter case");
+			expect(inbox?.[0]?.input.triggeringComment.body).toContain("src/adapter.ts:42");
+			expect(inbox?.[0]?.input.triggeringComment.body).toContain("Handle null too");
+			expect(inbox?.[0]?.input.triggeringComment.body).toContain("+read()");
+			expect(inbox?.[0]?.input.triggeringComment.actor).toBe("maintainer");
+		});
+	});
+
+	test.each([200, 503])(
+		"empty or unavailable review comments do not start partial work (%s)",
+		async (status) => {
+			const issueNumber = uniqueIssueNumber();
+			testEnv.GITHUB_APP_PRIVATE_KEY = await generatedPrivateKeyPem();
+			vi.stubGlobal("fetch", (input: Parameters<typeof fetch>[0]) =>
+				Promise.resolve(
+					new Response(
+						JSON.stringify(
+							(typeof input === "string"
+								? input
+								: input instanceof URL
+									? input.href
+									: input.url
+							).includes("/access_tokens")
+								? { token: "installation-token" }
+								: [],
+						),
+						{
+							status: (typeof input === "string"
+								? input
+								: input instanceof URL
+									? input.href
+									: input.url
+							).includes("/access_tokens")
+								? 200
+								: status,
+						},
+					),
+				),
+			);
+			const res = await postWebhook({
+				eventType: "pull_request_review",
+				payload: {
+					action: "submitted",
+					pull_request: {
+						number: 99,
+						user: { login: "emdashbot[bot]" },
+						head: { ref: `bot/fix-${issueNumber}` },
+					},
+					review: {
+						id: 77,
+						state: "commented",
+						body: "",
+						author_association: "MEMBER",
+						user: { login: "alice" },
+					},
+				},
+			});
+			expect(res.status).toBe(status === 200 ? 202 : 503);
+			expect(await testEnv.Orchestrator.getByName(`issue-${issueNumber}`).getInboxDepth()).toBe(0);
+		},
+	);
 
 	test("top-level bot PR feedback resolves its head branch before durable admission", async () => {
 		const issueNumber = uniqueIssueNumber();

--- a/infra/emdash-bot/tests/unit/github.test.ts
+++ b/infra/emdash-bot/tests/unit/github.test.ts
@@ -4,6 +4,7 @@ import {
 	createIssueComment,
 	findIssueCommentByMarker,
 	getIssueComments,
+	getPullRequestReviewComments,
 	getPullRequestHeadBranch,
 	listOpenManagedIssues,
 	updateIssueComment,
@@ -216,5 +217,37 @@ describe("GitHub dashboard requests", () => {
 			expect.stringContaining("labels=bot%3Aenhancement"),
 			expect.stringContaining("labels=bot%3Atask"),
 		]);
+	});
+});
+
+describe("GitHub submitted review comments", () => {
+	afterEach(() => vi.unstubAllGlobals());
+	test("collects every page with inline location and diff context", async () => {
+		const comment = {
+			body: "Check the empty case",
+			path: "src/adapter.ts",
+			line: 42,
+			diff_hunk: "@@ -1 +1 @@\n+read()",
+		};
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(jsonResponse(Array.from({ length: 100 }, () => ({ ...comment }))))
+			.mockResolvedValueOnce(
+				jsonResponse([{ ...comment, body: "Also test null", line: null, original_line: 12 }]),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+		const comments = await getPullRequestReviewComments("token", repo, 99, 77);
+		expect(comments).toHaveLength(101);
+		expect(comments[0]).toContain("src/adapter.ts:42");
+		expect(comments[0]).toContain("+read()");
+		expect(comments[100]).toContain("src/adapter.ts:12");
+		expect(comments[100]).toContain("Also test null");
+		expect(fetchMock.mock.calls[1]?.[0]).toContain(
+			"pulls/99/reviews/77/comments?per_page=100&page=2",
+		);
+	});
+	test("fails rather than omitting unavailable review comments", async () => {
+		vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(jsonResponse({}, 403)));
+		await expect(getPullRequestReviewComments("token", repo, 99, 77)).rejects.toThrow("403");
 	});
 });

--- a/infra/emdash-bot/tests/unit/webhook.test.ts
+++ b/infra/emdash-bot/tests/unit/webhook.test.ts
@@ -349,10 +349,11 @@ describe("normalizeWebhook", () => {
 			expect(r.event.actor).toBe("system");
 		});
 
-		test("changes_requested → pr.changes_requested", () => {
+		test("changes_requested starts a revision", () => {
 			const payload: PullRequestReviewEvent = {
 				action: "submitted",
 				review: {
+					id: 77,
 					state: "changes_requested",
 					author_association: "MEMBER",
 					user: { login: "alice" },
@@ -367,7 +368,7 @@ describe("normalizeWebhook", () => {
 			const r = normalizeWebhook({ eventType: "pull_request_review", payload });
 			expect(r.kind).toBe("dispatch");
 			if (r.kind !== "dispatch") return;
-			expect(r.event.event).toBe("pr.changes_requested");
+			expect(r.event.event).toBe("revise");
 		});
 
 		test("commented (no approval signal) is skipped", () => {
@@ -441,7 +442,7 @@ describe("bot pull request anchoring", () => {
 			payload: {
 				action: "submitted",
 				pull_request: pullRequest,
-				review: { state: "approved", user: { login: "alice" } },
+				review: { state: "approved", author_association: "MEMBER", user: { login: "alice" } },
 			},
 		});
 
@@ -533,5 +534,108 @@ describe("bot pull request anchoring", () => {
 		});
 
 		expect(result.kind).toBe("skip");
+	});
+});
+
+describe("maintainer review revisions", () => {
+	const pullRequest = {
+		number: 99,
+		user: { login: "emdashbot[bot]" },
+		head: { ref: "bot/fix-42" },
+	};
+	test.each(["changes_requested", "commented"])(
+		"%s carries the whole review without a mention",
+		(state) => {
+			const result = normalizeWebhook({
+				eventType: "pull_request_review",
+				deliveryId: "review-delivery",
+				payload: {
+					action: "submitted",
+					pull_request: pullRequest,
+					review: {
+						id: 77,
+						state,
+						body: "Cover the adapter case",
+						author_association: "MEMBER",
+						user: { login: "alice" },
+					},
+				},
+			});
+			expect(result).toMatchObject({
+				kind: "dispatch",
+				anchor: "issue-42",
+				event: {
+					event: "revise",
+					actor: "maintainer",
+					pullRequestNumber: 99,
+					reviewId: 77,
+					triggeringComment: {
+						body: "Cover the adapter case",
+						authorLogin: "alice",
+						actor: "maintainer",
+					},
+					deliveryId: "review-delivery",
+					needsClassify: false,
+				},
+			});
+		},
+	);
+	test.each(["NONE", "CONTRIBUTOR", undefined])(
+		"does not accept reviews from %s",
+		(association) => {
+			for (const state of ["approved", "changes_requested", "commented"]) {
+				expect(
+					normalizeWebhook({
+						eventType: "pull_request_review",
+						payload: {
+							action: "submitted",
+							pull_request: pullRequest,
+							review: {
+								id: 77,
+								state,
+								body: "change this",
+								author_association: association,
+								user: { login: "outsider" },
+							},
+						},
+					}).kind,
+				).toBe("skip");
+			}
+		},
+	);
+	test("an inline-only submitted review is collected as one revision", () => {
+		expect(
+			normalizeWebhook({
+				eventType: "pull_request_review",
+				payload: {
+					action: "submitted",
+					pull_request: pullRequest,
+					review: {
+						id: 77,
+						state: "commented",
+						body: "",
+						author_association: "OWNER",
+						user: { login: "alice" },
+					},
+				},
+			}),
+		).toMatchObject({ kind: "dispatch", event: { event: "revise", reviewId: 77 } });
+	});
+	test("bot reviews cannot trigger another run", () => {
+		expect(
+			normalizeWebhook({
+				eventType: "pull_request_review",
+				payload: {
+					action: "submitted",
+					pull_request: pullRequest,
+					review: {
+						id: 77,
+						state: "changes_requested",
+						author_association: "MEMBER",
+						user: { login: "reviewer[bot]" },
+					},
+				},
+			}).kind,
+		).toBe("skip");
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Implements a mechanism for handling maintainer reviews on bot-generated pull requests. This includes adding a new event for when review feedback is addressed and updating the state transitions accordingly.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Astra 6 / Codex

## Screenshots / test output

Not applicable

