### PR TITLE
fix(registry): restore signed label projection

### DIFF
--- a/apps/aggregator/src/index.ts
+++ b/apps/aggregator/src/index.ts
@@ -30,6 +30,7 @@ import {
 import { isCurrentSubject, listCurrentSubjects } from "./labeler-reconciliation-service.js";
 import { getListingPolicy } from "./listing-policy.js";
 import { enforceConfiguredProjection } from "./projection-enforcement.js";
+import { publicHealth } from "./public-health.js";
 import { drainDeadLetterBatch, processBatch } from "./records-consumer.js";
 import { RECORDS_DO_NAME } from "./records-do.js";
 import { handleXrpc } from "./routes/xrpc/router.js";
@@ -71,6 +72,7 @@ const STATUS_PATH = "/_admin/status";
 const RECONCILIATION_SUBJECTS_PATH = "/_internal/labeler/subjects";
 const RECONCILIATION_CURRENT_PATH = "/_internal/labeler/current";
 const LABEL_REPLAY_PATH = "/_admin/labels/replay";
+const HEALTH_PATH = "/health";
 
 /**
  * Cap on the explicit DID list a single POST may submit. Lower than the
@@ -200,6 +202,7 @@ function parseBackfillBody(body: unknown): BackfillRequest | { error: string } {
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 		const url = new URL(request.url);
+		if (url.pathname === HEALTH_PATH) return publicHealth(request, env);
 		if (url.pathname === RECONCILIATION_SUBJECTS_PATH) {
 			const denied = requireReconciliationAuth(request, env);
 			if (denied) return denied;

--- a/apps/aggregator/src/label-stream-client.ts
+++ b/apps/aggregator/src/label-stream-client.ts
@@ -1,4 +1,4 @@
-import { decodeFirst } from "@atcute/cbor";
+import { decodeFirst, fromBytes, isBytes } from "@atcute/cbor";
 import { fromBase64Pad, fromBase64Url } from "@atcute/multibase";
 import { parseSignedListingLabel, type SignedListingLabel } from "@emdash-cms/registry-moderation";
 
@@ -89,7 +89,15 @@ export function decodeLabelStreamFrame(bytes: Uint8Array): LabelStreamEvent | nu
 	if (!Array.isArray(labels) || labels.length < 1 || labels.length > MAX_LABELS_PER_FRAME) {
 		throw new TypeError("#labels labels count is invalid");
 	}
-	return { seq, labels };
+	return {
+		seq,
+		labels: labels.map((label) => {
+			if (!isPlainObject(label) || !isBytes(label["sig"])) {
+				throw new TypeError("subscribeLabels label signature is invalid");
+			}
+			return { ...label, sig: fromBytes(label["sig"]) };
+		}),
+	};
 }
 
 type Buffered = { value: LabelStreamEvent } | { error: unknown };

--- a/apps/aggregator/src/label-stream-client.ts
+++ b/apps/aggregator/src/label-stream-client.ts
@@ -1,5 +1,5 @@
 import { decodeFirst } from "@atcute/cbor";
-import { fromBase64Url } from "@atcute/multibase";
+import { fromBase64Pad, fromBase64Url } from "@atcute/multibase";
 import { parseSignedListingLabel, type SignedListingLabel } from "@emdash-cms/registry-moderation";
 
 import { isPlainObject } from "./utils.js";
@@ -285,9 +285,13 @@ function parseJsonSignedLabel(value: unknown): SignedListingLabel {
 	if (typeof encoded !== "string") throw new TypeError("queryLabels label signature is invalid");
 	let bytes: Uint8Array;
 	try {
-		bytes = fromBase64Url(encoded);
+		bytes = fromBase64Pad(encoded);
 	} catch {
-		throw new TypeError("queryLabels label signature is invalid");
+		try {
+			bytes = fromBase64Url(encoded);
+		} catch {
+			throw new TypeError("queryLabels label signature is invalid");
+		}
 	}
 	const label = { ...value, sig: bytes };
 	return parseSignedListingLabel(label);

--- a/apps/aggregator/src/public-health.ts
+++ b/apps/aggregator/src/public-health.ts
@@ -9,13 +9,62 @@ interface PublicHealthRow {
 	ready: number;
 	packages: number;
 	releases: number;
-	replay_pending: number;
 }
+
+interface PublicHealthSnapshot {
+	status: number;
+	body: {
+		service: "emdash-aggregator";
+		status: "ok" | "not-ready";
+		policyMode: "open" | "allowlist" | "projection";
+		projection: {
+			ready: boolean;
+			packages: number;
+			releases: number;
+		};
+	};
+}
+
+interface CachedPublicHealth {
+	expiresAt: number;
+	value: Promise<PublicHealthSnapshot>;
+}
+
+const PUBLIC_HEALTH_CACHE_TTL_MS = 5_000;
+const PUBLIC_HEALTH_CACHE_KEY = Symbol.for("emdash:aggregator:public-health-cache");
+const globals = globalThis as Record<symbol, unknown>;
+const publicHealthCache: WeakMap<object, CachedPublicHealth> =
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shared across duplicated Worker chunks
+	(globals[PUBLIC_HEALTH_CACHE_KEY] as WeakMap<object, CachedPublicHealth> | undefined) ??
+	(() => {
+		const cache = new WeakMap<object, CachedPublicHealth>();
+		globals[PUBLIC_HEALTH_CACHE_KEY] = cache;
+		return cache;
+	})();
 
 export async function publicHealth(request: Request, env: Env): Promise<Response> {
 	if (request.method !== "GET" && request.method !== "HEAD") {
 		return new Response(null, { status: 405, headers: { allow: "GET, HEAD" } });
 	}
+	const snapshot = await cachedPublicHealth(env);
+	const headers = { "cache-control": "no-store", "content-type": "application/json" };
+	if (request.method === "HEAD") return new Response(null, { status: snapshot.status, headers });
+	return Response.json(snapshot.body, { status: snapshot.status, headers });
+}
+
+function cachedPublicHealth(env: Env): Promise<PublicHealthSnapshot> {
+	const now = Date.now();
+	const cached = publicHealthCache.get(env);
+	if (cached && cached.expiresAt > now) return cached.value;
+	const value = readPublicHealth(env).catch((error: unknown) => {
+		if (publicHealthCache.get(env)?.value === value) publicHealthCache.delete(env);
+		throw error;
+	});
+	publicHealthCache.set(env, { expiresAt: now + PUBLIC_HEALTH_CACHE_TTL_MS, value });
+	return value;
+}
+
+async function readPublicHealth(env: Env): Promise<PublicHealthSnapshot> {
 	const policy = await getListingPolicy(env);
 	const requiresProjection = policy.mode === "projection";
 	const readinessSql = requiresProjection
@@ -36,12 +85,7 @@ export async function publicHealth(request: Request, env: Env): Promise<Response
 			   (SELECT COUNT(*) FROM public_releases release
 			    JOIN public_projection_state state
 			      ON state.active_generation = release.generation
-			    WHERE state.id = 1) AS releases,
-			   (SELECT COUNT(*) FROM labellers source
-			    WHERE source.active = 1 AND source.replay_pending = 1
-			      AND (source.required_positive = 1
-			        OR source.accepted_state = 1
-			        OR source.redaction = 1)) AS replay_pending`,
+			    WHERE state.id = 1) AS releases`,
 		)
 		.bind(...(requiresProjection ? activeProjectionPolicyBindings(policy) : []))
 		.first<PublicHealthRow>();
@@ -49,10 +93,9 @@ export async function publicHealth(request: Request, env: Env): Promise<Response
 
 	const ready = row.ready === 1;
 	const status = ready ? 200 : 503;
-	const headers = { "cache-control": "no-store", "content-type": "application/json" };
-	if (request.method === "HEAD") return new Response(null, { status, headers });
-	return Response.json(
-		{
+	return {
+		status,
+		body: {
 			service: "emdash-aggregator",
 			status: ready ? "ok" : "not-ready",
 			policyMode: policy.mode,
@@ -61,10 +104,6 @@ export async function publicHealth(request: Request, env: Env): Promise<Response
 				packages: row.packages,
 				releases: row.releases,
 			},
-			labelSources: {
-				replayPending: row.replay_pending,
-			},
 		},
-		{ status, headers },
-	);
+	};
 }

--- a/apps/aggregator/src/public-health.ts
+++ b/apps/aggregator/src/public-health.ts
@@ -1,0 +1,70 @@
+import {
+	ACTIVE_PROJECTION_JOINS_SQL,
+	ACTIVE_PROJECTION_POLICY_SQL,
+	activeProjectionPolicyBindings,
+	getListingPolicy,
+} from "./listing-policy.js";
+
+interface PublicHealthRow {
+	ready: number;
+	packages: number;
+	releases: number;
+	replay_pending: number;
+}
+
+export async function publicHealth(request: Request, env: Env): Promise<Response> {
+	if (request.method !== "GET" && request.method !== "HEAD") {
+		return new Response(null, { status: 405, headers: { allow: "GET, HEAD" } });
+	}
+	const policy = await getListingPolicy(env);
+	const requiresProjection = policy.mode === "projection";
+	const readinessSql = requiresProjection
+		? `EXISTS (
+			SELECT 1 FROM public_projection_state projection_state
+			${ACTIVE_PROJECTION_JOINS_SQL}
+			WHERE projection_state.id = 1 AND ${ACTIVE_PROJECTION_POLICY_SQL}
+		)`
+		: "1";
+	const row = await env.DB.withSession("first-primary")
+		.prepare(
+			`SELECT
+			   ${readinessSql} AS ready,
+			   (SELECT COUNT(*) FROM public_packages package
+			    JOIN public_projection_state state
+			      ON state.active_generation = package.generation
+			    WHERE state.id = 1) AS packages,
+			   (SELECT COUNT(*) FROM public_releases release
+			    JOIN public_projection_state state
+			      ON state.active_generation = release.generation
+			    WHERE state.id = 1) AS releases,
+			   (SELECT COUNT(*) FROM labellers source
+			    WHERE source.active = 1 AND source.replay_pending = 1
+			      AND (source.required_positive = 1
+			        OR source.accepted_state = 1
+			        OR source.redaction = 1)) AS replay_pending`,
+		)
+		.bind(...(requiresProjection ? activeProjectionPolicyBindings(policy) : []))
+		.first<PublicHealthRow>();
+	if (!row) throw new Error("aggregator health query returned no row");
+
+	const ready = row.ready === 1;
+	const status = ready ? 200 : 503;
+	const headers = { "cache-control": "no-store", "content-type": "application/json" };
+	if (request.method === "HEAD") return new Response(null, { status, headers });
+	return Response.json(
+		{
+			service: "emdash-aggregator",
+			status: ready ? "ok" : "not-ready",
+			policyMode: policy.mode,
+			projection: {
+				ready,
+				packages: row.packages,
+				releases: row.releases,
+			},
+			labelSources: {
+				replayPending: row.replay_pending,
+			},
+		},
+		{ status, headers },
+	);
+}

--- a/apps/aggregator/src/public-projection.ts
+++ b/apps/aggregator/src/public-projection.ts
@@ -554,7 +554,19 @@ function selectReleases(
 
 function groupLabels(rows: readonly LabelStateRow[]): Map<string, ListingLabelEvent[]> {
 	const grouped = new Map<string, ListingLabelEvent[]>();
+	const seen = new Set<string>();
 	for (const row of rows) {
+		const semanticKey = JSON.stringify([
+			row.src,
+			row.uri,
+			row.val,
+			row.cid,
+			row.neg,
+			row.cts,
+			row.exp,
+		]);
+		if (seen.has(semanticKey)) continue;
+		seen.add(semanticKey);
 		const label: ListingLabelEvent = {
 			ver: 1,
 			src: row.src,

--- a/apps/aggregator/test/label-ingest.test.ts
+++ b/apps/aggregator/test/label-ingest.test.ts
@@ -1,6 +1,6 @@
 import { encode } from "@atcute/cbor";
 import { P256PrivateKeyExportable, P256PublicKey, parsePublicMultikey } from "@atcute/crypto";
-import { toBase64Url } from "@atcute/multibase";
+import { toBase64Pad, toBase64Url } from "@atcute/multibase";
 import {
 	createListingLabelSigner,
 	verifyListingLabel,
@@ -1057,6 +1057,41 @@ describe("subscription frame bounds", () => {
 });
 
 describe("query replay bounds", () => {
+	it("decodes padded standard base64 signatures returned by queryLabels", async () => {
+		const signature = new Uint8Array(64).fill(255);
+		const client = new RealLabelQueryClient(async () =>
+			Response.json({
+				labels: [
+					{
+						ver: 1,
+						src: SOURCE,
+						uri: URI,
+						cid: CID_A,
+						val: "listing-passed",
+						cts: NOW,
+						sig: { $bytes: toBase64Pad(signature) },
+					},
+				],
+				cursor: "1",
+			}),
+		);
+
+		await expect(client.query("https://labels.example", SOURCE, 0)).resolves.toEqual({
+			labels: [
+				{
+					ver: 1,
+					src: SOURCE,
+					uri: URI,
+					cid: CID_A,
+					val: "listing-passed",
+					cts: NOW,
+					sig: signature,
+				},
+			],
+			nextCursor: 1,
+		});
+	});
+
 	it("decodes base64url signatures returned by queryLabels", async () => {
 		const signature = new Uint8Array(64).fill(255);
 		const client = new RealLabelQueryClient(async () =>

--- a/apps/aggregator/test/label-ingest.test.ts
+++ b/apps/aggregator/test/label-ingest.test.ts
@@ -1,8 +1,9 @@
-import { encode } from "@atcute/cbor";
+import { encode, toBytes } from "@atcute/cbor";
 import { P256PrivateKeyExportable, P256PublicKey, parsePublicMultikey } from "@atcute/crypto";
 import { toBase64Pad, toBase64Url } from "@atcute/multibase";
 import {
 	createListingLabelSigner,
+	parseSignedListingLabel,
 	verifyListingLabel,
 	type LabelDidDocument,
 	type ListingLabelSigner,
@@ -1040,6 +1041,33 @@ describe("subscription verification", () => {
 });
 
 describe("subscription frame bounds", () => {
+	it("decodes compact signature bytes from a label subscription frame", () => {
+		const signature = new Uint8Array(64).fill(255);
+		const header = encode({ op: 1, t: "#labels" });
+		const payload = encode({
+			seq: 1,
+			labels: [
+				{
+					ver: 1,
+					src: SOURCE,
+					uri: URI,
+					cid: CID_A,
+					val: "listing-passed",
+					cts: NOW,
+					sig: toBytes(signature),
+				},
+			],
+		});
+		const bytes = new Uint8Array(header.length + payload.length);
+		bytes.set(header);
+		bytes.set(payload, header.length);
+
+		const frame = decodeLabelStreamFrame(bytes);
+
+		expect(frame?.seq).toBe(1);
+		expect(() => parseSignedListingLabel(frame?.labels[0])).not.toThrow();
+	});
+
 	it("rejects oversized frames before CBOR decode", () => {
 		expect(() => decodeLabelStreamFrame(new Uint8Array(1024 * 1024 + 1))).toThrow(/frame exceeds/);
 	});

--- a/apps/aggregator/test/listing-projection.test.ts
+++ b/apps/aggregator/test/listing-projection.test.ts
@@ -204,6 +204,48 @@ describe("revision migration and ingest", () => {
 });
 
 describe("projection policy", () => {
+	it("materializes repeated signed deliveries as one semantic label", async () => {
+		await seedApprovedPackage({
+			did: DID_A,
+			slug: "demo",
+			profileCid: PROFILE_CID_1,
+			releaseCid: RELEASE_CID_1,
+		});
+		await seedLabelerRoles({ acceptedState: true, redaction: true, requiredPositive: true });
+		const uri = releaseUri(DID_A, "demo", "1.0.0");
+		const epoch = Math.floor(NOW.getTime() / 1_000);
+		for (const delivery of [1, 2]) {
+			await testEnv.DB.prepare(
+				`INSERT INTO listing_labels
+				   (digest, state_digest, src, uri, cid, val, neg, cts, cts_epoch,
+				    cts_fraction, exp, exp_epoch, sig, ver, received_at)
+				 VALUES (?, 'same-semantic-state', ?, ?, ?, 'listing-passed', 0, ?, ?, ?,
+				         NULL, NULL, ?, 1, ?)`,
+			)
+				.bind(
+					`delivery-${delivery}`,
+					LABELER_DID,
+					uri,
+					RELEASE_CID_1,
+					NOW.toISOString(),
+					epoch,
+					"0".repeat(32),
+					new Uint8Array([delivery]),
+					NOW.toISOString(),
+				)
+				.run();
+		}
+		await rebuild("projection");
+
+		const response = await xrpc(
+			"projection",
+			`${NSID.aggregatorGetLatestRelease}?did=${DID_A}&package=demo`,
+		);
+		const body = (await response.json()) as { labels: Array<{ val: string }> };
+
+		expect(body.labels.filter((label) => label.val === "listing-passed")).toHaveLength(1);
+	});
+
 	it("does not let the accepted-labelers header disable a required source", async () => {
 		const optionalSource = "did:plc:labeler000000000000000bb";
 		const policy: ListingModerationPolicy = {

--- a/apps/aggregator/test/smoke.test.ts
+++ b/apps/aggregator/test/smoke.test.ts
@@ -12,7 +12,7 @@
 
 import { INITIAL_LISTING_POLICY_FIXTURE } from "@emdash-cms/registry-moderation/fixtures";
 import { applyD1Migrations, env, SELF } from "cloudflare:test";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import { stageLabelSourceReplay } from "../src/label-source-health.js";
 import { getListingPolicy } from "../src/listing-policy.js";
@@ -30,7 +30,33 @@ beforeAll(async () => {
 });
 
 describe("aggregator scaffold smoke test", () => {
-	it("exposes public readiness without caching the result", async () => {
+	it("reuses a recent readiness snapshot across repeated probes", async () => {
+		let sessions = 0;
+		const db = new Proxy(env.DB, {
+			get(target, property, receiver) {
+				if (property !== "withSession") return Reflect.get(target, property, receiver);
+				return (...args: Parameters<D1Database["withSession"]>) => {
+					sessions++;
+					return target.withSession(...args);
+				};
+			},
+		});
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests override generated literal var bindings
+		const runtimeEnv = {
+			...env,
+			DB: db,
+			LISTING_POLICY_MODE: "open",
+			LISTING_ALLOWLIST: "[]",
+			LISTING_MODERATION_POLICY: JSON.stringify(INITIAL_LISTING_POLICY_FIXTURE),
+		} as unknown as Env;
+
+		await publicHealth(new Request("https://test/health"), runtimeEnv);
+		await publicHealth(new Request("https://test/health"), runtimeEnv);
+
+		expect(sessions).toBe(1);
+	});
+
+	it("exposes public readiness without cacheable response headers", async () => {
 		const response = await SELF.fetch("https://test/health");
 
 		expect(response.status).toBe(200);
@@ -43,9 +69,6 @@ describe("aggregator scaffold smoke test", () => {
 				ready: true,
 				packages: 0,
 				releases: 0,
-			},
-			labelSources: {
-				replayPending: 0,
 			},
 		});
 	});
@@ -115,18 +138,21 @@ describe("aggregator scaffold smoke test", () => {
 		)
 			.bind(generation, now)
 			.run();
+		const cacheTime = Date.now();
+		const dateNow = vi.spyOn(Date, "now").mockReturnValue(cacheTime);
 		expect((await publicHealth(new Request("https://test/health"), runtimeEnv)).status).toBe(200);
 
 		await stageLabelSourceReplay(testEnv.DB, source, observedAt);
+		dateNow.mockReturnValue(cacheTime + 5_001);
 
 		const response = await publicHealth(new Request("https://test/health"), runtimeEnv);
+		dateNow.mockRestore();
 
 		expect(response.status).toBe(503);
 		await expect(response.json()).resolves.toMatchObject({
 			status: "not-ready",
 			policyMode: "projection",
 			projection: { ready: false, packages: 0, releases: 0 },
-			labelSources: { replayPending: 1 },
 		});
 	});
 

--- a/apps/aggregator/test/smoke.test.ts
+++ b/apps/aggregator/test/smoke.test.ts
@@ -14,6 +14,8 @@ import { INITIAL_LISTING_POLICY_FIXTURE } from "@emdash-cms/registry-moderation/
 import { applyD1Migrations, env, SELF } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
 
+import { stageLabelSourceReplay } from "../src/label-source-health.js";
+import { getListingPolicy } from "../src/listing-policy.js";
 import { publicHealth } from "../src/public-health.js";
 
 interface TestEnv {
@@ -49,20 +51,30 @@ describe("aggregator scaffold smoke test", () => {
 	});
 
 	it("fails readiness while an authoritative label source needs replay", async () => {
-		const now = new Date().toISOString();
+		const observedAt = new Date();
+		const now = observedAt.toISOString();
+		const source = "did:web:labels.emdashcms.com";
+		const moderationPolicy = {
+			...INITIAL_LISTING_POLICY_FIXTURE,
+			requiredPositiveSources: [source],
+			acceptedStateSources: [source],
+			redactionSources: [source],
+		};
 		await testEnv.DB.prepare(
 			`INSERT INTO labellers
 			   (did, endpoint, signing_key, signing_key_id, trusted, added_at, last_resolved_at,
 			    active, required_positive, accepted_state, redaction, policy_version,
-			    replay_pending)
-			 VALUES (?, ?, '', '', 0, ?, ?, 1, 1, 1, 1, ?, 1)`,
+			    replay_pending, health_last_success_at, health_last_success_epoch)
+			 VALUES (?, ?, '', '', 1, ?, ?, 1, 1, 1, 1, ?, 0, ?, ?)`,
 		)
 			.bind(
-				"did:web:labels.emdashcms.com",
+				source,
 				"https://labels.emdashcms.com",
 				now,
 				now,
 				INITIAL_LISTING_POLICY_FIXTURE.policyVersion,
+				now,
+				observedAt.getTime(),
 			)
 			.run();
 		const runtimeEnv = {
@@ -70,8 +82,42 @@ describe("aggregator scaffold smoke test", () => {
 			DB: testEnv.DB,
 			LISTING_POLICY_MODE: "projection",
 			LISTING_ALLOWLIST: "[]",
-			LISTING_MODERATION_POLICY: JSON.stringify(INITIAL_LISTING_POLICY_FIXTURE),
+			LISTING_MODERATION_POLICY: JSON.stringify(moderationPolicy),
 		} as Env;
+		const policy = await getListingPolicy(runtimeEnv);
+		const control = await testEnv.DB.prepare(
+			"SELECT source_epoch FROM listing_projection_control WHERE id = 1",
+		).first<{ source_epoch: number }>();
+		if (!control) throw new Error("listing projection control row is missing");
+		const generation = "healthy-before-replay";
+		await testEnv.DB.prepare(
+			`INSERT INTO public_projection_generations
+			   (generation, policy_mode, policy_version, policy_hash,
+			    required_positive_sources, accepted_state_sources, redaction_sources,
+			    source_epoch, rebuild_sequence, created_at, completed_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
+		)
+			.bind(
+				generation,
+				policy.mode,
+				policy.moderationPolicyVersion,
+				policy.moderationPolicyHash,
+				policy.requiredPositiveSourcesJson,
+				policy.acceptedStateSourcesJson,
+				policy.redactionSourcesJson,
+				control.source_epoch,
+				now,
+				now,
+			)
+			.run();
+		await testEnv.DB.prepare(
+			"UPDATE public_projection_state SET active_generation = ?, updated_at = ? WHERE id = 1",
+		)
+			.bind(generation, now)
+			.run();
+		expect((await publicHealth(new Request("https://test/health"), runtimeEnv)).status).toBe(200);
+
+		await stageLabelSourceReplay(testEnv.DB, source, observedAt);
 
 		const response = await publicHealth(new Request("https://test/health"), runtimeEnv);
 

--- a/apps/aggregator/test/smoke.test.ts
+++ b/apps/aggregator/test/smoke.test.ts
@@ -10,8 +10,11 @@
  * of the suite assumes this passes.
  */
 
-import { applyD1Migrations, env } from "cloudflare:test";
+import { INITIAL_LISTING_POLICY_FIXTURE } from "@emdash-cms/registry-moderation/fixtures";
+import { applyD1Migrations, env, SELF } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
+
+import { publicHealth } from "../src/public-health.js";
 
 interface TestEnv {
 	DB: D1Database;
@@ -25,6 +28,62 @@ beforeAll(async () => {
 });
 
 describe("aggregator scaffold smoke test", () => {
+	it("exposes public readiness without caching the result", async () => {
+		const response = await SELF.fetch("https://test/health");
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("cache-control")).toBe("no-store");
+		await expect(response.json()).resolves.toEqual({
+			service: "emdash-aggregator",
+			status: "ok",
+			policyMode: "open",
+			projection: {
+				ready: true,
+				packages: 0,
+				releases: 0,
+			},
+			labelSources: {
+				replayPending: 0,
+			},
+		});
+	});
+
+	it("fails readiness while an authoritative label source needs replay", async () => {
+		const now = new Date().toISOString();
+		await testEnv.DB.prepare(
+			`INSERT INTO labellers
+			   (did, endpoint, signing_key, signing_key_id, trusted, added_at, last_resolved_at,
+			    active, required_positive, accepted_state, redaction, policy_version,
+			    replay_pending)
+			 VALUES (?, ?, '', '', 0, ?, ?, 1, 1, 1, 1, ?, 1)`,
+		)
+			.bind(
+				"did:web:labels.emdashcms.com",
+				"https://labels.emdashcms.com",
+				now,
+				now,
+				INITIAL_LISTING_POLICY_FIXTURE.policyVersion,
+			)
+			.run();
+		const runtimeEnv = {
+			...env,
+			DB: testEnv.DB,
+			LISTING_POLICY_MODE: "projection",
+			LISTING_ALLOWLIST: "[]",
+			LISTING_MODERATION_POLICY: JSON.stringify(INITIAL_LISTING_POLICY_FIXTURE),
+		} as Env;
+
+		const response = await publicHealth(new Request("https://test/health"), runtimeEnv);
+
+		expect(response.status).toBe(503);
+		await expect(response.json()).resolves.toMatchObject({
+			status: "not-ready",
+			policyMode: "projection",
+			projection: { ready: false, packages: 0, releases: 0 },
+			labelSources: { replayPending: 1 },
+		});
+	});
+
 	it("applies the initial migration and round-trips a packages row", async () => {
 		const now = new Date().toISOString();
 		await testEnv.DB.prepare(


### PR DESCRIPTION
## What does this PR do?

Repairs both production label-ingest decoders: padded standard Base64 from `com.atproto.label.queryLabels`, and the `@atcute/cbor` byte wrapper used by `subscribeLabels` frames. Workerd strictly rejected the former and the signed-label validator rejected the latter, so the aggregator retried from cursor zero and left the fail-closed public projection empty.

Deduplicates repeated signed deliveries when materializing public label arrays. Only identical semantic states collapse; distinct equal-time candidates remain visible to collision handling and continue to fail closed.

Adds a public `/health` readiness response that returns 503 when the configured projection generation or authoritative label-source freshness gate is unavailable. The primary-backed snapshot is cached in memory for five seconds, bounding repeated probe traffic while keeping the response itself `no-store`. This makes the same failure externally detectable without weakening exact-CID signed-label enforcement.

Production incident; no GitHub issue.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [x] I have included screenshots below if this PR changes the UI

The i18n item is not applicable because this changes only the aggregator Worker. A changeset is not applicable because `@emdash-cms/aggregator` is private and ignored by Changesets. The Discussion and screenshot items are not applicable because this is a production bug fix with no UI change.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Not applicable — no UI change.

Validated with:

- `pnpm --dir apps/aggregator test` — 288 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm --dir apps/aggregator build`
- `git diff --check`