### PR TITLE
fix(labeler): keep review queue current

### DIFF
--- a/apps/labeler/src/admin/App.tsx
+++ b/apps/labeler/src/admin/App.tsx
@@ -367,7 +367,7 @@ function ReviewWorkspace({
 				/>
 			) : (
 				<LayerCard className="overflow-hidden p-0">
-					<div className="grid min-w-0 lg:grid-cols-[280px_minmax(0,1fr)]">
+					<div className="grid min-w-0 lg:grid-cols-[320px_minmax(0,1fr)]">
 						<aside
 							className="border-b bg-kumo-recessed lg:border-b-0 lg:border-e"
 							aria-label={t`Assessment queue`}
@@ -375,6 +375,8 @@ function ReviewWorkspace({
 							<div className="flex overflow-x-auto lg:block">
 								{items.map((item) => {
 									const identity = assessmentListIdentity(item);
+									const itemStatus =
+										item.state === "review" ? t`Review required` : stateLabel(t, item.state);
 									return (
 										<button
 											key={item.run_key}
@@ -391,6 +393,9 @@ function ReviewWorkspace({
 												{item.subject_kind === "release"
 													? t`Release ${identity.version ?? ""}`
 													: t`Profile`}
+											</span>
+											<span className="mt-1 block truncate text-xs text-kumo-subtle">
+												{itemStatus} · {formatDate(item.updated_at)}
 											</span>
 										</button>
 									);

--- a/apps/labeler/src/operator/api.ts
+++ b/apps/labeler/src/operator/api.ts
@@ -55,6 +55,11 @@ const OPERATOR_ASSESSMENT_STATES = new Set([
 ]);
 const EFFECTIVE_OPERATOR_STATE_SQL = `CASE
 	WHEN assessment.state IN ('superseded', 'cancelled') THEN assessment.state
+	WHEN current_subject.uri IS NOT NULL AND current_subject.deleted_at IS NOT NULL THEN 'cancelled'
+	WHEN current_subject.uri IS NOT NULL
+	 AND current_subject.cid <> assessment.subject_cid THEN 'superseded'
+	WHEN current_assessment.assessment_id IS NOT NULL
+	 AND current_assessment.assessment_id <> assessment.run_key THEN 'superseded'
 	WHEN decision.action = 'approve' THEN 'passed'
 	WHEN decision.action = 'block' THEN 'blocked'
 	ELSE assessment.state
@@ -796,6 +801,11 @@ export async function readOperatorAssessmentPage(
 		   ORDER BY candidate.created_at DESC, candidate.id DESC
 		   LIMIT 1
 		 )
+		 LEFT JOIN current_assessments current_assessment
+		   ON current_assessment.subject_uri = assessment.subject_uri
+		  AND current_assessment.subject_cid = assessment.subject_cid
+		 LEFT JOIN current_subjects current_subject
+		   ON current_subject.uri = assessment.subject_uri
 		 WHERE ${EFFECTIVE_OPERATOR_STATE_SQL} = ?
 		   ${after}
 		 ORDER BY assessment.updated_at ASC, assessment.run_key ASC

--- a/apps/labeler/test/runtime-operator-api.test.ts
+++ b/apps/labeler/test/runtime-operator-api.test.ts
@@ -240,6 +240,106 @@ describe("operator mutation API", () => {
 });
 
 describe("operator review reads", () => {
+	it("lists only the current assessment run for an exact subject revision", async () => {
+		const db = new DatabaseSync(":memory:");
+		db.exec(`
+			CREATE TABLE assessments (
+				run_key TEXT PRIMARY KEY,
+				subject_uri TEXT NOT NULL,
+				subject_cid TEXT NOT NULL,
+				subject_kind TEXT NOT NULL,
+				state TEXT NOT NULL,
+				state_version INTEGER NOT NULL,
+				policy_version TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL,
+				completed_at TEXT
+			);
+			CREATE TABLE current_assessments (
+				subject_uri TEXT NOT NULL,
+				subject_cid TEXT NOT NULL,
+				assessment_id TEXT NOT NULL,
+				updated_at TEXT NOT NULL,
+				PRIMARY KEY (subject_uri, subject_cid)
+			);
+			CREATE TABLE current_subjects (
+				uri TEXT PRIMARY KEY,
+				cid TEXT NOT NULL,
+				deleted_at TEXT
+			);
+			CREATE TABLE operator_actions (
+				id INTEGER PRIMARY KEY,
+				action TEXT NOT NULL,
+				subject_uri TEXT,
+				subject_cid TEXT,
+				created_at TEXT
+			);
+		`);
+		const uri = "at://did:plc:fixture/profile/repeated";
+		const cid = "cid-repeated";
+		const insertAssessment = db.prepare(
+			`INSERT INTO assessments VALUES (?, ?, ?, 'profile', 'review', 1, 'policy-v1', ?, ?, NULL)`,
+		);
+		insertAssessment.run(
+			"assessment-stale-revision",
+			uri,
+			"cid-stale",
+			"2026-08-24T09:00:00.000Z",
+			"2026-08-24T09:00:00.000Z",
+		);
+		insertAssessment.run(
+			"assessment-old",
+			uri,
+			cid,
+			"2026-08-24T10:00:00.000Z",
+			"2026-08-24T10:00:00.000Z",
+		);
+		insertAssessment.run(
+			"assessment-current",
+			uri,
+			cid,
+			"2026-08-24T11:00:00.000Z",
+			"2026-08-24T11:00:00.000Z",
+		);
+		db.prepare("INSERT INTO current_assessments VALUES (?, ?, ?, ?)").run(
+			uri,
+			cid,
+			"assessment-current",
+			"2026-08-24T11:00:00.000Z",
+		);
+		db.prepare("INSERT INTO current_assessments VALUES (?, ?, ?, ?)").run(
+			uri,
+			"cid-stale",
+			"assessment-stale-revision",
+			"2026-08-24T09:00:00.000Z",
+		);
+		db.prepare("INSERT INTO current_subjects VALUES (?, ?, NULL)").run(uri, cid);
+
+		const page = await readOperatorAssessmentPage(
+			{
+				async all(sql, bindings) {
+					return db.prepare(sql).all(...bindings);
+				},
+			},
+			{ state: "review", limit: 10 },
+		);
+
+		expect(page.items.map((row) => row["run_key"])).toEqual(["assessment-current"]);
+		const superseded = await readOperatorAssessmentPage(
+			{
+				async all(sql, bindings) {
+					return db.prepare(sql).all(...bindings);
+				},
+			},
+			{ state: "superseded", limit: 10 },
+		);
+		expect(superseded.items.map((row) => row["run_key"])).toEqual([
+			"assessment-stale-revision",
+			"assessment-old",
+		]);
+		db.close();
+	});
+
 	it("returns the current operator session without exposing Access configuration", async () => {
 		const response = await handleOperatorApi(
 			new Request("https://labels.example/_admin/api/session"),
@@ -337,6 +437,18 @@ describe("operator review reads", () => {
 				subject_cid TEXT,
 				created_at TEXT
 			);
+			CREATE TABLE current_assessments (
+				subject_uri TEXT NOT NULL,
+				subject_cid TEXT NOT NULL,
+				assessment_id TEXT NOT NULL,
+				updated_at TEXT NOT NULL,
+				PRIMARY KEY (subject_uri, subject_cid)
+			);
+			CREATE TABLE current_subjects (
+				uri TEXT PRIMARY KEY,
+				cid TEXT NOT NULL,
+				deleted_at TEXT
+			);
 		`);
 		const insertAssessment = db.prepare(
 			`INSERT INTO assessments VALUES (?, ?, ?, 'profile', 'review', 1, 'policy-v1', ?, ?, NULL)`,
@@ -430,6 +542,18 @@ describe("operator review reads", () => {
 				subject_uri TEXT,
 				subject_cid TEXT,
 				created_at TEXT NOT NULL
+			);
+			CREATE TABLE current_assessments (
+				subject_uri TEXT NOT NULL,
+				subject_cid TEXT NOT NULL,
+				assessment_id TEXT NOT NULL,
+				updated_at TEXT NOT NULL,
+				PRIMARY KEY (subject_uri, subject_cid)
+			);
+			CREATE TABLE current_subjects (
+				uri TEXT PRIMARY KEY,
+				cid TEXT NOT NULL,
+				deleted_at TEXT
 			);
 		`);
 		const insertAssessment = db.prepare(

--- a/apps/labeler/test/ui/admin-app.test.tsx
+++ b/apps/labeler/test/ui/admin-app.test.tsx
@@ -171,6 +171,7 @@ describe("labeler admin application", () => {
 		expect(screen.getByText("By Justin Thompson · @justin.example")).toBeTruthy();
 		expect(screen.getByText("Queue newly published EmDash posts to Buffer channels.")).toBeTruthy();
 		expect(screen.getByText("No model findings")).toBeTruthy();
+		expect(screen.getByText(/Review required ·/)).toBeTruthy();
 		expect(screen.queryByText(item.subject_uri)).toBeNull();
 
 		fireEvent.click(screen.getByRole("button", { name: "Approve and next" }));


### PR DESCRIPTION
## What does this PR do?

Keeps the operator Review queue focused on the current actionable assessment for each listing revision. Older assessment runs for the same CID and assessments for stale CIDs appear under Superseded instead of being repeated in Review.

Queue rows also show when the assessment was updated and make the profile or release context easier to scan.

Follow-up to #2742.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — labeler-scoped typecheck passes; full repository CI is pending.
- [ ] `pnpm lint` passes — quick and labeler-scoped type-aware lint pass; full repository CI is pending.
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run — the four changed files were formatted with oxfmt.
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package) — not applicable; the labeler app is private.
- [x] New features link to an approved Discussion: not applicable; this is a bug fix.
- [x] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI GPT-5 Codex

## Screenshots / test output

Before and after screenshots are attached below.

- `pnpm --dir apps/labeler typecheck`
- `pnpm --dir apps/labeler test` — 232 tests passed
- `pnpm lint:quick`
- Focused type-aware labeler lint — 0 diagnostics

![Before: repeated indistinguishable assessments in the Review queue](https://github.com/user-attachments/assets/36c74d45-c4a7-4f7b-843e-6a49a522f1f4)

![After: current profile and release assessments with review status and timestamp](https://github.com/user-attachments/assets/8fcb8387-6777-4727-a474-99ca7dd7a42a)