### PR TITLE
fix(admin): only show Pending changes when a live revision exists

### DIFF
--- a/.changeset/lucky-moons-listen.md
+++ b/.changeset/lucky-moons-listen.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the content list showing a "Pending changes" badge on entries that have never been published. A draft or scheduled entry has a draft revision and no live revision, which the list read as a difference between the two. The badge now appears only where there is a published version for the changes to be pending against, matching the state the editor shows for the same entry.

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -37,6 +37,7 @@ import type {
 	ContentItem,
 	TrashedContentItem,
 } from "../lib/api.js";
+import { getDraftStatus } from "../lib/api.js";
 import {
 	ContentListColumnBoundary,
 	resolveContentListColumns,
@@ -1280,7 +1281,7 @@ function ContentListItem({
 			<td className="px-4 py-3">
 				<StatusBadge
 					status={item.status}
-					hasPendingChanges={!!item.draftRevisionId && item.draftRevisionId !== item.liveRevisionId}
+					hasPendingChanges={getDraftStatus(item) === "published_with_changes"}
 				/>
 			</td>
 			{showLocale && (

--- a/packages/admin/tests/components/ContentList.test.tsx
+++ b/packages/admin/tests/components/ContentList.test.tsx
@@ -369,6 +369,19 @@ describe("ContentList", () => {
 			expect(badge.querySelector("svg")).not.toBeNull();
 		});
 
+		it("does not show pending badge when the entry has never been published", async () => {
+			const items = [
+				makeItem({
+					id: "1",
+					status: "scheduled",
+					draftRevisionId: "rev_draft",
+					liveRevisionId: null,
+				}),
+			];
+			const screen = await render(<ContentList {...defaultProps} items={items} />);
+			expect(screen.getByText("Pending changes").query()).toBeNull();
+		});
+
 		it("does not show pending badge when revisions match", async () => {
 			const items = [
 				makeItem({


### PR DESCRIPTION
## What does this PR do?

The content list shows a **Pending changes** badge on entries that have never been published, so the same entry reads as both `Scheduled` and `Pending changes` at once. The editor disagrees with the list for that entry, and the list is the one that is wrong.

`ContentListItem` compares the revision pointers directly:

```tsx
hasPendingChanges={!!item.draftRevisionId && item.draftRevisionId !== item.liveRevisionId}
```

A draft or scheduled entry has a draft revision and `liveRevisionId === null`, so the two "differ" and the badge renders — but there is no published version for the changes to be pending against. The editor goes through `getContentPublishingState()`, which checks `isLive` first and correctly reports `scheduled` or `draft`.

The fix uses `getDraftStatus()`, which already encodes the rule and already lives in `lib/api`:

```ts
if (!item.liveRevisionId) return "unpublished";
if (item.draftRevisionId && item.draftRevisionId !== item.liveRevisionId)
	return "published_with_changes";
return "published";
```

Two lines: the badge condition and the import. The two screens now agree.

Found on a site running 0.37: a scheduled entry with several revisions and `live_revision_id` null was listed with pending changes while its editor showed only "Scheduled". Every unpublished entry that had been edited at least once was affected.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI — described instead, see below

Notes on the checklist, so the ticks are honest:

- No new strings, so nothing to wrap. No `messages.po` changes are included.
- `tests/components/ContentList.test.tsx` is 70/70, and `pnpm --filter @emdash-cms/admin typecheck` passes. `pnpm lint:json` reports nothing for the touched file; the repository has pre-existing diagnostics elsewhere that this branch does not add to.
- A few admin browser tests fail locally, but the set differs between runs (`SeoPanel`, `SocialSettings`, `LoginPage`, `router` and others) and never includes `ContentList`, so they look like local flakes rather than anything from this change.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Screenshots / test output

**No screenshot, deliberately.** The only site I can reproduce this on is a private pre-launch client site, and a shot of the affected list is a shot of unpublished client content and headlines. Describing it instead:

The status cell of an unpublished-but-edited entry renders two badges side by side — the lifecycle badge (`Scheduled`, blue, calendar icon) immediately followed by the companion badge (`Pending changes`, amber, arrows icon). After the fix the companion badge is gone and the lifecycle badge is unchanged. A published entry with unpublished edits still shows both, which the pre-existing test covers.

If a maintainer wants a rendered before/after, the fastest reproduction is a demo entry: create any entry in a collection with drafts enabled, save it without publishing, and it will show `Pending changes` on `main`.

Test added for the case that was not covered:

```
✓ ContentList > status badges > shows the Pending changes companion badge when revisions differ
✓ ContentList > status badges > does not show pending badge when the entry has never been published
✓ ContentList > status badges > does not show pending badge when revisions match

Test Files  1 passed (1)
     Tests  70 passed (70)
```
