### PR TITLE
Keep the edit proxy on collection reads in edit mode

### DIFF
--- a/.changeset/olive-crabs-repeat.md
+++ b/.changeset/olive-crabs-repeat.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes visual editing on list pages. Entries from `getEmDashCollection` now carry a working `edit` proxy in edit mode, so spreading `{...entry.edit.title}` renders the annotation and the toolbar makes the element editable. Previously every collection entry received a no-op proxy in every mode, so only pages built from `getEmDashEntry` were click-to-edit — fields shown exclusively in a list, and collections with no detail page, could not be edited on the page at all.

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -398,8 +398,21 @@ export async function getEmDashCollection<T extends string, D = InferCollectionD
 	// Cursor-paginated calls are exempt: their limit is part of the
 	// pagination contract.
 	const bucketed = bucketFilter(filter);
+
+	// Preview and edit-mode requests skip `loadCollectionCached`. That path
+	// reduces every entry to a JSON snapshot (`entrySnapshot`) and rebuilds it
+	// with `reviveEntry`, which cannot carry the `edit` proxy and re-attaches
+	// the no-op — so annotations spread as `{...entry.edit.title}` would render
+	// nothing on list pages. `getEmDashEntry` has the same bypass for the same
+	// reason (see its `serveDrafts` branch). The request-scoped cache still
+	// collapses duplicate queries within the render.
+	const ctx = getRequestContext();
+	const serveDrafts = ctx?.editMode === true || ctx?.preview !== undefined;
+
 	const cached = await requestCached(collectionCacheKey(type, bucketed.fetchFilter), () =>
-		loadCollectionCached<T, D>(type, bucketed.fetchFilter),
+		serveDrafts
+			? getEmDashCollectionUncached<T, D>(type, bucketed.fetchFilter)
+			: loadCollectionCached<T, D>(type, bucketed.fetchFilter),
 	);
 	return bucketed.requestedLimit === undefined
 		? cached

--- a/packages/core/tests/unit/query-collection-edit-proxy.test.ts
+++ b/packages/core/tests/unit/query-collection-edit-proxy.test.ts
@@ -1,0 +1,97 @@
+import type { Kysely } from "kysely";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { handleContentCreate } from "../../src/api/index.js";
+import type { Database } from "../../src/database/types.js";
+import { getEmDashCollection, getEmDashEntry } from "../../src/query.js";
+import { runWithContext } from "../../src/request-context.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../utils/test-db.js";
+
+vi.mock("astro:content", () => ({
+	getLiveCollection: vi.fn(),
+	getLiveEntry: vi.fn(),
+}));
+
+import { getLiveCollection, getLiveEntry } from "astro:content";
+
+/**
+ * Visual editing on list pages.
+ *
+ * `getEmDashCollection` used to route every read through `loadCollectionCached`,
+ * which reduces entries to a JSON snapshot and rebuilds them with
+ * `reviveEntry` — re-attaching the no-op `edit` proxy. The real proxy built in
+ * `getEmDashCollectionUncached` was therefore unreachable through the public
+ * API, and `{...entry.edit.title}` rendered no annotation on any list page.
+ */
+describe("getEmDashCollection edit proxy", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+		vi.mocked(getLiveCollection).mockReset();
+		vi.mocked(getLiveEntry).mockReset();
+	});
+
+	async function seedPost(title: string) {
+		const result = await handleContentCreate(db, "post", { data: { title }, status: "published" });
+		if (!result.success) throw new Error("Failed to create post");
+		return result.data!.item;
+	}
+
+	function mockLoaders(item: { id: string; slug: string }, title: string) {
+		const entry = {
+			id: item.slug,
+			data: { id: item.id, title, status: "published" },
+		};
+		vi.mocked(getLiveCollection).mockResolvedValue({
+			entries: [entry],
+			error: undefined,
+			cacheHint: {},
+		} as never);
+		vi.mocked(getLiveEntry).mockResolvedValue({
+			entry,
+			error: undefined,
+			cacheHint: {},
+		} as never);
+	}
+
+	it("annotates fields in edit mode, matching getEmDashEntry", async () => {
+		const item = await seedPost("Hello");
+		mockLoaders(item, "Hello");
+
+		const { collection, entry } = await runWithContext({ editMode: true, db }, async () => {
+			const list = await getEmDashCollection("post");
+			const single = await getEmDashEntry("post", item.slug);
+			return { collection: list.entries[0], entry: single.entry };
+		});
+
+		const annotation = { ...collection!.edit.title };
+		expect(annotation).toHaveProperty("data-emdash-ref");
+		expect(JSON.parse(annotation["data-emdash-ref"]!)).toMatchObject({
+			collection: "post",
+			id: item.id,
+			field: "title",
+		});
+
+		// The two read paths must agree — a field editable on a detail page is
+		// editable in a list, and vice versa.
+		expect({ ...entry!.edit.title }).toEqual(annotation);
+	});
+
+	it("emits no annotations outside edit mode", async () => {
+		const item = await seedPost("Hello");
+		mockLoaders(item, "Hello");
+
+		const collection = await runWithContext({ editMode: false, db }, async () => {
+			const list = await getEmDashCollection("post");
+			return list.entries[0];
+		});
+
+		expect({ ...collection!.edit.title }).toEqual({});
+		expect(Object.keys(collection!.edit)).toEqual([]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes visual editing on list pages. Entries returned by `getEmDashCollection` always carried a no-op `edit` proxy, in every mode, so spreading `{...entry.edit.title}` on a list rendered no annotation and the toolbar never picked the element up. Only pages built from `getEmDashEntry` were click-to-edit.

`getEmDashCollection` routed every read through `loadCollectionCached`, which reduces entries to a JSON snapshot (`entrySnapshot`) and rebuilds them with `reviveEntry`. A `Proxy` cannot survive that round-trip, so `reviveEntry` re-attaches the no-op — discarding the `createEditable` proxy that `getEmDashCollectionUncached` built one line earlier.

The round-trip ran unconditionally, not only on a cache hit, so the annotation was lost even with no L2 backend configured. `shouldBypass()` governs whether a snapshot is *stored*, not whether entries pass through it, which left this invariant — stated above `entrySnapshot` — unenforced on the load path:

> L2 is only consulted for anonymous, non-preview, non-edit requests (see `shouldBypass` in object-cache), where `edit` is always the no-op variant — so dropping and recreating it is lossless.

This bypasses the snapshot for preview and edit-mode requests, mirroring the `serveDrafts` branch `getEmDashEntry` already uses for the same reason. The request-scoped cache still collapses duplicate queries within a render, so repeated widget reads are unaffected; only the distributed snapshot is skipped, and only for requests that must never be shared anyway.

Closes #2785

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — not applicable, no admin UI strings
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — not applicable, bug fix
- [ ] I have included screenshots below if this PR changes the UI — not applicable, no UI change

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Screenshots / test output

No UI change.

`tests/unit/query-collection-edit-proxy.test.ts` reproduces the bug. Against `main` the first case fails:

```
 × annotates fields in edit mode, matching getEmDashEntry
   AssertionError: expected {} to have property "data-emdash-ref"
 Tests  1 failed | 1 passed (2)
```

With the fix, both pass. The second case pins the other half of the contract — that no annotations are emitted outside edit mode — so the bypass can't leak refs into shared HTML.

Full `packages/core` unit suite on this branch:

```
 Test Files  343 passed (343)
      Tests  4257 passed (4257)
```

`pnpm typecheck`, `pnpm lint` and `pnpm format` all clean.

### How this was found

Reported independently while building a site on `emdash@0.32.0`: FAQ, house-rules and supporters list pages were not editable, while the event detail page was. Confirmed at runtime in a single request with `editMode: true` — `getEmDashCollection` returned `Object.keys(entry.edit) === []` while `getEmDashEntry` returned a real annotation for the same session. Details in [#2785 (comment)](https://github.com/emdash-cms/emdash/issues/2785#issuecomment-5593509192).