### PR TITLE
test(admin): stop save-conflict checks depending on publish copy

### DIFF
--- a/packages/admin/tests/editor-save-conflict.test.tsx
+++ b/packages/admin/tests/editor-save-conflict.test.tsx
@@ -162,7 +162,7 @@ async function renderEditPage() {
 		params: { collection: "posts", id: "post_1" },
 	});
 	const screen = await render(<TestApp />);
-	await expect.element(screen.getByRole("button", { name: "Publish", exact: true })).toBeVisible();
+	await expect.element(screen.getByRole("textbox", { name: "Title" })).toBeVisible();
 	return screen;
 }
 


### PR DESCRIPTION
## What does this PR do?

Makes the save-conflict browser test wait for the editor's Title field before exercising conflict behavior.

The shared setup previously waited for a button named exactly `Publish`. Published entries with draft changes now correctly show `Publish changes`, so all five conflict cases timed out before reaching their assertions. Waiting for the field every case actually edits keeps the setup tied to the behavior under test rather than unrelated publishing copy.

No linked issue.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

`pnpm exec oxfmt --check tests/editor-save-conflict.test.tsx` passes. The full formatter was not run because the change was already formatted and a repository-wide rewrite would be out of scope. Translation, changeset, Discussion, and screenshot items are not applicable to this test-only change.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex (GPT-5)

## Screenshots / test output

Not applicable; this does not change the UI.

- `pnpm --filter @emdash-cms/admin test --run tests/editor-save-conflict.test.tsx` — 5 passed
- `pnpm typecheck` — passed
- `pnpm --silent lint:json` — 0 diagnostics
- `pnpm build` — passed
