### PR TITLE
test(cloudflare): cover the diagnostics for a missing platform binding

### DIFF
--- a/packages/cloudflare/tests/missing-bindings.test.ts
+++ b/packages/cloudflare/tests/missing-bindings.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Pins that the factory the runtime calls names the absent Cloudflare binding
+ * and the wrangler key that declares it.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Every factory below reads its binding off `env` when it is called, so one
+// mutable object serves both the absent-binding cases and Hyperdrive's
+// present-but-incomplete one. `vi.hoisted` runs before the `vi.mock` factory.
+const { fakeEnv } = vi.hoisted(() => ({ fakeEnv: {} as Record<string, unknown> }));
+
+vi.mock("cloudflare:workers", () => ({
+	env: fakeEnv,
+	waitUntil: () => {},
+	// `do-sql.ts` re-exports the EmDashDB class, whose module extends this.
+	DurableObject: class {
+		env = fakeEnv;
+	},
+}));
+
+import { createObjectCache } from "../src/cache/kv.js";
+import { createDialect as createD1Dialect } from "../src/db/d1.js";
+import { createDialect as createDurableObjectDialect } from "../src/db/do-sql.js";
+import { createDialect as createHyperdriveDialect } from "../src/db/hyperdrive.js";
+import { createStorage } from "../src/storage/r2.js";
+
+function thrown(call: () => unknown): Error & { code?: string } {
+	try {
+		call();
+	} catch (error) {
+		if (error instanceof Error) return error;
+		throw new Error(`expected an Error, received ${String(error)}`, { cause: error });
+	}
+	throw new Error("expected a missing-binding error, but the call returned");
+}
+
+describe("missing binding diagnostics", () => {
+	afterEach(() => {
+		for (const key of Object.keys(fakeEnv)) delete fakeEnv[key];
+	});
+
+	it("names the D1 binding and the wrangler key that declares it", () => {
+		const { message } = thrown(() => createD1Dialect({ binding: "SITE_DB" }));
+		expect(message).toContain("SITE_DB");
+		expect(message).toContain("d1_databases");
+	});
+
+	it("names the R2 binding and the wrangler key that declares it", () => {
+		const { message } = thrown(() => createStorage({ binding: "SITE_MEDIA" }));
+		expect(message).toContain("SITE_MEDIA");
+		expect(message).toContain("r2_buckets");
+	});
+
+	it("gives the R2 failure a code a caller can branch on", () => {
+		expect(thrown(() => createStorage({ binding: "SITE_MEDIA" })).code).toBe("BINDING_NOT_FOUND");
+	});
+
+	it("names the KV binding and the wrangler key that declares it", () => {
+		const { message } = thrown(() => createObjectCache({ binding: "SITE_CACHE" }));
+		expect(message).toContain("SITE_CACHE");
+		expect(message).toContain("kv_namespaces");
+	});
+
+	it("names the Durable Object binding and the wrangler key that declares it", () => {
+		const { message } = thrown(() => createDurableObjectDialect({ binding: "SITE_DO" }));
+		expect(message).toContain("SITE_DO");
+		expect(message).toContain("durable_objects");
+	});
+
+	it("names the Hyperdrive binding and the wrangler key that declares it", () => {
+		const { message } = thrown(() => createHyperdriveDialect({ binding: "SITE_PG" }));
+		expect(message).toContain("SITE_PG");
+		expect(message).toContain("hyperdrive");
+	});
+
+	it("separates a Hyperdrive binding without a connection string from an absent one", () => {
+		fakeEnv.SITE_PG = {};
+
+		const { message } = thrown(() => createHyperdriveDialect({ binding: "SITE_PG" }));
+
+		expect(message).toContain("SITE_PG");
+		expect(message).toContain("connectionString");
+		expect(message).not.toContain("not found");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Covers what the Cloudflare runtime reports when a platform binding is absent. The factory the runtime calls for D1, R2, KV, Durable Objects and Hyperdrive answers with the binding name the site configured and the wrangler key that declares it, but only the cloudflare-email plugin had a test holding that shape, so a rewrite that dropped either would ship unnoticed.

The new file drives each of the five, and adds the code carried on the R2 error and a Hyperdrive binding that is present without a connection string. Assertions read the binding name and the wrangler key out of the message rather than the whole string, so rewording stays free.

Part of #1686.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (n/a: no admin UI strings)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package) (n/a: test-only, no published behavior changes)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a: tests)
- [ ] I have included screenshots below if this PR changes the UI (n/a: no UI change)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5

## Screenshots / test output

Not applicable for screenshots. Each test was checked against a mutated source: a generic replacement for one message, or for the R2 error code, turns that test red and leaves the other six green.

```
D1 message generic             -> 1 failed | 6 passed
R2 message generic             -> 1 failed | 6 passed
R2 code changed                -> 1 failed | 6 passed
KV message generic             -> 1 failed | 6 passed
DO message generic             -> 1 failed | 6 passed
Hyperdrive missing generic     -> 1 failed | 6 passed
Hyperdrive incomplete generic  -> 1 failed | 6 passed
```

Against unmodified sources, `packages/cloudflare` is green:

```
 Test Files  37 passed | 1 skipped (38)
      Tests  419 passed | 2 skipped (421)
```

`pnpm typecheck`, `pnpm lint` and `pnpm format` are clean across the workspace. `pnpm test:e2e` was not run.
