### PR TITLE
fix(ui): restore playground stepper animation timings

### DIFF
--- a/.changeset/restore-playground-stepper-timing.md
+++ b/.changeset/restore-playground-stepper-timing.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/cloudflare": patch
+---
+
+Updates the Playground setup stepper to use slower completion transitions: 900 ms for checkmarks and color changes, 750 ms for connector fills, and a 300 ms handoff to the next step. Progress remains timer-based.

--- a/packages/cloudflare/src/db/playground-loading.ts
+++ b/packages/cloudflare/src/db/playground-loading.ts
@@ -156,8 +156,8 @@ export function renderPlaygroundLoadingPage(): string {
     stroke: var(--step-green-ring);
     stroke-dasharray: 100 0;
     transition:
-      stroke 400ms ease,
-      stroke-dasharray 400ms cubic-bezier(0.22, 1, 0.36, 1);
+      stroke 900ms ease,
+      stroke-dasharray 900ms cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   .pg-step.done .pg-ring-progress {
@@ -182,7 +182,7 @@ export function renderPlaygroundLoadingPage(): string {
 
   .pg-step.completing .pg-step-core {
     background: var(--step-green);
-    transition-duration: 400ms;
+    transition-duration: 900ms;
   }
 
   .pg-step.done .pg-step-core {
@@ -200,8 +200,8 @@ export function renderPlaygroundLoadingPage(): string {
     opacity: 0;
     transform: scale(0.35);
     transition:
-      opacity 400ms cubic-bezier(0.16, 1, 0.3, 1),
-      transform 400ms cubic-bezier(0.16, 1, 0.3, 1);
+      opacity 900ms cubic-bezier(0.16, 1, 0.3, 1),
+      transform 900ms cubic-bezier(0.16, 1, 0.3, 1);
   }
 
   .pg-step.completing .pg-check,
@@ -234,7 +234,7 @@ export function renderPlaygroundLoadingPage(): string {
 
   .pg-step.completing .pg-connector-fill {
     transform: scaleY(1);
-    transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    transition: transform 750ms cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   .pg-step.done .pg-connector-fill {
@@ -256,7 +256,7 @@ export function renderPlaygroundLoadingPage(): string {
   .pg-step.completing .pg-step-label,
   .pg-step.done .pg-step-label {
     color: var(--label-complete);
-    transition-duration: 400ms;
+    transition-duration: 900ms;
   }
 
   @keyframes pg-ring-spin {
@@ -382,8 +382,8 @@ export function renderPlaygroundLoadingPage(): string {
 (function() {
   var steps = ["step-db", "step-content", "step-ready"];
   var stepTimers = [];
-  var completionDuration = 400;
-  var nextStepDelay = 150;
+  var completionDuration = 900;
+  var nextStepDelay = 300;
 
   function setStepState(index, state) {
     var step = document.getElementById(steps[index]);

--- a/packages/cloudflare/tests/db/playground-loading.test.ts
+++ b/packages/cloudflare/tests/db/playground-loading.test.ts
@@ -40,7 +40,7 @@ describe("playground loading progress", () => {
 		expect(html).toContain('id="pg-error-message" role="alert"');
 	});
 
-	it("animates cosmetic setup stages without delaying a completed setup", async () => {
+	it.each([false, true])("animates cosmetic stages with slow setup: %s", async (slowSetup) => {
 		vi.useFakeTimers();
 		const elements = new Map(
 			[
@@ -81,8 +81,33 @@ describe("playground loading progress", () => {
 
 		await vi.advanceTimersByTimeAsync(800);
 		expect(elements.get("step-db")!.className).toBe("pg-step completing");
-		await vi.advanceTimersByTimeAsync(150);
+		await vi.advanceTimersByTimeAsync(299);
+		expect(elements.get("step-db")!.className).toBe("pg-step completing");
+		expect(elements.get("step-content")!.className).toBe("pg-step");
+		await vi.advanceTimersByTimeAsync(1);
 		expect(elements.get("step-content")!.className).toBe("pg-step active");
+
+		if (slowSetup) {
+			await vi.advanceTimersByTimeAsync(599);
+			expect(elements.get("step-db")!.className).toBe("pg-step completing");
+			await vi.advanceTimersByTimeAsync(1);
+			expect(elements.get("step-db")!.className).toBe("pg-step done");
+
+			await vi.advanceTimersByTimeAsync(300);
+			expect(elements.get("step-content")!.className).toBe("pg-step completing");
+			await vi.advanceTimersByTimeAsync(299);
+			expect(elements.get("step-ready")!.className).toBe("pg-step");
+			await vi.advanceTimersByTimeAsync(1);
+			expect(elements.get("step-ready")!.className).toBe("pg-step active");
+
+			await vi.advanceTimersByTimeAsync(599);
+			expect(elements.get("step-content")!.className).toBe("pg-step completing");
+			await vi.advanceTimersByTimeAsync(1);
+			expect(elements.get("step-content")!.className).toBe("pg-step done");
+			await vi.advanceTimersByTimeAsync(5_000);
+			expect(elements.get("step-ready")!.className).toBe("pg-step active");
+			expect(replace).not.toHaveBeenCalled();
+		}
 
 		resolveSetup(Response.json({ ok: true }));
 		await vi.advanceTimersByTimeAsync(0);
@@ -92,12 +117,17 @@ describe("playground loading progress", () => {
 		expect(elements.get("pg-message")!.textContent).toBe("Ready!");
 		expect(replace).not.toHaveBeenCalled();
 
-		await vi.advanceTimersByTimeAsync(399);
+		await vi.advanceTimersByTimeAsync(899);
 		expect(elements.get("step-ready")!.className).toBe("pg-step completing");
 		expect(replace).not.toHaveBeenCalled();
 
 		await vi.advanceTimersByTimeAsync(1);
 		expect(elements.get("step-ready")!.className).toBe("pg-step done");
 		expect(replace).toHaveBeenCalledWith("/_emdash/admin");
+
+		await vi.advanceTimersByTimeAsync(2_000);
+		expect(elements.get("step-content")!.className).toBe("pg-step done");
+		expect(elements.get("step-ready")!.className).toBe("pg-step done");
+		expect(replace).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/cloudflare/tests/db/playground-loading.test.ts
+++ b/packages/cloudflare/tests/db/playground-loading.test.ts
@@ -40,7 +40,7 @@ describe("playground loading progress", () => {
 		expect(html).toContain('id="pg-error-message" role="alert"');
 	});
 
-	it.each([false, true])("animates cosmetic stages with slow setup: %s", async (slowSetup) => {
+	it("animates cosmetic setup stages without delaying a completed setup", async () => {
 		vi.useFakeTimers();
 		const elements = new Map(
 			[
@@ -81,33 +81,8 @@ describe("playground loading progress", () => {
 
 		await vi.advanceTimersByTimeAsync(800);
 		expect(elements.get("step-db")!.className).toBe("pg-step completing");
-		await vi.advanceTimersByTimeAsync(299);
-		expect(elements.get("step-db")!.className).toBe("pg-step completing");
-		expect(elements.get("step-content")!.className).toBe("pg-step");
-		await vi.advanceTimersByTimeAsync(1);
+		await vi.advanceTimersByTimeAsync(300);
 		expect(elements.get("step-content")!.className).toBe("pg-step active");
-
-		if (slowSetup) {
-			await vi.advanceTimersByTimeAsync(599);
-			expect(elements.get("step-db")!.className).toBe("pg-step completing");
-			await vi.advanceTimersByTimeAsync(1);
-			expect(elements.get("step-db")!.className).toBe("pg-step done");
-
-			await vi.advanceTimersByTimeAsync(300);
-			expect(elements.get("step-content")!.className).toBe("pg-step completing");
-			await vi.advanceTimersByTimeAsync(299);
-			expect(elements.get("step-ready")!.className).toBe("pg-step");
-			await vi.advanceTimersByTimeAsync(1);
-			expect(elements.get("step-ready")!.className).toBe("pg-step active");
-
-			await vi.advanceTimersByTimeAsync(599);
-			expect(elements.get("step-content")!.className).toBe("pg-step completing");
-			await vi.advanceTimersByTimeAsync(1);
-			expect(elements.get("step-content")!.className).toBe("pg-step done");
-			await vi.advanceTimersByTimeAsync(5_000);
-			expect(elements.get("step-ready")!.className).toBe("pg-step active");
-			expect(replace).not.toHaveBeenCalled();
-		}
 
 		resolveSetup(Response.json({ ok: true }));
 		await vi.advanceTimersByTimeAsync(0);
@@ -124,10 +99,5 @@ describe("playground loading progress", () => {
 		await vi.advanceTimersByTimeAsync(1);
 		expect(elements.get("step-ready")!.className).toBe("pg-step done");
 		expect(replace).toHaveBeenCalledWith("/_emdash/admin");
-
-		await vi.advanceTimersByTimeAsync(2_000);
-		expect(elements.get("step-content")!.className).toBe("pg-step done");
-		expect(elements.get("step-ready")!.className).toBe("pg-step done");
-		expect(replace).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Restores the original Playground stepper animation timings from #2759, which were shortened when the setup flow was changed to UI-only progress.

- Restores completion animations from 400ms to 900ms
- Restores connector fills from 300ms to 750ms
- Restores the next-step handoff from 150ms to 300ms
- Keeps the existing easing curves and 800ms/2000ms cosmetic stage timers
- Keeps progress UI-only, with no streamed backend milestones
- Gives the final circle its full 900ms completion animation before redirecting to admin

Reduced-motion behavior is unchanged. No backend initialization changes are included.

Follow-up to #2759.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: gpt-5.6-sol

## Screenshots

| Before | After |
|--------|--------|
| <img width="654" height="635" alt="oldanimation" src="https://github.com/user-attachments/assets/c108555b-31b6-45d6-b353-aa0a1ce4e098" /> | <img width="654" height="635" alt="newanimation" src="https://github.com/user-attachments/assets/46a59ec0-f261-4142-b771-a4abba907add" /> |
