### PR TITLE
fix(bot): harden sandbox Git authentication and RPC replay

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -1003,7 +1003,10 @@ async function attachPublisherContainer(
 }
 
 function workspaceSandbox(id: string) {
-	return getSandbox(workerEnv.Sandbox, id, { sleepAfter: SANDBOX_SLEEP_AFTER_SECONDS });
+	return getSandbox(workerEnv.Sandbox, id, {
+		sleepAfter: SANDBOX_SLEEP_AFTER_SECONDS,
+		transport: "rpc",
+	});
 }
 
 async function recordBootstrapProgress(

--- a/infra/emdash-bot/.flue/cloudflare.ts
+++ b/infra/emdash-bot/.flue/cloudflare.ts
@@ -4,15 +4,9 @@
 import { Sandbox as BaseSandbox } from "@cloudflare/sandbox";
 
 import { forwardAnonymousRead } from "./lib/anonymous-egress.js";
-import {
-	githubGateDenialResponse,
-	inspectGithubRequest,
-	PUSH_CAPABILITY_HEADER,
-	pushCapabilityFromAuthorization,
-	verifyPushCapability,
-	withGithubAuthorization,
-} from "./lib/github-proxy.js";
-import { mintInstallationToken, readAppCreds } from "./lib/github.js";
+import { forwardGithubRequest } from "./lib/github-outbound.js";
+
+const GITHUB_TOKEN_BROKER = "github-installation-token";
 
 // Subclass so we can attach an outbound proxy to github.com. The handler runs
 // in the Worker runtime (outside the sandbox) with full env access; the
@@ -42,88 +36,13 @@ console.log("[sandbox/outbound] module loaded; outboundByHost set", {
 });
 
 async function handleAuthenticatedGithub(request: Request, env: Env): Promise<Response> {
-	const url = new URL(request.url);
-	const owner = env.GITHUB_OWNER;
-	const repo = env.GITHUB_REPO;
-	if (!owner || !repo) {
-		console.warn("[sandbox/outbound] no repo context configured");
-		return new Response("github proxy not configured", { status: 403 });
-	}
-
-	const forwarded = new Request(request);
-	const authorizationCapability = pushCapabilityFromAuthorization(
-		forwarded.headers.get("authorization"),
-	);
-	const legacyCapability = forwarded.headers.get(PUSH_CAPABILITY_HEADER);
-	const capability = authorizationCapability ?? legacyCapability;
-	const issueNumber = await verifyPushCapability(
-		capability,
-		env.GITHUB_WEBHOOK_SECRET,
-		owner,
-		repo,
-	);
-	forwarded.headers.delete("authorization");
-	forwarded.headers.delete(PUSH_CAPABILITY_HEADER);
-	const gate = await inspectGithubRequest(forwarded, url, owner, repo, issueNumber ?? undefined);
-	if (!gate.allowed) {
-		console.warn("[sandbox/outbound] denying", {
-			method: request.method,
-			host: url.host,
-			path: url.pathname,
-			stage: gate.stage,
-			reason: gate.reason,
-			capabilityPresent: capability !== null,
-			capabilityValid: issueNumber !== null,
-			capabilityTransport: authorizationCapability
-				? "authorization"
-				: legacyCapability
-					? "legacy-header"
-					: "missing",
-			...(gate.refs ? { refs: gate.refs } : {}),
-			...(gate.parseError ? { parseError: gate.parseError } : {}),
-		});
-		return githubGateDenialResponse(gate);
-	}
-
-	console.log("[sandbox/outbound] allow", {
-		method: request.method,
-		host: url.host,
-		path: url.pathname,
-		authentication: gate.authentication,
+	return forwardGithubRequest(request, {
+		owner: env.GITHUB_OWNER,
+		repo: env.GITHUB_REPO,
+		pushCapabilitySecret: env.GITHUB_WEBHOOK_SECRET,
+		getInstallationToken: () =>
+			env.Orchestrator.getByName(GITHUB_TOKEN_BROKER).getInstallationTokenForGitProxy(),
 	});
-
-	// The repo is public: when no usable App credential exists, forward the
-	// (already gated) request anonymously. Reads work; a push fails upstream.
-	let token: string | null = null;
-	if (gate.authentication === "installation") {
-		const creds = readAppCreds(env);
-		if (creds) {
-			try {
-				token = await mintInstallationToken(creds);
-			} catch (err) {
-				console.warn("[sandbox/outbound] token mint failed; forwarding anonymously", {
-					error: errorMessage(err),
-				});
-			}
-		}
-	}
-	const authed = withGithubAuthorization(forwarded, url.host, token);
-	authed.headers.set("user-agent", "emdash-bot");
-	try {
-		const res = await fetch(authed, { signal: AbortSignal.timeout(2 * 60_000) });
-		console.log("[sandbox/outbound] response", {
-			path: url.pathname,
-			status: res.status,
-		});
-		return res;
-	} catch (err) {
-		console.error("[sandbox/outbound] forward failed", { error: errorMessage(err) });
-		return new Response("forward failed", { status: 502 });
-	}
-}
-
-function errorMessage(error: unknown): string {
-	return error instanceof Error ? error.message : String(error);
 }
 
 export { ContainerProxy } from "@cloudflare/sandbox";

--- a/infra/emdash-bot/.flue/lib/exec-env.ts
+++ b/infra/emdash-bot/.flue/lib/exec-env.ts
@@ -924,6 +924,15 @@ function decodeBase64Bytes(encoded: string): Uint8Array {
 	return bytes;
 }
 
+function encodeBase64Bytes(bytes: Uint8Array): string {
+	const chunks: string[] = [];
+	const chunkSize = 32_768;
+	for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+		chunks.push(String.fromCharCode(...bytes.subarray(offset, offset + chunkSize)));
+	}
+	return btoa(chunks.join(""));
+}
+
 function parseCandidatePaths(raw: string): string[] {
 	if (raw === "") return [];
 	const paths = raw.split("\0");
@@ -980,15 +989,7 @@ export function fromSandbox(sandbox: Sandbox): ContainerBackend {
 				await sandbox.writeFile(path, content);
 				return;
 			}
-			await sandbox.writeFile(
-				path,
-				new ReadableStream<Uint8Array>({
-					start(controller) {
-						controller.enqueue(content);
-						controller.close();
-					},
-				}),
-			);
+			await sandbox.writeFile(path, encodeBase64Bytes(content), { encoding: "base64" });
 		},
 		async readFileBytes(path) {
 			const { content } = await sandbox.readFile(path, { encoding: "base64" });

--- a/infra/emdash-bot/.flue/lib/github-outbound.ts
+++ b/infra/emdash-bot/.flue/lib/github-outbound.ts
@@ -1,0 +1,126 @@
+import {
+	githubGateDenialResponse,
+	inspectGithubRequest,
+	PUSH_CAPABILITY_HEADER,
+	pushCapabilityFromAuthorization,
+	verifyPushCapability,
+	withGithubAuthorization,
+} from "./github-proxy.js";
+
+export interface GithubOutboundContext {
+	readonly owner: string;
+	readonly repo: string;
+	readonly pushCapabilitySecret: string;
+	readonly getInstallationToken: () => Promise<string>;
+}
+
+export async function forwardGithubRequest(
+	request: Request,
+	context: GithubOutboundContext,
+	upstreamFetch: typeof fetch = fetch,
+): Promise<Response> {
+	const url = new URL(request.url);
+	if (!context.owner || !context.repo) {
+		console.warn(JSON.stringify({ message: "github proxy not configured" }));
+		return new Response("github proxy not configured", { status: 403 });
+	}
+
+	const forwarded = new Request(request);
+	const authorizationCapability = pushCapabilityFromAuthorization(
+		forwarded.headers.get("authorization"),
+	);
+	const legacyCapability = forwarded.headers.get(PUSH_CAPABILITY_HEADER);
+	const capability = authorizationCapability ?? legacyCapability;
+	const issueNumber = await verifyPushCapability(
+		capability,
+		context.pushCapabilitySecret,
+		context.owner,
+		context.repo,
+	);
+	forwarded.headers.delete("authorization");
+	forwarded.headers.delete(PUSH_CAPABILITY_HEADER);
+	const gate = await inspectGithubRequest(
+		forwarded,
+		url,
+		context.owner,
+		context.repo,
+		issueNumber ?? undefined,
+	);
+	if (!gate.allowed) {
+		console.warn(
+			JSON.stringify({
+				message: "github proxy denied request",
+				method: request.method,
+				host: url.host,
+				path: url.pathname,
+				stage: gate.stage,
+				reason: gate.reason,
+				capabilityPresent: capability !== null,
+				capabilityValid: issueNumber !== null,
+				capabilityTransport: authorizationCapability
+					? "authorization"
+					: legacyCapability
+						? "legacy-header"
+						: "missing",
+				...(gate.refs ? { refs: gate.refs } : {}),
+				...(gate.parseError ? { parseError: gate.parseError } : {}),
+			}),
+		);
+		return githubGateDenialResponse(gate);
+	}
+
+	let token: string | null = null;
+	if (gate.authentication === "installation") {
+		try {
+			token = await context.getInstallationToken();
+		} catch (error) {
+			console.error(
+				JSON.stringify({
+					message: "github proxy authentication unavailable",
+					method: request.method,
+					path: url.pathname,
+					error: errorMessage(error),
+				}),
+			);
+			return new Response("github authentication unavailable", { status: 502 });
+		}
+	}
+
+	console.log(
+		JSON.stringify({
+			message: "github proxy forwarding request",
+			method: request.method,
+			host: url.host,
+			path: url.pathname,
+			authentication: gate.authentication,
+		}),
+	);
+	const authed = withGithubAuthorization(forwarded, url.host, token);
+	authed.headers.set("user-agent", "emdash-bot");
+	try {
+		const response = await upstreamFetch(authed, {
+			signal: AbortSignal.timeout(2 * 60_000),
+		});
+		console.log(
+			JSON.stringify({
+				message: "github proxy received response",
+				path: url.pathname,
+				status: response.status,
+			}),
+		);
+		return response;
+	} catch (error) {
+		console.error(
+			JSON.stringify({
+				message: "github proxy forward failed",
+				path: url.pathname,
+				error: errorMessage(error),
+			}),
+		);
+		return new Response("forward failed", { status: 502 });
+	}
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/infra/emdash-bot/.flue/lib/orchestrator.ts
+++ b/infra/emdash-bot/.flue/lib/orchestrator.ts
@@ -1144,6 +1144,14 @@ export class OrchestratorDO extends DurableObject<Env> {
 		return this.runExclusive(() => this.processCleanupOnClose(anchorNumber));
 	}
 
+	getInstallationTokenForGitProxy(): Promise<string> {
+		return this.runExclusive(async () => {
+			const creds = readAppCreds(this.env);
+			if (!creds) throw new Error("GitHub App credentials are not configured");
+			return this.getInstallationToken(creds);
+		});
+	}
+
 	private async processCleanupOnClose(anchorNumber: number): Promise<CleanupOutcome> {
 		await this.ctx.storage.put(STORAGE.anchorNumber, anchorNumber);
 		const creds = readAppCreds(this.env);

--- a/infra/emdash-bot/.flue/lib/router.ts
+++ b/infra/emdash-bot/.flue/lib/router.ts
@@ -258,7 +258,10 @@ export function resolve({
 	if (!from) return { kind: "noop", reason: "item has conflicting state labels" };
 	const t = findTransition(from, event);
 	if (!t) return { kind: "noop", reason: `no transition for ${from} + ${event}`, from };
-	const retry = from === "failed" && event === "retry" ? failedWriteRetry(retryMode) : null;
+	const retry =
+		(from === "failed" || from === "needs_attention") && event === "retry"
+			? failedWriteRetry(retryMode)
+			: null;
 	const to =
 		event === "resume" && resumeState
 			? resumeState

--- a/infra/emdash-bot/.flue/lib/router.ts
+++ b/infra/emdash-bot/.flue/lib/router.ts
@@ -259,7 +259,8 @@ export function resolve({
 	const t = findTransition(from, event);
 	if (!t) return { kind: "noop", reason: `no transition for ${from} + ${event}`, from };
 	const retry =
-		(from === "failed" || from === "needs_attention") && event === "retry"
+		event === "retry" &&
+		(from === "failed" || (from === "needs_attention" && retryMode === "revise"))
 			? failedWriteRetry(retryMode)
 			: null;
 	const to =

--- a/infra/emdash-bot/tests/integration/orchestrator.test.ts
+++ b/infra/emdash-bot/tests/integration/orchestrator.test.ts
@@ -65,6 +65,14 @@ describe("OrchestratorDO (workers-pool)", () => {
 		vi.unstubAllGlobals();
 	});
 
+	test("serves the cached installation token to the sandbox Git proxy", async () => {
+		testEnv.GITHUB_APP_PRIVATE_KEY = "test-key-present";
+		const stub = testEnv.Orchestrator.getByName(uniqueIssueName());
+		await stub.debugSetTokenCache("cached-token", Date.now() + 60 * 60 * 1000);
+
+		await expect(stub.getInstallationTokenForGitProxy()).resolves.toBe("cached-token");
+	});
+
 	test("review revisions publish progress and completion on the PR and remain reviewable", async () => {
 		const requests: Array<{ method: string; url: string; body: string }> = [];
 		testEnv.GITHUB_APP_PRIVATE_KEY = "test-key-present";

--- a/infra/emdash-bot/tests/unit/exec-env.test.ts
+++ b/infra/emdash-bot/tests/unit/exec-env.test.ts
@@ -222,6 +222,18 @@ describe("Sandbox container adapter", () => {
 
 		expect(bytes).toEqual(new TextEncoder().encode(content));
 	});
+
+	test("writes exact bytes over the HTTP transport without using a file stream", async () => {
+		const writeFile = vi.fn();
+		const sandbox = { writeFile } as unknown as Sandbox;
+		const bytes = new Uint8Array([0, 255, 1, 128]);
+
+		await fromSandbox(sandbox).writeFile("/tmp/candidate", bytes);
+
+		expect(writeFile).toHaveBeenCalledWith("/tmp/candidate", "AP8BgA==", {
+			encoding: "base64",
+		});
+	});
 });
 
 describe("ExecEnv container exec", () => {

--- a/infra/emdash-bot/tests/unit/github-outbound.test.ts
+++ b/infra/emdash-bot/tests/unit/github-outbound.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { forwardGithubRequest } from "../../.flue/lib/github-outbound.js";
+
+const OWNER = "emdash-cms";
+const REPO = "emdash";
+const gitInfoRefs = `https://github.com/${OWNER}/${REPO}.git/info/refs?service=git-upload-pack`;
+
+function context(getInstallationToken: () => Promise<string>) {
+	return {
+		owner: OWNER,
+		repo: REPO,
+		pushCapabilitySecret: "webhook-secret",
+		getInstallationToken,
+	};
+}
+
+describe("GitHub sandbox outbound authentication", () => {
+	test("adds the brokered installation token to configured-repository Git reads", async () => {
+		const upstream = vi.fn<typeof fetch>().mockResolvedValue(new Response("git response"));
+
+		const response = await forwardGithubRequest(
+			new Request(gitInfoRefs),
+			context(async () => "cached-installation-token"),
+			upstream,
+		);
+
+		expect(response.status).toBe(200);
+		expect(upstream).toHaveBeenCalledOnce();
+		const forwarded = upstream.mock.calls[0]?.[0];
+		expect(forwarded).toBeInstanceOf(Request);
+		expect((forwarded as Request).headers.get("authorization")).toBe(
+			`Basic ${btoa("x-access-token:cached-installation-token")}`,
+		);
+	});
+
+	test("fails closed when the installation-token broker is unavailable", async () => {
+		const upstream = vi.fn<typeof fetch>();
+
+		const response = await forwardGithubRequest(
+			new Request(gitInfoRefs),
+			context(async () => Promise.reject(new Error("token mint failed"))),
+			upstream,
+		);
+
+		expect(response.status).toBe(502);
+		await expect(response.text()).resolves.toBe("github authentication unavailable");
+		expect(upstream).not.toHaveBeenCalled();
+	});
+
+	test("keeps unrelated public GitHub reads anonymous", async () => {
+		const getInstallationToken = vi.fn(async () => "unused-token");
+		const upstream = vi.fn<typeof fetch>().mockResolvedValue(new Response("release"));
+
+		await forwardGithubRequest(
+			new Request("https://github.com/another/repo/releases/download/v1/file.tgz"),
+			context(getInstallationToken),
+			upstream,
+		);
+
+		expect(getInstallationToken).not.toHaveBeenCalled();
+		const forwarded = upstream.mock.calls[0]?.[0];
+		expect((forwarded as Request).headers.has("authorization")).toBe(false);
+	});
+});

--- a/infra/emdash-bot/tests/unit/lifecycle-v2.test.ts
+++ b/infra/emdash-bot/tests/unit/lifecycle-v2.test.ts
@@ -105,6 +105,21 @@ describe("maintainer-facing lifecycle", () => {
 		});
 	});
 
+	test("retries a failed PR revision as another revision", () => {
+		const decision = resolve({
+			labels: ["bot:bug", "bot:needs-attention"],
+			event: "retry",
+			actor: "maintainer",
+			retryMode: "revise",
+		});
+
+		expect(decision).toMatchObject({
+			kind: "transition",
+			to: "working",
+			action: "investigate.revise",
+		});
+	});
+
 	test("keeps legacy commands as deterministic aliases", () => {
 		expect(parseCommand("@emdashbot fix")).toEqual({ event: "work", arg: null });
 		expect(parseCommand("@emdashbot implement")).toEqual({ event: "work", arg: null });


### PR DESCRIPTION
## What does this PR do?

Hardens EmDashBot's sandbox repair path based on a live retry of #2945.

- Routes configured-repository Git authentication through a dedicated Orchestrator Durable Object that caches the GitHub App installation token for 55 minutes. The execution sandbox still receives no credentials.
- Fails configured-repository Git requests with an explicit 502 when authentication is unavailable instead of silently forwarding them anonymously.
- Uses the Sandbox SDK's primary RPC transport explicitly for every execution and publisher sandbox.
- Replays binary checkpoint data as base64 when using the transport-independent file API, avoiding the HTTP-only `writeFileStream requires the rpc transport` failure.
- Preserves `revise` mode when retrying a failed attached-PR repair, while legacy implementation failures continue through the unified `work` lane.

Live verification on #2945 reached dependency installation and agent execution after two earlier Git clone/fetch attempts failed with HTTP 429. The in-flight pre-RPC attempt then reproduced the file-stream transport failure, which the byte-write regression test covers.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

The bot package is private, so no changeset is required. This fix does not change the admin UI or add a feature.

Verified on the current branch:

- `pnpm --filter @emdash-cms/emdash-bot typecheck` (production build plus generated Wrangler RPC types)
- `pnpm --filter @emdash-cms/emdash-bot test:unit` — 345 tests
- `pnpm --filter @emdash-cms/emdash-bot test:workers` — 90 workerd/Durable Object tests
- `pnpm lint:quick`
- `git diff --check`

Deployed for live verification as Worker version `6ddc5ac6-e025-4e07-a764-e20d9adbc1dd`, preserving the unchanged container image.

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Not applicable; there is no UI change.
