### PR TITLE
fix(flue-review): exclude generated Worker types from reviews

### DIFF
--- a/infra/flue-review/.flue/lib/diff-budget.ts
+++ b/infra/flue-review/.flue/lib/diff-budget.ts
@@ -2,10 +2,19 @@
 // whole diff file, so an oversized diff (generated types, lockfiles, large
 // catalogs) lands in the model context verbatim and kills the model call.
 // Oversized per-file sections are elided down to their headers with a note;
-// the agent reads those files from the checkout instead.
+// the agent reads those files from the checkout instead. Generated Worker
+// types are always omitted from both paths by the review-context guards.
+
+import {
+	GENERATED_WORKER_TYPES_FILENAME,
+	GENERATED_WORKER_TYPES_NOTICE,
+} from "./review-context.js";
 
 const DEFAULT_PER_FILE_BYTES = 48 * 1024;
 const DEFAULT_TOTAL_BYTES = 384 * 1024;
+const GENERATED_WORKER_TYPES_DIFF_PATH = new RegExp(
+	`(?:^|/)${GENERATED_WORKER_TYPES_FILENAME.replaceAll(".", "\\.")}(?=["\\t ]|$)`,
+);
 
 export interface DiffBudget {
 	readonly perFileBytes?: number;
@@ -20,9 +29,18 @@ interface Section {
 export function elideLargeDiffSections(diff: string, budget: DiffBudget = {}): string {
 	const perFileBytes = budget.perFileBytes ?? DEFAULT_PER_FILE_BYTES;
 	const totalBytes = budget.totalBytes ?? DEFAULT_TOTAL_BYTES;
-	if (diff.length <= Math.min(perFileBytes, totalBytes)) return diff;
-
 	const sections = splitSections(diff);
+	for (const section of sections) {
+		if (isGeneratedWorkerTypesSection(section)) {
+			elide(section, GENERATED_WORKER_TYPES_NOTICE.trim());
+		}
+	}
+	if (
+		sections.reduce((total, section) => total + section.text.length, 0) <=
+		Math.min(perFileBytes, totalBytes)
+	) {
+		return sections.map((section) => section.text).join("");
+	}
 	for (const section of sections) {
 		if (!section.elided && section.text.length > perFileBytes) elide(section);
 	}
@@ -41,6 +59,12 @@ export function elideLargeDiffSections(diff: string, budget: DiffBudget = {}): s
 	return sections.map((s) => s.text).join("");
 }
 
+function isGeneratedWorkerTypesSection(section: Section): boolean {
+	const lineEnd = section.text.indexOf("\n");
+	const firstLine = lineEnd === -1 ? section.text : section.text.slice(0, lineEnd);
+	return GENERATED_WORKER_TYPES_DIFF_PATH.test(firstLine);
+}
+
 function splitSections(diff: string): Section[] {
 	const starts: number[] = [];
 	const re = /^diff --git /gm;
@@ -55,7 +79,7 @@ function splitSections(diff: string): Section[] {
 	return sections;
 }
 
-function elide(section: Section): void {
+function elide(section: Section, notice?: string): void {
 	// Mark unconditionally: a section this function cannot reduce must still
 	// leave the total-budget loop's candidate pool, or the loop never shrinks.
 	section.elided = true;
@@ -68,7 +92,8 @@ function elide(section: Section): void {
 	const body = lines.length - (headerEnd + 1);
 	section.text = [
 		...lines.slice(0, headerEnd + 1),
-		`(diff content elided: ${body} lines over the size budget -- read this file from the checkout instead)`,
+		notice ??
+			`(diff content elided: ${body} lines over the size budget -- read this file from the checkout instead)`,
 		"",
 	].join("\n");
 }

--- a/infra/flue-review/.flue/lib/review-context.ts
+++ b/infra/flue-review/.flue/lib/review-context.ts
@@ -1,0 +1,23 @@
+export const GENERATED_WORKER_TYPES_FILENAME = "worker-configuration.d.ts";
+export const GENERATED_WORKER_TYPES_NOTICE =
+	"(generated Worker types omitted from model review context)\n";
+
+interface ReviewWorkspace {
+	glob(pattern: string): Promise<Array<string | { path: string }>>;
+	writeFile(path: string, content: string): Promise<void>;
+}
+
+export async function omitGeneratedWorkerTypes(
+	workspace: ReviewWorkspace,
+	repoDir: string,
+): Promise<void> {
+	const files = await workspace.glob(`${repoDir}/**/${GENERATED_WORKER_TYPES_FILENAME}`);
+	await Promise.all(
+		files.map((file) =>
+			workspace.writeFile(
+				typeof file === "string" ? file : file.path,
+				GENERATED_WORKER_TYPES_NOTICE,
+			),
+		),
+	);
+}

--- a/infra/flue-review/.flue/workflows/review.ts
+++ b/infra/flue-review/.flue/workflows/review.ts
@@ -39,6 +39,7 @@ import {
 	removeReaction,
 	updateReviewCheck,
 } from "../lib/github.js";
+import { omitGeneratedWorkerTypes } from "../lib/review-context.js";
 import { formatReviewFailureSummary } from "../lib/review-failure.js";
 import { reviewResultSchema, type ReviewResult } from "../lib/review-schema.js";
 import {
@@ -186,6 +187,7 @@ async function hydrate(env: Env, payload: ReviewPayload): Promise<void> {
 	const workspace = getDefaultWorkspace(env.REVIEW_WORKSPACE, workspaceName());
 	hydrateStep(payload, "workspace created", t0);
 	if (await workspace.exists(HYDRATED)) {
+		await omitGeneratedWorkerTypes(workspace, REPO_DIR);
 		hydrateStep(payload, "already hydrated", t0);
 		return;
 	}
@@ -203,6 +205,7 @@ async function hydrate(env: Env, payload: ReviewPayload): Promise<void> {
 	const tarStream = response.body.pipeThrough(new DecompressionStream("gzip"));
 	const { files, bytes } = await untarInto(workspace, tarStream, REPO_DIR);
 	hydrateStep(payload, `untarred ${files} files ${bytes} bytes`, t0);
+	await omitGeneratedWorkerTypes(workspace, REPO_DIR);
 
 	await workspace.writeFile(HYDRATED, new Date().toISOString());
 	hydrateStep(payload, "hydrated", t0);

--- a/infra/flue-review/test/diff-budget.test.ts
+++ b/infra/flue-review/test/diff-budget.test.ts
@@ -20,6 +20,26 @@ describe("elideLargeDiffSections", () => {
 		expect(elideLargeDiffSections(diff)).toBe(diff);
 	});
 
+	it.each([
+		"worker-configuration.d.ts",
+		"infra/emdash-bot/worker-configuration.d.ts",
+		"packages/plugins/example/generated/worker-configuration.d.ts",
+	])("always omits generated Worker types at %s", (path) => {
+		const generated = fileSection(path, 2, "+declare const generatedSecret: string;");
+		const source = fileSection("src/a.ts", 2);
+		const out = elideLargeDiffSections(generated + source);
+
+		expect(out).toContain(`diff --git a/${path} b/${path}`);
+		expect(out).toContain("generated Worker types omitted from model review context");
+		expect(out).not.toContain("generatedSecret");
+		expect(out).toContain(source);
+	});
+
+	it("does not omit a similarly named source file", () => {
+		const diff = fileSection("src/worker-configuration.d.ts.template", 2);
+		expect(elideLargeDiffSections(diff)).toBe(diff);
+	});
+
 	it("elides a section over the per-file budget, keeping its header", () => {
 		const big = fileSection("types.d.ts", 2_000);
 		const small = fileSection("src/a.ts", 5);

--- a/infra/flue-review/test/review-context.test.ts
+++ b/infra/flue-review/test/review-context.test.ts
@@ -1,0 +1,32 @@
+import { createMemoryStateBackend } from "@cloudflare/shell";
+import { describe, expect, it } from "vitest";
+
+import {
+	GENERATED_WORKER_TYPES_NOTICE,
+	omitGeneratedWorkerTypes,
+} from "../.flue/lib/review-context.js";
+
+const generatedPaths = [
+	"/repo/worker-configuration.d.ts",
+	"/repo/infra/emdash-bot/worker-configuration.d.ts",
+	"/repo/packages/plugins/example/generated/worker-configuration.d.ts",
+];
+
+describe("omitGeneratedWorkerTypes", () => {
+	it("replaces generated Worker types at every path depth", async () => {
+		const similarPath = "/repo/src/worker-configuration.d.ts.template";
+		const backend = createMemoryStateBackend({
+			files: Object.fromEntries([
+				...generatedPaths.map((path) => [path, "declare const generatedSecret: string;\n"]),
+				[similarPath, "template content\n"],
+			]),
+		});
+
+		await omitGeneratedWorkerTypes(backend, "/repo");
+
+		for (const path of generatedPaths) {
+			expect(await backend.readFile(path)).toBe(GENERATED_WORKER_TYPES_NOTICE);
+		}
+		expect(await backend.readFile(similarPath)).toBe("template content\n");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Prevents EmDashBot reviews from sending generated `worker-configuration.d.ts` contents to the model, regardless of where the file appears in the repository tree.

The staged PR diff keeps the matching file header and adds an omission marker, so the reviewer still knows the generated file changed. Before the model session begins, workspace hydration replaces each matching file's contents with the same marker. Other `.d.ts` files and similarly named files remain available for review.

This addresses the model-request budget failure seen on #2949 without depending on that PR's branch.

Related: #2949

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

The root typecheck, full type-aware lint, i18n, changeset, Discussion, and screenshot items are not applicable to this private, non-UI tooling package. The package typecheck and target-scoped type-aware lint pass; `pnpm lint:quick` also passes repository-wide.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Not applicable; this PR does not change the UI.

Verified locally:

- `pnpm --dir infra/flue-review test` — 64 tests passed
- `pnpm --dir infra/flue-review typecheck`
- `pnpm --dir infra/flue-review build`
- `pnpm lint:quick`
- Target-scoped `pnpm --silent lint:json` — 0 diagnostics
- `pnpm format`
- `git diff --cached --check`
