### PR TITLE
Fix snapshots and backups on PostgreSQL

### DIFF
--- a/.changeset/bright-snapshots-travel.md
+++ b/.changeset/bright-snapshots-travel.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes snapshot exports and content backups on PostgreSQL so preview snapshots, manual backups, and scheduled backups include the same content and portable schema metadata as SQLite.

--- a/packages/core/src/api/handlers/snapshot.ts
+++ b/packages/core/src/api/handlers/snapshot.ts
@@ -12,6 +12,7 @@
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 
+import { listTableColumns, listTablesLike } from "../../database/dialect-helpers.js";
 import type { Database } from "../../database/types.js";
 
 // ─�� Preview signature verification ──────────────────────────────
@@ -211,10 +212,44 @@ function isExcluded(tableName: string): boolean {
 	return EXCLUDED_PREFIXES.some((prefix) => tableName.startsWith(prefix));
 }
 
-/** Column info from PRAGMA table_info */
-interface ColumnInfo {
-	name: string;
-	type: string;
+type SnapshotColumnType = "TEXT" | "INTEGER" | "REAL" | "BLOB" | "JSON";
+
+function normalizeColumnType(type: string): SnapshotColumnType {
+	switch (type.toLowerCase()) {
+		case "smallint":
+		case "integer":
+		case "bigint":
+		case "boolean":
+			return "INTEGER";
+		case "real":
+		case "double precision":
+		case "numeric":
+		case "decimal":
+			return "REAL";
+		case "blob":
+		case "bytea":
+			return "BLOB";
+		case "json":
+		case "jsonb":
+			return "JSON";
+		default:
+			return "TEXT";
+	}
+}
+
+function normalizeRows(
+	rows: Record<string, unknown>[],
+	types: Record<string, SnapshotColumnType>,
+): Record<string, unknown>[] {
+	for (const row of rows) {
+		for (const [column, type] of Object.entries(types)) {
+			const value = row[column];
+			if (type === "JSON" && value !== null && value !== undefined && typeof value !== "string") {
+				row[column] = JSON.stringify(value);
+			}
+		}
+	}
+	return rows;
 }
 
 export interface GenerateSnapshotOptions {
@@ -247,15 +282,7 @@ export async function generateSnapshot(
 	const includeTrashed = options?.includeTrashed ?? false;
 	const optionPrefixes = options?.optionPrefixes ?? SAFE_OPTIONS_PREFIXES;
 
-	// Discover all ec_* content tables
-	const tableResult = await sql<{ name: string }>`
-		SELECT name FROM sqlite_master
-		WHERE type = 'table'
-		AND name LIKE 'ec_%'
-		ORDER BY name
-	`.execute(db);
-
-	const contentTables = tableResult.rows.map((r) => r.name);
+	const contentTables = await listTablesLike(db, "ec_%");
 
 	// Build list of all tables to export
 	const allTables = [...contentTables, ...SYSTEM_TABLES];
@@ -266,80 +293,65 @@ export async function generateSnapshot(
 	for (const tableName of allTables) {
 		if (isExcluded(tableName)) continue;
 
-		// Validate identifier before interpolating into sql.raw().
-		// SYSTEM_TABLES are hardcoded and safe, but ec_* names come from
-		// sqlite_master and must be validated.
+		// Content table names come from the database catalog. Validate them
+		// before passing them to sql.ref().
 		if (!SAFE_TABLE_NAME.test(tableName)) continue;
 
-		try {
-			// Get column info via PRAGMA
-			const pragmaResult = await sql<ColumnInfo>`
-				PRAGMA table_info(${sql.raw(`"${tableName}"`)})
-			`.execute(db);
+		const columnInfo = await listTableColumns(db, tableName);
+		if (columnInfo.length === 0) continue;
 
-			if (pragmaResult.rows.length === 0) continue;
+		const columns = columnInfo.map((column) => column.name);
+		const types: Record<string, SnapshotColumnType> = {};
+		for (const column of columnInfo) {
+			types[column.name] = normalizeColumnType(column.type);
+		}
 
-			const columns = pragmaResult.rows.map((r) => r.name);
-			const types: Record<string, string> = {};
-			for (const row of pragmaResult.rows) {
-				types[row.name] = row.type || "TEXT";
-			}
+		schema[tableName] = { columns, types };
 
-			schema[tableName] = { columns, types };
+		let rows: Record<string, unknown>[];
 
-			// Fetch rows
-			let rows: Record<string, unknown>[];
-
-			if (tableName.startsWith("ec_")) {
-				if (includeTrashed) {
-					// Everything, including trash — full-fidelity backup export
-					rows = (
-						await sql<Record<string, unknown>>`
-						SELECT * FROM ${sql.raw(`"${tableName}"`)}
-					`.execute(db)
-					).rows;
-				} else if (includeDrafts) {
-					// Include all non-deleted content (published, draft, scheduled)
-					rows = (
-						await sql<Record<string, unknown>>`
-						SELECT * FROM ${sql.raw(`"${tableName}"`)}
-						WHERE deleted_at IS NULL
-					`.execute(db)
-					).rows;
-				} else {
-					// Only export published content
-					rows = (
-						await sql<Record<string, unknown>>`
-						SELECT * FROM ${sql.raw(`"${tableName}"`)}
-						WHERE deleted_at IS NULL
-						AND status = 'published'
-					`.execute(db)
-					).rows;
-				}
-			} else if (tableName === "options") {
-				// Filter options to safe rendering-only prefixes.
-				// Excludes plugin secrets, passkey challenges, and setup state.
+		if (tableName.startsWith("ec_")) {
+			if (includeTrashed) {
 				rows = (
 					await sql<Record<string, unknown>>`
-					SELECT * FROM ${sql.raw(`"${tableName}"`)}
-				`.execute(db)
-				).rows.filter((row) => {
-					const name = typeof row.name === "string" ? row.name : "";
-					return optionPrefixes.some((prefix) => name.startsWith(prefix));
-				});
+						SELECT * FROM ${sql.ref(tableName)}
+					`.execute(db)
+				).rows;
+			} else if (includeDrafts) {
+				rows = (
+					await sql<Record<string, unknown>>`
+						SELECT * FROM ${sql.ref(tableName)}
+						WHERE deleted_at IS NULL
+					`.execute(db)
+				).rows;
 			} else {
 				rows = (
 					await sql<Record<string, unknown>>`
-					SELECT * FROM ${sql.raw(`"${tableName}"`)}
-				`.execute(db)
+						SELECT * FROM ${sql.ref(tableName)}
+						WHERE deleted_at IS NULL
+						AND status = 'published'
+					`.execute(db)
 				).rows;
 			}
+		} else if (tableName === "options") {
+			rows = (
+				await sql<Record<string, unknown>>`
+					SELECT * FROM ${sql.ref(tableName)}
+				`.execute(db)
+			).rows.filter((row) => {
+				const name = typeof row.name === "string" ? row.name : "";
+				return optionPrefixes.some((prefix) => name.startsWith(prefix));
+			});
+		} else {
+			rows = (
+				await sql<Record<string, unknown>>`
+					SELECT * FROM ${sql.ref(tableName)}
+				`.execute(db)
+			).rows;
+		}
 
-			if (rows.length > 0) {
-				tables[tableName] = rows;
-			}
-		} catch {
-			// Table might not exist yet (e.g. pre-migration) — skip silently
+		if (rows.length > 0) {
+			tables[tableName] = normalizeRows(rows, types);
 		}
 	}
 

--- a/packages/core/src/database/dialect-helpers.ts
+++ b/packages/core/src/database/dialect-helpers.ts
@@ -207,6 +207,7 @@ export async function listTablesLike(db: Kysely<any>, pattern: string): Promise<
 		const result = await sql<{ table_name: string }>`
 			SELECT table_name FROM information_schema.tables
 			WHERE table_schema = current_schema() AND table_name LIKE ${pattern}
+			ORDER BY table_name
 		`.execute(db);
 		return result.rows.map((r) => r.table_name);
 	}
@@ -214,8 +215,46 @@ export async function listTablesLike(db: Kysely<any>, pattern: string): Promise<
 	const result = await sql<{ name: string }>`
 		SELECT name FROM sqlite_master
 		WHERE type = 'table' AND name LIKE ${pattern}
+		ORDER BY name
 	`.execute(db);
 	return result.rows.map((r) => r.name);
+}
+
+export interface TableColumnInfo {
+	name: string;
+	type: string;
+}
+
+/**
+ * List a table's columns in declaration order.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
+export async function listTableColumns(
+	db: Kysely<any>,
+	tableName: string,
+): Promise<TableColumnInfo[]> {
+	if (isPostgres(db)) {
+		const result = await sql<{
+			column_name: string;
+			data_type: string;
+		}>`
+			SELECT column_name, data_type
+			FROM information_schema.columns
+			WHERE table_schema = current_schema() AND table_name = ${tableName}
+			ORDER BY ordinal_position
+		`.execute(db);
+		return result.rows.map((column) => ({
+			name: column.column_name,
+			type: column.data_type,
+		}));
+	}
+
+	const result = await sql<{ name: string; type: string }>`
+		SELECT name, type
+		FROM pragma_table_info(${tableName})
+		ORDER BY cid
+	`.execute(db);
+	return result.rows;
 }
 
 /**

--- a/packages/core/tests/integration/database/list-tables-like.test.ts
+++ b/packages/core/tests/integration/database/list-tables-like.test.ts
@@ -27,7 +27,7 @@ describeEachDialect("listTablesLike schema scoping", (dialect) => {
 
 	it("finds content tables in the active schema", async () => {
 		const tables = await listTablesLike(ctx.db, "ec_%");
-		expect(tables.toSorted()).toEqual(["ec_page", "ec_post"]);
+		expect(tables).toEqual(["ec_page", "ec_post"]);
 	});
 
 	it("returns an empty list when nothing matches the pattern", async () => {

--- a/packages/core/tests/integration/snapshot/snapshot-dialects.test.ts
+++ b/packages/core/tests/integration/snapshot/snapshot-dialects.test.ts
@@ -1,0 +1,171 @@
+import { sql } from "kysely";
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import {
+	BACKUP_STORAGE_PREFIX,
+	generateBackupJson,
+	maybeRunScheduledBackup,
+	runBackupToStorage,
+	updateBackupSettings,
+} from "../../../src/api/handlers/backup.js";
+import { generateSnapshot } from "../../../src/api/handlers/snapshot.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import type { DownloadResult, Storage } from "../../../src/storage/types.js";
+import {
+	type DialectTestContext,
+	describeEachDialect,
+	setupForDialectWithCollections,
+	teardownForDialect,
+} from "../../utils/test-db.js";
+
+interface StoredFile {
+	body: Uint8Array;
+	contentType: string;
+	lastModified: Date;
+}
+
+function createStorage(): Storage & { files: Map<string, StoredFile> } {
+	const files = new Map<string, StoredFile>();
+
+	return {
+		files,
+		async upload(options) {
+			if (!(options.body instanceof Uint8Array)) {
+				throw new Error("test storage only supports Uint8Array bodies");
+			}
+			files.set(options.key, {
+				body: options.body,
+				contentType: options.contentType,
+				lastModified: new Date(),
+			});
+			return { key: options.key, url: `test://${options.key}`, size: options.body.byteLength };
+		},
+		async download(key): Promise<DownloadResult> {
+			const file = files.get(key);
+			if (!file) throw new Error(`not found: ${key}`);
+			return {
+				body: new Blob([file.body]).stream(),
+				contentType: file.contentType,
+				size: file.body.byteLength,
+			};
+		},
+		async delete(key) {
+			files.delete(key);
+		},
+		async exists(key) {
+			return files.has(key);
+		},
+		async list(options) {
+			const prefix = options?.prefix ?? "";
+			return {
+				files: [...files.entries()]
+					.filter(([key]) => key.startsWith(prefix))
+					.map(([key, file]) => ({
+						key,
+						size: file.body.byteLength,
+						lastModified: file.lastModified,
+					})),
+			};
+		},
+		async getSignedUploadUrl() {
+			throw new Error("not implemented");
+		},
+		getPublicUrl(key) {
+			return `test://${key}`;
+		},
+	};
+}
+
+async function insertPost(
+	ctx: DialectTestContext,
+	input: { id: string; slug: string; status: string; deletedAt?: string },
+): Promise<void> {
+	const timestamp = "2026-07-25T12:00:00.000Z";
+	await sql`
+		INSERT INTO ec_post (
+			id, slug, status, title, content, rating, created_at, updated_at, deleted_at, version
+		)
+		VALUES (
+			${input.id}, ${input.slug}, ${input.status}, ${input.slug}, ${JSON.stringify([])}, 4.5,
+			${timestamp}, ${timestamp}, ${input.deletedAt ?? null}, 1
+		)
+	`.execute(ctx.db);
+}
+
+describeEachDialect("snapshot generation", (dialect) => {
+	let ctx: DialectTestContext;
+
+	beforeEach(async () => {
+		ctx = await setupForDialectWithCollections(dialect);
+		await new SchemaRegistry(ctx.db).createField("post", {
+			slug: "rating",
+			label: "Rating",
+			type: "number",
+		});
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it("exports preview content and portable schema types", async () => {
+		await insertPost(ctx, { id: "published", slug: "published", status: "published" });
+		await insertPost(ctx, { id: "draft", slug: "draft", status: "draft" });
+		await insertPost(ctx, { id: "scheduled", slug: "scheduled", status: "scheduled" });
+		await insertPost(ctx, {
+			id: "trashed",
+			slug: "trashed",
+			status: "published",
+			deletedAt: "2026-07-25T13:00:00.000Z",
+		});
+
+		const snapshot = await generateSnapshot(ctx.db);
+
+		expect(snapshot.tables.ec_post?.map((row) => row.slug)).toEqual(["published"]);
+		expect(snapshot.tables.ec_post?.[0]?.content).toBe(JSON.stringify([]));
+		expect(snapshot.tables.ec_page).toBeUndefined();
+		expect(snapshot.schema.ec_page?.columns).toContain("id");
+		expect(snapshot.schema.ec_post?.columns.slice(0, 3)).toEqual(["id", "slug", "status"]);
+		expect(snapshot.schema.ec_post?.columns.at(-1)).toBe("rating");
+		expect(snapshot.schema.ec_post?.types).toMatchObject({
+			id: "TEXT",
+			version: "INTEGER",
+			content: "JSON",
+			rating: "REAL",
+		});
+	});
+
+	it("exports full backups through manual and scheduled storage paths", async () => {
+		await insertPost(ctx, { id: "published", slug: "published", status: "published" });
+		await insertPost(ctx, { id: "draft", slug: "draft", status: "draft" });
+		await insertPost(ctx, { id: "scheduled", slug: "scheduled", status: "scheduled" });
+		await insertPost(ctx, {
+			id: "trashed",
+			slug: "trashed",
+			status: "published",
+			deletedAt: "2026-07-25T13:00:00.000Z",
+		});
+
+		const backup = JSON.parse(await generateBackupJson(ctx.db));
+		expect(backup.tables.ec_post.map((row: { slug: string }) => row.slug).toSorted()).toEqual([
+			"draft",
+			"published",
+			"scheduled",
+			"trashed",
+		]);
+
+		const manualStorage = createStorage();
+		const manual = await runBackupToStorage(ctx.db, manualStorage, 7);
+		expect(manual.success).toBe(true);
+		if (!manual.success) return;
+		const manualFile = manualStorage.files.get(`${BACKUP_STORAGE_PREFIX}${manual.data.name}`);
+		expect(JSON.parse(new TextDecoder().decode(manualFile?.body)).format).toBe("emdash-backup");
+
+		const scheduledStorage = createStorage();
+		await updateBackupSettings(ctx.db, { enabled: true, retention: 7 });
+		await maybeRunScheduledBackup(ctx.db, scheduledStorage);
+		expect(scheduledStorage.files.size).toBe(1);
+		const scheduledFile = [...scheduledStorage.files.values()][0];
+		expect(JSON.parse(new TextDecoder().decode(scheduledFile?.body)).format).toBe("emdash-backup");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes snapshot generation on PostgreSQL by using dialect-aware table and column discovery in the active schema. Snapshot column metadata is normalized to the portable SQLite types used by preview databases, PostgreSQL JSON values are serialized consistently, and existing-table export failures are no longer swallowed as partial snapshots.

The dialect-aware coverage exercises preview filtering, empty table schemas, draft/scheduled/trashed backup content, manual archive creation, and scheduled archive creation against SQLite and PostgreSQL 16.

Closes #2233

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (not applicable: no admin UI strings changed)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: not applicable; this is a bug fix
- [x] I have included screenshots below if this PR changes the UI (not applicable: no UI changed)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI GPT-5 (Codex)

## Screenshots / test output

Screenshots are not applicable because this PR does not change the UI.

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm --filter emdash test --run` — 6,512 passed, 10 skipped
- `EMDASH_TEST_PG=<PostgreSQL 16 test database> pnpm --filter emdash test --run tests/integration/snapshot/snapshot-dialects.test.ts tests/integration/database/list-tables-like.test.ts` — 8 passed across SQLite and PostgreSQL
