### PR TITLE
fix(core): respect seeded collections for default taxonomies

### DIFF
--- a/.changeset/fuzzy-wolves-filter.md
+++ b/.changeset/fuzzy-wolves-filter.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes default category and tag taxonomies ignoring a site's configured collections during initial seeding, which caused taxonomy filters to return no matching content for collections other than `posts`.

--- a/packages/core/src/seed/apply.ts
+++ b/packages/core/src/seed/apply.ts
@@ -68,6 +68,31 @@ const SANITIZE_PATTERN = /[^a-zA-Z0-9_-]/g;
 /** Pattern to collapse multiple hyphens */
 const MULTIPLE_HYPHENS_PATTERN = /-+/g;
 
+function isUntouchedBuiltInTaxonomy(definition: {
+	id: string;
+	name: string;
+	label: string;
+	label_singular: string | null;
+	hierarchical: number;
+	collections: string | null;
+}): boolean {
+	const expected =
+		definition.name === "category"
+			? { id: "taxdef_category", label: "Categories", labelSingular: "Category", hierarchical: 1 }
+			: definition.name === "tag"
+				? { id: "taxdef_tag", label: "Tags", labelSingular: "Tag", hierarchical: 0 }
+				: null;
+
+	return (
+		expected !== null &&
+		definition.id === expected.id &&
+		definition.label === expected.label &&
+		definition.label_singular === expected.labelSingular &&
+		definition.hierarchical === expected.hierarchical &&
+		definition.collections === '["posts"]'
+	);
+}
+
 /**
  * Apply a seed file to the database
  *
@@ -317,7 +342,7 @@ export async function applySeed(
 				if (onConflict === "error") {
 					throw new Error(`Conflict: taxonomy "${taxonomy.name}" (${defLocale}) already exists`);
 				}
-				if (onConflict === "update") {
+				if (onConflict === "update" || isUntouchedBuiltInTaxonomy(existingDef)) {
 					await db
 						.updateTable("_emdash_taxonomy_defs")
 						.set({

--- a/packages/core/tests/integration/seed-on-conflict.test.ts
+++ b/packages/core/tests/integration/seed-on-conflict.test.ts
@@ -132,6 +132,42 @@ describe("applySeed onConflict modes", () => {
 	});
 
 	describe("onConflict: skip (default)", () => {
+		it.each([
+			["category", "Categories", true],
+			["tag", "Tags", false],
+		] as const)(
+			"replaces the untouched built-in %s taxonomy definition",
+			async (name, label, builtInHierarchical) => {
+				const seed: SeedFile = {
+					version: "1",
+					taxonomies: [{ name, label, hierarchical: false, collections: ["projects"] }],
+				};
+
+				await applySeed(db, seed, { onConflict: "skip" });
+
+				const taxonomy = await db
+					.selectFrom("_emdash_taxonomy_defs")
+					.select(["collections", "hierarchical"])
+					.where("name", "=", name)
+					.executeTakeFirstOrThrow();
+				expect(taxonomy).toMatchObject({ collections: '["projects"]', hierarchical: 0 });
+
+				seed.taxonomies![0]!.collections = ["posts"];
+				seed.taxonomies![0]!.hierarchical = builtInHierarchical;
+				await applySeed(db, seed, { onConflict: "skip" });
+
+				const preservedTaxonomy = await db
+					.selectFrom("_emdash_taxonomy_defs")
+					.select(["collections", "hierarchical"])
+					.where("name", "=", name)
+					.executeTakeFirstOrThrow();
+				expect(preservedTaxonomy).toMatchObject({
+					collections: '["projects"]',
+					hierarchical: 0,
+				});
+			},
+		);
+
 		it("skips existing collections", async () => {
 			const seed = createTestSeed();
 			// First apply


### PR DESCRIPTION
## What does this PR do?

Allows a site's initial seed to replace the untouched built-in `category` and `tag` taxonomy definitions created by migrations. This ensures templates and custom sites can associate those taxonomies with collections other than `posts`, so taxonomy filtering returns the seeded collection's content.

Normal `onConflict: "skip"` behavior is preserved after a built-in definition has been configured.

Reported directly; no issue.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (not applicable: bug fix)
- [ ] I have included screenshots below if this PR changes the UI (not applicable: no UI changes)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode with GPT-5.6-sol

## Screenshots / test output

Not applicable; no UI changes.

`pnpm --filter emdash exec vitest run tests/integration/seed-on-conflict.test.ts` (23 tests passed)
