### PR TITLE
fix(bot): allow Git large-push probes

### DIFF
--- a/infra/emdash-bot/.flue/lib/github-proxy.ts
+++ b/infra/emdash-bot/.flue/lib/github-proxy.ts
@@ -321,11 +321,21 @@ async function inspectReceivePack(
 				}
 				const length = Number.parseInt(header, 16);
 				if (length === 0) {
+					if (refs.length === 0) {
+						// Git probes chunked receive-pack support with one flush packet before large pushes.
+						if (buffer.length !== offset + 4) {
+							return { allowed: false, refs, parseError: "receive-pack probe has trailing data" };
+						}
+						const trailing = await reader.read();
+						return trailing.done
+							? { allowed: true, refs }
+							: { allowed: false, refs, parseError: "receive-pack probe has trailing data" };
+					}
 					const allowed = new Set([
 						`refs/heads/bot/fix-${issueNumber}`,
 						`refs/heads/bot/artifacts-${issueNumber}`,
 					]);
-					return { allowed: refs.length > 0 && refs.every((ref) => allowed.has(ref)), refs };
+					return { allowed: refs.every((ref) => allowed.has(ref)), refs };
 				}
 				if (length < 4 || length > MAX_RECEIVE_PACK_COMMAND_BYTES) {
 					return { allowed: false, refs, parseError: "invalid pkt-line length" };

--- a/infra/emdash-bot/tests/unit/github-proxy.test.ts
+++ b/infra/emdash-bot/tests/unit/github-proxy.test.ts
@@ -192,6 +192,35 @@ describe("gateGithubRequest", () => {
 		).resolves.toMatch(/current issue/);
 	});
 
+	test("allows Git's authenticated large-request probe without accepting trailing data", async () => {
+		const url = new URL("https://github.com/emdash-cms/emdash.git/git-receive-pack");
+		const probe = new Request(url, { method: "POST", body: "0000" });
+
+		await expect(inspectGithubRequest(probe.clone(), url, OWNER, REPO)).resolves.toMatchObject({
+			allowed: false,
+			stage: "capability",
+		});
+		await expect(inspectGithubRequest(probe.clone(), url, OWNER, REPO, 123)).resolves.toMatchObject(
+			{
+				allowed: true,
+				authentication: "installation",
+				refs: [],
+			},
+		);
+		await expect(
+			inspectGithubRequest(
+				new Request(url, { method: "POST", body: "0000PACKpayload" }),
+				url,
+				OWNER,
+				REPO,
+				123,
+			),
+		).resolves.toMatchObject({
+			allowed: false,
+			stage: "receive-pack",
+		});
+	});
+
 	test("inspects gzip-compressed receive-pack commands before allowing a push", async () => {
 		const url = new URL("https://github.com/emdash-cms/emdash.git/git-receive-pack");
 		const body = gzipSync(


### PR DESCRIPTION
## What does this PR do?

Allows EmDashBot's authenticated Git proxy to forward Git's exact four-byte `0000` receive-pack probe before a large, chunked push.

Git sends this non-mutating probe when a request does not fit in its HTTP post buffer. The proxy previously required every receive-pack request to contain at least one ref command, so it returned 403 before Git could send the real, ref-scoped candidate push. This caused the publication failures observed in #2693 and #2878 after their shallow workspaces fell behind `main`.

The proxy still requires a valid issue-scoped capability. It accepts only a body-ending empty flush as a probe; an empty flush with trailing data remains denied, and the subsequent real push still has every ref checked against the current issue's candidate and artifacts branches.

Related to #2693 and #2878.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. N/A: no admin UI strings changed.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package). N/A: this changes unpublished bot infrastructure.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... N/A: bug fix.
- [ ] I have included screenshots below if this PR changes the UI. N/A: no UI change.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Not applicable — no UI change.

Verified:

- `pnpm --filter @emdash-cms/emdash-bot test:unit` — 314 passed
- `pnpm --filter @emdash-cms/emdash-bot test:workers` — 87 passed
- `pnpm --filter @emdash-cms/emdash-bot build` — passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- Scoped oxfmt check — passed

`pnpm --filter @emdash-cms/emdash-bot typecheck` remains blocked on current `main` by generated Durable Object namespace types losing their RPC stub methods; the same unrelated errors occur without this change. The bot production build and both test suites pass.
