### PR TITLE
fix(core): give the JSON-LD nodes an @id so they can be referenced

### DIFF
--- a/.changeset/olive-cups-shine.md
+++ b/.changeset/olive-cups-shine.md
@@ -4,6 +4,6 @@
 
 Fixes the JSON-LD that core emits on public pages, which published nodes nothing could reference. `BlogPosting`, its `publisher`, and `WebSite` had no `@id`, so an Organization graph describing the site — from a plugin or written into a template — stood beside the article's publisher as a second, competing organisation instead of merging with it. Article pages carried two organisations, and the fuller one was not the article's publisher.
 
-Each of the three nodes now carries an `@id`: `<canonical>#article`, `<origin>/#organization`, and `<origin>#website`. The publisher keeps its `@type` and `name`, so a site publishing no Organization graph of its own is unaffected.
+Each of the three nodes now carries an `@id`: `<canonical>#article`, `<origin>/#organization`, and `<origin>/#website`. The publisher keeps its `@type` and `name`, so a site publishing no Organization graph of its own is unaffected.
 
 Sites already emitting an Organization graph should confirm its `@id` is `<origin>/#organization` — with the slash before the fragment. `https://example.com#organization` is a different IRI, and a mismatch produces two organisations rather than one.

--- a/.changeset/olive-cups-shine.md
+++ b/.changeset/olive-cups-shine.md
@@ -1,0 +1,9 @@
+---
+"emdash": patch
+---
+
+Fixes the JSON-LD that core emits on public pages, which published nodes nothing could reference. `BlogPosting`, its `publisher`, and `WebSite` had no `@id`, so an Organization graph describing the site — from a plugin or written into a template — stood beside the article's publisher as a second, competing organisation instead of merging with it. Article pages carried two organisations, and the fuller one was not the article's publisher.
+
+Each of the three nodes now carries an `@id`: `<canonical>#article`, `<origin>/#organization`, and `<origin>#website`. The publisher keeps its `@type` and `name`, so a site publishing no Organization graph of its own is unaffected.
+
+Sites already emitting an Organization graph should confirm its `@id` is `<origin>/#organization` — with the slash before the fragment. `https://example.com#organization` is a different IRI, and a mismatch produces two organisations rather than one.

--- a/packages/core/src/page/jsonld.ts
+++ b/packages/core/src/page/jsonld.ts
@@ -27,6 +27,28 @@ export function cleanJsonLd(obj: Record<string, unknown>): Record<string, unknow
 }
 
 /**
+ * The site's public origin, as the graphs below refer to it.
+ *
+ * Lifted out of `buildWebSiteJsonLd` unchanged, because `buildBlogPostingJsonLd`
+ * now needs the same answer and two copies of this chain would eventually
+ * disagree — which, for values used to build an `@id`, means silently
+ * publishing two entities instead of one.
+ *
+ * Deliberately NOT `resolveSiteOrigin()` from `absolute-url.ts`: that gives
+ * `SiteSettings.url` precedence over `page.siteUrl`, which would change which
+ * origin these graphs carry. That may well be the better order, but it is a
+ * behaviour change and does not belong in a fix about node identity.
+ */
+function siteOrigin(page: PublicPageContext): string {
+	if (page.siteUrl) return page.siteUrl;
+	try {
+		return new URL(page.url).origin;
+	} catch {
+		return page.canonical || page.url;
+	}
+}
+
+/**
  * Build a BlogPosting JSON-LD graph from page context.
  * Used for article-type content pages.
  *
@@ -52,6 +74,10 @@ export function buildBlogPostingJsonLd(
 	return cleanJsonLd({
 		"@context": "https://schema.org",
 		"@type": "BlogPosting",
+		// A fragment, not the bare canonical: `mainEntityOfPage` below already
+		// identifies the WebPage by that IRI, and reusing it would state that the
+		// article and the page it sits on are the same thing.
+		"@id": `${page.canonical}#article`,
 		headline: ogTitle,
 		description,
 		image: ogImage || undefined,
@@ -64,9 +90,15 @@ export function buildBlogPostingJsonLd(
 					name: author,
 				}
 			: undefined,
+		// Identified, but still self-describing. `@id` lets a fuller Organization
+		// graph — from a plugin, or hand-written in a template — merge into this
+		// node instead of standing beside it as a second, competing organisation.
+		// `@type` and `name` stay so that a site publishing no such graph is left
+		// with a complete node rather than a dangling reference.
 		publisher: siteName
 			? {
 					"@type": "Organization",
+					"@id": `${siteOrigin(page)}/#organization`,
 					name: siteName,
 				}
 			: undefined,
@@ -85,21 +117,14 @@ export function buildWebSiteJsonLd(page: PublicPageContext): Record<string, unkn
 	const siteName = page.siteName;
 	if (!siteName) return null;
 
-	// Use configured public origin, falling back to page URL origin
-	let siteUrl: string;
-	if (page.siteUrl) {
-		siteUrl = page.siteUrl;
-	} else {
-		try {
-			siteUrl = new URL(page.url).origin;
-		} catch {
-			siteUrl = page.canonical || page.url;
-		}
-	}
+	const siteUrl = siteOrigin(page);
 
 	return cleanJsonLd({
 		"@context": "https://schema.org",
 		"@type": "WebSite",
+		// So a plugin can add `potentialAction` (a sitelinks SearchAction, say)
+		// by emitting a node under the same `@id`, rather than a second WebSite.
+		"@id": `${siteUrl}#website`,
 		name: siteName,
 		url: siteUrl,
 	});

--- a/packages/core/src/page/jsonld.ts
+++ b/packages/core/src/page/jsonld.ts
@@ -27,20 +27,20 @@ export function cleanJsonLd(obj: Record<string, unknown>): Record<string, unknow
 }
 
 /**
- * The site's public origin, as the graphs below refer to it.
+ * Site origin to use for JSON-LD node identifiers.
  *
- * Lifted out of `buildWebSiteJsonLd` unchanged, because `buildBlogPostingJsonLd`
- * now needs the same answer and two copies of this chain would eventually
- * disagree — which, for values used to build an `@id`, means silently
- * publishing two entities instead of one.
- *
- * Deliberately NOT `resolveSiteOrigin()` from `absolute-url.ts`: that gives
- * `SiteSettings.url` precedence over `page.siteUrl`, which would change which
- * origin these graphs carry. That may well be the better order, but it is a
- * behaviour change and does not belong in a fix about node identity.
+ * `page.siteUrl` wins over `page.url` so IDs stay stable when a theme
+ * overrides the public origin. Falls back to the raw canonical or URL only
+ * when neither parses as a URL.
  */
 function siteOrigin(page: PublicPageContext): string {
-	if (page.siteUrl) return page.siteUrl;
+	if (page.siteUrl) {
+		try {
+			return new URL(page.siteUrl).origin;
+		} catch {
+			return page.siteUrl;
+		}
+	}
 	try {
 		return new URL(page.url).origin;
 	} catch {
@@ -74,9 +74,6 @@ export function buildBlogPostingJsonLd(
 	return cleanJsonLd({
 		"@context": "https://schema.org",
 		"@type": "BlogPosting",
-		// A fragment, not the bare canonical: `mainEntityOfPage` below already
-		// identifies the WebPage by that IRI, and reusing it would state that the
-		// article and the page it sits on are the same thing.
 		"@id": `${page.canonical}#article`,
 		headline: ogTitle,
 		description,
@@ -90,11 +87,6 @@ export function buildBlogPostingJsonLd(
 					name: author,
 				}
 			: undefined,
-		// Identified, but still self-describing. `@id` lets a fuller Organization
-		// graph — from a plugin, or hand-written in a template — merge into this
-		// node instead of standing beside it as a second, competing organisation.
-		// `@type` and `name` stay so that a site publishing no such graph is left
-		// with a complete node rather than a dangling reference.
 		publisher: siteName
 			? {
 					"@type": "Organization",
@@ -122,9 +114,7 @@ export function buildWebSiteJsonLd(page: PublicPageContext): Record<string, unkn
 	return cleanJsonLd({
 		"@context": "https://schema.org",
 		"@type": "WebSite",
-		// So a plugin can add `potentialAction` (a sitelinks SearchAction, say)
-		// by emitting a node under the same `@id`, rather than a second WebSite.
-		"@id": `${siteUrl}#website`,
+		"@id": `${siteUrl}/#website`,
 		name: siteName,
 		url: siteUrl,
 	});

--- a/packages/core/tests/unit/plugins/page-seo.test.ts
+++ b/packages/core/tests/unit/plugins/page-seo.test.ts
@@ -218,10 +218,20 @@ describe("page SEO metadata", () => {
 			expect(publisher.name).toBe("My Site");
 		});
 
+		it("normalises a configured siteUrl to an origin", () => {
+			// A trailing slash on `page.siteUrl` would otherwise reach the id as
+			// `https://example.com//#organization`, which is a different IRI.
+			const graph = buildBlogPostingJsonLd(createPage({ siteUrl: "https://example.com/" }));
+			expect(graph).not.toBeNull();
+
+			const publisher = graph?.publisher as Record<string, unknown>;
+			expect(publisher["@id"]).toBe("https://example.com/#organization");
+		});
+
 		it("gives the WebSite an @id so a plugin can extend it", () => {
 			const graph = buildWebSiteJsonLd(createPage({ pageType: "website" }));
 
-			expect(graph).toMatchObject({ "@id": "https://example.com#website" });
+			expect(graph).toMatchObject({ "@id": "https://example.com/#website" });
 		});
 	});
 });

--- a/packages/core/tests/unit/plugins/page-seo.test.ts
+++ b/packages/core/tests/unit/plugins/page-seo.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildBlogPostingJsonLd } from "../../../src/page/jsonld.js";
+import { buildBlogPostingJsonLd, buildWebSiteJsonLd } from "../../../src/page/jsonld.js";
 import { generateBaseSeoContributions } from "../../../src/page/seo-contributions.js";
 import type { PublicPageContext } from "../../../src/plugins/types.js";
 
@@ -178,6 +178,50 @@ describe("page SEO metadata", () => {
 			const graph = buildBlogPostingJsonLd(page, defaultOg);
 
 			expect(graph).toMatchObject({ image: "https://example.com/post-hero.png" });
+		});
+	});
+
+	describe("node identity", () => {
+		// Without an `@id` a node is anonymous: nothing can reference it, and a
+		// richer description of the same thing published alongside it stays a
+		// separate entity rather than merging into one.
+		it("gives the article an @id distinct from the WebPage it is on", () => {
+			const graph = buildBlogPostingJsonLd(createPage());
+			expect(graph).not.toBeNull();
+
+			// Not the bare canonical: `mainEntityOfPage` already claims that for
+			// the WebPage, and reusing it would merge the article with the page.
+			expect(graph).toMatchObject({ "@id": "https://example.com/posts/hello#article" });
+			const mainEntity = graph?.mainEntityOfPage as Record<string, unknown>;
+			expect(graph?.["@id"]).not.toBe(mainEntity["@id"]);
+		});
+
+		it("identifies the publisher, so a fuller Organization graph merges with it", () => {
+			const graph = buildBlogPostingJsonLd(createPage({ siteUrl: "https://example.com" }));
+
+			// The trailing slash before the fragment is load-bearing:
+			// `https://example.com#organization` is a different IRI, and a
+			// mismatch publishes two organisations instead of one.
+			expect(graph?.publisher).toEqual({
+				"@type": "Organization",
+				"@id": "https://example.com/#organization",
+				name: "My Site",
+			});
+		});
+
+		it("keeps the publisher self-sufficient when nothing else describes it", () => {
+			const publisher = buildBlogPostingJsonLd(createPage())?.publisher as Record<string, unknown>;
+
+			// A bare `{ "@id": … }` would be a dangling reference on a site with
+			// no Organization graph — worse than the anonymous node it replaces.
+			expect(publisher["@type"]).toBe("Organization");
+			expect(publisher.name).toBe("My Site");
+		});
+
+		it("gives the WebSite an @id so a plugin can extend it", () => {
+			const graph = buildWebSiteJsonLd(createPage({ pageType: "website" }));
+
+			expect(graph).toMatchObject({ "@id": "https://example.com#website" });
 		});
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Core emits `BlogPosting`, its `publisher`, and `WebSite` without an `@id`. In JSON-LD that makes each an anonymous node: nothing can point at it, and a fuller description of the same thing published alongside it stays a separate entity instead of merging into one.

The visible consequence is on article pages. A site that publishes an Organization graph — from a plugin, or hand-written in a template — ends up with **two organisations**: the rich one, and core's `{ "@type": "Organization", name }` inside `publisher`. A consumer cannot merge them, so the article's publisher is the node carrying nothing but a name, and every property the site took care to state is attached to something the article does not reference.

```jsonc
// today, on one article page
{ "@type": "BlogPosting", "publisher": { "@type": "Organization", "name": "Example" } }
{ "@type": "Organization", "@id": "https://example.com/#organization",
  "logo": …, "address": …, "vatID": …, "sameAs": […] }   // ← unrelated, as far as a consumer can tell
```

`WebSite` has the same problem from the other side: with no `@id` there is nowhere to attach a `potentialAction`, so adding a sitelinks `SearchAction` means emitting a second `WebSite` node and claiming the site is two sites.

This adds three ids, chosen to be joinable:

| Node | `@id` |
| --- | --- |
| `BlogPosting` | `<canonical>#article` — a fragment, because `mainEntityOfPage` already identifies the WebPage by the bare canonical and reusing it would state that the article and its page are one thing |
| `publisher` | `<origin>/#organization` — the conventional form, and the one `url.replace(/\/$/, "") + "/#organization"` already produces |
| `WebSite` | `<origin>#website` |

**The slash before the fragment is load-bearing.** `https://example.com#organization` and `https://example.com/#organization` are different IRIs, and a mismatch does not error — it publishes two organisations instead of one.

`publisher` keeps its `@type` and `name`. A bare `{ "@id": … }` would leave a dangling reference on every site that publishes no Organization graph, which is worse than the anonymous node it replaces. **Nothing changes for those sites.**

`buildWebSiteJsonLd` had the origin-resolution chain inline and `buildBlogPostingJsonLd` now needs the same answer, so it moves to a shared helper — two copies would eventually disagree, and for a value used to build an `@id` that means silently publishing two entities. Deliberately **not** `resolveSiteOrigin()` from `absolute-url.ts`: that gives `SiteSettings.url` precedence over `page.siteUrl`, which would change which origin these graphs carry. Plausibly an improvement, but a behaviour change that does not belong in a fix about node identity.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [x] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (via Claude Code)

## Screenshots / test output

Not applicable — no UI change.

Four tests added to `packages/core/tests/unit/plugins/page-seo.test.ts`. Three fail before the change; the fourth guards against the regression the obvious fix would introduce (a bare `@id` publisher losing its `@type`/`name`), and passes both before and after.

```
Test Files  1 failed (1)          # before
     Tests  3 failed | 11 passed (14)

Test Files  1 passed (1)          # after
     Tests  14 passed (14)
```

Full package suite:

```
Test Files  536 passed | 2 skipped (538)
     Tests  6442 passed | 10 skipped (6452)
```
