### PR TITLE
ci: exclude generated changelogs from format checks

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -5,6 +5,7 @@
 		"**/dist/**",
 		"**/node_modules/**",
 		"**/*.mdx",
+		"**/CHANGELOG.md",
 		"**/package.json",
 		"**/emdash-env.d.ts",
 		"**/worker-configuration.d.ts",


### PR DESCRIPTION
## What does this PR do?

Excludes generated `CHANGELOG.md` files from oxfmt checks. Changesets generates these files when it updates the release PR, so formatting is enforced on the source changesets instead of their generated aggregate output.

This unblocks release PR [#2833](https://github.com/emdash-cms/emdash/pull/2833), where the generated `packages/registry-client/CHANGELOG.md` currently fails the Format job.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — Not applicable; this is a formatter configuration change verified against the exact generated file from release PR #2833.
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — Not applicable; there are no user-visible strings.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package) — Not applicable; no published package changes.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... — Not applicable; this is not a feature.
- [ ] I have included screenshots below if this PR changes the UI — Not applicable; there are no UI changes.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI GPT-5 (Codex)

## Screenshots / test output

Not applicable; there are no UI changes.

The targeted fixture copies the exact failing changelog and formatter config from release PR #2833:

- Existing config: oxfmt reports `packages/registry-client/CHANGELOG.md` as unformatted.
- This PR's config: the same directory-level check passes because the generated changelog is excluded.

Also verified with `pnpm lint`, `pnpm typecheck`, `pnpm format`, `pnpm format:check`, and `git diff --check`.
