### PR TITLE
ci: exclude generated release action bundle from CodeQL

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,4 @@
+name: CodeQL config
+
+paths-ignore:
+  - apps/release-action/dist/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -87,6 +87,7 @@ jobs:
         if: steps.decide.outputs.analyze == 'true'
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
+          config-file: ./.github/codeql-config.yml
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL analysis


### PR DESCRIPTION
## What does this PR do?

Excludes the committed `apps/release-action/dist/**` bundle from CodeQL analysis while continuing to scan the action's TypeScript source under `apps/release-action/src/**`.

The bundle contains generated third-party code and can produce alerts that are not actionable in EmDash source, such as the finding currently blocking #2864. CI still rebuilds the bundle and verifies that `apps/release-action/dist/index.js` matches the source-generated output.

Related: #2864

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

Formatting note: Oxfmt excludes `.github` files. Both YAML files parse successfully, and `git diff --check` passes.

Tests note: this is CodeQL workflow configuration only. Targeted validation was YAML parsing, workflow diff inspection, `pnpm typecheck`, `pnpm lint:quick`, and `pnpm lint:json` with zero diagnostics.

Changeset, localization, feature Discussion, and screenshots are not applicable because this changes CI configuration only.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Not applicable; this PR has no UI changes.
