### PR TITLE
fix(bot): retry publisher clones on fresh sandboxes

### DIFF
--- a/infra/emdash-bot/.flue/agents/investigate.ts
+++ b/infra/emdash-bot/.flue/agents/investigate.ts
@@ -56,6 +56,7 @@ import { buildTimeoutSummaryPrompt, isTimeoutSummaryDelivery } from "../lib/time
 import { untarInto } from "../lib/untar.js";
 import { updateWorkPlan, type WorkPlan } from "../lib/work-plan.js";
 import {
+	attachPublisherWorkspaceWithRetry,
 	attachWorkspaceWithRetry,
 	prepareWorkspaceBeforeModel,
 	WORKSPACE_SANDBOX_ATTEMPT_LIMIT,
@@ -965,7 +966,37 @@ async function attachPublisherContainer(
 	id: string,
 	input: InvestigateData,
 ): Promise<ContainerBackend> {
-	const container = fromSandbox(workspaceSandbox(`${id}-publisher`));
+	return attachPublisherWorkspaceWithRetry({
+		agentId: id,
+		attach: ({ sandboxId }) => attachPublisherContainerAttempt(sandboxId, input),
+		discard: async ({ sandboxId }) => {
+			await withDeadline(
+				workspaceSandbox(sandboxId).destroy(),
+				DEFAULT_RPC_TIMEOUT_MS,
+				"failed publisher sandbox cleanup",
+			);
+		},
+		onRetry: async ({ attempt, error }) => {
+			console.warn("[investigate] retrying publisher on a fresh sandbox", {
+				runId: input.runId,
+				attempt: attempt + 1,
+				error: errorMessage(error),
+			});
+		},
+		onDiscardFailure: async ({ sandboxId, discardError }) => {
+			console.warn("[investigate] failed publisher sandbox cleanup", {
+				sandboxId,
+				error: errorMessage(discardError),
+			});
+		},
+	});
+}
+
+async function attachPublisherContainerAttempt(
+	id: string,
+	input: InvestigateData,
+): Promise<ContainerBackend> {
+	const container = fromSandbox(workspaceSandbox(id));
 	await prepareContainer(container, input, true);
 	return container;
 }

--- a/infra/emdash-bot/.flue/lib/workspace-attachment.ts
+++ b/infra/emdash-bot/.flue/lib/workspace-attachment.ts
@@ -25,7 +25,7 @@ interface WorkspaceRetry extends WorkspaceAttempt {
 	readonly error: unknown;
 }
 
-export async function attachWorkspaceWithRetry<T>(options: {
+interface WorkspaceAttachmentOptions<T> {
 	readonly agentId: string;
 	readonly startAttempt: number;
 	readonly attach: (attempt: WorkspaceAttempt) => Promise<T>;
@@ -35,7 +35,22 @@ export async function attachWorkspaceWithRetry<T>(options: {
 	readonly onDiscardFailure?: (
 		failure: WorkspaceAttemptFailure & { readonly discardError: unknown },
 	) => Promise<void>;
-}): Promise<T> {
+}
+
+export function attachPublisherWorkspaceWithRetry<T>(
+	options: Omit<WorkspaceAttachmentOptions<T>, "startAttempt">,
+): Promise<T> {
+	const { agentId, ...callbacks } = options;
+	return attachWorkspaceWithRetry({
+		...callbacks,
+		agentId: `${agentId}-publisher`,
+		startAttempt: 0,
+	});
+}
+
+export async function attachWorkspaceWithRetry<T>(
+	options: WorkspaceAttachmentOptions<T>,
+): Promise<T> {
 	if (
 		!Number.isSafeInteger(options.startAttempt) ||
 		options.startAttempt < 0 ||

--- a/infra/emdash-bot/tests/unit/workspace-attachment.test.ts
+++ b/infra/emdash-bot/tests/unit/workspace-attachment.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 
 import {
+	attachPublisherWorkspaceWithRetry,
 	attachWorkspaceWithRetry,
 	prepareWorkspaceBeforeModel,
 } from "../../.flue/lib/workspace-attachment.js";
@@ -87,6 +88,33 @@ describe("workspace attachment", () => {
 
 		expect(attach).toHaveBeenCalledTimes(2);
 		expect(discard).toHaveBeenCalledOnce();
+	});
+
+	test("retries a publisher GitHub 429 on a fresh publisher sandbox", async () => {
+		const attached: string[] = [];
+		const discarded: string[] = [];
+
+		await expect(
+			attachPublisherWorkspaceWithRetry({
+				agentId: "investigate-2973-run",
+				attach: async ({ sandboxId }) => {
+					attached.push(sandboxId);
+					if (attached.length === 1) {
+						throw new Error("container setup failed (128): The requested URL returned error: 429");
+					}
+					return "ready";
+				},
+				discard: async ({ sandboxId }) => {
+					discarded.push(sandboxId);
+				},
+			}),
+		).resolves.toBe("ready");
+
+		expect(attached).toEqual([
+			"investigate-2973-run-publisher",
+			"investigate-2973-run-publisher-r1",
+		]);
+		expect(discarded).toEqual(["investigate-2973-run-publisher"]);
 	});
 
 	test("continues on a fresh sandbox when failed-sandbox cleanup also fails", async () => {


### PR DESCRIPTION
## What does this PR do?

Retries transient GitHub clone failures when the bot attaches its separate credentialed publisher checkout. Execution workspaces already moved across fresh sandbox IDs after HTTP 429 responses, but publication always retried the same `-publisher` sandbox, so a completed and verified candidate could still be stranded.

Publisher attachment now uses the same bounded three-attempt policy with isolated IDs (`-publisher`, `-publisher-r1`, and `-publisher-r2`). A failed sandbox is destroyed before the next attempt, cleanup failure does not hide the original retry, and the final platform error is preserved when all attempts fail.

Related to #2973.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

The i18n, changeset, Discussion, and screenshot items are not applicable: this changes only internal bot execution infrastructure.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex (GPT-5)

## Screenshots / test output

Not applicable; no UI changes.

- `pnpm --dir infra/emdash-bot test:unit` — 351 passed
- `pnpm --dir infra/emdash-bot test:workers` — 90 passed
- `pnpm --dir infra/emdash-bot build`
- `pnpm --dir infra/emdash-bot typecheck`
- `pnpm lint`
- `pnpm format:check`
