### PR TITLE
Stabilize media detail panel browser tests

### DIFF
--- a/packages/admin/tests/components/ImageDetailPanel.test.tsx
+++ b/packages/admin/tests/components/ImageDetailPanel.test.tsx
@@ -208,7 +208,7 @@ describe("ImageDetailPanel", () => {
 			await expect.element(screen.getByRole("option", { name: "None" })).toBeVisible();
 			expect(screen.getByRole("option", { name: "Wide" }).query()).toBeNull();
 			expect(screen.getByRole("option", { name: "Full" }).query()).toBeNull();
-			await userEvent.keyboard("{End}{Enter}");
+			await screen.getByRole("option", { name: "Right" }).click();
 			await expect.element(select).toHaveTextContent("Right");
 			await screen.getByRole("button", { name: "Apply" }).click();
 			expect(onUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ alignment: "right" }));

--- a/packages/admin/tests/components/MediaDetailPanel.test.tsx
+++ b/packages/admin/tests/components/MediaDetailPanel.test.tsx
@@ -478,10 +478,12 @@ describe("MediaDetailPanel", () => {
 		const detailsPane = screen.getByTestId("media-detail-dialog-details-column").element();
 
 		screen.getByRole("tab", { name: "Edit image" }).element().click();
-		await vi.waitFor(() => expect(dialog.style.height).toBe(""));
-		expect(body.style.overflowY).toBe("");
-		expect(previewPane.style.overflowY).toBe("");
-		expect(detailsPane.style.overflowY).toBe("");
+		await vi.waitFor(() => {
+			expect(dialog.style.height).toBe("");
+			expect(body.style.overflowY).toBe("");
+			expect(previewPane.style.overflowY).toBe("");
+			expect(detailsPane.style.overflowY).toBe("");
+		});
 
 		screen.getByRole("tab", { name: "Details" }).element().click();
 		expect(body.style.overflowY).toBe("hidden");

--- a/packages/admin/tests/components/MediaDetailPanelNavigation.test.tsx
+++ b/packages/admin/tests/components/MediaDetailPanelNavigation.test.tsx
@@ -148,11 +148,11 @@ describe("MediaDetailPanel usage navigation", () => {
 		screen.getByRole("tab", { name: "Used in" }).element().click();
 		await vi.waitFor(() => expect(fetchMediaUsageDetails).toHaveBeenCalledTimes(1));
 		await vi.waitFor(() => expect(dialog.style.height).toBe(""));
-		const loadingHeight = dialog.getBoundingClientRect().height;
+		const loadingHeight = dialog.offsetHeight;
 
 		resolveUsage(usageDetails);
 		await expect.element(screen.getByRole("link", { name: /Launch notes/ })).toBeVisible();
-		expect(dialog.getBoundingClientRect().height).toBeCloseTo(loadingHeight, 0);
+		expect(dialog.offsetHeight).toBe(loadingHeight);
 	});
 
 	it("makes no usage request for provider media", async () => {


### PR DESCRIPTION
## What does this PR do?

Fix intermittent browser-test failures caused by keyboard focus timing and dialog animations. Select the intended alignment option directly, wait for height and overflow cleanup together, and measure layout height without the opening scale animation.

Follow-up to #2931 and #2861. CI examples: [alignment selection](https://github.com/emdash-cms/emdash/actions/runs/34130593800/job/101786506904) and [usage height](https://github.com/emdash-cms/emdash/actions/runs/34031623899). The scrollbar cleanup failure was also reproduced locally.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run (used scoped `oxfmt --ignore-path .gitignore` on the three changed test files)
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

Changeset, i18n, Discussion and screenshots are not applicable because this PR changes only tests.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-6 (Codex)
## Screenshots / test output

Not applicable: no UI changes.

The three panel suites passed five consecutive runs, with 128 tests passing per run:

```sh
pnpm --filter @emdash-cms/admin exec env CI=1 vitest run \
  tests/components/ImageDetailPanel.test.tsx \
  tests/components/MediaDetailPanel.test.tsx \
  tests/components/MediaDetailPanelNavigation.test.tsx
```

`pnpm typecheck`, `pnpm lint`, scoped formatting and `git diff --check` passed.

Broader browser-suite runs hit separate intermittent failures in `SeoPanel` (debounce call count), `PortableTextEditor` (clipboard-button click intercepted) and `SocialSettings` (Save locator timeout). Those tests are unchanged; the full browser suite is not reported as passing.
