### PR TITLE
fix(core): handle Postgres pool failures

### DIFF
--- a/.changeset/safe-postgres-pools.md
+++ b/.changeset/safe-postgres-pools.md
@@ -1,0 +1,7 @@
+---
+"emdash": patch
+---
+
+Fixes PostgreSQL deployments crashing when an idle pooled connection fails. EmDash now logs the idle-client error without exposing connection credentials while node-postgres discards the failed client and keeps the pool available.
+
+The `postgres()` adapter's `pool` option also accepts `connectionTimeoutMillis` and `idleTimeoutMillis`. Set `connectionTimeoutMillis` to bound how long a request waits for a connection when PostgreSQL is unreachable. Both options remain unset by default, preserving node-postgres's existing timeout behavior.

--- a/docs/src/content/docs/deployment/database.mdx
+++ b/docs/src/content/docs/deployment/database.mdx
@@ -202,18 +202,22 @@ database: postgres({
 });
 ```
 
-| Option             | Type      | Description                          |
-| ------------------ | --------- | ------------------------------------ |
-| `connectionString` | `string`  | PostgreSQL connection URL            |
-| `host`             | `string`  | Database host                        |
-| `port`             | `number`  | Database port                        |
-| `database`         | `string`  | Database name                        |
-| `user`             | `string`  | Database user                        |
-| `password`         | `string`  | Database password                    |
-| `ssl`              | `boolean` | Enable SSL                           |
-| `pool.min`         | `number`  | Minimum pool connections (default 0) |
-| `pool.max`         | `number`  | Maximum pool connections (default 10)|
+| Option                         | Type      | Description                                          |
+| ------------------------------ | --------- | ---------------------------------------------------- |
+| `connectionString`             | `string`  | PostgreSQL connection URL                            |
+| `host`                         | `string`  | Database host                                        |
+| `port`                         | `number`  | Database port                                        |
+| `database`                     | `string`  | Database name                                        |
+| `user`                         | `string`  | Database user                                        |
+| `password`                     | `string`  | Database password                                    |
+| `ssl`                          | `boolean` | Enable SSL                                           |
+| `pool.min`                     | `number`  | Minimum pool connections (default 0)                 |
+| `pool.max`                     | `number`  | Maximum pool connections (default 10)                |
+| `pool.connectionTimeoutMillis` | `number`  | Maximum connection wait (pg default: 0, no timeout)  |
+| `pool.idleTimeoutMillis`       | `number`  | Idle-client lifetime (pg default: 10,000 ms)         |
 | `migrationConnectionStringEnv` | `string` | Migration connection-string variable name (default `DATABASE_URL`) |
+
+Set `pool.connectionTimeoutMillis` to a nonzero value to bound how long a request waits when PostgreSQL is unreachable or no pooled connection becomes available. Set `pool.idleTimeoutMillis` to `0` to keep idle clients open until the pool closes. Omitting either option preserves the pg default.
 
 ### Database role requirements
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -551,17 +551,19 @@ libsql({
 
 PostgreSQL database with connection pooling.
 
-| Option             | Type      | Description                          |
-| ------------------ | --------- | ------------------------------------ |
-| `connectionString` | `string`  | PostgreSQL connection URL            |
-| `host`             | `string`  | Database host                        |
-| `port`             | `number`  | Database port                        |
-| `database`         | `string`  | Database name                        |
-| `user`             | `string`  | Database user                        |
-| `password`         | `string`  | Database password                    |
-| `ssl`              | `boolean` | Enable SSL                           |
-| `pool.min`         | `number`  | Minimum pool size (default: 0)       |
-| `pool.max`         | `number`  | Maximum pool size (default: 10)      |
+| Option                         | Type      | Description                                          |
+| ------------------------------ | --------- | ---------------------------------------------------- |
+| `connectionString`             | `string`  | PostgreSQL connection URL                            |
+| `host`                         | `string`  | Database host                                        |
+| `port`                         | `number`  | Database port                                        |
+| `database`                     | `string`  | Database name                                        |
+| `user`                         | `string`  | Database user                                        |
+| `password`                     | `string`  | Database password                                    |
+| `ssl`                          | `boolean` | Enable SSL                                           |
+| `pool.min`                     | `number`  | Minimum pool size (default: 0)                       |
+| `pool.max`                     | `number`  | Maximum pool size (default: 10)                      |
+| `pool.connectionTimeoutMillis` | `number`  | Maximum connection wait (pg default: 0, no timeout)  |
+| `pool.idleTimeoutMillis`       | `number`  | Idle-client lifetime (pg default: 10,000 ms)         |
 | `migrationConnectionStringEnv` | `string` | Migration connection-string variable name (default `DATABASE_URL`) |
 
 The following example connects with a connection string:

--- a/packages/core/src/db/adapters.ts
+++ b/packages/core/src/db/adapters.ts
@@ -199,7 +199,14 @@ export interface PostgresConfig {
 	user?: string;
 	password?: string;
 	ssl?: boolean;
-	pool?: { min?: number; max?: number };
+	pool?: {
+		min?: number;
+		max?: number;
+		/** Maximum time to wait for a connection, in milliseconds. Uses the pg default when omitted. */
+		connectionTimeoutMillis?: number;
+		/** Time before an idle client is closed, in milliseconds. Uses the pg default when omitted. */
+		idleTimeoutMillis?: number;
+	};
 	migrationConnectionStringEnv?: string;
 }
 

--- a/packages/core/src/db/postgres.ts
+++ b/packages/core/src/db/postgres.ts
@@ -11,6 +11,26 @@ import { Pool } from "pg";
 import { FailFastPostgresDialect } from "../database/pg-migration-lock.js";
 import type { PostgresConfig } from "./adapters.js";
 
+const URL_PATTERN = /[A-Za-z][A-Za-z0-9+.-]*:\/\/\S+/g;
+const CREDENTIAL_PATTERN = /\b(auth|credential|key|password|secret|signature|token)\s*[=:]\s*\S+/gi;
+const ERROR_CODE_PATTERN = /^[A-Za-z0-9_-]{1,32}$/;
+
+function redactPoolErrorMessage(message: string): string {
+	return message
+		.replace(URL_PATTERN, "[REDACTED_URL]")
+		.replace(CREDENTIAL_PATTERN, "$1=[REDACTED]")
+		.replaceAll(/[\r\n\t]/g, " ")
+		.slice(0, 1_000);
+}
+
+function logPoolError(error: Error): void {
+	// pg attaches the failed client to this error, which can contain connection credentials.
+	const code = "code" in error && typeof error.code === "string" ? error.code : undefined;
+	const safeCode = code && ERROR_CODE_PATTERN.test(code) ? ` (${code})` : "";
+	const message = redactPoolErrorMessage(error.message) || "Unknown error";
+	console.error(`[emdash] PostgreSQL idle client error${safeCode}: ${message}`);
+}
+
 /**
  * Create a PostgreSQL dialect from config
  */
@@ -25,7 +45,10 @@ export function createDialect(config: PostgresConfig): PostgresDialect {
 		ssl: config.ssl,
 		min: config.pool?.min ?? 0,
 		max: config.pool?.max ?? 10,
+		connectionTimeoutMillis: config.pool?.connectionTimeoutMillis,
+		idleTimeoutMillis: config.pool?.idleTimeoutMillis,
 	});
+	pool.on("error", logPoolError);
 
 	// Fail-fast migration locking instead of Kysely's blocking advisory
 	// lock — see pg-migration-lock.ts (#1744).

--- a/packages/core/tests/unit/db/postgres-pool.test.ts
+++ b/packages/core/tests/unit/db/postgres-pool.test.ts
@@ -1,0 +1,91 @@
+import { inspect } from "node:util";
+
+import type { Driver } from "kysely";
+import { Pool } from "pg";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { PostgresConfig } from "../../../src/db/adapters.js";
+import { createDialect } from "../../../src/db/postgres.js";
+
+const drivers: Driver[] = [];
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.all(drivers.splice(0).map((driver) => driver.destroy()));
+});
+
+async function capturePool(config: PostgresConfig): Promise<Pool> {
+	const pools: Pool[] = [];
+	const captured = new Error("pool captured");
+	const connect = vi.spyOn(Pool.prototype, "connect").mockImplementation(function (this: Pool) {
+		pools.push(this);
+		return Promise.reject(captured);
+	});
+	const driver = createDialect(config).createDriver();
+	drivers.push(driver);
+	await driver.init();
+
+	try {
+		await expect(driver.acquireConnection()).rejects.toBe(captured);
+	} finally {
+		connect.mockRestore();
+	}
+
+	const pool = pools[0];
+	if (!pool) throw new Error("createDialect did not create a pg.Pool");
+	return pool;
+}
+
+describe("PostgreSQL pool configuration", () => {
+	it("applies configured connection and idle timeouts to pg.Pool", async () => {
+		const pool = await capturePool({
+			connectionString: "postgres://localhost/emdash",
+			pool: {
+				connectionTimeoutMillis: 2_500,
+				idleTimeoutMillis: 30_000,
+			},
+		});
+
+		expect(pool.options.connectionTimeoutMillis).toBe(2_500);
+		expect(pool.options.idleTimeoutMillis).toBe(30_000);
+	});
+
+	it("preserves pg.Pool timeout defaults when options are omitted", async () => {
+		const defaults = new Pool();
+		const pool = await capturePool({ connectionString: "postgres://localhost/emdash" });
+
+		try {
+			expect(pool.options.connectionTimeoutMillis).toBe(defaults.options.connectionTimeoutMillis);
+			expect(pool.options.idleTimeoutMillis).toBe(defaults.options.idleTimeoutMillis);
+		} finally {
+			await defaults.end();
+		}
+	});
+});
+
+describe("PostgreSQL idle-client errors", () => {
+	it("handles the pool error without exposing the failed client's credentials", async () => {
+		const pool = await capturePool({ connectionString: "postgres://localhost/emdash" });
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+		const password = "idle-client-password";
+		const client = {
+			connectionParameters: {
+				connectionString: `postgres://emdash:${password}@db.example.com/site`,
+				password,
+			},
+		};
+		const error = Object.assign(
+			new Error(
+				`connection reset by peer for postgres://emdash:${password}@db.example.com/site password=${password}`,
+			),
+			{ client, code: "ECONNRESET" },
+		);
+
+		expect(() => pool.emit("error", error, client)).not.toThrow();
+
+		const output = inspect(consoleError.mock.calls, { depth: 10 });
+		expect(output).toContain("ECONNRESET");
+		expect(output).toContain("connection reset by peer");
+		expect(output).not.toContain(password);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Handles node-postgres errors from idle pooled clients so a managed-database failover does not become an unhandled `EventEmitter` error that can terminate the Node.js process. The handler records a bounded, credential-redacted diagnostic and leaves node-postgres responsible for discarding the failed client.

Adds `pool.connectionTimeoutMillis` and `pool.idleTimeoutMillis` to the `postgres()` adapter. Configured values reach `pg.Pool`; omitting them preserves node-postgres's defaults. The changeset and PostgreSQL configuration docs describe the new options and compatibility behavior.

Closes #2752

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Not applicable: this change adds no admin UI strings.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: Not applicable; this is a bug fix.
- [ ] I have included screenshots below if this PR changes the UI. Not applicable: this change has no UI.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Screenshots are not applicable because this change has no UI.

Validation:

- `pnpm --filter emdash build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm --filter emdash test --run tests/unit/db tests/unit/migrations tests/unit/database/pg-migration-lock.test.ts` — 11 files, 79 tests passed
- `pnpm --dir docs build`
