### PR TITLE
docs(core): name the published package in the Cloudflare sandbox runner examples

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -19,9 +19,6 @@
 		},
 		"packages/admin": {},
 		"packages/gutenberg-to-portable-text": {},
-		"packages/sandbox-cloudflare": {
-			"ignoreDependencies": ["cloudflare"]
-		},
 		"packages/plugins/*": {},
 		"demos/*": {
 			"entry": ["src/**/*.{ts,astro}"],

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -259,12 +259,13 @@ export interface EmDashConfig {
 	 *
 	 * @example
 	 * ```ts
+	 * import { sandbox } from "@emdash-cms/cloudflare";
 	 * import { untrustedPlugin } from "some-third-party-plugin";
 	 *
 	 * emdash({
 	 *   plugins: [trustedPlugin()],     // runs in host
 	 *   sandboxed: [untrustedPlugin()], // runs in isolate
-	 *   sandboxRunner: "@emdash-cms/sandbox-cloudflare",
+	 *   sandboxRunner: sandbox(),
 	 * })
 	 * ```
 	 */
@@ -275,8 +276,10 @@ export interface EmDashConfig {
 	 *
 	 * @example
 	 * ```ts
+	 * import { sandbox } from "@emdash-cms/cloudflare";
+	 *
 	 * emdash({
-	 *   sandboxRunner: "@emdash-cms/sandbox-cloudflare",
+	 *   sandboxRunner: sandbox(),
 	 * })
 	 * ```
 	 */
@@ -367,9 +370,11 @@ export interface EmDashConfig {
 	 *
 	 * @example
 	 * ```ts
+	 * import { sandbox } from "@emdash-cms/cloudflare";
+	 *
 	 * emdash({
 	 *   marketplace: "https://marketplace.emdashcms.com",
-	 *   sandboxRunner: "@emdash-cms/sandbox-cloudflare",
+	 *   sandboxRunner: sandbox(),
 	 * })
 	 * ```
 	 */
@@ -385,13 +390,15 @@ export interface EmDashConfig {
 	 *
 	 * @example
 	 * ```ts
+	 * import { sandbox } from "@emdash-cms/cloudflare";
+	 *
 	 * emdash({
 	 *   experimental: {
 	 *     registry: {
 	 *       aggregatorUrl: "https://registry.emdashcms.com",
 	 *     },
 	 *   },
-	 *   sandboxRunner: "@emdash-cms/sandbox-cloudflare",
+	 *   sandboxRunner: sandbox(),
 	 * })
 	 * ```
 	 */

--- a/packages/core/src/plugins/sandbox/types.ts
+++ b/packages/core/src/plugins/sandbox/types.ts
@@ -273,11 +273,11 @@ export class SandboxUnavailableError extends Error {
 
 /**
  * Factory function type for creating sandbox runners.
- * Exported by platform adapters (e.g., @emdash-cms/adapter-cloudflare/sandbox).
+ * Exported by platform adapters (e.g., @emdash-cms/cloudflare/sandbox).
  *
  * @example
  * ```typescript
- * // In @emdash-cms/adapter-cloudflare/sandbox.ts
+ * // In @emdash-cms/cloudflare/sandbox
  * export const createSandboxRunner: SandboxRunnerFactory = (options) => {
  *   return new CloudflareSandboxRunner(options);
  * };


### PR DESCRIPTION
## What does this PR do?

Four `emdash()` options and the `SandboxRunnerFactory` docstring name `@emdash-cms/sandbox-cloudflare` and `@emdash-cms/adapter-cloudflare`. Neither is published (`npm install` returns 404) and neither has existed in this repository. The specifier becomes a static import in a generated virtual module, so copying an example fails the build on an unresolved module, and these examples also ship in the published `.d.mts`.

The four examples now call `sandbox()`, as every Cloudflare configuration in the tree already does; the docstring names the subpath that helper returns. `knip.json` also loses a workspace entry for `packages/sandbox-cloudflare`, a directory that has never existed; knip reports the same findings without it.

Comments and configuration only, so nothing changes at runtime. The same name on the plugin installing page is left to #2351, which rewrites that block.

Part of #1680.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) (`emdash`: 536 files, 6438 tests green; the root `pnpm test` fails in `registry-verification` on this machine before and after this change, unrelated to it)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) (n/a: comments and tooling configuration, nothing executable changes)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (n/a: no admin UI strings)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package) (n/a: documentation only, no published behaviour changes)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a: not a feature)
- [ ] I have included screenshots below if this PR changes the UI (n/a: no UI change)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5

## Screenshots / test output

Not applicable for screenshots.

```
pnpm typecheck    exit 0
pnpm lint         exit 0
pnpm format:check exit 0
pnpm --filter emdash test
  Test Files  536 passed | 2 skipped (538)
       Tests  6438 passed | 10 skipped (6448)
```

`knip` reports the same findings with the workspace entry present and removed, timestamps aside.
