### PR TITLE
fix(core): prevent object cache initialization hangs

### DIFF
--- a/.changeset/object-cache-init-timeout.md
+++ b/.changeset/object-cache-init-timeout.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes Cloudflare Workers requests hanging indefinitely after another request is cancelled while the object cache backend is loading. A timed-out request now bypasses the cache and loads the requested data directly, while later requests can initialize the cache again.

--- a/packages/core/src/object-cache/index.ts
+++ b/packages/core/src/object-cache/index.ts
@@ -46,6 +46,8 @@ interface BackendHolder {
 	backend: ObjectCacheBackend | null;
 	/** In-flight initialization promise (dedupes concurrent first calls). */
 	initPromise: Promise<ObjectCacheBackend | null> | null;
+	/** `Date.now()` when the in-flight initialization started. */
+	initPromiseAt?: number;
 	config: Required<Pick<ObjectCacheRuntimeConfig, "keyPrefix">> & {
 		defaultTtl: number;
 		revalidate: number;
@@ -124,6 +126,18 @@ function raceInFlightEpochRead(
 	let timer: ReturnType<typeof setTimeout>;
 	const timeout = new Promise<number>((resolve) => {
 		timer = setTimeout(resolve, Math.max(ms, 1), fallback);
+	});
+	return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/** Bound a waiter on another request's backend initialization. */
+function raceInFlightBackendInit(
+	promise: Promise<ObjectCacheBackend | null>,
+	ms: number,
+): Promise<ObjectCacheBackend | null> {
+	let timer: ReturnType<typeof setTimeout>;
+	const timeout = new Promise<ObjectCacheBackend | null>((resolve) => {
+		timer = setTimeout(resolve, Math.max(ms, 1), null);
 	});
 	return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
@@ -215,8 +229,15 @@ const contentWritePersist: { pending: boolean } =
  */
 async function getBackend(): Promise<ObjectCacheBackend | null> {
 	if (holder.initialized) return holder.backend;
-	if (holder.initPromise) return holder.initPromise;
+	if (holder.initPromise) {
+		const age = Date.now() - (holder.initPromiseAt ?? 0);
+		const deadline = epochReadDeadline();
+		if (age < deadline) {
+			return raceInFlightBackendInit(holder.initPromise, deadline - age);
+		}
+	}
 
+	holder.initPromiseAt = Date.now();
 	holder.initPromise = (async () => {
 		try {
 			const mod: {
@@ -258,10 +279,19 @@ async function getBackend(): Promise<ObjectCacheBackend | null> {
 		}
 		holder.initialized = true;
 		holder.initPromise = null;
+		holder.initPromiseAt = undefined;
 		return holder.backend;
 	})();
 
-	return holder.initPromise;
+	const started = holder.initPromise;
+	after(() =>
+		started.then(
+			() => undefined,
+			() => undefined,
+		),
+	);
+
+	return started;
 }
 
 /**
@@ -278,6 +308,7 @@ export function __setObjectCacheBackendForTests(
 ): void {
 	holder.initialized = true;
 	holder.initPromise = null;
+	holder.initPromiseAt = undefined;
 	holder.backend = backend;
 	holder.config = { ...holder.config, ...config };
 	epochCache.clear();
@@ -286,6 +317,17 @@ export function __setObjectCacheBackendForTests(
 	lastContentWrite.promise = undefined;
 	lastContentWrite.promiseAt = undefined;
 	contentWritePersist.pending = false;
+}
+
+/** @internal */
+export function __setObjectCacheBackendInitForTests(
+	promise: Promise<ObjectCacheBackend | null>,
+	startedAt: number,
+): void {
+	holder.initialized = false;
+	holder.backend = null;
+	holder.initPromise = promise;
+	holder.initPromiseAt = startedAt;
 }
 
 /** Build the backend key for a namespace's epoch anchor. */

--- a/packages/core/tests/unit/object-cache.test.ts
+++ b/packages/core/tests/unit/object-cache.test.ts
@@ -5,6 +5,7 @@ vi.mock("virtual:emdash/wait-until", () => ({ waitUntil: undefined }), { virtual
 import { decode, encode } from "../../src/object-cache/codec.js";
 import {
 	__setObjectCacheBackendForTests,
+	__setObjectCacheBackendInitForTests,
 	cachedQuery,
 	getLastContentWriteAt,
 	invalidateCollectionCache,
@@ -17,6 +18,18 @@ import { runWithContext } from "../../src/request-context.js";
 /** Flush the microtask + macrotask queue so deferred `after()` writes land. */
 async function flush(): Promise<void> {
 	await new Promise((r) => setTimeout(r, 0));
+}
+
+function neverSettles<T>(): Promise<T> {
+	return new Promise(() => {});
+}
+
+function withTestDeadline<T>(promise: Promise<T>, ms = 200): Promise<T> {
+	let timer: ReturnType<typeof setTimeout>;
+	const timeout = new Promise<never>((_resolve, reject) => {
+		timer = setTimeout(() => reject(new Error("test deadline exceeded")), ms);
+	});
+	return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
 /** A simple in-memory backend with call spies, isolated per test. */
@@ -440,6 +453,40 @@ describe("cachedQuery", () => {
 		await cachedQuery({ namespace: "posts", key: "k", load });
 		// The second post-recovery call is served from cache (load not re-run).
 		expect(load.mock.calls.length).toBe(calls);
+	});
+
+	it("reclaims a dead backend initialization after its deadline", async () => {
+		__setObjectCacheBackendForTests(null, { timeout: 20 });
+		vi.spyOn(Date, "now").mockReturnValue(10_000);
+		__setObjectCacheBackendInitForTests(neverSettles(), 8_979);
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		try {
+			const load = vi.fn(() => Promise.resolve({ n: 1 }));
+			await expect(
+				withTestDeadline(cachedQuery({ namespace: "t", key: "k", load })),
+			).resolves.toEqual({ n: 1 });
+			expect(load).toHaveBeenCalledTimes(1);
+		} finally {
+			warnSpy.mockRestore();
+			vi.restoreAllMocks();
+		}
+	});
+
+	it("bounds a waiter on another request's backend initialization", async () => {
+		__setObjectCacheBackendForTests(null, { timeout: 20 });
+		vi.spyOn(Date, "now").mockReturnValue(10_000);
+		__setObjectCacheBackendInitForTests(neverSettles(), 8_990);
+
+		try {
+			const load = vi.fn(() => Promise.resolve({ n: 1 }));
+			await expect(
+				withTestDeadline(cachedQuery({ namespace: "t", key: "k", load })),
+			).resolves.toEqual({ n: 1 });
+			expect(load).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.restoreAllMocks();
+		}
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Prevents a cancelled Cloudflare Workers request from leaving the object cache's shared backend initialization permanently pending for every later request in the isolate.

Backend initialization now records its start time. Concurrent callers wait only for the remaining initialization deadline, fall back to the existing direct load path on timeout, and replace initialization state that has exceeded the deadline. The started work is anchored through `after()` so workerd can keep it alive after the originating response ends. Successful initialization remains deduplicated and adds no database queries.

Adds regression coverage for reclaiming an over-deadline initialization and for a concurrent waiter timing out instead of hanging. Reported with downstream production verification by @Tommacek in #2626.

Closes #2626

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — the focused cache tests and complete `emdash` package suite pass
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Not applicable: this changes no admin UI strings.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: not applicable to this bug fix
- [x] I have included screenshots below if this PR changes the UI — not applicable; this changes no UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex, adapting the unpublished EmDashBot candidate generated with Kimi K2.7 Code

## Screenshots / test output

Not applicable: no UI changes.

Verified on current `origin/main`:

```text
pnpm typecheck
  34 workspace projects passed

pnpm lint
  passed with zero warnings

pnpm --filter emdash test tests/unit/object-cache.test.ts tests/unit/object-cache-comments-schema.test.ts tests/unit/object-cache-content.test.ts tests/unit/taxonomies/entry-terms-object-cache.test.ts tests/unit/taxonomies/term-list-object-cache.test.ts
  58 passed

pnpm --filter emdash test
  6,360 passed, 9 skipped

pnpm query-counts --skip-seed
  SQLite query counts and query text match the committed snapshots

pnpm --filter emdash build
  passed
```

Two unrelated baseline/tooling limitations remain:

- `pnpm --filter emdash test:workerd` passes 23 tests and fails three assertions in `loader-wide-collection-d1.test.ts`; the same three failures reproduce unchanged in a clean `origin/main` worktree.
- `publint` passes, but `attw` 0.18.2 crashes internally with `Cannot read properties of undefined (reading 'filename')`, including when run directly against an explicitly packed tarball.
