### PR TITLE
fix(admin): match sidebar active state when a plugin page path is "/"

### DIFF
--- a/.changeset/sidebar-active-trailing-slash.md
+++ b/.changeset/sidebar-active-trailing-slash.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the sidebar active state for a plugin admin page declared with `path: "/"`. The nav target for such a page carries a trailing slash (`/plugins/<id>/`) while the router navigates without it, so the exact comparison in `isItemActive` never matched and the item stayed unhighlighted. This affected the shipped forms plugin's "Forms" page. Both sides are now normalized before comparing, and the admin root keeps its exact match.

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -222,13 +222,31 @@ export function resolveItemPath(item: NavItem): string {
 	return path;
 }
 
-/** Checks if a nav item is active based on the current router path. */
+const TRAILING_SLASHES = /\/+$/;
+
+/**
+ * Drop trailing slashes so a target and the router's path compare equal.
+ * "/" keeps its meaning: it is the admin root, not an empty path.
+ */
+function stripTrailingSlash(value: string): string {
+	return value.length > 1 ? value.replace(TRAILING_SLASHES, "") : value;
+}
+
+/**
+ * Checks if a nav item is active based on the current router path.
+ *
+ * Both sides are normalized because a plugin page declared with `path: "/"`
+ * makes the target `/plugins/<id>/`, while the router navigates to the same
+ * URL without the trailing slash — an exact compare would never match.
+ */
 export function isItemActive(itemPath: string, currentPath: string): boolean {
 	const queryIndex = itemPath.indexOf("?");
-	const path = queryIndex === -1 ? itemPath : itemPath.slice(0, queryIndex);
+	const raw = queryIndex === -1 ? itemPath : itemPath.slice(0, queryIndex);
+	const path = stripTrailingSlash(raw);
+	const current = stripTrailingSlash(currentPath);
 	return path === "/"
-		? currentPath === "/"
-		: currentPath === path || currentPath.startsWith(`${path}/`);
+		? current === "/"
+		: current === path || current.startsWith(`${path}/`);
 }
 
 /**

--- a/packages/admin/tests/components/Sidebar.test.tsx
+++ b/packages/admin/tests/components/Sidebar.test.tsx
@@ -100,6 +100,23 @@ describe("isItemActive", () => {
 	it("matches taxonomy links independently of their locale query", () => {
 		expect(isItemActive("/taxonomies/course?locale=de", "/taxonomies/course")).toBe(true);
 	});
+
+	it('matches a plugin page declared with path "/", whose target carries a trailing slash', () => {
+		expect(isItemActive("/plugins/emdash-forms/", "/plugins/emdash-forms")).toBe(true);
+	});
+
+	it("still matches nested routes under a plugin page", () => {
+		expect(isItemActive("/plugins/emdash-forms/", "/plugins/emdash-forms/submissions")).toBe(true);
+	});
+
+	it("does not match a different plugin whose id shares a prefix", () => {
+		expect(isItemActive("/plugins/emdash-forms/", "/plugins/emdash-forms-extra")).toBe(false);
+	});
+
+	it("keeps the admin root exact", () => {
+		expect(isItemActive("/", "/media")).toBe(false);
+		expect(isItemActive("/", "/")).toBe(true);
+	});
 });
 
 describe("NavIcon", () => {


### PR DESCRIPTION
## What does this PR do?

A plugin admin page declared with `path: "/"` never gets the active state in the sidebar. The link works and the page renders; only the highlight is missing, so the sidebar shows no selected item while you are on that page. This affects the shipped `@emdash-cms/plugin-forms`, whose first page is declared as `{ path: "/", label: "Forms" }`.

`Sidebar.tsx` builds the target by concatenation (`/plugins/${pluginId}${page.path}`), so `path: "/"` yields `/plugins/<id>/` with a trailing slash, while the router navigates to `/plugins/<id>`. `isItemActive` compared the two exactly, so the item could never match.

This normalizes the trailing slash on both sides before comparing, keeping `"/"` exact for the admin root. The fix is in the comparison rather than in the item builder, so it covers any nav item whose target ends in a slash, not just plugin pages.

Closes #2988

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — no new strings
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — not a feature
- [x] I have included screenshots below if this PR changes the UI

**Environment note, so the three unchecked boxes above are not a mystery:** I could not run the repo's own `typecheck`, `lint` and `test` locally. A scoped install (`pnpm install --filter @emdash-cms/admin...`) leaves the other workspace packages unbuilt, so `pnpm typecheck` in `packages/admin` fails on `@emdash-cms/blocks`, `@emdash-cms/plugin-types` and `@emdash-cms/registry-client` — pre-existing resolution errors unrelated to this change, and CONTRIBUTING says `pnpm build` is required first. The admin suite also runs in browser mode, which I did not set up. What I did run is below. CI is the source of truth here.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code). A human reviewed the diff and the measurements before it was opened.

## Screenshots / test output

Both screenshots are from EmDash 0.36.0 running in `astro dev`, same sidebar, same session. The site has two plugins with admin pages: the shipped forms plugin (`path: "/"`, hits the bug) and a local email provider that works around it with `path: "/status"`.

**Before — the forms plugin page is open (`/plugins/emdash-forms`), and no sidebar item is highlighted:**

<!-- ARRASTE AQUI a imagem "antes" -->

**After — the same sidebar with a page whose path has a segment (`/plugins/ses-email/status`), where the highlight appears as expected. This is the state the patch gives back to `path: "/"` pages:**

<!-- ARRASTE AQUI a imagem "depois" -->

The rendered pixels do not change; what changes is which item receives the active state. The measurement behind the screenshots, reading `data-active` on the sidebar anchors in the page:

```
current path /_emdash/admin/plugins/emdash-forms
  /_emdash/admin/plugins/ses-email/status        act=
  /_emdash/admin/plugins/emdash-forms            act=          <- should be active
  /_emdash/admin/plugins/emdash-forms/submissions act=

current path /_emdash/admin/plugins/ses-email/status
  /_emdash/admin/plugins/ses-email/status        act=true
  /_emdash/admin/plugins/emdash-forms            act=
  /_emdash/admin/plugins/emdash-forms/submissions act=
```

Targeted verification of the new comparison, including the cases the existing behavior must keep:

```
PASS  isItemActive("/taxonomies/course?locale=de", "/taxonomies/course") -> true   existing: query is ignored
PASS  isItemActive("/plugins/emdash-forms/", "/plugins/emdash-forms") -> true   new: plugin page declared with path "/"
PASS  isItemActive("/plugins/emdash-forms/", "/plugins/emdash-forms/submissions") -> true   new: nested route stays active
PASS  isItemActive("/plugins/emdash-forms/", "/plugins/emdash-forms-extra") -> false   new: sibling sharing a prefix must not match
PASS  isItemActive("/", "/media") -> false   new: admin root stays exact
PASS  isItemActive("/", "/") -> true   new: admin root matches itself
PASS  isItemActive("/media", "/media") -> true   existing: plain route
PASS  isItemActive("/media", "/media/123") -> true   existing: nested under a plain route
PASS  isItemActive("/media", "/mediation") -> false   existing: prefix collision

9/9 passed
```

Four of these are added to the existing `isItemActive` block in `packages/admin/tests/components/Sidebar.test.tsx`.
