### PR TITLE
Improve passkey onboarding across account creation

### DIFF
--- a/.changeset/calm-keys-guide.md
+++ b/.changeset/calm-keys-guide.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Improves passkey account creation with device-aware guidance before the browser prompt. EmDash explains what a passkey is and where it is saved, detects when a built-in authenticator is unavailable, and guides users through Windows Hello, another device, or a security key. Compatible browsers receive a preference for the selected path, while the browser continues to control the secure passkey prompt.

--- a/e2e/tests/invite-flow.spec.ts
+++ b/e2e/tests/invite-flow.spec.ts
@@ -144,8 +144,12 @@ test.describe("Invite Accept Page", () => {
 			await expect(admin.page.locator("text=You've been invited!")).toBeVisible();
 			await expect(admin.page.getByLabel("Email")).toHaveValue("invite-ui@example.com");
 			await expect(admin.page.locator("text=AUTHOR")).toBeVisible();
-			await expect(admin.page.locator("text=Create your passkey")).toBeVisible();
-			await expect(admin.page.getByRole("button", { name: "Create Account" })).toBeVisible();
+			await expect(
+				admin.page.getByRole("heading", {
+					name: "With a passkey, you don’t need to remember complex passwords",
+				}),
+			).toBeVisible();
+			await expect(admin.page.getByRole("button", { name: "Create passkey" })).toBeVisible();
 		});
 	});
 });
@@ -206,7 +210,7 @@ test.describe("Full invite flow with passkey registration", () => {
 			await expect(page.getByLabel("Email")).toHaveValue(inviteEmail);
 			await expect(page.locator("text=AUTHOR")).toBeVisible();
 
-			// Step 5: Fill in name and click Create Account
+			// Step 5: Fill in name and create a passkey
 			const nameInput = page.getByLabel("Your name (optional)");
 			await nameInput.fill("Invited User");
 
@@ -215,10 +219,14 @@ test.describe("Full invite flow with passkey registration", () => {
 					return new URL(response.url()).pathname === "/_emdash/api/auth/invite/complete";
 				})
 				.then((response) => response.status());
-			await page.getByRole("button", { name: "Create Account" }).click();
+			await page.getByRole("button", { name: "Create passkey" }).click();
 			expect(await completionResponsePromise).toBe(200);
 
-			// Step 6: Wait for passkey flow to complete and redirect
+			// Step 6: Confirm the completed passkey flow and continue
+			await expect(page.getByRole("heading", { name: "Passkey created" })).toBeVisible();
+			await page.getByRole("button", { name: "Open the dashboard" }).click();
+
+			// Step 7: Wait for the dashboard redirect
 			await expect(page).toHaveURL(ADMIN_URL_PATTERN, { timeout: 60_000 });
 			const welcomeDialog = page.getByRole("dialog", { name: /Welcome to EmDash/ });
 			await expect(welcomeDialog).toBeVisible({ timeout: 15_000 });

--- a/e2e/tests/invite-flow.spec.ts
+++ b/e2e/tests/invite-flow.spec.ts
@@ -27,6 +27,7 @@ import { addVirtualWebAuthnAuthenticator } from "../fixtures/virtual-authenticat
 const ADMIN_URL_PATTERN = /\/_emdash\/admin\/?$/;
 const INVITE_URL_REGEX = /https?:\/\/[^\s]+\/admin\/invite\/accept\?token=[^\s]+/;
 const URL_IN_TEXT_REGEX = /https?:\/\/[^\s]+/;
+const PASSKEY_ACTION_REGEX = /^(Create passkey|Use another device|Use a security key)$/;
 
 const SERVER_INFO_PATH = join(tmpdir(), "emdash-pw-server.json");
 
@@ -149,7 +150,9 @@ test.describe("Invite Accept Page", () => {
 					name: "With a passkey, you don’t need to remember complex passwords",
 				}),
 			).toBeVisible();
-			await expect(admin.page.getByRole("button", { name: "Create passkey" })).toBeVisible();
+			await expect(
+				admin.page.getByRole("button", { name: PASSKEY_ACTION_REGEX }).first(),
+			).toBeVisible();
 		});
 	});
 });

--- a/e2e/tests/passkey-full-setup-virtual-auth.spec.ts
+++ b/e2e/tests/passkey-full-setup-virtual-auth.spec.ts
@@ -60,12 +60,18 @@ test.describe("Setup wizard passkey with virtual authenticator (localhost)", () 
 			await page.getByLabel("Your Name").fill("Virtual Auth User");
 			await page.getByRole("button", { name: "Continue" }).click();
 
-			await expect(page.locator("text=Choose how to sign in")).toBeVisible();
-			await page.getByRole("button", { name: "Create Passkey" }).click();
+			await expect(
+				page.getByRole("heading", {
+					name: "With a passkey, you don’t need to remember complex passwords",
+				}),
+			).toBeVisible();
+			await page.getByRole("button", { name: "Create passkey" }).click();
+			await expect(page.getByRole("heading", { name: "Passkey created" })).toBeVisible();
+			await page.getByRole("button", { name: "Open the dashboard" }).click();
 
 			// admin-verify creates the user but does not set a session; wizard sends user to /_emdash/admin and auth redirects to login.
 			await expect(page).toHaveURL(ADMIN_AFTER_SETUP_URL, { timeout: 60_000 });
-			await expect(page.locator("text=Choose how to sign in")).toHaveCount(0);
+			await expect(page.getByRole("heading", { name: "Passkey created" })).toHaveCount(0);
 			await expect(page.locator("text=Registration was cancelled or timed out")).toHaveCount(0);
 			await expect(page.locator("text=Invalid origin")).toHaveCount(0);
 		} finally {

--- a/e2e/tests/setup-wizard.spec.ts
+++ b/e2e/tests/setup-wizard.spec.ts
@@ -90,7 +90,12 @@ test.describe("Setup Wizard", () => {
 		await admin.page.getByRole("button", { name: "Continue" }).click();
 
 		await expect(admin.page.locator("text=Secure your account")).toBeVisible();
-		await expect(admin.page.locator("text=Choose how to sign in")).toBeVisible();
+		await expect(
+			admin.page.getByRole("heading", {
+				name: "With a passkey, you don’t need to remember complex passwords",
+			}),
+		).toBeVisible();
+		await expect(admin.page.getByRole("button", { name: "Create passkey" })).toBeVisible();
 	});
 
 	test("setup wizard not accessible after setup complete", async ({ admin }) => {

--- a/e2e/tests/setup-wizard.spec.ts
+++ b/e2e/tests/setup-wizard.spec.ts
@@ -15,6 +15,7 @@ import { refreshServerPatAfterDevBypass } from "../fixtures/refresh-server-pat";
 
 const BASE_URL = "http://localhost:4444";
 const ADMIN_DASHBOARD_PATTERN = /\/_emdash\/admin\/?$/;
+const PASSKEY_ACTION_REGEX = /^(Create passkey|Use another device|Use a security key)$/;
 
 async function resetSetup(): Promise<void> {
 	const res = await fetch(`${BASE_URL}/_emdash/api/setup/dev-reset`, {
@@ -95,7 +96,9 @@ test.describe("Setup Wizard", () => {
 				name: "With a passkey, you don’t need to remember complex passwords",
 			}),
 		).toBeVisible();
-		await expect(admin.page.getByRole("button", { name: "Create passkey" })).toBeVisible();
+		await expect(
+			admin.page.getByRole("button", { name: PASSKEY_ACTION_REGEX }).first(),
+		).toBeVisible();
 	});
 
 	test("setup wizard not accessible after setup complete", async ({ admin }) => {

--- a/packages/admin/src/components/InviteAcceptPage.tsx
+++ b/packages/admin/src/components/InviteAcceptPage.tsx
@@ -30,6 +30,7 @@ function handleInviteSuccess() {
 function RegisterStep({ inviteData, token }: RegisterStepProps) {
 	const { t } = useLingui();
 	const [name, setName] = React.useState("");
+	const [passkeyComplete, setPasskeyComplete] = React.useState(false);
 	const buttonProviders = useAuthProviderList().filter((p) => p.LoginButton);
 
 	return (
@@ -66,27 +67,25 @@ function RegisterStep({ inviteData, token }: RegisterStepProps) {
 				type="text"
 				value={name}
 				onChange={(e) => setName(e.target.value)}
-				placeholder="Jane Doe"
+				placeholder={t`Jane Doe`}
 				autoComplete="name"
 				autoFocus
 			/>
 
 			<div className="pt-4 border-t">
-				<h3 className="text-sm font-medium mb-3">{t`Create your passkey`}</h3>
-				<p className="text-sm text-kumo-subtle mb-4">
-					{t`Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key.`}
-				</p>
-
 				<PasskeyRegistration
 					optionsEndpoint="/_emdash/api/auth/invite/register-options"
 					verifyEndpoint="/_emdash/api/auth/invite/complete"
 					onSuccess={handleInviteSuccess}
-					buttonText={t`Create Account`}
 					additionalData={{ token, name: name || undefined }}
+					showEducation
+					showSuccessStep
+					successButtonText={t`Open the dashboard`}
+					onSuccessReady={() => setPasskeyComplete(true)}
 				/>
 			</div>
 
-			{buttonProviders.length > 0 && (
+			{!passkeyComplete && buttonProviders.length > 0 && (
 				<>
 					{/* Divider */}
 					<div className="relative">

--- a/packages/admin/src/components/SetupWizard.tsx
+++ b/packages/admin/src/components/SetupWizard.tsx
@@ -250,6 +250,7 @@ interface AuthMethodStepProps {
 function AuthMethodStep({ adminData, providers, onBack }: AuthMethodStepProps) {
 	const { t } = useLingui();
 	const [activeProvider, setActiveProvider] = React.useState<string | null>(null);
+	const [passkeyComplete, setPasskeyComplete] = React.useState(false);
 
 	const buttonProviders = providers.filter((p) => p.LoginButton);
 	const hasProviders = buttonProviders.length > 0;
@@ -283,24 +284,20 @@ function AuthMethodStep({ adminData, providers, onBack }: AuthMethodStepProps) {
 
 	return (
 		<div className="space-y-6">
-			{/* Passkey option */}
-			<div className="text-center">
-				<h3 className="text-lg font-medium">{t`Choose how to sign in`}</h3>
-				<p className="text-sm text-kumo-subtle mt-1">
-					{t`Pick any method to create your admin account.`}
-				</p>
-			</div>
-
 			<PasskeyRegistration
 				optionsEndpoint="/_emdash/api/setup/admin"
 				verifyEndpoint="/_emdash/api/setup/admin/verify"
 				onSuccess={handleSetupSuccess}
-				buttonText={t`Create Passkey`}
 				additionalData={{ ...adminData }}
+				showEducation
+				showSuccessStep
+				successButtonText={t`Open the dashboard`}
+				onSuccessReady={() => setPasskeyComplete(true)}
+				onBack={onBack}
 			/>
 
 			{/* Auth provider options */}
-			{hasProviders && (
+			{!passkeyComplete && hasProviders && (
 				<>
 					<div className="relative">
 						<div className="absolute inset-0 flex items-center">
@@ -327,10 +324,6 @@ function AuthMethodStep({ adminData, providers, onBack }: AuthMethodStepProps) {
 					</div>
 				</>
 			)}
-
-			<Button type="button" variant="ghost" onClick={onBack} className="w-full">
-				{t`← Back`}
-			</Button>
 		</div>
 	);
 }

--- a/packages/admin/src/components/SignupPage.tsx
+++ b/packages/admin/src/components/SignupPage.tsx
@@ -189,6 +189,7 @@ function handleSignupSuccess() {
 function VerifyStep({ verifyResult, token, onBack: _onBack }: VerifyStepProps) {
 	const { t } = useLingui();
 	const [name, setName] = React.useState("");
+	const [passkeyComplete, setPasskeyComplete] = React.useState(false);
 
 	return (
 		<div className="space-y-6">
@@ -209,32 +210,32 @@ function VerifyStep({ verifyResult, token, onBack: _onBack }: VerifyStepProps) {
 				</p>
 			</div>
 
-			{/* Email display (read-only) */}
-			<Input label={t`Email`} value={verifyResult.email} disabled className="bg-kumo-tint" />
+			{!passkeyComplete && (
+				<>
+					<Input label={t`Email`} value={verifyResult.email} disabled className="bg-kumo-tint" />
 
-			{/* Name input (optional) */}
-			<Input
-				label={t`Your name (optional)`}
-				type="text"
-				value={name}
-				onChange={(e) => setName(e.target.value)}
-				placeholder={t`Jane Doe`}
-				autoComplete="name"
-			/>
+					<Input
+						label={t`Your name (optional)`}
+						type="text"
+						value={name}
+						onChange={(e) => setName(e.target.value)}
+						placeholder={t`Jane Doe`}
+						autoComplete="name"
+					/>
+				</>
+			)}
 
 			{/* Passkey registration */}
 			<div className="pt-4 border-t">
-				<h3 className="text-sm font-medium mb-3">{t`Create your passkey`}</h3>
-				<p className="text-sm text-kumo-subtle mb-4">
-					{t`Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key.`}
-				</p>
-
 				<PasskeyRegistration
 					optionsEndpoint="/_emdash/api/setup/admin"
 					verifyEndpoint="/_emdash/api/auth/signup/complete"
 					onSuccess={handleSignupSuccess}
-					buttonText={t`Create Account`}
 					additionalData={{ token, name: name || undefined }}
+					showEducation
+					showSuccessStep
+					successButtonText={t`Open the dashboard`}
+					onSuccessReady={() => setPasskeyComplete(true)}
 				/>
 			</div>
 		</div>

--- a/packages/admin/src/components/auth/PasskeyRegistration.tsx
+++ b/packages/admin/src/components/auth/PasskeyRegistration.tsx
@@ -106,7 +106,7 @@ export interface PasskeyRegistrationProps {
 	additionalData?: Record<string, unknown>;
 	/** Show researched onboarding guidance before browser-owned passkey UI */
 	showEducation?: boolean;
-	/** Keep the success confirmation visible until the user continues */
+	/** Keep the educational flow's success confirmation visible until the user continues. Requires showEducation. */
 	showSuccessStep?: boolean;
 	/** Button shown after a successful educational flow */
 	successButtonText?: string;
@@ -495,7 +495,7 @@ export function PasskeyRegistration({
 		);
 	}
 
-	if (showEducation && state.status === "success") {
+	if (showEducation && showSuccessStep && state.status === "success") {
 		return (
 			<div className="space-y-5 text-center">
 				<div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-kumo-success/10 text-kumo-success">
@@ -538,6 +538,7 @@ export function PasskeyRegistration({
 				</div>
 				<LinkButton
 					href="ms-settings:signinoptions"
+					external
 					icon={<WindowsLogo />}
 					className="w-full justify-center"
 				>

--- a/packages/admin/src/components/auth/PasskeyRegistration.tsx
+++ b/packages/admin/src/components/auth/PasskeyRegistration.tsx
@@ -11,15 +11,27 @@
  * - User settings (adding additional passkeys)
  */
 
-import { Button, Input } from "@cloudflare/kumo";
+import { Button, Input, LinkButton, Loader } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
+import {
+	DeviceMobile,
+	Fingerprint,
+	Info,
+	Key,
+	ShieldCheck,
+	Usb,
+	WindowsLogo,
+} from "@phosphor-icons/react";
 import * as React from "react";
 
 import { apiFetch, parseApiResponse } from "../../lib/api/client";
 import {
+	detectPasskeyPlatform,
+	getPasskeyClientCapabilities,
 	isPasskeyEnvironmentUsable,
 	isWebAuthnSecureContext,
 } from "../../lib/webauthn-environment";
+import type { PasskeyClientCapabilities, PasskeyPlatform } from "../../lib/webauthn-environment";
 import { InsecurePasskeyContextMessage } from "./PasskeyContextMessage.js";
 
 // ============================================================================
@@ -51,6 +63,7 @@ interface PublicKeyCredentialCreationOptionsJSON {
 	}>;
 	timeout?: number;
 	attestation?: "none" | "indirect" | "direct";
+	hints?: PasskeyPreference[];
 	authenticatorSelection?: {
 		authenticatorAttachment?: "platform" | "cross-platform";
 		residentKey?: "discouraged" | "preferred" | "required";
@@ -91,6 +104,16 @@ export interface PasskeyRegistrationProps {
 	showNameInput?: boolean;
 	/** Additional data to send with requests */
 	additionalData?: Record<string, unknown>;
+	/** Show researched onboarding guidance before browser-owned passkey UI */
+	showEducation?: boolean;
+	/** Keep the success confirmation visible until the user continues */
+	showSuccessStep?: boolean;
+	/** Button shown after a successful educational flow */
+	successButtonText?: string;
+	/** Called when an educational success screen replaces surrounding choices */
+	onSuccessReady?: () => void;
+	/** Return to the account-details step from the top-level educational view */
+	onBack?: () => void;
 }
 
 const EMPTY_DATA: Record<string, unknown> = {};
@@ -99,7 +122,17 @@ type RegistrationState =
 	| { status: "idle" }
 	| { status: "loading"; message: string }
 	| { status: "error"; message: string }
-	| { status: "success" };
+	| { status: "success"; result: unknown };
+
+type PasskeyPreference = "client-device" | "hybrid" | "security-key";
+
+interface PublicKeyCredentialCreationOptionsWithHints extends PublicKeyCredentialCreationOptions {
+	hints?: PasskeyPreference[];
+}
+
+type CapabilityState =
+	| { status: "checking" }
+	| { status: "ready"; capabilities: PasskeyClientCapabilities };
 
 /**
  * Convert base64url to ArrayBuffer
@@ -131,6 +164,94 @@ function bufferToBase64url(buffer: ArrayBuffer): string {
 	return base64.replace(BASE64_PLUS_REGEX, "-").replace(BASE64_SLASH_REGEX, "_");
 }
 
+interface PlatformCopy {
+	name: string;
+	unlock: string;
+	storage: string;
+	icon: React.ReactNode;
+}
+
+function usePlatformCopy(platform: PasskeyPlatform): PlatformCopy {
+	const { t } = useLingui();
+	switch (platform) {
+		case "windows":
+			return {
+				name: t`the Windows passkey prompt`,
+				unlock: t`Choose Windows Hello or another available credential manager, then confirm with your PIN, fingerprint, or face.`,
+				storage: t`Windows will show which credential manager will save it before creating it.`,
+				icon: <WindowsLogo className="h-5 w-5" />,
+			};
+		case "macos":
+			return {
+				name: t`the macOS passkey prompt`,
+				unlock: t`Choose Touch ID or another available credential manager, then confirm with your fingerprint or Mac password.`,
+				storage: t`Your credential manager, such as iCloud Keychain, saves it and may sync it to your other devices.`,
+				icon: <Fingerprint className="h-5 w-5" />,
+			};
+		case "ios":
+			return {
+				name: t`your device's passkey prompt`,
+				unlock: t`Confirm with Face ID, Touch ID, or your device passcode.`,
+				storage: t`Your credential manager, such as iCloud Keychain, saves it and may sync it to your other devices.`,
+				icon: <DeviceMobile className="h-5 w-5" />,
+			};
+		case "android":
+			return {
+				name: t`the Android passkey prompt`,
+				unlock: t`Confirm with your fingerprint, face, or PIN.`,
+				storage: t`Your credential manager, such as Google Password Manager, saves it and may sync it to your other devices.`,
+				icon: <DeviceMobile className="h-5 w-5" />,
+			};
+		default:
+			return {
+				name: t`your device's passkey prompt`,
+				unlock: t`Confirm using the secure prompt from your device or credential manager.`,
+				storage: t`Your device's credential manager saves it and will show you where before creating it.`,
+				icon: <ShieldCheck className="h-5 w-5" />,
+			};
+	}
+}
+
+function PasskeyIntroduction({ storage }: { storage: string }) {
+	const { t } = useLingui();
+	return (
+		<div className="space-y-4">
+			<div className="text-center">
+				<div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-2xl bg-kumo-brand/10 text-kumo-link">
+					<Key className="h-7 w-7" />
+				</div>
+				<h3 className="text-lg font-semibold">
+					{t`With a passkey, you don’t need to remember complex passwords`}
+				</h3>
+			</div>
+
+			<div className="space-y-3 text-start">
+				<div className="flex items-start gap-3">
+					<div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-kumo-brand/10 text-kumo-link">
+						<Key className="h-4 w-4" />
+					</div>
+					<div>
+						<h4 className="text-sm font-medium">{t`What is a passkey?`}</h4>
+						<p className="mt-1 text-sm text-kumo-subtle">
+							{t`An encrypted digital key you unlock using your fingerprint, face, PIN, or device password.`}
+						</p>
+					</div>
+				</div>
+
+				<div className="flex items-start gap-3">
+					<div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-kumo-brand/10 text-kumo-link">
+						<ShieldCheck className="h-4 w-4" />
+					</div>
+					<div>
+						<h4 className="text-sm font-medium">{t`Where is it saved?`}</h4>
+						<p className="mt-1 text-sm text-kumo-subtle">{storage}</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
 /**
  * PasskeyRegistration Component
  */
@@ -142,157 +263,210 @@ export function PasskeyRegistration({
 	buttonText,
 	showNameInput = false,
 	additionalData = EMPTY_DATA,
+	showEducation = false,
+	showSuccessStep = false,
+	successButtonText,
+	onSuccessReady,
+	onBack,
 }: PasskeyRegistrationProps) {
 	const { t } = useLingui();
 	const resolvedButtonText = buttonText ?? t`Register Passkey`;
+	const resolvedSuccessButtonText = successButtonText ?? t`Continue`;
 	const [state, setState] = React.useState<RegistrationState>({
 		status: "idle",
 	});
 	const [passkeyName, setPasskeyName] = React.useState("");
+	const [preference, setPreference] = React.useState<PasskeyPreference | null>(null);
+	const [showWindowsHelloHelp, setShowWindowsHelloHelp] = React.useState(false);
+	const [recheckFailed, setRecheckFailed] = React.useState(false);
+	const [capabilityState, setCapabilityState] = React.useState<CapabilityState>({
+		status: "checking",
+	});
 
 	// Secure context (HTTPS or http://localhost) + PublicKeyCredential
 	const isSupported = React.useMemo(() => isPasskeyEnvironmentUsable(), []);
+	const platform = React.useMemo(() => detectPasskeyPlatform(), []);
+	const platformCopy = usePlatformCopy(platform);
 	const insecureContext = React.useMemo(
 		() => typeof window !== "undefined" && !isWebAuthnSecureContext(),
 		[],
 	);
 
-	const handleRegister = React.useCallback(async () => {
-		if (!isSupported) {
-			setState({
-				status: "error",
-				message: t`WebAuthn is not supported in this browser`,
-			});
-			return;
-		}
+	const checkCapabilities = React.useCallback(async () => {
+		setCapabilityState({ status: "checking" });
+		const capabilities = await getPasskeyClientCapabilities();
+		setCapabilityState({ status: "ready", capabilities });
+		return capabilities;
+	}, []);
 
-		try {
-			// Step 1: Get registration options from server
-			setState({ status: "loading", message: t`Preparing registration...` });
+	React.useEffect(() => {
+		if (!showEducation || !isSupported) return;
+		let active = true;
+		void (async () => {
+			const capabilities = await getPasskeyClientCapabilities();
+			if (active) setCapabilityState({ status: "ready", capabilities });
+		})();
+		return () => {
+			active = false;
+		};
+	}, [isSupported, showEducation]);
 
-			const optionsResponse = await apiFetch(optionsEndpoint, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify(additionalData),
-			});
-
-			const optionsData = await parseApiResponse<{
-				options: PublicKeyCredentialCreationOptionsJSON;
-			}>(optionsResponse, t`Failed to get registration options`);
-			const { options } = optionsData;
-
-			// Step 2: Create credential with browser
-			setState({ status: "loading", message: t`Waiting for passkey...` });
-
-			// Convert options to the format expected by the browser
-			const publicKeyOptions: PublicKeyCredentialCreationOptions = {
-				challenge: base64urlToBuffer(options.challenge),
-				rp: options.rp,
-				user: {
-					id: base64urlToBuffer(options.user.id),
-					name: options.user.name,
-					displayName: options.user.displayName,
-				},
-				pubKeyCredParams: options.pubKeyCredParams,
-				timeout: options.timeout,
-				attestation: options.attestation,
-				authenticatorSelection: options.authenticatorSelection,
-				excludeCredentials: options.excludeCredentials?.map((cred) => ({
-					type: cred.type,
-					id: base64urlToBuffer(cred.id),
-					transports: cred.transports,
-				})),
-			};
-
-			const rawCredential = await navigator.credentials.create({
-				publicKey: publicKeyOptions,
-			});
-
-			if (!rawCredential) {
-				throw new Error("No credential returned from authenticator");
+	const handleRegister = React.useCallback(
+		async (selectedPreference?: PasskeyPreference) => {
+			if (!isSupported) {
+				setState({
+					status: "error",
+					message: t`WebAuthn is not supported in this browser`,
+				});
+				return;
 			}
 
-			// Step 3: Send credential to server for verification
-			setState({ status: "loading", message: t`Verifying...` });
+			try {
+				// Step 1: Get registration options from server
+				setState({ status: "loading", message: t`Preparing registration...` });
 
-			// navigator.credentials.create() with publicKey returns PublicKeyCredential
-			const credential = rawCredential as PublicKeyCredential;
-			const attestationResponse = credential.response as AuthenticatorAttestationResponse;
+				const optionsResponse = await apiFetch(optionsEndpoint, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(additionalData),
+				});
 
-			// authenticatorAttachment exists at runtime on PublicKeyCredential but isn't in the base type definition
-			const rawAttachment =
-				"authenticatorAttachment" in credential ? credential.authenticatorAttachment : undefined;
-			const authenticatorAttachment =
-				rawAttachment === "platform" || rawAttachment === "cross-platform"
-					? rawAttachment
-					: undefined;
+				const optionsData = await parseApiResponse<{
+					options: PublicKeyCredentialCreationOptionsJSON;
+				}>(optionsResponse, t`Failed to get registration options`);
+				const { options } = optionsData;
 
-			const registrationResponse: RegistrationResponse = {
-				id: credential.id,
-				rawId: bufferToBase64url(credential.rawId),
-				type: "public-key",
-				response: {
-					clientDataJSON: bufferToBase64url(attestationResponse.clientDataJSON),
-					attestationObject: bufferToBase64url(attestationResponse.attestationObject),
-					transports: attestationResponse.getTransports?.() as AuthenticatorTransport[] | undefined,
-				},
-				authenticatorAttachment,
-			};
+				// Step 2: Create credential with browser
+				setState({ status: "loading", message: t`Waiting for passkey...` });
 
-			const verifyResponse = await apiFetch(verifyEndpoint, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({
-					credential: registrationResponse,
-					name: passkeyName || undefined,
-					...additionalData,
-				}),
-			});
+				// Convert options to the format expected by the browser
+				const publicKeyOptions: PublicKeyCredentialCreationOptionsWithHints = {
+					challenge: base64urlToBuffer(options.challenge),
+					rp: options.rp,
+					user: {
+						id: base64urlToBuffer(options.user.id),
+						name: options.user.name,
+						displayName: options.user.displayName,
+					},
+					pubKeyCredParams: options.pubKeyCredParams,
+					timeout: options.timeout,
+					attestation: options.attestation,
+					authenticatorSelection: options.authenticatorSelection,
+					excludeCredentials: options.excludeCredentials?.map((cred) => ({
+						type: cred.type,
+						id: base64urlToBuffer(cred.id),
+						transports: cred.transports,
+					})),
+					hints: selectedPreference ? [selectedPreference] : options.hints,
+				};
 
-			const result = await parseApiResponse<unknown>(
-				verifyResponse,
-				t`Failed to verify registration`,
-			);
+				const rawCredential = await navigator.credentials.create({
+					publicKey: publicKeyOptions,
+				});
 
-			setState({ status: "success" });
-			onSuccess(result);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : t`Registration failed`;
-
-			// Handle specific WebAuthn errors
-			let userMessage = message;
-			if (error instanceof DOMException) {
-				switch (error.name) {
-					case "NotAllowedError":
-						userMessage = t`Registration was cancelled or timed out. Please try again.`;
-						break;
-					case "InvalidStateError":
-						userMessage = t`This passkey is already registered on this device.`;
-						break;
-					case "NotSupportedError":
-						userMessage = t`Your device doesn't support the required security features.`;
-						break;
-					case "SecurityError":
-						userMessage = t`Security error. Make sure you're on a secure connection.`;
-						break;
-					default:
-						userMessage = t`Authentication error: ${error.message}`;
+				if (!rawCredential) {
+					throw new Error("No credential returned from authenticator");
 				}
-			}
 
-			setState({ status: "error", message: userMessage });
-			onError?.(new Error(userMessage));
+				// Step 3: Send credential to server for verification
+				setState({ status: "loading", message: t`Verifying...` });
+
+				// navigator.credentials.create() with publicKey returns PublicKeyCredential
+				const credential = rawCredential as PublicKeyCredential;
+				const attestationResponse = credential.response as AuthenticatorAttestationResponse;
+
+				// authenticatorAttachment exists at runtime on PublicKeyCredential but isn't in the base type definition
+				const rawAttachment =
+					"authenticatorAttachment" in credential ? credential.authenticatorAttachment : undefined;
+				const authenticatorAttachment =
+					rawAttachment === "platform" || rawAttachment === "cross-platform"
+						? rawAttachment
+						: undefined;
+
+				const registrationResponse: RegistrationResponse = {
+					id: credential.id,
+					rawId: bufferToBase64url(credential.rawId),
+					type: "public-key",
+					response: {
+						clientDataJSON: bufferToBase64url(attestationResponse.clientDataJSON),
+						attestationObject: bufferToBase64url(attestationResponse.attestationObject),
+						transports: attestationResponse.getTransports?.() as
+							| AuthenticatorTransport[]
+							| undefined,
+					},
+					authenticatorAttachment,
+				};
+
+				const verifyResponse = await apiFetch(verifyEndpoint, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						credential: registrationResponse,
+						name: passkeyName || undefined,
+						...additionalData,
+					}),
+				});
+
+				const result = await parseApiResponse<unknown>(
+					verifyResponse,
+					t`Failed to verify registration`,
+				);
+
+				setState({ status: "success", result });
+				if (showSuccessStep) onSuccessReady?.();
+				else onSuccess(result);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : t`Registration failed`;
+
+				// Handle specific WebAuthn errors
+				let userMessage = message;
+				if (error instanceof DOMException) {
+					switch (error.name) {
+						case "NotAllowedError":
+							userMessage = t`Registration was cancelled or timed out. Please try again.`;
+							break;
+						case "InvalidStateError":
+							userMessage = t`This passkey is already registered on this device.`;
+							break;
+						case "NotSupportedError":
+							userMessage = t`Your device doesn't support the required security features.`;
+							break;
+						case "SecurityError":
+							userMessage = t`Security error. Make sure you're on a secure connection.`;
+							break;
+						default:
+							userMessage = t`Authentication error: ${error.message}`;
+					}
+				}
+
+				setState({ status: "error", message: userMessage });
+				onError?.(new Error(userMessage));
+			}
+		},
+		[
+			isSupported,
+			optionsEndpoint,
+			verifyEndpoint,
+			additionalData,
+			passkeyName,
+			onSuccess,
+			onError,
+			onSuccessReady,
+			showSuccessStep,
+			t,
+		],
+	);
+
+	const handleCheckAgain = React.useCallback(async () => {
+		setRecheckFailed(false);
+		const capabilities = await checkCapabilities();
+		if (capabilities.platformAuthenticator) {
+			setShowWindowsHelloHelp(false);
+			setPreference("client-device");
+		} else {
+			setRecheckFailed(true);
 		}
-	}, [
-		isSupported,
-		optionsEndpoint,
-		verifyEndpoint,
-		additionalData,
-		passkeyName,
-		onSuccess,
-		onError,
-		t,
-	]);
+	}, [checkCapabilities]);
 
 	// Not usable (insecure origin vs missing API — browser hides WebAuthn the same way)
 	if (!isSupported) {
@@ -308,6 +482,271 @@ export function PasskeyRegistration({
 						</>
 					)}
 				</p>
+			</div>
+		);
+	}
+
+	if (showEducation && capabilityState.status === "checking") {
+		return (
+			<div className="flex items-center justify-center gap-3 py-8 text-sm text-kumo-subtle">
+				<Loader />
+				{t`Checking this device for passkey support...`}
+			</div>
+		);
+	}
+
+	if (showEducation && state.status === "success") {
+		return (
+			<div className="space-y-5 text-center">
+				<div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-kumo-success/10 text-kumo-success">
+					<ShieldCheck className="h-7 w-7" />
+				</div>
+				<div>
+					<h3 className="text-lg font-semibold">{t`Passkey created`}</h3>
+					<p className="mt-2 text-sm text-kumo-subtle">
+						{t`It is stored by the authenticator or credential manager you selected in the secure system prompt.`}
+					</p>
+				</div>
+				<p className="rounded-lg bg-kumo-tint p-3 text-start text-sm text-kumo-subtle">
+					{t`You can view, rename, or add more passkeys later in Security settings.`}
+				</p>
+				<Button
+					type="button"
+					className="w-full justify-center"
+					onClick={() => onSuccess(state.result)}
+				>
+					{resolvedSuccessButtonText}
+				</Button>
+			</div>
+		);
+	}
+
+	const capabilities = capabilityState.status === "ready" ? capabilityState.capabilities : null;
+	const noPlatformAuthenticator = capabilities?.platformAuthenticator === false;
+
+	if (showEducation && showWindowsHelloHelp) {
+		return (
+			<div className="space-y-5">
+				<div className="text-center">
+					<div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-2xl bg-kumo-brand/10 text-kumo-link">
+						<WindowsLogo className="h-7 w-7" />
+					</div>
+					<h3 className="text-lg font-semibold">{t`Set up Windows Hello`}</h3>
+					<p className="mt-2 text-sm text-kumo-subtle">
+						{t`In Windows Settings, open Accounts, then Sign-in options, and set up a PIN. Fingerprint and face recognition are optional.`}
+					</p>
+				</div>
+				<LinkButton
+					href="ms-settings:signinoptions"
+					icon={<WindowsLogo />}
+					className="w-full justify-center"
+				>
+					{t`Open Windows settings`}
+				</LinkButton>
+				<Button
+					type="button"
+					variant="outline"
+					className="w-full justify-center"
+					loading={capabilityState.status === "checking"}
+					onClick={() => void handleCheckAgain()}
+				>
+					{t`I've set it up — check again`}
+				</Button>
+				{recheckFailed && (
+					<p className="rounded-lg bg-kumo-warning/10 p-3 text-sm text-kumo-warning">
+						{t`Windows Hello still isn't available to this browser. You can try another device or a security key instead.`}
+					</p>
+				)}
+				<Button
+					type="button"
+					variant="ghost"
+					className="w-full justify-center"
+					onClick={() => setShowWindowsHelloHelp(false)}
+				>
+					{t`Choose another option`}
+				</Button>
+			</div>
+		);
+	}
+
+	if (showEducation && noPlatformAuthenticator && preference === null) {
+		return (
+			<div className="space-y-5">
+				<PasskeyIntroduction
+					storage={t`Choose a credential manager on this device, another device, or a security key.`}
+				/>
+				<div className="flex items-start gap-3 rounded-lg bg-kumo-warning/10 p-3 text-start">
+					<Info className="mt-0.5 h-5 w-5 shrink-0 text-kumo-warning" />
+					<div>
+						<h4 className="text-sm font-medium text-kumo-warning">
+							{platform === "windows"
+								? t`No Windows Hello authenticator found`
+								: t`No built-in passkey authenticator found`}
+						</h4>
+						<p className="mt-1 text-sm text-kumo-subtle">
+							{t`We checked before opening the browser's passkey prompt so you can choose what happens next.`}
+						</p>
+					</div>
+				</div>
+
+				<div className="space-y-3">
+					{platform === "windows" && (
+						<Button
+							type="button"
+							variant="outline"
+							icon={<WindowsLogo />}
+							className="w-full justify-start"
+							onClick={() => setShowWindowsHelloHelp(true)}
+						>
+							{t`Set up Windows Hello`}
+						</Button>
+					)}
+					{capabilities?.hybridTransport !== false && (
+						<Button
+							type="button"
+							variant="outline"
+							icon={<DeviceMobile />}
+							className="w-full justify-start"
+							onClick={() => setPreference("hybrid")}
+						>
+							{t`Use another device`}
+						</Button>
+					)}
+					<Button
+						type="button"
+						variant="outline"
+						icon={<Usb />}
+						className="w-full justify-start"
+						onClick={() => setPreference("security-key")}
+					>
+						{t`Use a security key`}
+					</Button>
+				</div>
+				{onBack && (
+					<Button type="button" variant="ghost" className="w-full justify-center" onClick={onBack}>
+						{t`Back`}
+					</Button>
+				)}
+			</div>
+		);
+	}
+
+	if (showEducation && preference === "hybrid") {
+		return (
+			<div className="space-y-5">
+				<PasskeyIntroduction
+					storage={t`The credential manager on the phone or tablet you choose saves it. EmDash does not receive the passkey.`}
+				/>
+				<div>
+					<h4 className="text-sm font-medium">{t`What happens next?`}</h4>
+					<ol className="mt-3 space-y-2 ps-5 text-sm text-kumo-subtle">
+						<li>{t`The browser will usually show a QR code.`}</li>
+						<li>{t`Scan it with a nearby phone or tablet.`}</li>
+						<li>{t`Approve with that device's face, fingerprint, PIN, or passcode.`}</li>
+					</ol>
+				</div>
+				<div className="flex items-start gap-3 rounded-lg bg-kumo-tint p-3 text-start">
+					<DeviceMobile className="mt-0.5 h-5 w-5 shrink-0 text-kumo-link" />
+					<div>
+						<h4 className="text-sm font-medium">{t`Next, the browser's passkey window will open`}</h4>
+						<p className="mt-1 text-sm text-kumo-subtle">
+							{t`The browser controls the exact prompt and may offer another compatible method.`}
+						</p>
+					</div>
+				</div>
+				{state.status === "error" && (
+					<div className="rounded-lg bg-kumo-danger/10 p-4 text-sm text-kumo-danger">
+						{state.message}
+					</div>
+				)}
+				<div className="flex gap-3">
+					<Button type="button" variant="outline" onClick={() => setPreference(null)}>
+						{t`Back`}
+					</Button>
+					<Button
+						type="button"
+						className="flex-1 justify-center"
+						loading={state.status === "loading"}
+						onClick={() => void handleRegister("hybrid")}
+					>
+						{t`Continue with another device`}
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
+	if (showEducation && preference === "security-key") {
+		return (
+			<div className="space-y-5">
+				<PasskeyIntroduction
+					storage={t`The passkey is saved on your physical security key and can be used on compatible devices.`}
+				/>
+				<div className="flex items-start gap-3 rounded-lg bg-kumo-tint p-3 text-start">
+					<Usb className="mt-0.5 h-5 w-5 shrink-0 text-kumo-link" />
+					<div>
+						<h4 className="text-sm font-medium">{t`Next, the browser's passkey window will open`}</h4>
+						<p className="mt-1 text-sm text-kumo-subtle">
+							{t`Insert or tap your security key when the browser asks.`}
+						</p>
+					</div>
+				</div>
+				{state.status === "error" && (
+					<div className="rounded-lg bg-kumo-danger/10 p-4 text-sm text-kumo-danger">
+						{state.message}
+					</div>
+				)}
+				<div className="flex gap-3">
+					<Button type="button" variant="outline" onClick={() => setPreference(null)}>
+						{t`Back`}
+					</Button>
+					<Button
+						type="button"
+						className="flex-1 justify-center"
+						loading={state.status === "loading"}
+						onClick={() => void handleRegister("security-key")}
+					>
+						{t`Continue with security key`}
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
+	if (showEducation) {
+		const selectedPreference =
+			preference ?? (capabilities?.platformAuthenticator === true ? "client-device" : undefined);
+		return (
+			<div className="space-y-5">
+				<PasskeyIntroduction storage={platformCopy.storage} />
+				<div className="flex items-start gap-3 rounded-lg bg-kumo-tint p-3 text-start">
+					<div className="mt-0.5 shrink-0 text-kumo-link">{platformCopy.icon}</div>
+					<div>
+						<h4 className="text-sm font-medium">{t`Next, ${platformCopy.name} will open`}</h4>
+						<p className="mt-1 text-sm text-kumo-subtle">{platformCopy.unlock}</p>
+					</div>
+				</div>
+				{state.status === "error" && (
+					<div className="rounded-lg bg-kumo-danger/10 p-4 text-sm text-kumo-danger">
+						{state.message}
+					</div>
+				)}
+				<Button
+					type="button"
+					className="w-full justify-center"
+					loading={state.status === "loading"}
+					onClick={() => void handleRegister(selectedPreference)}
+				>
+					{t`Create passkey`}
+				</Button>
+				<p className="text-center text-xs text-kumo-subtle">
+					{t`EmDash never receives your PIN, password, or biometric information.`}
+				</p>
+				{onBack && (
+					<Button type="button" variant="ghost" className="w-full justify-center" onClick={onBack}>
+						{t`Back`}
+					</Button>
+				)}
 			</div>
 		);
 	}
@@ -348,7 +787,7 @@ export function PasskeyRegistration({
 			{/* Register button */}
 			<Button
 				type="button"
-				onClick={handleRegister}
+				onClick={() => void handleRegister()}
 				loading={state.status === "loading"}
 				className="w-full justify-center"
 				variant="primary"

--- a/packages/admin/src/lib/webauthn-environment.ts
+++ b/packages/admin/src/lib/webauthn-environment.ts
@@ -23,3 +23,86 @@ export function isPublicKeyCredentialConstructorAvailable(): boolean {
 export function isPasskeyEnvironmentUsable(): boolean {
 	return isWebAuthnSecureContext() && isPublicKeyCredentialConstructorAvailable();
 }
+
+export type PasskeyPlatform = "windows" | "macos" | "ios" | "android" | "other";
+
+export interface PasskeyClientCapabilities {
+	platformAuthenticator: boolean | null;
+	hybridTransport: boolean | null;
+}
+
+type CapabilityMethod = () => Promise<unknown>;
+
+function getCapabilityMethod(name: string): CapabilityMethod | null {
+	if (!isPublicKeyCredentialConstructorAvailable()) return null;
+	const value: unknown = Reflect.get(window.PublicKeyCredential, name);
+	if (typeof value !== "function") return null;
+	return () => Reflect.apply(value, window.PublicKeyCredential, []);
+}
+
+function readBooleanCapability(value: unknown, name: string): boolean | null {
+	if (typeof value !== "object" || value === null) return null;
+	const capability: unknown = Reflect.get(value, name);
+	return typeof capability === "boolean" ? capability : null;
+}
+
+/**
+ * Detect authenticator capabilities before opening browser-owned WebAuthn UI.
+ * `null` means the browser cannot report that capability, so callers should
+ * retain the ordinary browser chooser rather than assuming it is unavailable.
+ */
+export async function getPasskeyClientCapabilities(): Promise<PasskeyClientCapabilities> {
+	if (!isPasskeyEnvironmentUsable()) {
+		return { platformAuthenticator: null, hybridTransport: null };
+	}
+
+	let platformAuthenticator: boolean | null = null;
+	let hybridTransport: boolean | null = null;
+	const getClientCapabilities = getCapabilityMethod("getClientCapabilities");
+	if (getClientCapabilities) {
+		try {
+			const capabilities = await getClientCapabilities();
+			platformAuthenticator = readBooleanCapability(
+				capabilities,
+				"userVerifyingPlatformAuthenticator",
+			);
+			hybridTransport = readBooleanCapability(capabilities, "hybridTransport");
+		} catch {
+			// Older capability detection below may still be available.
+		}
+	}
+
+	if (platformAuthenticator === null) {
+		const isPlatformAuthenticatorAvailable = getCapabilityMethod(
+			"isUserVerifyingPlatformAuthenticatorAvailable",
+		);
+		if (isPlatformAuthenticatorAvailable) {
+			try {
+				const available = await isPlatformAuthenticatorAvailable();
+				platformAuthenticator = typeof available === "boolean" ? available : null;
+			} catch {
+				platformAuthenticator = null;
+			}
+		}
+	}
+
+	return { platformAuthenticator, hybridTransport };
+}
+
+/** Platform is only a copy hint; authenticator capability controls behavior. */
+export function detectPasskeyPlatform(
+	userAgent = globalThis.navigator?.userAgent ?? "",
+): PasskeyPlatform {
+	const normalized = userAgent.toLowerCase();
+	if (normalized.includes("android")) return "android";
+	if (
+		normalized.includes("iphone") ||
+		normalized.includes("ipad") ||
+		(normalized.includes("macintosh") && normalized.includes("mobile"))
+	) {
+		return "ios";
+	}
+	if (normalized.includes("windows")) return "windows";
+	if (normalized.includes("macintosh") || normalized.includes("mac os")) return "macos";
+	return "other";
+}

--- a/packages/admin/tests/components/PasskeyRegistration.test.tsx
+++ b/packages/admin/tests/components/PasskeyRegistration.test.tsx
@@ -1,0 +1,164 @@
+import * as React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { render } from "../utils/render.tsx";
+
+const mockGetPasskeyClientCapabilities = vi.fn();
+
+vi.mock("../../src/lib/webauthn-environment", async () => {
+	const actual = await vi.importActual("../../src/lib/webauthn-environment");
+	return {
+		...actual,
+		detectPasskeyPlatform: () => "windows",
+		getPasskeyClientCapabilities: () => mockGetPasskeyClientCapabilities(),
+		isPasskeyEnvironmentUsable: () => true,
+		isWebAuthnSecureContext: () => true,
+	};
+});
+
+const mockApiFetch = vi.fn();
+
+vi.mock("../../src/lib/api/client", async () => {
+	const actual = await vi.importActual("../../src/lib/api/client");
+	return {
+		...actual,
+		apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+	};
+});
+
+const { PasskeyRegistration } = await import("../../src/components/auth/PasskeyRegistration");
+
+function registrationOptionsResponse() {
+	return new Response(
+		JSON.stringify({
+			data: {
+				options: {
+					challenge: "AQ",
+					rp: { id: "example.com", name: "Example" },
+					user: { id: "AQ", name: "user@example.com", displayName: "User" },
+					pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+				},
+			},
+		}),
+		{ status: 200 },
+	);
+}
+
+describe("PasskeyRegistration", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetPasskeyClientCapabilities.mockResolvedValue({
+			platformAuthenticator: true,
+			hybridTransport: true,
+		});
+	});
+
+	it("explains what a passkey is and where it is saved before opening system UI", async () => {
+		const screen = await render(
+			<PasskeyRegistration
+				optionsEndpoint="/options"
+				verifyEndpoint="/verify"
+				onSuccess={() => {}}
+				showEducation
+			/>,
+		);
+
+		await expect
+			.element(screen.getByText("With a passkey, you don’t need to remember complex passwords"))
+			.toBeInTheDocument();
+		await expect.element(screen.getByText("What is a passkey?")).toBeInTheDocument();
+		await expect.element(screen.getByText("Where is it saved?")).toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("button", { name: "Create passkey" }))
+			.toBeInTheDocument();
+	});
+
+	it("explains the available choices instead of opening a confusing chooser without Hello", async () => {
+		mockGetPasskeyClientCapabilities.mockResolvedValue({
+			platformAuthenticator: false,
+			hybridTransport: true,
+		});
+
+		const screen = await render(
+			<PasskeyRegistration
+				optionsEndpoint="/options"
+				verifyEndpoint="/verify"
+				onSuccess={() => {}}
+				showEducation
+			/>,
+		);
+
+		await expect
+			.element(screen.getByText("No Windows Hello authenticator found"))
+			.toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("button", { name: "Set up Windows Hello" }))
+			.toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("button", { name: "Use another device" }))
+			.toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("button", { name: "Use a security key" }))
+			.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Create passkey" }).query()).toBeNull();
+
+		await screen.getByRole("button", { name: "Set up Windows Hello" }).click();
+		await expect
+			.element(screen.getByRole("link", { name: "Open Windows settings" }))
+			.toBeInTheDocument();
+		await expect
+			.element(screen.getByRole("button", { name: "I've set it up — check again" }))
+			.toBeInTheDocument();
+	});
+
+	it("asks the browser to prefer the hybrid flow after another device is chosen", async () => {
+		mockGetPasskeyClientCapabilities.mockResolvedValue({
+			platformAuthenticator: false,
+			hybridTransport: true,
+		});
+		mockApiFetch
+			.mockResolvedValueOnce(registrationOptionsResponse())
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ data: { success: true } }), { status: 200 }),
+			);
+
+		const create = vi.spyOn(navigator.credentials, "create").mockResolvedValue({
+			id: "credential-id",
+			rawId: new Uint8Array([1]).buffer,
+			type: "public-key",
+			authenticatorAttachment: "cross-platform",
+			response: {
+				clientDataJSON: new Uint8Array([1]).buffer,
+				attestationObject: new Uint8Array([1]).buffer,
+				getTransports: () => ["hybrid"],
+			},
+		} as unknown as PublicKeyCredential);
+
+		const onSuccess = vi.fn();
+		const screen = await render(
+			<PasskeyRegistration
+				optionsEndpoint="/options"
+				verifyEndpoint="/verify"
+				onSuccess={onSuccess}
+				showEducation
+				showSuccessStep
+				successButtonText="Open dashboard"
+			/>,
+		);
+
+		await screen.getByRole("button", { name: "Use another device" }).click();
+		await screen.getByRole("button", { name: "Continue with another device" }).click();
+
+		await vi.waitFor(() => {
+			expect(create).toHaveBeenCalledOnce();
+		});
+		const request = create.mock.calls[0]?.[0] as CredentialCreationOptions & {
+			publicKey: PublicKeyCredentialCreationOptions & { hints?: string[] };
+		};
+		expect(request.publicKey.hints).toEqual(["hybrid"]);
+		await expect.element(screen.getByText("Passkey created")).toBeInTheDocument();
+		expect(onSuccess).not.toHaveBeenCalled();
+		await screen.getByRole("button", { name: "Open dashboard" }).click();
+		expect(onSuccess).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/admin/tests/lib/webauthn-environment.test.ts
+++ b/packages/admin/tests/lib/webauthn-environment.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 
 import {
+	detectPasskeyPlatform,
+	getPasskeyClientCapabilities,
 	isPasskeyEnvironmentUsable,
 	isPublicKeyCredentialConstructorAvailable,
 	isWebAuthnSecureContext,
@@ -50,5 +52,56 @@ describe("webauthn-environment", () => {
 		});
 		expect(isWebAuthnSecureContext()).toBe(false);
 		expect(isPasskeyEnvironmentUsable()).toBe(false);
+	});
+
+	it("reports platform and hybrid authenticator capabilities", async () => {
+		Object.defineProperty(globalThis.window, "isSecureContext", {
+			value: true,
+			configurable: true,
+		});
+		const getClientCapabilities = vi.fn().mockResolvedValue({
+			userVerifyingPlatformAuthenticator: false,
+			hybridTransport: true,
+		});
+		Object.defineProperty(globalThis.window, "PublicKeyCredential", {
+			value: Object.assign(function PublicKeyCredential() {}, { getClientCapabilities }),
+			configurable: true,
+			writable: true,
+		});
+
+		await expect(getPasskeyClientCapabilities()).resolves.toEqual({
+			platformAuthenticator: false,
+			hybridTransport: true,
+		});
+		expect(getClientCapabilities).toHaveBeenCalledOnce();
+	});
+
+	it("falls back to the older platform-authenticator capability check", async () => {
+		Object.defineProperty(globalThis.window, "isSecureContext", {
+			value: true,
+			configurable: true,
+		});
+		const isUserVerifyingPlatformAuthenticatorAvailable = vi.fn().mockResolvedValue(true);
+		Object.defineProperty(globalThis.window, "PublicKeyCredential", {
+			value: Object.assign(function PublicKeyCredential() {}, {
+				isUserVerifyingPlatformAuthenticatorAvailable,
+			}),
+			configurable: true,
+			writable: true,
+		});
+
+		await expect(getPasskeyClientCapabilities()).resolves.toEqual({
+			platformAuthenticator: true,
+			hybridTransport: null,
+		});
+	});
+
+	it("uses platform detection only to tailor explanatory copy", () => {
+		expect(detectPasskeyPlatform("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")).toBe("windows");
+		expect(detectPasskeyPlatform("Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)")).toBe("macos");
+		expect(
+			detectPasskeyPlatform("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) Mobile/15E148"),
+		).toBe("ios");
+		expect(detectPasskeyPlatform("Mozilla/5.0 (Linux; Android 15; Pixel 9)")).toBe("android");
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Improves passkey account creation across initial setup, self-signup, and invite acceptance.

- Explains what a passkey is and where it is saved before opening browser-owned passkey UI.
- Detects whether a local platform authenticator and cross-device transport are available.
- Guides Windows users through setting up Windows Hello when no local authenticator is available.
- Explains cross-device and security-key paths before invoking them, then supplies the corresponding WebAuthn UI hint to compatible browsers.
- Shows a confirmation screen after the passkey is created, before continuing to the dashboard.

The copy and interaction sequence follow the [FIDO Alliance passkey design guidance](https://www.passkeycentral.org/design-guidelines/required-patterns/create-view-and-manage-passkeys-in-account-settings). The browser continues to control the secure passkey prompt and may ignore UI hints when the requested authenticator is unavailable.

No linked issue.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: Not applicable; this is a bug fix.
- [x] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.6 Codex

## Screenshots / test output

### Invite acceptance

![Invite acceptance page explaining what a passkey is, where it is saved, and what the macOS prompt will do](https://github.com/user-attachments/assets/7ee35c02-ea45-4e17-8d49-acaec4de5b90)

### Windows without a local authenticator

![Passkey setup detecting that Windows Hello is unavailable and offering Windows Hello setup, another device, or a security key](https://github.com/user-attachments/assets/dec876da-74ab-4d85-8244-d3e949ebafdd)

### Cross-device passkey

![Cross-device passkey setup explaining the QR-code flow before opening the browser prompt](https://github.com/user-attachments/assets/97093802-097e-406a-a3f8-387d2932df8e)

Validation:

- `pnpm typecheck`
- `pnpm lint:json` — 0 diagnostics
- `pnpm --filter @emdash-cms/admin build`
- `pnpm --filter @emdash-cms/admin test --run` — 159 files, 2,047 tests
- Live browser verification in English and Arabic RTL
