### PR TITLE
fix(bot): stop repeated repairs and preserve rejection feedback

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -29,6 +29,7 @@ import {
 	requireCandidatePublication,
 	type CandidatePublication,
 } from "../lib/candidate-publisher.js";
+import { applyCandidateForRevision } from "../lib/candidate-revision.js";
 import { contextRegistry } from "../lib/context-registry.js";
 import { type ContainerBackend, ExecEnv, fromSandbox, quote } from "../lib/exec-env.js";
 import { createPushCapability, githubPushUrl } from "../lib/github-proxy.js";
@@ -946,7 +947,7 @@ async function attachContainerAttempt(
 		},
 	});
 	if (input.mode === "revise" && input.previousBranchSha) {
-		await applyCandidateForRevision(container, input.previousBranchSha);
+		await applyCandidateForRevision(container, input.previousBranchSha, cloneRef(input));
 	}
 	return {
 		...container,
@@ -958,39 +959,6 @@ async function attachContainerAttempt(
 			return result.exitCode === 0 && result.stdout.trim() === "true";
 		},
 	};
-}
-
-async function applyCandidateForRevision(
-	container: ContainerBackend,
-	candidateSha: string,
-): Promise<void> {
-	const fetch = await container.exec(
-		`git fetch --depth ${CLONE_DEPTH} origin ${quote(candidateSha)}`,
-		{
-			cwd: REPO_DIR,
-			timeoutMs: 5 * 60_000,
-		},
-	);
-	if (fetch.exitCode !== 0) {
-		throw new Error(`candidate fetch failed (${fetch.exitCode}): ${fetch.stderr.slice(-500)}`);
-	}
-	const apply = await container.exec(
-		[
-			"candidate=FETCH_HEAD",
-			'base="$(git merge-base HEAD "$candidate")"',
-			'test -n "$base"',
-			'git diff --binary "$base" "$candidate" -- > /tmp/emdash-candidate.patch',
-			"git apply --3way --whitespace=nowarn /tmp/emdash-candidate.patch",
-		].join(" && "),
-		{ cwd: REPO_DIR, timeoutMs: 5 * 60_000 },
-	);
-	if (apply.exitCode === 0) return;
-	const conflicts = await container.exec("git ls-files -u", {
-		cwd: REPO_DIR,
-		timeoutMs: DEFAULT_RPC_TIMEOUT_MS,
-	});
-	if (conflicts.exitCode === 0 && conflicts.stdout.trim() !== "") return;
-	throw new Error(`candidate rebase setup failed (${apply.exitCode}): ${apply.stderr.slice(-500)}`);
 }
 
 async function attachPublisherContainer(

--- a/infra/emdash-bot/.flue/lib/candidate-revision.ts
+++ b/infra/emdash-bot/.flue/lib/candidate-revision.ts
@@ -1,0 +1,61 @@
+import type { ContainerBackend } from "./exec-env.js";
+import { quote } from "./exec-env.js";
+
+const CANDIDATE_FETCH_DEPTH = 50;
+const CANDIDATE_DEEPEN_STEPS = [256, 1024] as const;
+const COMMAND_TIMEOUT_MS = 5 * 60_000;
+const CONFLICT_CHECK_TIMEOUT_MS = 2 * 60_000;
+
+export async function applyCandidateForRevision(
+	container: ContainerBackend,
+	candidateSha: string,
+	baseRef: string,
+): Promise<void> {
+	const fetch = await container.exec(
+		`git fetch --depth ${CANDIDATE_FETCH_DEPTH} origin ${quote(candidateSha)}`,
+		{ cwd: "/workspace/repo", timeoutMs: COMMAND_TIMEOUT_MS },
+	);
+	if (fetch.exitCode !== 0) {
+		throw new Error(`candidate fetch failed (${fetch.exitCode}): ${fetch.stderr.slice(-500)}`);
+	}
+
+	const base = await findMergeBase(container, candidateSha, baseRef);
+	const apply = await container.exec(
+		`git diff --binary ${quote(base)} ${quote(candidateSha)} -- > /tmp/emdash-candidate.patch && git apply --3way --whitespace=nowarn /tmp/emdash-candidate.patch`,
+		{ cwd: "/workspace/repo", timeoutMs: COMMAND_TIMEOUT_MS },
+	);
+	if (apply.exitCode === 0) return;
+	const conflicts = await container.exec("git ls-files -u", {
+		cwd: "/workspace/repo",
+		timeoutMs: CONFLICT_CHECK_TIMEOUT_MS,
+	});
+	if (conflicts.exitCode === 0 && conflicts.stdout.trim() !== "") return;
+	throw new Error(`candidate rebase setup failed (${apply.exitCode}): ${apply.stderr.slice(-500)}`);
+}
+
+async function findMergeBase(
+	container: ContainerBackend,
+	candidateSha: string,
+	baseRef: string,
+): Promise<string> {
+	for (const deepen of [null, ...CANDIDATE_DEEPEN_STEPS]) {
+		if (deepen !== null) {
+			const result = await container.exec(
+				`git fetch --deepen ${deepen} origin ${quote(candidateSha)} ${quote(baseRef)}`,
+				{ cwd: "/workspace/repo", timeoutMs: COMMAND_TIMEOUT_MS },
+			);
+			if (result.exitCode !== 0) {
+				throw new Error(
+					`candidate history deepen failed (${result.exitCode}): ${result.stderr.slice(-500)}`,
+				);
+			}
+		}
+		const result = await container.exec(`git merge-base HEAD ${quote(candidateSha)}`, {
+			cwd: "/workspace/repo",
+			timeoutMs: COMMAND_TIMEOUT_MS,
+		});
+		const base = result.stdout.trim();
+		if (result.exitCode === 0 && base !== "") return base;
+	}
+	throw new Error("candidate history has no merge base after deepening");
+}

--- a/infra/emdash-bot/.flue/lib/machine.json
+++ b/infra/emdash-bot/.flue/lib/machine.json
@@ -1310,6 +1310,13 @@
 		},
 		{
 			"from": "reproduced",
+			"event": "needs_changes",
+			"to": "working",
+			"action": "investigate.work",
+			"note": "late candidate feedback starts a new work run after the candidate expired"
+		},
+		{
+			"from": "reproduced",
 			"event": "fix",
 			"to": "fixing",
 			"action": "investigate.fix"
@@ -1335,6 +1342,13 @@
 			"event": "work",
 			"to": "working",
 			"action": "investigate.work"
+		},
+		{
+			"from": "diagnosed",
+			"event": "needs_changes",
+			"to": "working",
+			"action": "investigate.work",
+			"note": "candidate feedback remains actionable after a diagnosis-only run"
 		},
 		{
 			"from": "diagnosed",

--- a/infra/emdash-bot/.flue/lib/machine.ts
+++ b/infra/emdash-bot/.flue/lib/machine.ts
@@ -1063,11 +1063,25 @@ export const TRANSITIONS: Transition[] = [
 
 	// --- verdict disposal edges (maintainer disposes; humans dispose) ---
 	{ from: "reproduced", event: "work", to: "working", action: "investigate.work" },
+	{
+		from: "reproduced",
+		event: "needs_changes",
+		to: "working",
+		action: "investigate.work",
+		note: "late candidate feedback starts a new work run after the candidate expired",
+	},
 	{ from: "reproduced", event: "fix", to: "fixing", action: "investigate.fix" },
 	{ from: "reproduced", event: "implement", to: "fixing", action: "investigate.fix" },
 	{ from: "reproduced", event: "decline", to: "declined" },
 	{ from: "reproduced", event: "take_over", to: "human_owned" },
 	{ from: "diagnosed", event: "work", to: "working", action: "investigate.work" },
+	{
+		from: "diagnosed",
+		event: "needs_changes",
+		to: "working",
+		action: "investigate.work",
+		note: "candidate feedback remains actionable after a diagnosis-only run",
+	},
 	{ from: "diagnosed", event: "fix", to: "fixing", action: "investigate.fix" },
 	{ from: "diagnosed", event: "implement", to: "fixing", action: "investigate.fix" },
 	{ from: "diagnosed", event: "decline", to: "declined" },

--- a/infra/emdash-bot/.flue/lib/pull-request-monitor.ts
+++ b/infra/emdash-bot/.flue/lib/pull-request-monitor.ts
@@ -26,9 +26,13 @@ export function assessPullRequest(
 		problems.push(`Failing checks: ${checks.join(", ") || "unknown check"}.`);
 	}
 	if (problems.length > 0) {
+		const hasStableRepairCause =
+			status.review === "changes-requested" || status.failingChecks.length > 0;
 		const fingerprint = JSON.stringify({
 			headSha: status.headSha,
-			mergeability: status.mergeability,
+			// A check/review repair already rebuilds on the current base. GitHub's
+			// transient unknown/conflicting/mergeable oscillation is not new work.
+			mergeability: hasStableRepairCause ? "conflicting" : status.mergeability,
 			review: status.review,
 			failingChecks: status.failingChecks.map(({ name }) => name).toSorted(),
 		});

--- a/infra/emdash-bot/.flue/lib/router.ts
+++ b/infra/emdash-bot/.flue/lib/router.ts
@@ -52,6 +52,7 @@ function isMachineActor(value: string): value is Actor {
 const MENTION_RE = /^[ \t]*@emdashbot(?=\s|$)([\s\S]*)/m;
 const WS_RE = /\s+/g;
 const UNDERSCORE_RE = /_/g;
+const NEEDS_CHANGES_WITH_FEEDBACK_RE = /^(?:reject|needs[ _]changes)\s+([\s\S]+)$/i;
 
 /**
  * The state id encoded in a label set.
@@ -124,6 +125,10 @@ export interface ParsedCommand {
 export function parseCommand(body: string | null | undefined): ParsedCommand | null {
 	const text = parseMention(body);
 	if (text === null) return null;
+	const needsChanges = NEEDS_CHANGES_WITH_FEEDBACK_RE.exec(text);
+	if (needsChanges?.[1]) {
+		return { event: "needs_changes", arg: needsChanges[1].trim() };
+	}
 	const normalized = text.trim().toLowerCase().replace(WS_RE, " ");
 	const aliased = VERB_ALIASES[normalized];
 	const event = aliased ?? (isKnownEvent(normalized) ? normalized : null);

--- a/infra/emdash-bot/.flue/lib/workspace-attachment.ts
+++ b/infra/emdash-bot/.flue/lib/workspace-attachment.ts
@@ -2,6 +2,7 @@ export const WORKSPACE_SANDBOX_ATTEMPT_LIMIT = 3;
 
 const TRANSIENT_FAILURE_PATTERNS = [
 	/^HTTP error! status: 5\d\d\b/i,
+	/\bHTTP 429\b|requested URL returned error: 429/i,
 	/^internal error; reference\s*=\s*[a-z0-9]+$/i,
 	/network connection lost/i,
 	/container suddenly disconnected/i,

--- a/infra/emdash-bot/BOT_STATE_MACHINE.md
+++ b/infra/emdash-bot/BOT_STATE_MACHINE.md
@@ -178,9 +178,11 @@ Entry state: `unmanaged`. Kinds: `bug`, `enhancement`, `task`.
 | `investigating` | `agent.skipped` | `blocked` | — |
 | `investigating` | `agent.failed` | `needs_attention` | — |
 | `reproduced` | `work` | `working` | `investigate.work` |
+| `reproduced` | `needs_changes` | `working` | `investigate.work` |
 | `reproduced` | `decline` | `declined` | — |
 | `reproduced` | `take_over` | `human_owned` | — |
 | `diagnosed` | `work` | `working` | `investigate.work` |
+| `diagnosed` | `needs_changes` | `working` | `investigate.work` |
 | `diagnosed` | `decline` | `declined` | — |
 | `diagnosed` | `take_over` | `human_owned` | — |
 | `diagnosed` | `investigate` | `investigating` | `investigate.diagnose` |
@@ -304,9 +306,11 @@ stateDiagram-v2
     investigating --> blocked: agent.skipped
     investigating --> needs_attention: agent.failed
     reproduced --> working: work / investigate.work
+    reproduced --> working: needs_changes / investigate.work
     reproduced --> declined: decline
     reproduced --> human_owned: take_over
     diagnosed --> working: work / investigate.work
+    diagnosed --> working: needs_changes / investigate.work
     diagnosed --> declined: decline
     diagnosed --> human_owned: take_over
     diagnosed --> investigating: investigate / investigate.diagnose

--- a/infra/emdash-bot/tests/unit/candidate-revision.test.ts
+++ b/infra/emdash-bot/tests/unit/candidate-revision.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import { applyCandidateForRevision } from "../../.flue/lib/candidate-revision.js";
+import type { ContainerBackend } from "../../.flue/lib/exec-env.js";
+
+function containerWith(...results: Array<{ exitCode: number; stdout: string; stderr: string }>): {
+	container: ContainerBackend;
+	commands: string[];
+} {
+	const commands: string[] = [];
+	return {
+		commands,
+		container: {
+			isReady: async () => true,
+			exec: async (command) => {
+				commands.push(command);
+				return results.shift() ?? { exitCode: 0, stdout: "", stderr: "" };
+			},
+			writeFile: async () => {},
+			readFileBytes: async () => new Uint8Array(),
+		},
+	};
+}
+
+describe("candidate revision history", () => {
+	test("deepens both histories when a depth-50 checkout has no merge base", async () => {
+		const fake = containerWith(
+			{ exitCode: 0, stdout: "", stderr: "" },
+			{ exitCode: 1, stdout: "", stderr: "" },
+			{ exitCode: 0, stdout: "", stderr: "" },
+			{ exitCode: 0, stdout: "base-sha\n", stderr: "" },
+			{ exitCode: 0, stdout: "", stderr: "" },
+		);
+
+		await applyCandidateForRevision(fake.container, "candidate-sha", "current-main-sha");
+
+		expect(fake.commands).toHaveLength(5);
+		expect(fake.commands[2]).toContain("git fetch --deepen 256 origin");
+		expect(fake.commands[2]).toContain("'candidate-sha'");
+		expect(fake.commands[2]).toContain("'current-main-sha'");
+		expect(fake.commands[4]).toContain("git diff --binary 'base-sha' 'candidate-sha'");
+	});
+});

--- a/infra/emdash-bot/tests/unit/lifecycle-v2.test.ts
+++ b/infra/emdash-bot/tests/unit/lifecycle-v2.test.ts
@@ -128,4 +128,30 @@ describe("maintainer-facing lifecycle", () => {
 		expect(parseCommand("@emdashbot reject")).toEqual({ event: "needs_changes", arg: null });
 		expect(parseCommand("@emdashbot resume")).toEqual({ event: "retry", arg: null });
 	});
+
+	test("keeps rejection feedback deterministic after the candidate expires", () => {
+		expect(parseCommand("@emdashbot reject look at the comments and try again")).toEqual({
+			event: "needs_changes",
+			arg: "look at the comments and try again",
+		});
+		expect(parseCommand("@emdashbot needs changes account for dense bylines")).toEqual({
+			event: "needs_changes",
+			arg: "account for dense bylines",
+		});
+
+		for (const state of ["reproduced", "diagnosed"] as const) {
+			const decision = resolve({
+				labels: ["bot:bug", `bot:${state}`],
+				event: "needs_changes",
+				arg: "account for dense bylines",
+				actor: "maintainer",
+			});
+			expect(decision).toMatchObject({
+				kind: "transition",
+				to: "working",
+				action: "investigate.work",
+				arg: "account for dense bylines",
+			});
+		}
+	});
 });

--- a/infra/emdash-bot/tests/unit/pull-request-monitor.test.ts
+++ b/infra/emdash-bot/tests/unit/pull-request-monitor.test.ts
@@ -55,6 +55,32 @@ describe("pull request monitoring", () => {
 		}
 	});
 
+	test("does not repeat a stable repair when GitHub toggles mergeability", () => {
+		const conflicting = assessPullRequest(
+			status({
+				mergeability: "conflicting",
+				review: "changes-requested",
+				checks: "failing",
+				failingChecks: [{ name: "Smoke Tests", url: null }],
+			}),
+			null,
+		);
+		expect(conflicting.kind).toBe("repair");
+		if (conflicting.kind !== "repair") return;
+
+		expect(
+			assessPullRequest(
+				status({
+					mergeability: "unknown",
+					review: "changes-requested",
+					checks: "failing",
+					failingChecks: [{ name: "Smoke Tests", url: null }],
+				}),
+				conflicting.fingerprint,
+			),
+		).toEqual({ kind: "waiting" });
+	});
+
 	test("projects merged and closed pull requests", () => {
 		expect(assessPullRequest(status({ state: "merged" }), null)).toEqual({ kind: "merged" });
 		expect(assessPullRequest(status({ state: "closed" }), null)).toEqual({ kind: "closed" });

--- a/infra/emdash-bot/tests/unit/workspace-attachment.test.ts
+++ b/infra/emdash-bot/tests/unit/workspace-attachment.test.ts
@@ -65,6 +65,30 @@ describe("workspace attachment", () => {
 		expect(discard).not.toHaveBeenCalled();
 	});
 
+	test("retries a GitHub 429 on a fresh sandbox", async () => {
+		const attach = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(
+				new Error(
+					"container setup failed (128): fatal: unable to access repository: The requested URL returned error: 429",
+				),
+			)
+			.mockResolvedValueOnce("ready");
+		const discard = vi.fn(async () => {});
+
+		await expect(
+			attachWorkspaceWithRetry({
+				agentId: "investigate-2797-run",
+				startAttempt: 0,
+				attach,
+				discard,
+			}),
+		).resolves.toBe("ready");
+
+		expect(attach).toHaveBeenCalledTimes(2);
+		expect(discard).toHaveBeenCalledOnce();
+	});
+
 	test("continues on a fresh sandbox when failed-sandbox cleanup also fails", async () => {
 		const attached: string[] = [];
 		const cleanupFailures: unknown[] = [];


### PR DESCRIPTION
## What does this PR do?

Fixes two lifecycle regressions found through live use after #2949 and #2953 merged.

- Stops attached PRs from repeatedly launching the same repair when GitHub alternates mergeability between `conflicting` and `unknown`. When a failing check or changes-requested review already defines the repair, mergeability changes no longer create a new fingerprint. Conflict-only PRs still trigger conflict repair.
- Parses `@emdashbot reject <details>` and `@emdashbot needs changes <details>` deterministically instead of sending the explicit command through intent classification.
- Treats late candidate feedback as new work when an expired candidate has already returned to `reproduced`, or when an earlier misclassification left the issue `diagnosed`.

Live evidence:

- #2925 launched three identical revision runs while GitHub alternated its mergeability response.
- On #2616, the candidate expired before `@emdashbot reject look at the comments and try again`; classification selected `investigate`, producing another diagnosis instead of a replacement candidate.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

The bot package is private, so no changeset is required. This does not change the admin UI or add a feature.

Verified:

- `pnpm --filter @emdash-cms/emdash-bot typecheck` (production build plus generated Wrangler RPC types)
- `pnpm --filter @emdash-cms/emdash-bot test:unit` — 347 tests
- Focused router, webhook, lifecycle, and PR-monitor tests — 120 tests
- `pnpm lint:quick`
- `pnpm format`
- `git diff --check`

Deployed for live verification as Worker version `1dcfdbfd-67b6-48ce-b383-a0abd786a1a3`, preserving the unchanged container image.

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Not applicable; there is no UI change.
