### PR TITLE
test(core): correct D1 wide-loader boundary

### DIFF
--- a/packages/core/tests/workerd/loader-wide-collection-d1.test.ts
+++ b/packages/core/tests/workerd/loader-wide-collection-d1.test.ts
@@ -22,14 +22,14 @@ declare module "cloudflare:test" {
  * The loader's entry read at the widest collection D1 can still return.
  *
  * D1 caps a result set at 100 columns. `loadEntry` selects `c.*` plus the
- * folded hydration columns, so 96 table columns is the widest collection that
- * still leaves them room under the cap.
+ * five folded hydration columns, so 95 table columns is the widest collection
+ * that still leaves them room under the cap.
  */
 const COLLECTION = "wide_d1";
 /** Takes `ec_wide_d1` to LOADABLE_TABLE_WIDTH alongside `title`. */
-const USER_FIELD_COUNT = 80;
+const USER_FIELD_COUNT = 79;
 /** 15 system columns plus `title` plus USER_FIELD_COUNT. */
-const LOADABLE_TABLE_WIDTH = 96;
+const LOADABLE_TABLE_WIDTH = 95;
 
 let db: Kysely<Database>;
 let seoRepo: SeoRepository;
@@ -87,17 +87,16 @@ describe("loader on a wide collection on D1", () => {
 		expect(await listColumns(db, `ec_${COLLECTION}`)).toHaveLength(LOADABLE_TABLE_WIDTH);
 	});
 
-	it("rejects five flat columns on top of c.* at this width", async () => {
-		// Five alias columns on top of `c.*` ask D1 for 101 columns here, and
+	it("rejects six flat columns on top of c.* at this width", async () => {
+		// Six alias columns on top of `c.*` ask D1 for 101 columns here, and
 		// D1 refuses the statement rather than truncating it.
 		await expect(
-			sql
-				.raw(
-					`SELECT c.*, s.seo_no_index, s.seo_canonical, s.seo_title, s.seo_description, s.seo_image
-					 FROM ec_${COLLECTION} c
-					 LEFT JOIN _emdash_seo s ON s.collection = '${COLLECTION}' AND s.content_id = c.id`,
-				)
-				.execute(db),
+			sql<Record<string, unknown>>`
+				SELECT c.*, s.content_id AS seo_content_id, s.seo_no_index, s.seo_canonical, s.seo_title, s.seo_description, s.seo_image
+				FROM ${sql.ref(`ec_${COLLECTION}`)} c
+				LEFT JOIN ${sql.ref("_emdash_seo")} s
+				ON s.collection = ${COLLECTION} AND s.content_id = c.id
+			`.execute(db),
 		).rejects.toThrow(/too many columns in result set/);
 	});
 
@@ -109,7 +108,7 @@ describe("loader on a wide collection on D1", () => {
 		const data = (loaded as { data: Record<string, unknown> }).data;
 		expect(data.title).toBe("Wide Entry");
 		expect(data.field_1).toBe("value-1");
-		expect(data.field_80).toBe("value-80");
+		expect(data.field_79).toBe("value-79");
 	});
 
 	it("still attaches data.seo at the loadable width", async () => {


### PR DESCRIPTION
## What does this PR do?

Corrects the real-D1 wide-loader fixture after boolean-field normalization added a fifth folded result column. The current fixture creates a 96-column content table, so `loadEntry()` requests 101 columns and its positive loader assertions fail against D1's 100-column result limit.

The loadable fixture now creates 95 table columns, putting the real loader query exactly at 100. The negative control adds six flat columns so it still proves that D1 rejects 101 columns. The control query also uses Kysely's parameterized SQL helpers instead of interpolated raw SQL.

This changes test coverage only; runtime behavior is unchanged. It is a follow-up to #2879 and #2822 and unblocks the shared D1 check failing on #2935 and other current PRs.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Not applicable: this test-only change adds no admin UI strings.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package). Not applicable: published behavior is unchanged.
- [ ] New features link to an approved Discussion: Not applicable; this is a test correction.
- [ ] I have included screenshots below if this PR changes the UI. Not applicable: this change has no UI.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Screenshots are not applicable because this change has no UI.

Validation:

- Before the correction: 2 passed, 3 failed in `loader-wide-collection-d1.test.ts`
- `pnpm --filter emdash exec vitest run --config vitest.workerd.config.ts tests/workerd/loader-wide-collection-d1.test.ts` — 5 passed
- `pnpm --filter emdash exec vitest run --config vitest.workerd.config.ts` — 7 files, 26 tests passed
- `pnpm --filter emdash... build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
