### PR TITLE
fix(admin): reduce spacing around editor images

### DIFF
--- a/.changeset/tidy-editor-image-spacing.md
+++ b/.changeset/tidy-editor-image-spacing.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes excessive vertical space between images and surrounding text in the admin editor.

--- a/packages/admin/src/components/editor/ImageNode.tsx
+++ b/packages/admin/src/components/editor/ImageNode.tsx
@@ -215,7 +215,7 @@ function ImageNodeView({
 				selected && "ring-2 ring-kumo-brand ring-offset-2 rounded-lg",
 			)}
 		>
-			<figure className="relative">
+			<figure className="relative my-0!">
 				<img
 					src={displaySrc}
 					alt={node.attrs.alt || ""}

--- a/packages/admin/tests/editor/image-alignment.test.tsx
+++ b/packages/admin/tests/editor/image-alignment.test.tsx
@@ -20,6 +20,7 @@ function TestEditor({
 }) {
 	const editor = useEditor({
 		extensions: [StarterKit, ImageExtension],
+		editorProps: { attributes: { class: "prose prose-sm sm:prose-base flow-root" } },
 		content: {
 			type: "doc",
 			content: [
@@ -66,6 +67,38 @@ afterEach(async () => {
 });
 
 describe("Editor image alignment", () => {
+	it.each([
+		{ width: 1280, caption: "" },
+		{ width: 1280, caption: "Diagram caption" },
+		{ width: 390, caption: "" },
+		{ width: 390, caption: "Diagram caption" },
+	])(
+		"keeps image spacing compact at $width px with caption '$caption'",
+		async ({ width, caption }) => {
+			await page.viewport(width, 800);
+			const { editor, image, host } = await renderImage({ caption });
+			editor.commands.insertContentAt(0, {
+				type: "paragraph",
+				content: [{ type: "text", text: "Preceding text" }],
+			});
+			const before = host.querySelector("p")!;
+			const after = host.querySelector("p:last-child")!;
+			const figcaption = host.querySelector("figcaption");
+			const imageBounds = image.getBoundingClientRect();
+
+			expect(imageBounds.top - before.getBoundingClientRect().bottom).toBeCloseTo(16, 0);
+			expect(
+				after.getBoundingClientRect().top - (figcaption ?? image).getBoundingClientRect().bottom,
+			).toBeCloseTo(16, 0);
+			if (caption) {
+				expect(figcaption).not.toBeNull();
+				const captionGap = figcaption!.getBoundingClientRect().top - imageBounds.bottom;
+				expect(captionGap).toBeGreaterThan(0);
+				expect(captionGap).toBeLessThan(16);
+			}
+		},
+	);
+
 	it.each([
 		{ displayWidth: 1200, displayHeight: 800, ratio: 1.5 },
 		{ displayWidth: 1200, displayHeight: 600, ratio: 2 },


### PR DESCRIPTION
## What does this PR do?

Fixes oversized gaps between image blocks and surrounding text in the admin editor. Reset the image figure's vertical margins so the image wrapper controls spacing: 32px to 16px on desktop, and 24px to 16px on mobile. Caption spacing and image alignment are preserved.

The reset overrides the responsive typography styles. Browser regression tests measure the rendered gaps with and without captions at both viewport sizes. All four new cases fail on the original code and pass with the fix.

Reported while editing content; no existing issue. Based on the latest fetched `main` (`3b6a1b203`).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. N/A: no user-facing strings added or changed.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A, focused bug fix.
- [x] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-6 (Codex).

## Screenshots / test output

- `pnpm build` and the updated admin package build passed.
- `pnpm --dir packages/admin exec vitest run tests/editor/image-alignment.test.tsx tests/editor/image-selection.test.tsx`: 14 passed.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, and `git diff --check` passed.
- Verified the full admin editor in English and Arabic, including Arabic at 390px, light/dark appearance, and no browser errors.

Before: the image is separated from the surrounding paragraphs by 32px on desktop.

![Admin editor before the fix, with large gaps above the image and below its caption](https://github.com/user-attachments/assets/bdcffabc-dc01-4e6d-8d4d-5d1cfeaf5636)

After: both gaps are 16px, and the caption remains close to the image.

![Admin editor after the fix, with compact spacing between the image block and its surrounding paragraphs](https://github.com/user-attachments/assets/4666b83e-bdbd-4d92-b34a-537dd65a95d1)

Arabic layout:

![Arabic admin editor with right-to-left content and compact spacing around the image block](https://github.com/user-attachments/assets/4e555480-fc4c-4c2d-b76e-ae26d0e4c2b5)
