### PR TITLE
fix(editor): preserve payload-less Portable Text blocks

### DIFF
--- a/.changeset/preserve-custom-block-round-trips.md
+++ b/.changeset/preserve-custom-block-round-trips.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": patch
+"emdash": patch
+---
+
+Fixes Portable Text editors replacing payload-less custom blocks with an `[Unknown block type: …]` paragraph during autosave. Custom blocks, existing block and span keys, supported marks, and link definitions now survive editor round trips, and an editor-generated trailing paragraph is not saved.

--- a/.changeset/preserve-custom-block-round-trips.md
+++ b/.changeset/preserve-custom-block-round-trips.md
@@ -3,4 +3,6 @@
 "emdash": patch
 ---
 
-Fixes Portable Text editors replacing payload-less custom blocks with an `[Unknown block type: …]` paragraph during autosave. Custom blocks, existing block and span keys, supported marks, and link definitions now survive editor round trips, and an editor-generated trailing paragraph is not saved.
+Fixes the admin rich-text editor replacing payload-less custom blocks with an `[Unknown block type: …]` paragraph during autosave. Custom blocks, existing block and span keys, supported marks, and link definitions survive editor round trips, and the editor does not save a synthetic trailing paragraph.
+
+Applications using the exported converters can pass `{ preserveIdentity: true }` to `portableTextToProsemirror()` and add `portableTextIdentityExtensions` to their TipTap schema for the same lossless behavior. The default conversion remains compatible with standard ProseMirror schemas.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -865,7 +865,9 @@ function convertPMNode(
 				_type: blockType,
 				_key: portableTextKeyFromAttrs(attrs) ?? originalBlock?._key ?? generateKey(),
 			};
-			const identityField = originalBlock ? customBlockIdentityField(originalBlock) : "id";
+			const identityField = originalBlock
+				? (customBlockIdentityField(originalBlock) ?? (pluginId ? "id" : undefined))
+				: "id";
 			if (identityField) result[identityField] = pluginId;
 			return result as PortableTextBlock;
 		}

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -1284,19 +1284,8 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 
 		case "gallery": {
 			const galleryBlock = block as { _type: "gallery"; _key: string; [key: string]: unknown };
-			// A gallery without an images array is malformed — keep the visible
-			// placeholder rather than silently rendering an empty grid.
 			if (!Array.isArray(galleryBlock.images)) {
-				return {
-					type: "paragraph",
-					content: [
-						{
-							type: "text",
-							text: `[Unknown block type: ${block._type}]`,
-							marks: [{ type: "code" }],
-						},
-					],
-				};
+				return convertCustomBlock(block);
 			}
 			return {
 				type: "gallery",
@@ -1382,22 +1371,23 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 		}
 
 		default: {
-			// Treat unknown block types as plugin blocks (embeds)
-			// These have an id field (or url for backwards compat) for the embed source,
-			// OR Block Kit field data stored as top-level keys (e.g., formId for forms plugin)
-			const record = block as Record<string, unknown>;
-			return {
-				type: "pluginBlock",
-				attrs: {
-					blockType: block._type,
-					id: attrStr(record.id) ?? attrStr(record.url) ?? "",
-					data: customBlockData(block),
-					[PORTABLE_TEXT_KEY_ATTR]: block._key,
-					[PORTABLE_TEXT_BLOCK_ATTR]: block,
-				},
-			};
+			return convertCustomBlock(block);
 		}
 	}
+}
+
+function convertCustomBlock(block: PortableTextBlock): unknown {
+	const record = block as Record<string, unknown>;
+	return {
+		type: "pluginBlock",
+		attrs: {
+			blockType: block._type,
+			id: attrStr(record.id) ?? attrStr(record.url) ?? "",
+			data: customBlockData(block),
+			[PORTABLE_TEXT_KEY_ATTR]: block._key,
+			[PORTABLE_TEXT_BLOCK_ATTR]: block,
+		},
+	};
 }
 
 function convertPTList(

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -1455,11 +1455,9 @@ function convertPTListItem(
 		// item's nested subtree. A new sub-list only starts when we hit
 		// another block at that root level with a different `listItem` type;
 		// deeper blocks (level > minLevel) belong to the current group as
-		// descendants regardless of their own `listItem`. The previous
-		// grouping broke on any type change at any depth, so a deep mixed
-		// tree like `bullet L1 → number L2 → bullet L3 → number L2` would
-		// emit C(L3) as a sibling list under A(L1) instead of nesting it
-		// under B(L2), then degrade C to L2 on round-trip.
+		// descendants regardless of their own `listItem`. A deep mixed tree
+		// like `bullet L1 → number L2 → bullet L3 → number L2` stays nested
+		// under B(L2) and preserves its original level on round-trip.
 		let minLevel = Infinity;
 		for (const ni of nestedItems) {
 			const level = ni.level || 2;

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -90,7 +90,7 @@ import {
 	type Icon,
 } from "@phosphor-icons/react";
 import { X } from "@phosphor-icons/react";
-import { Extension, type Range } from "@tiptap/core";
+import { Extension, Mark, type Range } from "@tiptap/core";
 import CharacterCount from "@tiptap/extension-character-count";
 import Focus from "@tiptap/extension-focus";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -261,6 +261,153 @@ function sanitizeGalleryImages(value: unknown, withKeys = false): GalleryImage[]
 // Helpers for safely extracting typed values from ProseMirror attrs (Record<string, any>)
 const attrStr = (v: unknown): string | undefined => (typeof v === "string" && v ? v : undefined);
 const attrNum = (v: unknown): number | undefined => (typeof v === "number" && v ? v : undefined);
+
+const PORTABLE_TEXT_BLOCK_ATTR = "emdashPortableTextBlock";
+const PORTABLE_TEXT_KEY_ATTR = "emdashPortableTextKey";
+const PORTABLE_TEXT_SPAN_MARK = "emdashPortableTextSpan";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function attrsWithPortableTextKey(
+	attrs: Record<string, unknown> | undefined,
+	key: string,
+): Record<string, unknown> {
+	return { ...attrs, [PORTABLE_TEXT_KEY_ATTR]: key };
+}
+
+function portableTextKeyFromAttrs(attrs: Record<string, unknown> | undefined): string | undefined {
+	return attrStr(attrs?.[PORTABLE_TEXT_KEY_ATTR]);
+}
+
+function portableTextSpanKeyFromMarks(marks: unknown[] | undefined): string | undefined {
+	for (const mark of marks ?? []) {
+		if (!isRecord(mark) || mark.type !== PORTABLE_TEXT_SPAN_MARK || !isRecord(mark.attrs)) continue;
+		const key = attrStr(mark.attrs.key);
+		if (key) return key;
+	}
+	return undefined;
+}
+
+function portableTextMarkDefsFromMarks(marks: unknown[] | undefined): PortableTextMarkDef[] {
+	const identity = (marks ?? []).find(
+		(mark) => isRecord(mark) && mark.type === PORTABLE_TEXT_SPAN_MARK && isRecord(mark.attrs),
+	);
+	if (!isRecord(identity) || !isRecord(identity.attrs) || !Array.isArray(identity.attrs.markDefs)) {
+		return [];
+	}
+	return identity.attrs.markDefs.filter(
+		(markDef): markDef is PortableTextMarkDef =>
+			isRecord(markDef) && typeof markDef._type === "string" && typeof markDef._key === "string",
+	);
+}
+
+function portableTextBlockFromAttrs(
+	attrs: Record<string, unknown> | undefined,
+): PortableTextBlock | undefined {
+	const block = attrs?.[PORTABLE_TEXT_BLOCK_ATTR];
+	if (!isRecord(block) || typeof block._type !== "string" || typeof block._key !== "string") {
+		return undefined;
+	}
+	return block as PortableTextBlock;
+}
+
+function customBlockData(block: PortableTextBlock): Record<string, unknown> {
+	const {
+		_type: _blockType,
+		_key: _blockKey,
+		id: _id,
+		url: _url,
+		...rest
+	} = block as Record<string, unknown>;
+	return Object.fromEntries(Object.entries(rest).filter(([key]) => !key.startsWith("_")));
+}
+
+function customBlockIdentity(block: PortableTextBlock): string {
+	const record = block as Record<string, unknown>;
+	return attrStr(record.id) ?? attrStr(record.url) ?? "";
+}
+
+function customBlockIdentityField(block: PortableTextBlock): "id" | "url" | undefined {
+	if (Object.hasOwn(block, "id")) return "id";
+	if (Object.hasOwn(block, "url")) return "url";
+	return undefined;
+}
+
+function equalJsonValues(left: unknown, right: unknown): boolean {
+	if (Object.is(left, right)) return true;
+	if (Array.isArray(left) || Array.isArray(right)) {
+		return (
+			Array.isArray(left) &&
+			Array.isArray(right) &&
+			left.length === right.length &&
+			left.every((value, index) => equalJsonValues(value, right[index]))
+		);
+	}
+	if (!isRecord(left) || !isRecord(right)) return false;
+	const leftKeys = Object.keys(left).filter((key) => left[key] !== undefined);
+	const rightKeys = Object.keys(right).filter((key) => right[key] !== undefined);
+	return (
+		leftKeys.length === rightKeys.length &&
+		leftKeys.every((key) => Object.hasOwn(right, key) && equalJsonValues(left[key], right[key]))
+	);
+}
+
+const PortableTextIdentityExtension = Extension.create({
+	name: "emdashPortableTextIdentity",
+
+	addGlobalAttributes() {
+		const hiddenAttribute = { default: null, rendered: false };
+		return [
+			{
+				types: [
+					"paragraph",
+					"heading",
+					"blockquote",
+					"codeBlock",
+					"htmlBlock",
+					"image",
+					"horizontalRule",
+					"gallery",
+					"table",
+					"tableRow",
+					"tableCell",
+					"tableHeader",
+					"pluginBlock",
+				],
+				attributes: { [PORTABLE_TEXT_KEY_ATTR]: hiddenAttribute },
+			},
+			{
+				types: ["pluginBlock"],
+				attributes: { [PORTABLE_TEXT_BLOCK_ATTR]: hiddenAttribute },
+			},
+		];
+	},
+});
+
+// ProseMirror text nodes cannot carry schema attributes, so a non-rendered mark
+// keeps each Portable Text span's key and referenced mark definitions attached.
+const PortableTextSpanIdentity = Mark.create({
+	name: PORTABLE_TEXT_SPAN_MARK,
+	inclusive: false,
+	spanning: false,
+
+	addAttributes() {
+		return {
+			key: { default: null, rendered: false },
+			markDefs: { default: [], rendered: false },
+		};
+	},
+
+	parseHTML() {
+		return [];
+	},
+
+	renderHTML() {
+		return ["span", 0];
+	},
+});
 
 const MAX_ORDERED_LIST_START = 2_147_483_647;
 
@@ -433,19 +580,36 @@ function prosemirrorToPortableText(doc: {
 	assertProseMirrorMarksSupported(doc);
 
 	const blocks: PortableTextBlock[] = [];
+	const usedBlockKeys = new Set<string>();
 
 	for (let i = 0; i < doc.content.length; i++) {
-		const converted = convertPMNode(doc.content[i]!, `root:${i}`);
-		if (converted) {
-			if (Array.isArray(converted)) {
-				blocks.push(...converted);
-			} else {
-				blocks.push(converted);
+		const node = doc.content[i]!;
+		if (i === doc.content.length - 1 && isUnkeyedEmptyParagraph(node)) continue;
+		const converted = convertPMNode(node, `root:${i}`);
+		for (const block of converted ? (Array.isArray(converted) ? converted : [converted]) : []) {
+			let key = block._key;
+			if (usedBlockKeys.has(key)) {
+				do key = generateKey();
+				while (usedBlockKeys.has(key));
 			}
+			usedBlockKeys.add(key);
+			blocks.push(key === block._key ? block : { ...block, _key: key });
 		}
 	}
 
 	return blocks;
+}
+
+function isUnkeyedEmptyParagraph(node: {
+	type: string;
+	attrs?: Record<string, unknown>;
+	content?: unknown[];
+}): boolean {
+	return (
+		node.type === "paragraph" &&
+		(node.content?.length ?? 0) === 0 &&
+		portableTextKeyFromAttrs(node.attrs) === undefined
+	);
 }
 
 function convertPMNode(
@@ -466,10 +630,10 @@ function convertPMNode(
 			const textAlign = ta === "center" || ta === "right" || ta === "justify" ? ta : undefined;
 			return {
 				_type: "block",
-				_key: generateKey(),
+				_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 				style: "normal",
 				children,
-				markDefs: markDefs.length > 0 ? markDefs : undefined,
+				...(markDefs.length > 0 ? { markDefs } : {}),
 				...(textAlign ? { textAlign } : {}),
 			};
 		}
@@ -487,7 +651,7 @@ function convertPMNode(
 			const textAlign = ta === "center" || ta === "right" || ta === "justify" ? ta : undefined;
 			return {
 				_type: "block",
-				_key: generateKey(),
+				_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 				style: headingStyle,
 				children,
 				markDefs: markDefs.length > 0 ? markDefs : undefined,
@@ -505,6 +669,7 @@ function convertPMNode(
 			const blocks: PortableTextTextBlock[] = [];
 			const blockquoteContent = (node.content || []) as Array<{
 				type: string;
+				attrs?: Record<string, unknown>;
 				content?: unknown[];
 			}>;
 			for (const child of blockquoteContent) {
@@ -513,7 +678,10 @@ function convertPMNode(
 					if (children.length > 0) {
 						blocks.push({
 							_type: "block",
-							_key: generateKey(),
+							_key:
+								portableTextKeyFromAttrs(child.attrs) ??
+								portableTextKeyFromAttrs(node.attrs) ??
+								generateKey(),
 							style: "blockquote",
 							children,
 							markDefs: markDefs.length > 0 ? markDefs : undefined,
@@ -533,7 +701,7 @@ function convertPMNode(
 			const rawLanguage = node.attrs?.language;
 			return {
 				_type: "code",
-				_key: generateKey(),
+				_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 				code,
 				language: typeof rawLanguage === "string" ? rawLanguage : undefined,
 			};
@@ -543,7 +711,7 @@ function convertPMNode(
 			const rawHtml = node.attrs?.html;
 			return {
 				_type: "htmlBlock",
-				_key: generateKey(),
+				_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 				html: typeof rawHtml === "string" ? rawHtml : "",
 			};
 		}
@@ -560,7 +728,7 @@ function convertPMNode(
 			// non-LQIP meta keys are never silently dropped on editor round-trip).
 			return {
 				_type: "image",
-				_key: generateKey(),
+				_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 				asset: {
 					_ref: attrStr(attrs.mediaId) ?? "",
 					url: attrStr(attrs.src) ?? "",
@@ -581,7 +749,7 @@ function convertPMNode(
 		case "horizontalRule":
 			return {
 				_type: "break",
-				_key: generateKey(),
+				_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 				style: "lineBreak",
 			};
 
@@ -589,18 +757,20 @@ function convertPMNode(
 			const columns = node.attrs?.columns;
 			return {
 				_type: "gallery",
-				_key: generateKey(),
+				_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 				images: sanitizeGalleryImages(node.attrs?.images, true),
 				...(typeof columns === "number" ? { columns } : {}),
 			};
 		}
 
 		case "table": {
-			const tableKey = generateKey();
+			const tableKey = portableTextKeyFromAttrs(node.attrs) ?? generateKey();
 			const tableContent = (node.content || []) as Array<{
 				type: string;
+				attrs?: Record<string, unknown>;
 				content?: Array<{
 					type: string;
+					attrs?: Record<string, unknown>;
 					content?: unknown[];
 				}>;
 			}>;
@@ -644,7 +814,8 @@ function convertPMNode(
 
 						return {
 							_type: "tableCell" as const,
-							_key: `${tableKey}_r${rowIndex}_c${cellIndex}`,
+							_key:
+								portableTextKeyFromAttrs(cell.attrs) ?? `${tableKey}_r${rowIndex}_c${cellIndex}`,
 							content: contentSpans,
 							isHeader,
 							markDefs: cellMarkDefs.length > 0 ? cellMarkDefs : undefined,
@@ -653,7 +824,7 @@ function convertPMNode(
 
 					return {
 						_type: "tableRow" as const,
-						_key: `${tableKey}_r${rowIndex}`,
+						_key: portableTextKeyFromAttrs(row.attrs) ?? `${tableKey}_r${rowIndex}`,
 						cells,
 					};
 				});
@@ -667,13 +838,36 @@ function convertPMNode(
 		}
 
 		case "pluginBlock": {
-			const { blockType, id: pluginId, data } = node.attrs ?? {};
-			return {
-				...(data && typeof data === "object" ? data : {}),
-				_type: typeof blockType === "string" ? blockType : "embed",
-				_key: generateKey(),
-				id: typeof pluginId === "string" ? pluginId : "",
+			const attrs = node.attrs ?? {};
+			const blockType = typeof attrs.blockType === "string" ? attrs.blockType : "embed";
+			const pluginId = typeof attrs.id === "string" ? attrs.id : "";
+			const data = isRecord(attrs.data) ? attrs.data : {};
+			const originalBlock = portableTextBlockFromAttrs(attrs);
+
+			if (
+				originalBlock &&
+				originalBlock._type === blockType &&
+				customBlockIdentity(originalBlock) === pluginId &&
+				equalJsonValues(customBlockData(originalBlock), data)
+			) {
+				return { ...originalBlock };
+			}
+
+			const result: Record<string, unknown> = {
+				...(originalBlock
+					? Object.fromEntries(
+							Object.entries(originalBlock).filter(
+								([key]) => key.startsWith("_") && key !== "_type" && key !== "_key",
+							),
+						)
+					: {}),
+				...data,
+				_type: blockType,
+				_key: portableTextKeyFromAttrs(attrs) ?? originalBlock?._key ?? generateKey(),
 			};
+			const identityField = originalBlock ? customBlockIdentityField(originalBlock) : "id";
+			if (identityField) result[identityField] = pluginId;
+			return result as PortableTextBlock;
 		}
 
 		default:
@@ -707,7 +901,7 @@ function convertList(
 					if (children.length > 0) {
 						blocks.push({
 							_type: "block",
-							_key: generateKey(),
+							_key: portableTextKeyFromAttrs(child.attrs) ?? generateKey(),
 							style: "normal",
 							listItem,
 							level,
@@ -754,6 +948,18 @@ function convertInlineContent(
 	const children: PortableTextSpan[] = [];
 	const markDefs: PortableTextMarkDef[] = [];
 	const markDefMap = new Map<string, string>();
+	const usedSpanKeys = new Set<string>();
+	const claimSpanKey = (preferred?: string) => {
+		if (preferred && !usedSpanKeys.has(preferred)) {
+			usedSpanKeys.add(preferred);
+			return preferred;
+		}
+		let key: string;
+		do key = generateKey();
+		while (usedSpanKeys.has(key));
+		usedSpanKeys.add(key);
+		return key;
+	};
 
 	const typedNodes = nodes as Array<{
 		type: string;
@@ -763,19 +969,32 @@ function convertInlineContent(
 	for (const node of typedNodes) {
 		if (node.type === "text" && node.text) {
 			const marks: string[] = [];
+			const originalMarkDefs = portableTextMarkDefsFromMarks(node.marks);
 
 			for (const mark of node.marks || []) {
-				const markType = convertMark(mark, markDefs, markDefMap);
+				const markType = convertMark(mark, markDefs, markDefMap, originalMarkDefs);
 				if (markType) {
 					marks.push(markType);
 				}
 			}
 
+			const preferredKey = portableTextSpanKeyFromMarks(node.marks);
+			const normalizedMarks = marks.length > 0 ? marks : undefined;
+			const previous = children.at(-1);
+			if (
+				preferredKey &&
+				previous?._key === preferredKey &&
+				equalJsonValues(previous.marks, normalizedMarks)
+			) {
+				previous.text += node.text;
+				continue;
+			}
+
 			children.push({
 				_type: "span",
-				_key: generateKey(),
+				_key: claimSpanKey(preferredKey),
 				text: node.text,
-				marks: marks.length > 0 ? marks : undefined,
+				marks: normalizedMarks,
 			});
 		} else if (node.type === "hardBreak") {
 			if (children.length > 0 && !preserveHardBreakBoundary) {
@@ -784,7 +1003,7 @@ function convertInlineContent(
 			} else {
 				children.push({
 					_type: "span",
-					_key: generateKey(),
+					_key: claimSpanKey(portableTextSpanKeyFromMarks(node.marks)),
 					text: "\n",
 				});
 			}
@@ -794,7 +1013,7 @@ function convertInlineContent(
 	if (children.length === 0) {
 		children.push({
 			_type: "span",
-			_key: generateKey(),
+			_key: claimSpanKey(),
 			text: "",
 		});
 	}
@@ -806,6 +1025,7 @@ function convertMark(
 	mark: { type: string; attrs?: Record<string, unknown> },
 	markDefs: PortableTextMarkDef[],
 	markDefMap: Map<string, string>,
+	originalMarkDefs: PortableTextMarkDef[],
 ): string | null {
 	switch (mark.type) {
 		case "bold":
@@ -825,20 +1045,26 @@ function convertMark(
 			return "superscript";
 		case "code":
 			return "code";
+		case PORTABLE_TEXT_SPAN_MARK:
+			return null;
 		case "link": {
 			const rawHref = mark.attrs?.href;
 			const href = typeof rawHref === "string" ? rawHref : "";
-			if (markDefMap.has(href)) {
-				return markDefMap.get(href)!;
+			const originalMarkDef = originalMarkDefs.find((markDef) => markDef._type === "link");
+			const mapKey = originalMarkDef ? `key:${originalMarkDef._key}` : `href:${href}`;
+			if (markDefMap.has(mapKey)) {
+				return markDefMap.get(mapKey)!;
 			}
-			const key = generateKey();
+			const key = originalMarkDef?._key || generateKey();
+			const blank = mark.attrs?.target === "_blank";
 			markDefs.push({
+				...originalMarkDef,
 				_type: "link",
 				_key: key,
 				href,
-				blank: mark.attrs?.target === "_blank",
+				...(blank || (originalMarkDef && Object.hasOwn(originalMarkDef, "blank")) ? { blank } : {}),
 			});
-			markDefMap.set(href, key);
+			markDefMap.set(mapKey, key);
 			return key;
 		}
 		default:
@@ -966,13 +1192,17 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 					const level = parseInt(style.substring(1), 10);
 					return {
 						type: "heading",
-						attrs: { level, ...(textAlign ? { textAlign } : {}) },
+						attrs: attrsWithPortableTextKey(
+							{ level, ...(textAlign ? { textAlign } : {}) },
+							block._key,
+						),
 						content: pmContent.length > 0 ? pmContent : undefined,
 					};
 				}
 				case "blockquote":
 					return {
 						type: "blockquote",
+						attrs: attrsWithPortableTextKey(undefined, block._key),
 						content: [
 							{
 								type: "paragraph",
@@ -983,7 +1213,7 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 				default:
 					return {
 						type: "paragraph",
-						attrs: textAlign ? { textAlign } : undefined,
+						attrs: attrsWithPortableTextKey(textAlign ? { textAlign } : undefined, block._key),
 						content: pmContent.length > 0 ? pmContent : undefined,
 					};
 			}
@@ -1009,21 +1239,24 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 						: null;
 			return {
 				type: "image",
-				attrs: {
-					src: imageBlock.asset.url || `/_emdash/api/media/file/${imageBlock.asset._ref}`,
-					alt: imageBlock.alt || "",
-					title: imageBlock.caption || "",
-					caption: imageBlock.caption || "",
-					mediaId: imageBlock.asset._ref,
-					provider: canonicalMediaProviderId(imageBlock.asset.provider),
-					width: imageBlock.width,
-					height: imageBlock.height,
-					blurhash,
-					dominantColor,
-					displayWidth: imageBlock.displayWidth,
-					displayHeight: imageBlock.displayHeight,
-					alignment: imageBlock.alignment,
-				},
+				attrs: attrsWithPortableTextKey(
+					{
+						src: imageBlock.asset.url || `/_emdash/api/media/file/${imageBlock.asset._ref}`,
+						alt: imageBlock.alt || "",
+						title: imageBlock.caption || "",
+						caption: imageBlock.caption || "",
+						mediaId: imageBlock.asset._ref,
+						provider: canonicalMediaProviderId(imageBlock.asset.provider),
+						width: imageBlock.width,
+						height: imageBlock.height,
+						blurhash,
+						dominantColor,
+						displayWidth: imageBlock.displayWidth,
+						displayHeight: imageBlock.displayHeight,
+						alignment: imageBlock.alignment,
+					},
+					block._key,
+				),
 			};
 		}
 
@@ -1036,13 +1269,16 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 					: null;
 			return {
 				type: "codeBlock",
-				attrs: { language },
+				attrs: attrsWithPortableTextKey({ language }, block._key),
 				content: codeBlock.code ? [{ type: "text", text: codeBlock.code }] : undefined,
 			};
 		}
 
 		case "break":
-			return { type: "horizontalRule" };
+			return {
+				type: "horizontalRule",
+				attrs: attrsWithPortableTextKey(undefined, block._key),
+			};
 
 		case "gallery": {
 			const galleryBlock = block as { _type: "gallery"; _key: string; [key: string]: unknown };
@@ -1062,10 +1298,13 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 			}
 			return {
 				type: "gallery",
-				attrs: {
-					images: sanitizeGalleryImages(galleryBlock.images),
-					columns: typeof galleryBlock.columns === "number" ? galleryBlock.columns : undefined,
-				},
+				attrs: attrsWithPortableTextKey(
+					{
+						images: sanitizeGalleryImages(galleryBlock.images),
+						columns: typeof galleryBlock.columns === "number" ? galleryBlock.columns : undefined,
+					},
+					galleryBlock._key,
+				),
 			};
 		}
 
@@ -1073,7 +1312,7 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 			const htmlBlock = block as { _type: "htmlBlock"; _key: string; html?: string };
 			return {
 				type: "htmlBlock",
-				attrs: { html: htmlBlock.html || "" },
+				attrs: attrsWithPortableTextKey({ html: htmlBlock.html || "" }, htmlBlock._key),
 			};
 		}
 
@@ -1116,6 +1355,7 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 
 					return {
 						type: cellType,
+						attrs: attrsWithPortableTextKey(undefined, cell._key),
 						content: [
 							{
 								type: "paragraph",
@@ -1127,12 +1367,14 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 
 				return {
 					type: "tableRow",
+					attrs: attrsWithPortableTextKey(undefined, row._key),
 					content: cells,
 				};
 			});
 
 			return {
 				type: "table",
+				attrs: attrsWithPortableTextKey(undefined, tableBlock._key),
 				content: rows,
 			};
 		}
@@ -1141,30 +1383,16 @@ function convertPTBlock(block: PortableTextBlock): unknown {
 			// Treat unknown block types as plugin blocks (embeds)
 			// These have an id field (or url for backwards compat) for the embed source,
 			// OR Block Kit field data stored as top-level keys (e.g., formId for forms plugin)
-			const { _type, _key, id, url, ...rest } = block as Record<string, unknown>;
-			// Filter out _-prefixed keys to prevent accumulation across edit cycles
-			const data = Object.fromEntries(Object.entries(rest).filter(([k]) => !k.startsWith("_")));
-			const hasFieldData = Object.keys(data).length > 0;
-			if (id || url || hasFieldData) {
-				return {
-					type: "pluginBlock",
-					attrs: {
-						blockType: _type,
-						id: id || url || "",
-						data,
-					},
-				};
-			}
-			// Truly unknown blocks with no data at all
+			const record = block as Record<string, unknown>;
 			return {
-				type: "paragraph",
-				content: [
-					{
-						type: "text",
-						text: `[Unknown block type: ${block._type}]`,
-						marks: [{ type: "code" }],
-					},
-				],
+				type: "pluginBlock",
+				attrs: {
+					blockType: block._type,
+					id: attrStr(record.id) ?? attrStr(record.url) ?? "",
+					data: customBlockData(block),
+					[PORTABLE_TEXT_KEY_ATTR]: block._key,
+					[PORTABLE_TEXT_BLOCK_ATTR]: block,
+				},
 			};
 		}
 	}
@@ -1226,6 +1454,7 @@ function convertPTListItem(
 	const pmContent = convertPTSpans(item.children, item.markDefs || []);
 	content.push({
 		type: "paragraph",
+		attrs: attrsWithPortableTextKey(undefined, item._key),
 		content: pmContent.length > 0 ? pmContent : undefined,
 	});
 
@@ -1284,6 +1513,7 @@ function convertPTSpans(spans: PortableTextSpan[], markDefs: PortableTextMarkDef
 
 	for (const span of spans) {
 		if (span._type !== "span") continue;
+		const referencedMarkDefs = markDefs.filter((markDef) => span.marks?.includes(markDef._key));
 
 		const parts = span.text.split("\n");
 
@@ -1291,19 +1521,31 @@ function convertPTSpans(spans: PortableTextSpan[], markDefs: PortableTextMarkDef
 			const text = parts[i]!;
 
 			if (text.length > 0) {
-				const marks = convertPTMarks(span.marks || [], markDefsMap);
+				const marks = [
+					...convertPTMarks(span.marks || [], markDefsMap),
+					{
+						type: PORTABLE_TEXT_SPAN_MARK,
+						attrs: { key: span._key, markDefs: referencedMarkDefs },
+					},
+				];
 				const node: { type: string; text: string; marks?: unknown[] } = {
 					type: "text",
 					text,
 				};
-				if (marks.length > 0) {
-					node.marks = marks;
-				}
+				node.marks = marks;
 				nodes.push(node);
 			}
 
 			if (i < parts.length - 1) {
-				nodes.push({ type: "hardBreak" });
+				nodes.push({
+					type: "hardBreak",
+					marks: [
+						{
+							type: PORTABLE_TEXT_SPAN_MARK,
+							attrs: { key: span._key, markDefs: referencedMarkDefs },
+						},
+					],
+				});
 			}
 		}
 	}
@@ -2623,6 +2865,7 @@ export function PortableTextEditor({
 
 	// Use a ref for onChange to avoid recreating the editor when the callback changes
 	const onChangeRef = React.useRef(onChange);
+	const lastPortableTextValueRef = React.useRef(value || []);
 	React.useEffect(() => {
 		onChangeRef.current = onChange;
 	}, [onChange]);
@@ -2822,6 +3065,8 @@ export function PortableTextEditor({
 	// All mutable state (filterCommands, onChange) is accessed via refs.
 	const extensions = React.useMemo(
 		() => [
+			PortableTextIdentityExtension,
+			PortableTextSpanIdentity,
 			StarterKit.configure({
 				heading: {
 					levels: [1, 2, 3, 4, 5, 6],
@@ -2912,6 +3157,8 @@ export function PortableTextEditor({
 				const pmDoc = doc as Parameters<typeof prosemirrorToPortableText>[0];
 				try {
 					const portableText = prosemirrorToPortableText(pmDoc);
+					if (equalJsonValues(portableText, lastPortableTextValueRef.current)) return;
+					lastPortableTextValueRef.current = portableText;
 					cb(portableText);
 				} catch (error) {
 					if (error instanceof UnsupportedPortableTextMarksError) {

--- a/packages/admin/src/lib/portable-text-marks.ts
+++ b/packages/admin/src/lib/portable-text-marks.ts
@@ -20,6 +20,7 @@ const SUPPORTED_PROSEMIRROR_MARKS = new Set([
 	"superscript",
 	"code",
 	"link",
+	"emdashPortableTextSpan",
 ]);
 
 type UnknownRecord = Record<string, unknown>;

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -304,6 +304,144 @@ describe("plugin block helpers", () => {
 // =============================================================================
 
 describe("Portable Text ↔ ProseMirror conversion", () => {
+	it("preserves existing keys and supported link mark definitions", () => {
+		const blocks = [
+			{
+				_type: "block" as const,
+				_key: "block-1",
+				style: "normal" as const,
+				children: [
+					{
+						_type: "span" as const,
+						_key: "span-1",
+						text: "Linked text",
+						marks: ["strong", "link-1"],
+					},
+				],
+				markDefs: [
+					{
+						_type: "link",
+						_key: "link-1",
+						href: "https://example.com",
+						blank: true,
+					},
+				],
+			},
+		];
+
+		const roundTripped = _prosemirrorToPortableText(_portableTextToProsemirror(blocks));
+
+		expect(roundTripped).toEqual(blocks);
+	});
+
+	it("keeps a no-op editor update lossless", async () => {
+		const onChange = vi.fn();
+		const blocks = [
+			{
+				_type: "block" as const,
+				_key: "block-1",
+				style: "normal" as const,
+				children: [
+					{
+						_type: "span" as const,
+						_key: "span-1",
+						text: "Linked text",
+						marks: ["link-1"],
+					},
+				],
+				markDefs: [
+					{
+						_type: "link",
+						_key: "link-1",
+						href: "https://example.com",
+					},
+				],
+			},
+			{ _type: "test.divider", _key: "divider-1" },
+		];
+		const { editor } = await renderAndGetEditor({
+			value: blocks,
+			onChange,
+			pluginBlocks: [
+				{
+					type: "test.divider",
+					pluginId: "test-blocks",
+					label: "Divider",
+					fields: [],
+				},
+			],
+		});
+
+		const roundTripped = _prosemirrorToPortableText(
+			editor.getJSON() as Parameters<typeof _prosemirrorToPortableText>[0],
+		);
+
+		expect(roundTripped).toEqual(blocks);
+
+		await React.act(async () => {
+			editor.commands.setContent(editor.getJSON(), { emitUpdate: true });
+		});
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("keeps span keys unique when an edit splits existing text", async () => {
+		const onChange = vi.fn();
+		const { editor } = await renderAndGetEditor({
+			value: [
+				{
+					_type: "block",
+					_key: "block-1",
+					style: "normal",
+					children: [
+						{
+							_type: "span",
+							_key: "span-1",
+							text: "Hello world",
+						},
+					],
+				},
+			],
+			onChange,
+		});
+
+		editor.chain().focus().setTextSelection({ from: 1, to: 6 }).toggleBold().run();
+		await vi.waitFor(() => expect(onChange).toHaveBeenCalled(), { timeout: 2000 });
+
+		const block = onChange.mock.lastCall?.[0][0] as { children: Array<{ _key: string }> };
+		const keys = block.children.map((span) => span._key);
+		expect(keys).toContain("span-1");
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+
+	it("keeps block keys unique when an edit splits a paragraph", async () => {
+		const onChange = vi.fn();
+		const { editor } = await renderAndGetEditor({
+			value: [
+				{
+					_type: "block",
+					_key: "block-1",
+					style: "normal",
+					children: [
+						{
+							_type: "span",
+							_key: "span-1",
+							text: "Hello world",
+						},
+					],
+				},
+			],
+			onChange,
+		});
+
+		editor.chain().focus().setTextSelection(6).splitBlock().run();
+		await vi.waitFor(() => expect(onChange).toHaveBeenCalled(), { timeout: 2000 });
+
+		const blocks = onChange.mock.lastCall?.[0] ?? [];
+		const keys = blocks.map((block) => block._key);
+		expect(keys).toContain("block-1");
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+
 	it("rejects mixed unsupported decorators across nested and spanning text", () => {
 		const blocks = [
 			{
@@ -433,6 +571,27 @@ describe("Portable Text ↔ ProseMirror conversion", () => {
 		const p = pm.querySelector("p");
 		expect(p).toBeTruthy();
 		expect(p!.textContent).toBe("Hello world");
+	});
+
+	it("does not report a change when mounting a payload-less registered block", async () => {
+		const onChange = vi.fn();
+		await render(
+			<PortableTextEditor
+				value={[{ _type: "test.divider", _key: "divider-1" }]}
+				onChange={onChange}
+				pluginBlocks={[
+					{
+						type: "test.divider",
+						pluginId: "test-blocks",
+						label: "Divider",
+						fields: [],
+					},
+				]}
+			/>,
+		);
+		await waitForEditor();
+
+		expect(onChange).not.toHaveBeenCalled();
 	});
 
 	it("renders an h1 heading", async () => {

--- a/packages/admin/tests/editor/plugin-block-conversion.test.ts
+++ b/packages/admin/tests/editor/plugin-block-conversion.test.ts
@@ -205,6 +205,24 @@ describe("Plugin block round-trip", () => {
 		expect(roundTripped).toEqual(original);
 	});
 
+	it("persists an identity added while editing a payload-less custom block", () => {
+		const document = portableTextToProsemirror([{ _type: "test.embed", _key: "embed-1" }]);
+		const node = document.content?.[0] as {
+			attrs: { id: string };
+		};
+		node.attrs.id = "https://example.com/embed";
+
+		const roundTripped = prosemirrorToPortableText(document);
+
+		expect(roundTripped).toEqual([
+			{
+				_type: "test.embed",
+				_key: "embed-1",
+				id: "https://example.com/embed",
+			},
+		]);
+	});
+
 	it("basic plugin block survives round-trip", () => {
 		const original = [ptPluginBlock("youtube", "https://youtu.be/abc")];
 		const pm = portableTextToProsemirror(original);

--- a/packages/admin/tests/editor/plugin-block-conversion.test.ts
+++ b/packages/admin/tests/editor/plugin-block-conversion.test.ts
@@ -205,6 +205,14 @@ describe("Plugin block round-trip", () => {
 		expect(roundTripped).toEqual(original);
 	});
 
+	it("preserves a gallery block that has no images array", () => {
+		const original = [{ _type: "gallery", _key: "gallery-1", legacySource: "import" }];
+
+		const roundTripped = prosemirrorToPortableText(portableTextToProsemirror(original));
+
+		expect(roundTripped).toEqual(original);
+	});
+
 	it("persists an identity added while editing a payload-less custom block", () => {
 		const document = portableTextToProsemirror([{ _type: "test.embed", _key: "embed-1" }]);
 		const node = document.content?.[0] as {

--- a/packages/admin/tests/editor/plugin-block-conversion.test.ts
+++ b/packages/admin/tests/editor/plugin-block-conversion.test.ts
@@ -151,12 +151,16 @@ describe("PT → PM: plugin blocks", () => {
 		expect(node.attrs.id).toBe("https://example.com");
 	});
 
-	it("treats blocks without id, url, or data as unknown (paragraph fallback)", () => {
+	it("represents blocks without id, url, or data as opaque plugin blocks", () => {
 		const block = { _type: "mystery", _key: "k1" };
 		const pm = portableTextToProsemirror([block]);
-		const node = pm.content?.[0] as { type: string };
+		const node = pm.content?.[0] as {
+			type: string;
+			attrs: { blockType: string; id: string; data: Record<string, unknown> };
+		};
 
-		expect(node.type).toBe("paragraph");
+		expect(node.type).toBe("pluginBlock");
+		expect(node.attrs).toMatchObject({ blockType: "mystery", id: "", data: {} });
 	});
 
 	it("converts blocks with field data but no id/url to pluginBlock", () => {
@@ -193,6 +197,14 @@ describe("PT → PM: plugin blocks", () => {
 // =============================================================================
 
 describe("Plugin block round-trip", () => {
+	it("preserves a payload-less custom block unchanged", () => {
+		const original = [{ _type: "test.divider", _key: "divider-1" }];
+
+		const roundTripped = prosemirrorToPortableText(portableTextToProsemirror(original));
+
+		expect(roundTripped).toEqual(original);
+	});
+
 	it("basic plugin block survives round-trip", () => {
 		const original = [ptPluginBlock("youtube", "https://youtu.be/abc")];
 		const pm = portableTextToProsemirror(original);
@@ -218,8 +230,7 @@ describe("Plugin block round-trip", () => {
 		});
 	});
 
-	it("_-prefixed keys do not accumulate across round-trips", () => {
-		// Simulate a block that somehow has _-prefixed keys in data
+	it("opaque metadata survives repeated round-trips without accumulating", () => {
 		const withLeakyKeys = [
 			ptPluginBlock("youtube", "vid-1", {
 				_createdAt: "2024-01-01",
@@ -227,19 +238,15 @@ describe("Plugin block round-trip", () => {
 			}),
 		];
 
-		// First round-trip should strip _-prefixed keys
 		const pm1 = portableTextToProsemirror(withLeakyKeys);
 		const rt1 = prosemirrorToPortableText(pm1);
 
-		expect(rt1[0]).toMatchObject({ _type: "youtube", id: "vid-1", caption: "test" });
-		expect(rt1[0]).not.toHaveProperty("_createdAt");
+		expect(rt1).toEqual(withLeakyKeys);
 
-		// Second round-trip should be stable
 		const pm2 = portableTextToProsemirror(rt1);
 		const rt2 = prosemirrorToPortableText(pm2);
 
-		expect(rt2[0]).toMatchObject({ _type: "youtube", id: "vid-1", caption: "test" });
-		expect(Object.keys(rt2[0]!).filter((k) => k.startsWith("_"))).toEqual(["_type", "_key"]);
+		expect(rt2).toEqual(withLeakyKeys);
 	});
 
 	it("field-data block (no id) survives round-trip", () => {
@@ -247,12 +254,7 @@ describe("Plugin block round-trip", () => {
 		const pm = portableTextToProsemirror(original);
 		const roundTripped = prosemirrorToPortableText(pm);
 
-		expect(roundTripped).toHaveLength(1);
-		expect(roundTripped[0]).toMatchObject({
-			_type: "emdash-form",
-			id: "",
-			formId: "abc-123",
-		});
+		expect(roundTripped).toEqual(original);
 	});
 
 	it("data with _type/_key fields cannot overwrite block identity after round-trip", () => {

--- a/packages/admin/tests/editor/plugin-block-conversion.test.ts
+++ b/packages/admin/tests/editor/plugin-block-conversion.test.ts
@@ -289,12 +289,12 @@ describe("Plugin block round-trip", () => {
 			pmPluginBlock("youtube", "vid-1", { _type: "evil", _key: "evil", caption: "test" }),
 		);
 
-		// PM → PT: fix 5 ensures _type/_key are set after data spread
+		// _type and _key are reassigned after data fields are spread, so data cannot overwrite identity.
 		const pt = prosemirrorToPortableText(doc);
 		expect(pt[0]!._type).toBe("youtube");
 		expect(pt[0]!._key).not.toBe("evil");
 
-		// PT → PM → PT: fix 6 strips _-prefixed keys, so they don't persist
+		// _-prefixed data keys are stripped on the next round-trip, so they cannot restore forged identity.
 		const pm2 = portableTextToProsemirror(pt);
 		const rt = prosemirrorToPortableText(pm2);
 		expect(rt[0]!._type).toBe("youtube");

--- a/packages/core/src/content/converters/index.ts
+++ b/packages/core/src/content/converters/index.ts
@@ -6,4 +6,6 @@
 
 export { prosemirrorToPortableText } from "./prosemirror-to-portable-text.js";
 export { portableTextToProsemirror } from "./portable-text-to-prosemirror.js";
+export type { PortableTextToProsemirrorOptions } from "./portable-text-to-prosemirror.js";
+export { portableTextIdentityExtensions } from "./portable-text-identity.js";
 export * from "./types.js";

--- a/packages/core/src/content/converters/mark-safety.ts
+++ b/packages/core/src/content/converters/mark-safety.ts
@@ -22,6 +22,7 @@ const SUPPORTED_PROSEMIRROR_MARKS = new Set([
 	"superscript",
 	"code",
 	"link",
+	"emdashPortableTextSpan",
 ]);
 
 type UnknownRecord = Record<string, unknown>;

--- a/packages/core/src/content/converters/portable-text-identity.ts
+++ b/packages/core/src/content/converters/portable-text-identity.ts
@@ -1,9 +1,11 @@
+import { Extension, Mark, Node, type Extensions } from "@tiptap/core";
+
 import type { PortableTextBlock, PortableTextMarkDef } from "./types.js";
 
 export const PORTABLE_TEXT_BLOCK_NODE = "emdashPortableTextBlock";
 export const PORTABLE_TEXT_BLOCK_ATTR = "emdashPortableTextBlock";
 export const PORTABLE_TEXT_KEY_ATTR = "emdashPortableTextKey";
-export const PORTABLE_TEXT_MARK_DEF_ATTR = "emdashPortableTextMarkDef";
+export const PORTABLE_TEXT_SPAN_MARK = "emdashPortableTextSpan";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -23,14 +25,26 @@ export function portableTextKeyFromAttrs(
 	return typeof key === "string" && key ? key : undefined;
 }
 
-export function portableTextMarkDefFromAttrs(
-	attrs: Record<string, unknown> | undefined,
-): PortableTextMarkDef | undefined {
-	const markDef = attrs?.[PORTABLE_TEXT_MARK_DEF_ATTR];
-	if (!isRecord(markDef) || typeof markDef._type !== "string" || typeof markDef._key !== "string") {
-		return undefined;
+export function portableTextSpanKeyFromMarks(marks: unknown[] | undefined): string | undefined {
+	for (const mark of marks ?? []) {
+		if (!isRecord(mark) || mark.type !== PORTABLE_TEXT_SPAN_MARK || !isRecord(mark.attrs)) continue;
+		const key = mark.attrs.key;
+		if (typeof key === "string" && key) return key;
 	}
-	return { ...markDef, _type: markDef._type, _key: markDef._key };
+	return undefined;
+}
+
+export function portableTextMarkDefsFromMarks(marks: unknown[] | undefined): PortableTextMarkDef[] {
+	const identity = (marks ?? []).find(
+		(mark) => isRecord(mark) && mark.type === PORTABLE_TEXT_SPAN_MARK && isRecord(mark.attrs),
+	);
+	if (!isRecord(identity) || !isRecord(identity.attrs) || !Array.isArray(identity.attrs.markDefs)) {
+		return [];
+	}
+	return identity.attrs.markDefs.filter(
+		(markDef): markDef is PortableTextMarkDef =>
+			isRecord(markDef) && typeof markDef._type === "string" && typeof markDef._key === "string",
+	);
 }
 
 export function portableTextBlockFromAttrs(
@@ -42,3 +56,84 @@ export function portableTextBlockFromAttrs(
 	}
 	return { ...block, _type: block._type, _key: block._key };
 }
+
+export const PortableTextIdentityExtension = Extension.create({
+	name: "emdashPortableTextIdentity",
+
+	addGlobalAttributes() {
+		const hiddenAttribute = { default: null, rendered: false };
+		return [
+			{
+				types: [
+					"paragraph",
+					"heading",
+					"blockquote",
+					"codeBlock",
+					"htmlBlock",
+					"image",
+					"horizontalRule",
+					"gallery",
+					PORTABLE_TEXT_BLOCK_NODE,
+				],
+				attributes: { [PORTABLE_TEXT_KEY_ATTR]: hiddenAttribute },
+			},
+		];
+	},
+});
+
+export const PortableTextSpanIdentity = Mark.create({
+	name: PORTABLE_TEXT_SPAN_MARK,
+	inclusive: false,
+	spanning: false,
+
+	addAttributes() {
+		return {
+			key: { default: null, rendered: false },
+			markDefs: { default: [], rendered: false },
+		};
+	},
+
+	parseHTML() {
+		return [];
+	},
+
+	renderHTML() {
+		return ["span", 0];
+	},
+});
+
+export const PortableTextOpaqueBlock = Node.create({
+	name: PORTABLE_TEXT_BLOCK_NODE,
+	group: "block",
+	atom: true,
+	selectable: true,
+	draggable: true,
+
+	addAttributes() {
+		return {
+			[PORTABLE_TEXT_BLOCK_ATTR]: { default: null, rendered: false },
+		};
+	},
+
+	parseHTML() {
+		return [{ tag: "div[data-emdash-portable-text-block]" }];
+	},
+
+	renderHTML({ node }) {
+		const blockType = portableTextBlockFromAttrs(node.attrs)?._type ?? "unknown";
+		return [
+			"div",
+			{
+				"data-emdash-portable-text-block": blockType,
+				contenteditable: "false",
+			},
+			`[Unknown block type: ${blockType}]`,
+		];
+	},
+});
+
+export const portableTextIdentityExtensions: Extensions = [
+	PortableTextIdentityExtension,
+	PortableTextSpanIdentity,
+	PortableTextOpaqueBlock,
+];

--- a/packages/core/src/content/converters/portable-text-identity.ts
+++ b/packages/core/src/content/converters/portable-text-identity.ts
@@ -1,0 +1,44 @@
+import type { PortableTextBlock, PortableTextMarkDef } from "./types.js";
+
+export const PORTABLE_TEXT_BLOCK_NODE = "emdashPortableTextBlock";
+export const PORTABLE_TEXT_BLOCK_ATTR = "emdashPortableTextBlock";
+export const PORTABLE_TEXT_KEY_ATTR = "emdashPortableTextKey";
+export const PORTABLE_TEXT_MARK_DEF_ATTR = "emdashPortableTextMarkDef";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function attrsWithPortableTextKey(
+	attrs: Record<string, unknown> | undefined,
+	key: string,
+): Record<string, unknown> {
+	return { ...attrs, [PORTABLE_TEXT_KEY_ATTR]: key };
+}
+
+export function portableTextKeyFromAttrs(
+	attrs: Record<string, unknown> | undefined,
+): string | undefined {
+	const key = attrs?.[PORTABLE_TEXT_KEY_ATTR];
+	return typeof key === "string" && key ? key : undefined;
+}
+
+export function portableTextMarkDefFromAttrs(
+	attrs: Record<string, unknown> | undefined,
+): PortableTextMarkDef | undefined {
+	const markDef = attrs?.[PORTABLE_TEXT_MARK_DEF_ATTR];
+	if (!isRecord(markDef) || typeof markDef._type !== "string" || typeof markDef._key !== "string") {
+		return undefined;
+	}
+	return { ...markDef, _type: markDef._type, _key: markDef._key };
+}
+
+export function portableTextBlockFromAttrs(
+	attrs: Record<string, unknown> | undefined,
+): PortableTextBlock | undefined {
+	const block = attrs?.[PORTABLE_TEXT_BLOCK_ATTR];
+	if (!isRecord(block) || typeof block._type !== "string" || typeof block._key !== "string") {
+		return undefined;
+	}
+	return { ...block, _type: block._type, _key: block._key };
+}

--- a/packages/core/src/content/converters/portable-text-to-prosemirror.ts
+++ b/packages/core/src/content/converters/portable-text-to-prosemirror.ts
@@ -205,8 +205,8 @@ function isImageBlock(block: PortableTextBlock): block is PortableTextImageBlock
 }
 
 /**
- * Type guard for gallery blocks. Requires an `images` array — a gallery
- * without one is malformed and falls through to the unknown-block path.
+ * Type guard for gallery blocks that carry a usable `images` array.
+ * Galleries without one are handled separately in `convertBlock`.
  */
 function isGalleryBlock(block: PortableTextBlock): block is PortableTextGalleryBlock {
 	return block._type === "gallery" && "images" in block && Array.isArray(block.images);

--- a/packages/core/src/content/converters/portable-text-to-prosemirror.ts
+++ b/packages/core/src/content/converters/portable-text-to-prosemirror.ts
@@ -18,7 +18,7 @@ import {
 import {
 	PORTABLE_TEXT_BLOCK_ATTR,
 	PORTABLE_TEXT_BLOCK_NODE,
-	PORTABLE_TEXT_MARK_DEF_ATTR,
+	PORTABLE_TEXT_SPAN_MARK,
 	attrsWithPortableTextKey,
 } from "./portable-text-identity.js";
 import type {
@@ -34,10 +34,19 @@ import type {
 	PortableTextCodeBlock,
 } from "./types.js";
 
-/**
- * Convert Portable Text to ProseMirror document
- */
-export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMirrorDocument {
+export interface PortableTextToProsemirrorOptions {
+	/**
+	 * Preserve custom blocks and Portable Text keys through a ProseMirror round trip.
+	 * Add `portableTextIdentityExtensions` to the TipTap schema when this is enabled.
+	 */
+	preserveIdentity?: boolean;
+}
+
+/** Convert Portable Text to a ProseMirror document. */
+export function portableTextToProsemirror(
+	blocks: PortableTextBlock[],
+	options: PortableTextToProsemirrorOptions = {},
+): ProseMirrorDocument {
 	if (!blocks || blocks.length === 0) {
 		return {
 			type: "doc",
@@ -45,6 +54,7 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 		};
 	}
 	assertPortableTextMarksSupported(blocks);
+	const preserveIdentity = options.preserveIdentity === true;
 
 	const content: ProseMirrorNode[] = [];
 	let i = 0;
@@ -86,7 +96,7 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 				}
 			}
 
-			content.push(convertList(listBlocks, listType, `root:${runStart}`));
+			content.push(convertList(listBlocks, listType, `root:${runStart}`, preserveIdentity));
 		} else if (isTextBlock(block) && block.style === "blockquote") {
 			// Collect a blockquote "run": Portable Text is flat, so a
 			// multi-paragraph quote is stored as consecutive blocks with
@@ -111,16 +121,20 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 			content.push({
 				type: "blockquote",
 				content: quoteBlocks.map((quoteBlock) => {
-					const paragraph = convertSpans(quoteBlock.children, quoteBlock.markDefs || []);
+					const paragraph = convertSpans(
+						quoteBlock.children,
+						quoteBlock.markDefs || [],
+						preserveIdentity,
+					);
 					return {
 						type: "paragraph",
-						attrs: attrsWithPortableTextKey(undefined, quoteBlock._key),
+						attrs: identityAttrs(undefined, quoteBlock._key, preserveIdentity),
 						content: paragraph.length > 0 ? paragraph : undefined,
 					};
 				}),
 			});
 		} else {
-			const converted = convertBlock(block);
+			const converted = convertBlock(block, preserveIdentity);
 			if (converted) {
 				content.push(converted);
 			}
@@ -132,6 +146,14 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 		type: "doc",
 		content: content.length > 0 ? content : [{ type: "paragraph" }],
 	});
+}
+
+function identityAttrs(
+	attrs: Record<string, unknown> | undefined,
+	key: string,
+	preserveIdentity: boolean,
+): Record<string, unknown> | undefined {
+	return preserveIdentity ? attrsWithPortableTextKey(attrs, key) : attrs;
 }
 
 function getListMetadata(
@@ -200,41 +222,45 @@ function isCodeBlock(block: PortableTextBlock): block is PortableTextCodeBlock {
 /**
  * Convert a single Portable Text block to ProseMirror node
  */
-function convertBlock(block: PortableTextBlock): ProseMirrorNode | null {
+function convertBlock(block: PortableTextBlock, preserveIdentity: boolean): ProseMirrorNode | null {
 	if (isTextBlock(block)) {
-		return convertTextBlock(block);
+		return convertTextBlock(block, preserveIdentity);
 	}
 	if (isImageBlock(block)) {
-		return convertImage(block);
+		return convertImage(block, preserveIdentity);
 	}
 	if (block._type === "image") {
 		// Malformed image block (no asset wrapper) — extract url from top level
-		return convertMalformedImage(block);
+		return convertMalformedImage(block, preserveIdentity);
 	}
 	if (isGalleryBlock(block)) {
 		return {
 			type: "gallery",
-			attrs: attrsWithPortableTextKey(
+			attrs: identityAttrs(
 				{
 					images: sanitizeGalleryImages(block.images),
 					columns: typeof block.columns === "number" ? block.columns : undefined,
 				},
 				block._key,
+				preserveIdentity,
 			),
 		};
 	}
 	if (isCodeBlock(block)) {
-		return convertCodeBlock(block);
+		return convertCodeBlock(block, preserveIdentity);
 	}
 	if (block._type === "htmlBlock") {
 		const hb = block as PortableTextBlock & { html?: string };
 		return {
 			type: "htmlBlock",
-			attrs: attrsWithPortableTextKey({ html: hb.html || "" }, block._key),
+			attrs: identityAttrs({ html: hb.html || "" }, block._key, preserveIdentity),
 		};
 	}
 	if (block._type === "break") {
-		return { type: "horizontalRule", attrs: attrsWithPortableTextKey(undefined, block._key) };
+		return {
+			type: "horizontalRule",
+			attrs: identityAttrs(undefined, block._key, preserveIdentity),
+		};
 	}
 	if (block._type === "gallery") {
 		return {
@@ -248,22 +274,35 @@ function convertBlock(block: PortableTextBlock): ProseMirrorNode | null {
 			],
 		};
 	}
-	// Keep custom blocks opaque so fields that this converter does not understand
-	// can pass through an editor round-trip unchanged.
+	if (preserveIdentity) {
+		return {
+			type: PORTABLE_TEXT_BLOCK_NODE,
+			attrs: { [PORTABLE_TEXT_BLOCK_ATTR]: block },
+		};
+	}
 	return {
-		type: PORTABLE_TEXT_BLOCK_NODE,
-		attrs: { [PORTABLE_TEXT_BLOCK_ATTR]: block },
+		type: "paragraph",
+		content: [
+			{
+				type: "text",
+				text: `[Unknown block type: ${block._type}]`,
+				marks: [{ type: "code" }],
+			},
+		],
 	};
 }
 
 /**
  * Convert text block to ProseMirror paragraph or heading
  */
-function convertTextBlock(block: PortableTextTextBlock): ProseMirrorNode | null {
+function convertTextBlock(
+	block: PortableTextTextBlock,
+	preserveIdentity: boolean,
+): ProseMirrorNode | null {
 	const { style = "normal", children, markDefs = [] } = block;
 
 	// Convert children to ProseMirror nodes
-	const content = convertSpans(children, markDefs);
+	const content = convertSpans(children, markDefs, preserveIdentity);
 
 	// Determine node type based on style
 	switch (style) {
@@ -276,12 +315,13 @@ function convertTextBlock(block: PortableTextTextBlock): ProseMirrorNode | null 
 			const level = parseInt(style.substring(1), 10);
 			return {
 				type: "heading",
-				attrs: attrsWithPortableTextKey(
+				attrs: identityAttrs(
 					{
 						level,
 						...(block.textAlign ? { textAlign: block.textAlign } : {}),
 					},
 					block._key,
+					preserveIdentity,
 				),
 				content: content.length > 0 ? content : undefined,
 			};
@@ -290,7 +330,7 @@ function convertTextBlock(block: PortableTextTextBlock): ProseMirrorNode | null 
 		case "blockquote":
 			return {
 				type: "blockquote",
-				attrs: attrsWithPortableTextKey(undefined, block._key),
+				attrs: identityAttrs(undefined, block._key, preserveIdentity),
 				content: [
 					{
 						type: "paragraph",
@@ -303,9 +343,10 @@ function convertTextBlock(block: PortableTextTextBlock): ProseMirrorNode | null 
 		default:
 			return {
 				type: "paragraph",
-				attrs: attrsWithPortableTextKey(
+				attrs: identityAttrs(
 					block.textAlign ? { textAlign: block.textAlign } : undefined,
 					block._key,
+					preserveIdentity,
 				),
 				content: content.length > 0 ? content : undefined,
 			};
@@ -319,6 +360,7 @@ function convertList(
 	items: PortableTextTextBlock[],
 	listType: "bullet" | "number",
 	context: string,
+	preserveIdentity: boolean,
 ): ProseMirrorNode {
 	// Group items by level
 	const rootItems: ProseMirrorNode[] = [];
@@ -339,11 +381,19 @@ function convertList(
 			}
 
 			rootItems.push(
-				convertListItem(item, nestedItems, listType, `${context}:${rootItems.length}`),
+				convertListItem(
+					item,
+					nestedItems,
+					listType,
+					`${context}:${rootItems.length}`,
+					preserveIdentity,
+				),
 			);
 		} else {
 			// Orphan nested item - treat as root
-			rootItems.push(convertListItem(item, [], listType, `${context}:${rootItems.length}`));
+			rootItems.push(
+				convertListItem(item, [], listType, `${context}:${rootItems.length}`, preserveIdentity),
+			);
 			i++;
 		}
 	}
@@ -366,14 +416,15 @@ function convertListItem(
 	nestedItems: PortableTextTextBlock[],
 	parentListType: "bullet" | "number",
 	context: string,
+	preserveIdentity: boolean,
 ): ProseMirrorNode {
 	const content: ProseMirrorNode[] = [];
 
 	// Add paragraph content
-	const spans = convertSpans(item.children, item.markDefs || []);
+	const spans = convertSpans(item.children, item.markDefs || [], preserveIdentity);
 	content.push({
 		type: "paragraph",
-		attrs: attrsWithPortableTextKey(undefined, item._key),
+		attrs: identityAttrs(undefined, item._key, preserveIdentity),
 		content: spans.length > 0 ? spans : undefined,
 	});
 
@@ -415,7 +466,12 @@ function convertListItem(
 					level: (ni.level || 2) - 1,
 				}));
 				content.push(
-					convertList(adjustedGroup, anchorType, `${context}:nested:${j - nestedGroup.length}`),
+					convertList(
+						adjustedGroup,
+						anchorType,
+						`${context}:nested:${j - nestedGroup.length}`,
+						preserveIdentity,
+					),
 				);
 			}
 		}
@@ -433,12 +489,14 @@ function convertListItem(
 function convertSpans(
 	spans: PortableTextSpan[],
 	markDefs: PortableTextMarkDef[],
+	preserveIdentity: boolean,
 ): ProseMirrorNode[] {
 	const nodes: ProseMirrorNode[] = [];
 	const markDefsMap = new Map(markDefs.map((md) => [md._key, md]));
 
 	for (const span of spans) {
 		if (span._type !== "span") continue;
+		const referencedMarkDefs = markDefs.filter((markDef) => span.marks?.includes(markDef._key));
 
 		// Handle newlines in text
 		const parts = span.text.split("\n");
@@ -449,10 +507,15 @@ function convertSpans(
 			// Add text node
 			if (text.length > 0) {
 				const marks = convertMarks(span.marks || [], markDefsMap);
+				if (preserveIdentity) {
+					marks.push({
+						type: PORTABLE_TEXT_SPAN_MARK,
+						attrs: { key: span._key, markDefs: referencedMarkDefs },
+					});
+				}
 				const node: ProseMirrorNode = {
 					type: "text",
 					text,
-					attrs: attrsWithPortableTextKey(undefined, span._key),
 				};
 				if (marks.length > 0) node.marks = marks;
 				nodes.push(node);
@@ -460,10 +523,19 @@ function convertSpans(
 
 			// Add hard break between parts (not after last)
 			if (i < parts.length - 1) {
-				nodes.push({
-					type: "hardBreak",
-					attrs: attrsWithPortableTextKey(undefined, span._key),
-				});
+				nodes.push(
+					preserveIdentity
+						? {
+								type: "hardBreak",
+								marks: [
+									{
+										type: PORTABLE_TEXT_SPAN_MARK,
+										attrs: { key: span._key, markDefs: referencedMarkDefs },
+									},
+								],
+							}
+						: { type: "hardBreak" },
+				);
 			}
 		}
 	}
@@ -519,7 +591,6 @@ function convertMarks(
 						attrs: {
 							href: markDef.href,
 							target: markDef.blank ? "_blank" : null,
-							[PORTABLE_TEXT_MARK_DEF_ATTR]: markDef,
 						},
 					});
 				} else {
@@ -548,10 +619,10 @@ function imageAlignment(value: unknown): PortableTextImageBlock["alignment"] {
 /**
  * Convert image block to ProseMirror
  */
-function convertImage(block: PortableTextImageBlock): ProseMirrorNode {
+function convertImage(block: PortableTextImageBlock, preserveIdentity: boolean): ProseMirrorNode {
 	return {
 		type: "image",
-		attrs: attrsWithPortableTextKey(
+		attrs: identityAttrs(
 			{
 				src: block.asset.url || block.asset._ref,
 				alt: block.alt || "",
@@ -565,6 +636,7 @@ function convertImage(block: PortableTextImageBlock): ProseMirrorNode {
 				alignment: imageAlignment(block.alignment),
 			},
 			block._key,
+			preserveIdentity,
 		),
 	};
 }
@@ -574,7 +646,10 @@ function convertImage(block: PortableTextImageBlock): ProseMirrorNode {
  * Handles blocks like `{ _type: "image", url: "...", alt: "..." }` that may
  * originate from migrations or third-party imports.
  */
-function convertMalformedImage(block: PortableTextBlock): ProseMirrorNode {
+function convertMalformedImage(
+	block: PortableTextBlock,
+	preserveIdentity: boolean,
+): ProseMirrorNode {
 	// PortableTextUnknownBlock allows indexed access via [key: string]: unknown
 	const url = "url" in block && typeof block.url === "string" ? block.url : "";
 	const alt = "alt" in block && typeof block.alt === "string" ? block.alt : "";
@@ -591,7 +666,7 @@ function convertMalformedImage(block: PortableTextBlock): ProseMirrorNode {
 			: undefined;
 	return {
 		type: "image",
-		attrs: attrsWithPortableTextKey(
+		attrs: identityAttrs(
 			{
 				src: url,
 				alt,
@@ -605,6 +680,7 @@ function convertMalformedImage(block: PortableTextBlock): ProseMirrorNode {
 				alignment: imageAlignment("alignment" in block ? block.alignment : undefined),
 			},
 			block._key,
+			preserveIdentity,
 		),
 	};
 }
@@ -612,14 +688,18 @@ function convertMalformedImage(block: PortableTextBlock): ProseMirrorNode {
 /**
  * Convert code block to ProseMirror
  */
-function convertCodeBlock(block: PortableTextCodeBlock): ProseMirrorNode {
+function convertCodeBlock(
+	block: PortableTextCodeBlock,
+	preserveIdentity: boolean,
+): ProseMirrorNode {
 	return {
 		type: "codeBlock",
-		attrs: attrsWithPortableTextKey(
+		attrs: identityAttrs(
 			{
 				language: block.language || null,
 			},
 			block._key,
+			preserveIdentity,
 		),
 		content: block.code ? [{ type: "text", text: block.code }] : undefined,
 	};

--- a/packages/core/src/content/converters/portable-text-to-prosemirror.ts
+++ b/packages/core/src/content/converters/portable-text-to-prosemirror.ts
@@ -15,6 +15,12 @@ import {
 	normalizeListId,
 	normalizeListStart,
 } from "./numbered-list.js";
+import {
+	PORTABLE_TEXT_BLOCK_ATTR,
+	PORTABLE_TEXT_BLOCK_NODE,
+	PORTABLE_TEXT_MARK_DEF_ATTR,
+	attrsWithPortableTextKey,
+} from "./portable-text-identity.js";
 import type {
 	ProseMirrorDocument,
 	ProseMirrorNode,
@@ -108,6 +114,7 @@ export function portableTextToProsemirror(blocks: PortableTextBlock[]): ProseMir
 					const paragraph = convertSpans(quoteBlock.children, quoteBlock.markDefs || []);
 					return {
 						type: "paragraph",
+						attrs: attrsWithPortableTextKey(undefined, quoteBlock._key),
 						content: paragraph.length > 0 ? paragraph : undefined,
 					};
 				}),
@@ -207,10 +214,13 @@ function convertBlock(block: PortableTextBlock): ProseMirrorNode | null {
 	if (isGalleryBlock(block)) {
 		return {
 			type: "gallery",
-			attrs: {
-				images: sanitizeGalleryImages(block.images),
-				columns: typeof block.columns === "number" ? block.columns : undefined,
-			},
+			attrs: attrsWithPortableTextKey(
+				{
+					images: sanitizeGalleryImages(block.images),
+					columns: typeof block.columns === "number" ? block.columns : undefined,
+				},
+				block._key,
+			),
 		};
 	}
 	if (isCodeBlock(block)) {
@@ -220,22 +230,29 @@ function convertBlock(block: PortableTextBlock): ProseMirrorNode | null {
 		const hb = block as PortableTextBlock & { html?: string };
 		return {
 			type: "htmlBlock",
-			attrs: { html: hb.html || "" },
+			attrs: attrsWithPortableTextKey({ html: hb.html || "" }, block._key),
 		};
 	}
 	if (block._type === "break") {
-		return { type: "horizontalRule" };
+		return { type: "horizontalRule", attrs: attrsWithPortableTextKey(undefined, block._key) };
 	}
-	// Unknown block - wrap in a div or preserve as placeholder
+	if (block._type === "gallery") {
+		return {
+			type: "paragraph",
+			content: [
+				{
+					type: "text",
+					text: `[Unknown block type: ${block._type}]`,
+					marks: [{ type: "code" }],
+				},
+			],
+		};
+	}
+	// Keep custom blocks opaque so fields that this converter does not understand
+	// can pass through an editor round-trip unchanged.
 	return {
-		type: "paragraph",
-		content: [
-			{
-				type: "text",
-				text: `[Unknown block type: ${block._type}]`,
-				marks: [{ type: "code" }],
-			},
-		],
+		type: PORTABLE_TEXT_BLOCK_NODE,
+		attrs: { [PORTABLE_TEXT_BLOCK_ATTR]: block },
 	};
 }
 
@@ -259,10 +276,13 @@ function convertTextBlock(block: PortableTextTextBlock): ProseMirrorNode | null 
 			const level = parseInt(style.substring(1), 10);
 			return {
 				type: "heading",
-				attrs: {
-					level,
-					...(block.textAlign ? { textAlign: block.textAlign } : {}),
-				},
+				attrs: attrsWithPortableTextKey(
+					{
+						level,
+						...(block.textAlign ? { textAlign: block.textAlign } : {}),
+					},
+					block._key,
+				),
 				content: content.length > 0 ? content : undefined,
 			};
 		}
@@ -270,6 +290,7 @@ function convertTextBlock(block: PortableTextTextBlock): ProseMirrorNode | null 
 		case "blockquote":
 			return {
 				type: "blockquote",
+				attrs: attrsWithPortableTextKey(undefined, block._key),
 				content: [
 					{
 						type: "paragraph",
@@ -282,7 +303,10 @@ function convertTextBlock(block: PortableTextTextBlock): ProseMirrorNode | null 
 		default:
 			return {
 				type: "paragraph",
-				attrs: block.textAlign ? { textAlign: block.textAlign } : undefined,
+				attrs: attrsWithPortableTextKey(
+					block.textAlign ? { textAlign: block.textAlign } : undefined,
+					block._key,
+				),
 				content: content.length > 0 ? content : undefined,
 			};
 	}
@@ -349,6 +373,7 @@ function convertListItem(
 	const spans = convertSpans(item.children, item.markDefs || []);
 	content.push({
 		type: "paragraph",
+		attrs: attrsWithPortableTextKey(undefined, item._key),
 		content: spans.length > 0 ? spans : undefined,
 	});
 
@@ -427,16 +452,18 @@ function convertSpans(
 				const node: ProseMirrorNode = {
 					type: "text",
 					text,
+					attrs: attrsWithPortableTextKey(undefined, span._key),
 				};
-				if (marks.length > 0) {
-					node.marks = marks;
-				}
+				if (marks.length > 0) node.marks = marks;
 				nodes.push(node);
 			}
 
 			// Add hard break between parts (not after last)
 			if (i < parts.length - 1) {
-				nodes.push({ type: "hardBreak" });
+				nodes.push({
+					type: "hardBreak",
+					attrs: attrsWithPortableTextKey(undefined, span._key),
+				});
 			}
 		}
 	}
@@ -492,6 +519,7 @@ function convertMarks(
 						attrs: {
 							href: markDef.href,
 							target: markDef.blank ? "_blank" : null,
+							[PORTABLE_TEXT_MARK_DEF_ATTR]: markDef,
 						},
 					});
 				} else {
@@ -523,18 +551,21 @@ function imageAlignment(value: unknown): PortableTextImageBlock["alignment"] {
 function convertImage(block: PortableTextImageBlock): ProseMirrorNode {
 	return {
 		type: "image",
-		attrs: {
-			src: block.asset.url || block.asset._ref,
-			alt: block.alt || "",
-			title: block.caption || "",
-			mediaId: block.asset._ref,
-			provider: block.asset.provider,
-			width: block.width,
-			height: block.height,
-			displayWidth: block.displayWidth,
-			displayHeight: block.displayHeight,
-			alignment: imageAlignment(block.alignment),
-		},
+		attrs: attrsWithPortableTextKey(
+			{
+				src: block.asset.url || block.asset._ref,
+				alt: block.alt || "",
+				title: block.caption || "",
+				mediaId: block.asset._ref,
+				provider: block.asset.provider,
+				width: block.width,
+				height: block.height,
+				displayWidth: block.displayWidth,
+				displayHeight: block.displayHeight,
+				alignment: imageAlignment(block.alignment),
+			},
+			block._key,
+		),
 	};
 }
 
@@ -560,18 +591,21 @@ function convertMalformedImage(block: PortableTextBlock): ProseMirrorNode {
 			: undefined;
 	return {
 		type: "image",
-		attrs: {
-			src: url,
-			alt,
-			title: caption,
-			mediaId: undefined,
-			provider: undefined,
-			width,
-			height,
-			displayWidth,
-			displayHeight,
-			alignment: imageAlignment("alignment" in block ? block.alignment : undefined),
-		},
+		attrs: attrsWithPortableTextKey(
+			{
+				src: url,
+				alt,
+				title: caption,
+				mediaId: undefined,
+				provider: undefined,
+				width,
+				height,
+				displayWidth,
+				displayHeight,
+				alignment: imageAlignment("alignment" in block ? block.alignment : undefined),
+			},
+			block._key,
+		),
 	};
 }
 
@@ -581,9 +615,12 @@ function convertMalformedImage(block: PortableTextBlock): ProseMirrorNode {
 function convertCodeBlock(block: PortableTextCodeBlock): ProseMirrorNode {
 	return {
 		type: "codeBlock",
-		attrs: {
-			language: block.language || null,
-		},
+		attrs: attrsWithPortableTextKey(
+			{
+				language: block.language || null,
+			},
+			block._key,
+		),
 		content: block.code ? [{ type: "text", text: block.code }] : undefined,
 	};
 }

--- a/packages/core/src/content/converters/portable-text-to-prosemirror.ts
+++ b/packages/core/src/content/converters/portable-text-to-prosemirror.ts
@@ -440,11 +440,9 @@ function convertListItem(
 		// item's nested subtree. A new sub-list only starts when we hit
 		// another block at that root level with a different `listItem` type;
 		// deeper blocks (level > minLevel) belong to the current group as
-		// descendants regardless of their own `listItem`. The previous
-		// grouping broke on any type change at any depth, so a deep mixed
-		// tree like `bullet L1 → number L2 → bullet L3 → number L2` would
-		// emit C(L3) as a sibling list under A(L1) instead of nesting it
-		// under B(L2), then degrade C to L2 on round-trip.
+		// descendants regardless of their own `listItem`. A deep mixed tree
+		// like `bullet L1 → number L2 → bullet L3 → number L2` stays nested
+		// under B(L2) and preserves its original level on round-trip.
 		let minLevel = Infinity;
 		for (const ni of nestedItems) {
 			const level = ni.level || 2;

--- a/packages/core/src/content/converters/portable-text-to-prosemirror.ts
+++ b/packages/core/src/content/converters/portable-text-to-prosemirror.ts
@@ -263,6 +263,12 @@ function convertBlock(block: PortableTextBlock, preserveIdentity: boolean): Pros
 		};
 	}
 	if (block._type === "gallery") {
+		if (preserveIdentity) {
+			return {
+				type: PORTABLE_TEXT_BLOCK_NODE,
+				attrs: { [PORTABLE_TEXT_BLOCK_ATTR]: block },
+			};
+		}
 		return {
 			type: "paragraph",
 			content: [

--- a/packages/core/src/content/converters/prosemirror-to-portable-text.ts
+++ b/packages/core/src/content/converters/prosemirror-to-portable-text.ts
@@ -12,9 +12,11 @@ import {
 import { readOrderedListMetadata, type OrderedListMetadata } from "./numbered-list.js";
 import {
 	PORTABLE_TEXT_BLOCK_NODE,
+	PORTABLE_TEXT_SPAN_MARK,
 	portableTextBlockFromAttrs,
 	portableTextKeyFromAttrs,
-	portableTextMarkDefFromAttrs,
+	portableTextMarkDefsFromMarks,
+	portableTextSpanKeyFromMarks,
 } from "./portable-text-identity.js";
 import type {
 	ProseMirrorDocument,
@@ -417,15 +419,17 @@ function convertInlineContent(nodes: ProseMirrorNode[]): {
 	for (const node of nodes) {
 		if (node.type === "text" && node.text) {
 			const marks: string[] = [];
+			const originalMarkDefs = portableTextMarkDefsFromMarks(node.marks);
 
 			for (const mark of node.marks || []) {
-				const markType = convertMark(mark, markDefs, markDefMap);
+				const markType = convertMark(mark, markDefs, markDefMap, originalMarkDefs);
 				if (markType) {
 					marks.push(markType);
 				}
 			}
 
-			const preferredKey = portableTextKeyFromAttrs(node.attrs);
+			const preferredKey =
+				portableTextSpanKeyFromMarks(node.marks) ?? portableTextKeyFromAttrs(node.attrs);
 			const normalizedMarks = marks.length > 0 ? marks : undefined;
 			const previous = children.at(-1);
 			if (
@@ -451,7 +455,9 @@ function convertInlineContent(nodes: ProseMirrorNode[]): {
 			} else {
 				children.push({
 					_type: "span",
-					_key: claimSpanKey(portableTextKeyFromAttrs(node.attrs)),
+					_key: claimSpanKey(
+						portableTextSpanKeyFromMarks(node.marks) ?? portableTextKeyFromAttrs(node.attrs),
+					),
 					text: "\n",
 				});
 			}
@@ -477,6 +483,7 @@ function convertMark(
 	mark: ProseMirrorMark,
 	markDefs: PortableTextMarkDef[],
 	markDefMap: Map<string, string>,
+	originalMarkDefs: PortableTextMarkDef[],
 ): string | null {
 	switch (mark.type) {
 		case "bold":
@@ -503,9 +510,12 @@ function convertMark(
 		case "code":
 			return "code";
 
+		case PORTABLE_TEXT_SPAN_MARK:
+			return null;
+
 		case "link": {
 			const href = (typeof mark.attrs?.href === "string" ? mark.attrs.href : "") || "";
-			const originalMarkDef = portableTextMarkDefFromAttrs(mark.attrs);
+			const originalMarkDef = originalMarkDefs.find((markDef) => markDef._type === "link");
 			const mapKey = originalMarkDef ? `key:${originalMarkDef._key}` : `href:${href}`;
 
 			// Check if we already have a mark def for this link

--- a/packages/core/src/content/converters/prosemirror-to-portable-text.ts
+++ b/packages/core/src/content/converters/prosemirror-to-portable-text.ts
@@ -297,7 +297,10 @@ function convertBlockquote(
 			if (children.length > 0) {
 				blocks.push({
 					_type: "block",
-					_key: portableTextKeyFromAttrs(child.attrs) ?? generateKey(),
+					_key:
+						portableTextKeyFromAttrs(child.attrs) ??
+						portableTextKeyFromAttrs(node.attrs) ??
+						generateKey(),
 					style: "blockquote",
 					children,
 					markDefs: markDefs.length > 0 ? markDefs : undefined,

--- a/packages/core/src/content/converters/prosemirror-to-portable-text.ts
+++ b/packages/core/src/content/converters/prosemirror-to-portable-text.ts
@@ -10,6 +10,12 @@ import {
 	assertProseMirrorMarksSupported,
 } from "./mark-safety.js";
 import { readOrderedListMetadata, type OrderedListMetadata } from "./numbered-list.js";
+import {
+	PORTABLE_TEXT_BLOCK_NODE,
+	portableTextBlockFromAttrs,
+	portableTextKeyFromAttrs,
+	portableTextMarkDefFromAttrs,
+} from "./portable-text-identity.js";
 import type {
 	ProseMirrorDocument,
 	ProseMirrorNode,
@@ -41,19 +47,31 @@ export function prosemirrorToPortableText(doc: ProseMirrorDocument): PortableTex
 	assertProseMirrorMarksSupported(doc);
 
 	const blocks: PortableTextBlock[] = [];
+	const usedBlockKeys = new Set<string>();
 
 	for (const [i, node] of doc.content.entries()) {
+		if (i === doc.content.length - 1 && isUnkeyedEmptyParagraph(node)) continue;
 		const converted = convertNode(node, `root:${i}`);
-		if (converted) {
-			if (Array.isArray(converted)) {
-				blocks.push(...converted);
-			} else {
-				blocks.push(converted);
+		for (const block of converted ? (Array.isArray(converted) ? converted : [converted]) : []) {
+			let key = block._key;
+			if (usedBlockKeys.has(key)) {
+				do key = generateKey();
+				while (usedBlockKeys.has(key));
 			}
+			usedBlockKeys.add(key);
+			blocks.push(key === block._key ? block : { ...block, _key: key });
 		}
 	}
 
 	return blocks;
+}
+
+function isUnkeyedEmptyParagraph(node: ProseMirrorNode): boolean {
+	return (
+		node.type === "paragraph" &&
+		(node.content?.length ?? 0) === 0 &&
+		portableTextKeyFromAttrs(node.attrs) === undefined
+	);
 }
 
 /**
@@ -64,6 +82,9 @@ function convertNode(
 	path: string,
 ): PortableTextBlock | PortableTextBlock[] | null {
 	switch (node.type) {
+		case PORTABLE_TEXT_BLOCK_NODE:
+			return portableTextBlockFromAttrs(node.attrs) ?? null;
+
 		case "paragraph":
 			return convertParagraph(node);
 
@@ -94,7 +115,7 @@ function convertNode(
 		case "horizontalRule":
 			return {
 				_type: "break",
-				_key: generateKey(),
+				_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 				style: "lineBreak",
 			};
 
@@ -125,10 +146,10 @@ function convertParagraph(node: ProseMirrorNode): PortableTextTextBlock | null {
 
 	return {
 		_type: "block",
-		_key: generateKey(),
+		_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 		style: "normal",
 		children,
-		markDefs: markDefs.length > 0 ? markDefs : undefined,
+		...(markDefs.length > 0 ? { markDefs } : {}),
 		...(textAlign ? { textAlign } : {}),
 	};
 }
@@ -170,7 +191,7 @@ function convertHeading(node: ProseMirrorNode): PortableTextTextBlock | null {
 
 	return {
 		_type: "block",
-		_key: generateKey(),
+		_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 		style,
 		children,
 		markDefs: markDefs.length > 0 ? markDefs : undefined,
@@ -218,7 +239,7 @@ function convertListItem(
 			if (children.length > 0) {
 				blocks.push({
 					_type: "block",
-					_key: generateKey(),
+					_key: portableTextKeyFromAttrs(child.attrs) ?? generateKey(),
 					style: "normal",
 					listItem,
 					level,
@@ -274,7 +295,7 @@ function convertBlockquote(
 			if (children.length > 0) {
 				blocks.push({
 					_type: "block",
-					_key: generateKey(),
+					_key: portableTextKeyFromAttrs(child.attrs) ?? generateKey(),
 					style: "blockquote",
 					children,
 					markDefs: markDefs.length > 0 ? markDefs : undefined,
@@ -295,7 +316,7 @@ function convertCodeBlock(node: ProseMirrorNode): PortableTextCodeBlock {
 
 	return {
 		_type: "code",
-		_key: generateKey(),
+		_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 		code,
 		language: language || undefined,
 	};
@@ -308,7 +329,7 @@ function convertHtmlBlock(node: ProseMirrorNode): PortableTextHtmlBlock {
 	const rawHtml = node.attrs?.html;
 	return {
 		_type: "htmlBlock",
-		_key: generateKey(),
+		_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 		html: typeof rawHtml === "string" ? rawHtml : "",
 	};
 }
@@ -331,7 +352,7 @@ function convertImage(node: ProseMirrorNode): PortableTextImageBlock {
 
 	return {
 		_type: "image",
-		_key: generateKey(),
+		_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 		asset: {
 			// Use mediaId as _ref if available (for proper provider lookups)
 			_ref: mediaId || src || "",
@@ -364,7 +385,7 @@ function convertGallery(node: ProseMirrorNode): PortableTextGalleryBlock {
 	const columns = node.attrs?.columns;
 	return {
 		_type: "gallery",
-		_key: generateKey(),
+		_key: portableTextKeyFromAttrs(node.attrs) ?? generateKey(),
 		images: sanitizeGalleryImages(node.attrs?.images, generateKey),
 		...(typeof columns === "number" ? { columns } : {}),
 	};
@@ -380,6 +401,18 @@ function convertInlineContent(nodes: ProseMirrorNode[]): {
 	const children: PortableTextSpan[] = [];
 	const markDefs: PortableTextMarkDef[] = [];
 	const markDefMap = new Map<string, string>(); // href -> key
+	const usedSpanKeys = new Set<string>();
+	const claimSpanKey = (preferred?: string) => {
+		if (preferred && !usedSpanKeys.has(preferred)) {
+			usedSpanKeys.add(preferred);
+			return preferred;
+		}
+		let key: string;
+		do key = generateKey();
+		while (usedSpanKeys.has(key));
+		usedSpanKeys.add(key);
+		return key;
+	};
 
 	for (const node of nodes) {
 		if (node.type === "text" && node.text) {
@@ -392,11 +425,23 @@ function convertInlineContent(nodes: ProseMirrorNode[]): {
 				}
 			}
 
+			const preferredKey = portableTextKeyFromAttrs(node.attrs);
+			const normalizedMarks = marks.length > 0 ? marks : undefined;
+			const previous = children.at(-1);
+			if (
+				preferredKey &&
+				previous?._key === preferredKey &&
+				JSON.stringify(previous.marks) === JSON.stringify(normalizedMarks)
+			) {
+				previous.text += node.text;
+				continue;
+			}
+
 			children.push({
 				_type: "span",
-				_key: generateKey(),
+				_key: claimSpanKey(preferredKey),
 				text: node.text,
-				marks: marks.length > 0 ? marks : undefined,
+				marks: normalizedMarks,
 			});
 		} else if (node.type === "hardBreak") {
 			// Hard breaks become newlines in the text
@@ -406,7 +451,7 @@ function convertInlineContent(nodes: ProseMirrorNode[]): {
 			} else {
 				children.push({
 					_type: "span",
-					_key: generateKey(),
+					_key: claimSpanKey(portableTextKeyFromAttrs(node.attrs)),
 					text: "\n",
 				});
 			}
@@ -417,7 +462,7 @@ function convertInlineContent(nodes: ProseMirrorNode[]): {
 	if (children.length === 0) {
 		children.push({
 			_type: "span",
-			_key: generateKey(),
+			_key: claimSpanKey(),
 			text: "",
 		});
 	}
@@ -460,21 +505,25 @@ function convertMark(
 
 		case "link": {
 			const href = (typeof mark.attrs?.href === "string" ? mark.attrs.href : "") || "";
+			const originalMarkDef = portableTextMarkDefFromAttrs(mark.attrs);
+			const mapKey = originalMarkDef ? `key:${originalMarkDef._key}` : `href:${href}`;
 
 			// Check if we already have a mark def for this link
-			if (markDefMap.has(href)) {
-				return markDefMap.get(href)!;
+			if (markDefMap.has(mapKey)) {
+				return markDefMap.get(mapKey)!;
 			}
 
 			// Create new mark def
-			const key = generateKey();
+			const key = originalMarkDef?._key || generateKey();
+			const blank = mark.attrs?.target === "_blank";
 			markDefs.push({
+				...originalMarkDef,
 				_type: "link",
 				_key: key,
 				href,
-				blank: mark.attrs?.target === "_blank",
+				...(blank || (originalMarkDef && Object.hasOwn(originalMarkDef, "blank")) ? { blank } : {}),
 			});
-			markDefMap.set(href, key);
+			markDefMap.set(mapKey, key);
 
 			return key;
 		}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -107,8 +107,13 @@ export type {
 } from "./api/index.js";
 
 // Content converters (Portable Text <-> ProseMirror)
-export { prosemirrorToPortableText, portableTextToProsemirror } from "./content/index.js";
+export {
+	portableTextIdentityExtensions,
+	prosemirrorToPortableText,
+	portableTextToProsemirror,
+} from "./content/index.js";
 export type {
+	PortableTextToProsemirrorOptions,
 	PortableTextSpan,
 	PortableTextMarkDef,
 	PortableTextLinkMark,

--- a/packages/core/tests/unit/converters/custom-block-round-trip.test.ts
+++ b/packages/core/tests/unit/converters/custom-block-round-trip.test.ts
@@ -76,6 +76,16 @@ describe("Portable Text converter identity preservation", () => {
 		expect(roundTripped).toEqual(blocks);
 	});
 
+	it("preserves a gallery block that has no images array in identity mode", () => {
+		const blocks: PortableTextBlock[] = [
+			{ _type: "gallery", _key: "gallery-1", legacySource: "import" },
+		];
+
+		const roundTripped = prosemirrorToPortableText(portableTextToIdentityDocument(blocks));
+
+		expect(roundTripped).toEqual(blocks);
+	});
+
 	it("preserves existing keys and supported link mark definitions", () => {
 		const blocks: PortableTextBlock[] = [
 			{

--- a/packages/core/tests/unit/converters/custom-block-round-trip.test.ts
+++ b/packages/core/tests/unit/converters/custom-block-round-trip.test.ts
@@ -1,14 +1,77 @@
+import { getSchema } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
 import { describe, expect, it } from "vitest";
 
+import { portableTextIdentityExtensions } from "../../../src/content/converters/portable-text-identity.js";
 import { portableTextToProsemirror } from "../../../src/content/converters/portable-text-to-prosemirror.js";
 import { prosemirrorToPortableText } from "../../../src/content/converters/prosemirror-to-portable-text.js";
 import type { PortableTextBlock } from "../../../src/content/converters/types.js";
 
+function portableTextToIdentityDocument(blocks: PortableTextBlock[]) {
+	return portableTextToProsemirror(blocks, { preserveIdentity: true });
+}
+
 describe("Portable Text converter identity preservation", () => {
+	it("emits text JSON that survives a standard ProseMirror schema", () => {
+		const document = portableTextToProsemirror([
+			{
+				_type: "block",
+				_key: "block-1",
+				style: "normal",
+				children: [{ _type: "span", _key: "span-1", text: "Hello world" }],
+			},
+		]);
+		const schema = getSchema([StarterKit]);
+
+		const parsed = schema.nodeFromJSON(document);
+
+		expect(parsed.toJSON()).toEqual(JSON.parse(JSON.stringify(document)));
+	});
+
+	it("uses standard-schema nodes for custom blocks by default", () => {
+		const document = portableTextToProsemirror([{ _type: "test.divider", _key: "divider-1" }]);
+		const schema = getSchema([StarterKit]);
+
+		expect(() => schema.nodeFromJSON(document)).not.toThrow();
+	});
+
+	it("preserves identities through the matching ProseMirror extensions", () => {
+		const blocks: PortableTextBlock[] = [
+			{
+				_type: "block",
+				_key: "block-1",
+				style: "normal",
+				children: [
+					{
+						_type: "span",
+						_key: "span-1",
+						text: "Hello world",
+						marks: ["link-1"],
+					},
+				],
+				markDefs: [
+					{
+						_type: "link",
+						_key: "link-1",
+						href: "https://example.com",
+					},
+				],
+			},
+			{ _type: "test.divider", _key: "divider-1" },
+		];
+		const schema = getSchema([StarterKit, ...portableTextIdentityExtensions]);
+		const document = portableTextToIdentityDocument(blocks);
+
+		const parsed = schema.nodeFromJSON(document);
+		const roundTripped = prosemirrorToPortableText(parsed.toJSON());
+
+		expect(roundTripped).toEqual(blocks);
+	});
+
 	it("preserves a payload-less custom block unchanged", () => {
 		const blocks: PortableTextBlock[] = [{ _type: "test.divider", _key: "divider-1" }];
 
-		const roundTripped = prosemirrorToPortableText(portableTextToProsemirror(blocks));
+		const roundTripped = prosemirrorToPortableText(portableTextToIdentityDocument(blocks));
 
 		expect(roundTripped).toEqual(blocks);
 	});
@@ -38,7 +101,7 @@ describe("Portable Text converter identity preservation", () => {
 			},
 		];
 
-		const roundTripped = prosemirrorToPortableText(portableTextToProsemirror(blocks));
+		const roundTripped = prosemirrorToPortableText(portableTextToIdentityDocument(blocks));
 
 		expect(roundTripped).toEqual(blocks);
 	});
@@ -60,13 +123,13 @@ describe("Portable Text converter identity preservation", () => {
 			},
 		];
 
-		const roundTripped = prosemirrorToPortableText(portableTextToProsemirror(blocks));
+		const roundTripped = prosemirrorToPortableText(portableTextToIdentityDocument(blocks));
 
 		expect(roundTripped).toEqual(blocks);
 	});
 
 	it("assigns a new key when ProseMirror splits a keyed block", () => {
-		const document = portableTextToProsemirror([
+		const document = portableTextToIdentityDocument([
 			{
 				_type: "block",
 				_key: "block-1",

--- a/packages/core/tests/unit/converters/custom-block-round-trip.test.ts
+++ b/packages/core/tests/unit/converters/custom-block-round-trip.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { portableTextToProsemirror } from "../../../src/content/converters/portable-text-to-prosemirror.js";
+import { prosemirrorToPortableText } from "../../../src/content/converters/prosemirror-to-portable-text.js";
+import type { PortableTextBlock } from "../../../src/content/converters/types.js";
+
+describe("Portable Text converter identity preservation", () => {
+	it("preserves a payload-less custom block unchanged", () => {
+		const blocks: PortableTextBlock[] = [{ _type: "test.divider", _key: "divider-1" }];
+
+		const roundTripped = prosemirrorToPortableText(portableTextToProsemirror(blocks));
+
+		expect(roundTripped).toEqual(blocks);
+	});
+
+	it("preserves existing keys and supported link mark definitions", () => {
+		const blocks: PortableTextBlock[] = [
+			{
+				_type: "block",
+				_key: "block-1",
+				style: "normal",
+				children: [
+					{
+						_type: "span",
+						_key: "span-1",
+						text: "Linked text",
+						marks: ["strong", "link-1"],
+					},
+				],
+				markDefs: [
+					{
+						_type: "link",
+						_key: "link-1",
+						href: "https://example.com",
+						blank: true,
+					},
+				],
+			},
+		];
+
+		const roundTripped = prosemirrorToPortableText(portableTextToProsemirror(blocks));
+
+		expect(roundTripped).toEqual(blocks);
+	});
+
+	it("keeps one span identity across hard breaks", () => {
+		const blocks: PortableTextBlock[] = [
+			{
+				_type: "block",
+				_key: "block-1",
+				style: "normal",
+				children: [
+					{
+						_type: "span",
+						_key: "span-1",
+						text: "First line\nSecond line",
+						marks: ["code"],
+					},
+				],
+			},
+		];
+
+		const roundTripped = prosemirrorToPortableText(portableTextToProsemirror(blocks));
+
+		expect(roundTripped).toEqual(blocks);
+	});
+
+	it("assigns a new key when ProseMirror splits a keyed block", () => {
+		const document = portableTextToProsemirror([
+			{
+				_type: "block",
+				_key: "block-1",
+				style: "normal",
+				children: [{ _type: "span", _key: "span-1", text: "Hello world" }],
+			},
+		]);
+		document.content.push({ ...document.content[0]! });
+
+		const roundTripped = prosemirrorToPortableText(document);
+		const keys = roundTripped.map((block) => block._key);
+
+		expect(keys).toContain("block-1");
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+});

--- a/packages/core/tests/unit/converters/custom-block-round-trip.test.ts
+++ b/packages/core/tests/unit/converters/custom-block-round-trip.test.ts
@@ -2,7 +2,10 @@ import { getSchema } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import { describe, expect, it } from "vitest";
 
-import { portableTextIdentityExtensions } from "../../../src/content/converters/portable-text-identity.js";
+import {
+	attrsWithPortableTextKey,
+	portableTextIdentityExtensions,
+} from "../../../src/content/converters/portable-text-identity.js";
 import { portableTextToProsemirror } from "../../../src/content/converters/portable-text-to-prosemirror.js";
 import { prosemirrorToPortableText } from "../../../src/content/converters/prosemirror-to-portable-text.js";
 import type { PortableTextBlock } from "../../../src/content/converters/types.js";
@@ -136,6 +139,26 @@ describe("Portable Text converter identity preservation", () => {
 		const roundTripped = prosemirrorToPortableText(portableTextToIdentityDocument(blocks));
 
 		expect(roundTripped).toEqual(blocks);
+	});
+
+	it("reads a block key from a blockquote wrapper", () => {
+		const blocks = prosemirrorToPortableText({
+			type: "doc",
+			content: [
+				{
+					type: "blockquote",
+					attrs: attrsWithPortableTextKey(undefined, "quote-1"),
+					content: [
+						{
+							type: "paragraph",
+							content: [{ type: "text", text: "Quoted text" }],
+						},
+					],
+				},
+			],
+		});
+
+		expect(blocks[0]).toMatchObject({ _type: "block", _key: "quote-1", style: "blockquote" });
 	});
 
 	it("assigns a new key when ProseMirror splits a keyed block", () => {


### PR DESCRIPTION
## What does this PR do?

Preserves Portable Text custom blocks that contain only `_type` and `_key` when the admin editor loads and serializes an entry. These blocks now use an opaque ProseMirror representation instead of becoming an `[Unknown block type: …]` paragraph.

The editor also carries existing block, span, and link-definition identities through supported round trips, assigns fresh keys when an edit splits a keyed node, ignores a synthetic trailing paragraph, and suppresses semantically unchanged updates so opening an entry does not enqueue a destructive autosave. Editing a formerly payload-less block to add a URL now persists that new identity.

The public converter keeps its default output compatible with standard ProseMirror schemas. Callers that need lossless keys and opaque custom blocks can enable `preserveIdentity` and add the exported `portableTextIdentityExtensions` to their TipTap schema.

Closes #2535

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). No user-visible strings were added.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: Not applicable; this is a bug fix.
- [x] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI GPT-5 Codex

## Screenshots / test output

![Content editor showing the payload-less Tweet custom block intact and the entry marked Saved](https://github.com/user-attachments/assets/369fc22d-27fa-4c05-b1de-acc9e6d436fb)

```text
pnpm typecheck
  34 workspace projects passed

pnpm lint
  0 diagnostics

pnpm format:check
  passed

Focused admin converter/editor suites
  3 files, 104 tests passed

Core converter suites
  12 files, 72 tests passed

Full core suite
  530 files passed, 2 skipped
  6,366 tests passed, 9 skipped
```

The broad admin run completed 2,002 tests successfully. Three concurrency-sensitive cases failed in that combined run and passed when rerun in isolation. The five setup failures in `editor-save-conflict.test.tsx` reproduce unchanged on an untouched `origin/main` checkout before this branch's code is applied.

`publint` passes for the packed `emdash` package. `attw` completes its pack step and then exits with its existing internal `Cannot read properties of undefined (reading 'filename')` error.
