### PR TITLE
test(core): cover migration retry and upgrades from existing data on D1

### DIFF
--- a/packages/core/tests/workerd/d1-schema.ts
+++ b/packages/core/tests/workerd/d1-schema.ts
@@ -95,3 +95,34 @@ export async function listColumns(db: Kysely<Database>, table: string): Promise<
 	const rows = await sql<{ name: string }>`PRAGMA table_info(${sql.ref(table)})`.execute(db);
 	return rows.rows.map((row) => row.name);
 }
+
+/**
+ * Create the collection table a site would have carried into migration 004.
+ *
+ * `SchemaRegistry` builds an `ec_*` table with the system columns listed in
+ * `schema/registry.ts`. Six of them arrive later, from migrations 013, 014,
+ * 019 and 031, so a collection that predates those carries the other nine.
+ */
+export async function seedLegacyCollection(db: Kysely<Database>): Promise<void> {
+	await sql`
+		CREATE TABLE ec_probe (
+			id TEXT PRIMARY KEY,
+			slug TEXT NOT NULL,
+			title TEXT,
+			body TEXT,
+			status TEXT DEFAULT 'draft',
+			author_id TEXT,
+			created_at TEXT,
+			updated_at TEXT,
+			published_at TEXT,
+			deleted_at TEXT,
+			version INTEGER DEFAULT 1
+		)
+	`.execute(db);
+	await sql`
+		INSERT INTO ec_probe (id, slug, title, status) VALUES ('p1', 'probe-1', 'Probe', 'draft')
+	`.execute(db);
+	await sql`
+		INSERT INTO _emdash_collections (id, slug, label) VALUES ('c1', 'probe', 'Probe')
+	`.execute(db);
+}

--- a/packages/core/tests/workerd/d1-schema.ts
+++ b/packages/core/tests/workerd/d1-schema.ts
@@ -97,11 +97,12 @@ export async function listColumns(db: Kysely<Database>, table: string): Promise<
 }
 
 /**
- * Create the collection table a site would have carried into migration 004.
+ * Seed the collection a site would have carried into migration 004.
  *
- * `SchemaRegistry` builds an `ec_*` table with the system columns listed in
- * `schema/registry.ts`. Six of them arrive later, from migrations 013, 014,
- * 019 and 031, so a collection that predates those carries the other nine.
+ * `SchemaRegistry` gives a content table the system columns listed in
+ * `schema/registry.ts` plus one per field. Six system columns arrive later,
+ * from migrations 013, 014, 019 and 031, so this carries the other nine plus
+ * two ordinary fields.
  */
 export async function seedLegacyCollection(db: Kysely<Database>): Promise<void> {
 	await sql`

--- a/packages/core/tests/workerd/migrations-d1.test.ts
+++ b/packages/core/tests/workerd/migrations-d1.test.ts
@@ -14,7 +14,13 @@ import {
 } from "../../src/database/migrations/runner.js";
 import type { Database } from "../../src/database/types.js";
 import { seedPreI18nSchema } from "../utils/pre-i18n-schema.js";
-import { listColumns, listIndexes, listTables, resetD1Schema } from "./d1-schema.js";
+import {
+	listColumns,
+	listIndexes,
+	listTables,
+	resetD1Schema,
+	seedLegacyCollection,
+} from "./d1-schema.js";
 
 declare module "cloudflare:test" {
 	interface ProvidedEnv {
@@ -35,6 +41,11 @@ beforeEach(async () => {
 afterAll(async () => {
 	await db.destroy();
 });
+
+async function migrateThrough(name: string): Promise<void> {
+	const { error } = await createMigrator(db).migrateTo(name);
+	if (error) throw error;
+}
 
 describe("core migrations on D1", () => {
 	it("applies every registered migration to an empty database", async () => {
@@ -63,10 +74,6 @@ describe("retry after a partial run on D1", () => {
 	// the schema changed and the bookkeeping row missing. The next request
 	// reruns the migration against its own output, and an unguarded CREATE
 	// there fails on every boot from then on.
-	async function migrateThrough(name: string): Promise<void> {
-		const { error } = await createMigrator(db).migrateTo(name);
-		if (error) throw error;
-	}
 
 	it("finishes 016 after a run that stopped after its first statement", async () => {
 		await migrateThrough("015_indexes");
@@ -205,5 +212,52 @@ describe("040 byline rebuild on D1", () => {
 		const columns = await listColumns(db, "_emdash_bylines");
 		expect(columns).toContain("locale");
 		expect(columns).toContain("translation_group");
+	});
+});
+
+describe("replay idempotence on D1", () => {
+	// Migrations after this one guard their DDL against a replay; most up to it
+	// do not, so the replay below starts past it.
+	const LAST_UNGUARDED_MIGRATION = "032_rate_limits";
+
+	// A migration that iterates `ec_*` tables is inert on an empty database.
+	async function seedCollectionAfterRegistry(): Promise<string[]> {
+		await migrateThrough("003_schema_registry");
+		await seedLegacyCollection(db);
+		return MIGRATION_NAMES.slice(MIGRATION_NAMES.indexOf("003_schema_registry") + 1);
+	}
+
+	it("applies every migration to a database that already holds a collection", async () => {
+		const remaining = await seedCollectionAfterRegistry();
+
+		const { applied } = await runMigrations(db);
+
+		expect(applied).toEqual(remaining);
+		expect((await getExactMigrationStatus(db)).pending).toEqual([]);
+	});
+
+	it("replays every migration written since the guarded-DDL pattern", async () => {
+		const remaining = await seedCollectionAfterRegistry();
+		const migrations = new Map(
+			(await createMigrator(db).getMigrations()).map((info) => [info.name, info.migration]),
+		);
+		const guarded = new Set(
+			MIGRATION_NAMES.slice(MIGRATION_NAMES.indexOf(LAST_UNGUARDED_MIGRATION) + 1),
+		);
+		const failed: string[] = [];
+
+		for (const name of remaining) {
+			await migrateThrough(name);
+			if (!guarded.has(name)) continue;
+			const migration = migrations.get(name);
+			if (!migration) throw new Error(`no migration is registered as ${name}`);
+			try {
+				await migration.up(db);
+			} catch (error) {
+				failed.push(`${name}: ${error instanceof Error ? error.message : String(error)}`);
+			}
+		}
+
+		expect(failed).toEqual([]);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Extends the D1 migration covers from single migrations to the registered set.
AGENTS.md asks for a retry after a partial run and an upgrade from existing
data. Both are covered today for migrations 016, 036 and 040 and for nothing
else, so a new migration that breaks either ships.

D1 auto-commits DDL and the migrator writes its bookkeeping row only after `up`
returns, so a run that dies partway leaves the schema changed and the migration
pending. The next boot replays it against its own output, and an unguarded
statement there fails on every boot from then on.

Migrations 002 to 032 predate the guarded-DDL pattern and 26 of the 30 fail that
replay. Repairing them is a decision of its own, so the first cover asserts the
boundary rather than the block: everything written since 032 survives a replay.
The second runs the chain over a collection, which no existing cover does. Both
start from one as it stood before 013, 014, 019 and 031: the nine system columns
that predate them, plus two ordinary fields, because a migration iterating
`ec_*` tables is inert on an empty database. No source file changes.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (n/a: no admin UI strings)
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package) (n/a: test-only, no published package changes)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a: not a feature)
- [ ] I have included screenshots below if this PR changes the UI (n/a: no UI change)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5

## Screenshots / test output

Not applicable for screenshots.

Both covers were checked against a mutated source, one mutation at a time:

```
# 1. IF NOT EXISTS removed from the index create in migration 074
× replay idempotence on D1 > replays every migration written since the guarded-DDL pattern
  expected [ Array(1) ] to deeply equal []
  + "074_content_deleted_scheduled_index: D1_ERROR: index idx_ec_probe_del_sched already exists: SQLITE_ERROR"

# 2. one duplicate ADD COLUMN added to migration 013's ec_* loop
× replay idempotence on D1 > applies every migration to a database that already holds a collection
  Migration failed: D1_ERROR: duplicate column name: status: SQLITE_ERROR: duplicate
  column name: status: SQLITE_ERROR (migration: 013_scheduled_publishing)
× replay idempotence on D1 > replays every migration written since the guarded-DDL pattern
  D1_ERROR: duplicate column name: status: SQLITE_ERROR
  ✓ core migrations on D1 > applies every registered migration to an empty database
  ... 8 further pre-existing covers green
```

The second mutation fails on any database that has a collection, and all nine
covers that existed before this PR stay green.

```
pnpm exec vitest run --config vitest.workerd.config.ts   7 files, 28 passed
pnpm exec vitest run (packages/core)                     536 files, 6438 passed, 10 skipped
```
