### PR TITLE
fix(cli): send --force through to the API when deleting a collection

### DIFF
--- a/.changeset/quiet-hats-delete.md
+++ b/.changeset/quiet-hats-delete.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `emdash schema delete --force` so it can delete a collection that still has content. The flag only skipped the confirmation prompt and was never sent to the API, which then refused with "Use force: true to delete". `EmDashClient.deleteCollection` accepts `{ force: true }` for the same purpose.

--- a/packages/core/src/cli/commands/schema.ts
+++ b/packages/core/src/cli/commands/schema.ts
@@ -132,8 +132,6 @@ const deleteCommand = defineCommand({
 				}
 			}
 			const client = createClientFromArgs(args);
-			// The API refuses a collection with content unless told to force;
-			// without this the flag only ever skipped the prompt above.
 			await client.deleteCollection(args.collection, { force: args.force });
 			consola.success(`Deleted collection "${args.collection}"`);
 		} catch (error) {

--- a/packages/core/src/cli/commands/schema.ts
+++ b/packages/core/src/cli/commands/schema.ts
@@ -115,7 +115,7 @@ const deleteCommand = defineCommand({
 		},
 		force: {
 			type: "boolean",
-			description: "Skip confirmation",
+			description: "Skip confirmation and delete even if the collection has content",
 		},
 		...commonArgs,
 	},
@@ -132,7 +132,9 @@ const deleteCommand = defineCommand({
 				}
 			}
 			const client = createClientFromArgs(args);
-			await client.deleteCollection(args.collection);
+			// The API refuses a collection with content unless told to force;
+			// without this the flag only ever skipped the prompt above.
+			await client.deleteCollection(args.collection, { force: args.force });
 			consola.success(`Deleted collection "${args.collection}"`);
 		} catch (error) {
 			consola.error(error instanceof Error ? error.message : "Unknown error");

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -544,9 +544,16 @@ export class EmDashClient {
 		return data.item;
 	}
 
-	/** Delete a collection */
-	async deleteCollection(slug: string): Promise<void> {
-		await this.request<unknown>("DELETE", `/schema/collections/${encodeURIComponent(slug)}`);
+	/**
+	 * Delete a collection. A collection that still has content is refused
+	 * unless `force` is set, which the route reads as `?force=true`.
+	 */
+	async deleteCollection(slug: string, options?: { force?: boolean }): Promise<void> {
+		const query = options?.force ? "?force=true" : "";
+		await this.request<unknown>(
+			"DELETE",
+			`/schema/collections/${encodeURIComponent(slug)}${query}`,
+		);
 	}
 
 	/** Create a field on a collection */

--- a/packages/core/tests/unit/client/client.test.ts
+++ b/packages/core/tests/unit/client/client.test.ts
@@ -532,6 +532,30 @@ describe("EmDashClient", () => {
 	});
 
 	describe("schema methods", () => {
+		it("deleteCollection sends force to the API as a query parameter", async () => {
+			const calledPaths: string[] = [];
+			const backend: Interceptor = async (req) => {
+				const url = new URL(req.url);
+				calledPaths.push(`${req.method} ${url.pathname}${url.search}`);
+				return jsonResponse({});
+			};
+			const client = new EmDashClient({
+				baseUrl: "http://localhost:4321",
+				token: "test",
+				interceptors: [backend],
+			});
+
+			await client.deleteCollection("posts");
+			await client.deleteCollection("posts", { force: false });
+			await client.deleteCollection("posts", { force: true });
+
+			expect(calledPaths).toEqual([
+				"DELETE /_emdash/api/schema/collections/posts",
+				"DELETE /_emdash/api/schema/collections/posts",
+				"DELETE /_emdash/api/schema/collections/posts?force=true",
+			]);
+		});
+
 		it("schema route wraps JSON exports in the API data envelope", async () => {
 			const db = await setupTestDatabaseWithCollections();
 


### PR DESCRIPTION
## What does this PR do?

`emdash schema delete --force` consumed the flag to skip its own confirmation prompt and then called the client without it, so the API refused any collection that still had content — with an error naming the very option the user had just passed. There was no other CLI path through.

`EmDashClient.deleteCollection` now takes `{ force?: boolean }` and sends it as `?force=true`, the way the route already reads it; the command passes its flag along. The flag keeps a single meaning — "don't ask, just delete" — since the prompt existed to guard exactly the destructive case. Test added for the client's query string; changeset included.

Closes #2994

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion
- [ ] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5.1 (Claude Code)

## Screenshots / test output

```
tests/unit/client/client.test.ts  44 passed
```