### PR TITLE
fix(bot): recover workspace base after retries

### DIFF
--- a/infra/emdash-bot/.flue/lib/exec-env.ts
+++ b/infra/emdash-bot/.flue/lib/exec-env.ts
@@ -229,14 +229,14 @@ export class ExecEnv {
 	}
 
 	async execWritable(command: string, options: ExecOptions = {}): Promise<ExecResult> {
+		await this.#snapshotBase();
 		const result = await this.exec(command, options);
 		await this.checkpointContainer();
 		return result;
 	}
 
 	async checkpointContainer(): Promise<void> {
-		const baseRef = this.#snapshotBaseRef;
-		if (!baseRef) throw new Error("workspace snapshot base is not initialized");
+		const baseRef = await this.#snapshotBase();
 		const container = await this.container();
 		const pathsResult = await this.#bounded(
 			container.exec(
@@ -286,6 +286,13 @@ export class ExecEnv {
 			this.#bounded(this.#state.writeFile(DELETED_LOG, JSON.stringify(deleted)), "writeFile"),
 			this.#bounded(this.#state.writeFile(MODE_LOG, JSON.stringify(modes)), "writeFile"),
 		]);
+	}
+
+	async #snapshotBase(): Promise<string> {
+		const baseRef = this.#snapshotBaseRef ?? (await this.#readMarker());
+		if (!baseRef) throw new Error("workspace snapshot base is not initialized");
+		this.#snapshotBaseRef = baseRef;
+		return baseRef;
 	}
 
 	async #checkpointPath(container: ContainerBackend, path: string): Promise<CandidatePathState> {

--- a/infra/emdash-bot/tests/unit/exec-env.test.ts
+++ b/infra/emdash-bot/tests/unit/exec-env.test.ts
@@ -255,6 +255,24 @@ describe("ExecEnv container exec", () => {
 		expect(fs.files.get("/.emdash-bot/changes.json")).toBe('["/repo/src/a.ts"]');
 	});
 
+	test("recovers the snapshot base after the execution environment is reconstructed", async () => {
+		const fs = fakeState();
+		const initial = makeEnv({ state: fs.state });
+		await initial.ensureRepo({ dir: "/repo", ref: "base-sha" });
+
+		const con = fakeContainer();
+		con.queueExecResults(
+			{ exitCode: 0, stdout: "passed", stderr: "" },
+			{ exitCode: 0, stdout: "\n", stderr: "" },
+		);
+		const resumed = makeEnv({ state: fs.state, container: con.container });
+
+		await expect(resumed.execWritable("pnpm test")).resolves.toMatchObject({ stdout: "passed" });
+
+		expect(con.execs[1]).toContain("git diff --name-only -z");
+		expect(con.execs[1]).toContain("base-sha");
+	});
+
 	test("rejects a shell-created symlink that escapes the repository", async () => {
 		const fs = fakeState();
 		const con = fakeContainer();


### PR DESCRIPTION
## What does this PR do?

Restores the workspace snapshot base when an investigation resumes in a fresh Worker context. The hydrated ref is durable in the VFS marker, while the `ExecEnv` field that held it was process-local. After a Flue retry, writable shell commands could therefore run against the restored checkout but fail while checkpointing with `workspace snapshot base is not initialized`.

Writable execution now reloads that ref from the hydration marker before running, and checkpointing uses the recovered value. A regression test reconstructs `ExecEnv` over the same durable VFS and verifies that the resumed command checkpoints against the original base.

Related to #2965.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

The i18n, changeset, Discussion, and screenshot items are not applicable: this changes only internal bot execution infrastructure.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex (GPT-5)

## Screenshots / test output

Not applicable; no UI changes.

- `pnpm --dir infra/emdash-bot test:unit` — 350 passed
- `pnpm --dir infra/emdash-bot test:workers` — 90 passed
- `pnpm --dir infra/emdash-bot build`
- `pnpm --dir infra/emdash-bot typecheck`
- `pnpm lint`
- `pnpm format:check`
