### PR TITLE
fix(cloudflare): preserve plugin storage rows on unique conflicts

### DIFF
--- a/.changeset/quiet-maps-stay.md
+++ b/.changeset/quiet-maps-stay.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/cloudflare": patch
+---
+
+Fixes sandboxed plugin `ctx.kv.set()`, collection `put()`, and `putMany()` writes on Cloudflare D1 to preserve creation timestamps when overwriting keys. Unique constraint conflicts reject the write and retain the existing record. `putMany()` keeps writes completed before a failing item.

--- a/packages/cloudflare/src/sandbox/bridge.ts
+++ b/packages/cloudflare/src/sandbox/bridge.ts
@@ -289,7 +289,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 	async kvSet(key: string, value: unknown): Promise<void> {
 		const { pluginId } = this.ctx.props;
 		await this.env.DB.prepare(
-			"INSERT OR REPLACE INTO _plugin_storage (plugin_id, collection, id, data, updated_at) VALUES (?, '__kv', ?, ?, datetime('now'))",
+			"INSERT INTO _plugin_storage (plugin_id, collection, id, data, updated_at) VALUES (?, '__kv', ?, ?, datetime('now')) ON CONFLICT (plugin_id, collection, id) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at",
 		)
 			.bind(pluginId, key, JSON.stringify(value))
 			.run();
@@ -343,7 +343,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 			throw new Error(`Storage collection not declared: ${collection}`);
 		}
 		await this.env.DB.prepare(
-			"INSERT OR REPLACE INTO _plugin_storage (plugin_id, collection, id, data, updated_at) VALUES (?, ?, ?, ?, datetime('now'))",
+			"INSERT INTO _plugin_storage (plugin_id, collection, id, data, updated_at) VALUES (?, ?, ?, ?, datetime('now')) ON CONFLICT (plugin_id, collection, id) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at",
 		)
 			.bind(pluginId, collection, id, JSON.stringify(data))
 			.run();
@@ -440,7 +440,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 		// In future, we could use batch API
 		for (const item of items) {
 			await this.env.DB.prepare(
-				"INSERT OR REPLACE INTO _plugin_storage (plugin_id, collection, id, data, updated_at) VALUES (?, ?, ?, ?, datetime('now'))",
+				"INSERT INTO _plugin_storage (plugin_id, collection, id, data, updated_at) VALUES (?, ?, ?, ?, datetime('now')) ON CONFLICT (plugin_id, collection, id) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at",
 			)
 				.bind(pluginId, collection, item.id, JSON.stringify(item.data))
 				.run();

--- a/packages/core/tests/workerd/fixtures/plugin-storage-worker.ts
+++ b/packages/core/tests/workerd/fixtures/plugin-storage-worker.ts
@@ -1,0 +1,3 @@
+import { PluginBridge as StorageBridge } from "../../../../cloudflare/src/sandbox/bridge.js";
+
+export class PluginBridge extends StorageBridge {}

--- a/packages/core/tests/workerd/plugin-storage-upserts-d1.test.ts
+++ b/packages/core/tests/workerd/plugin-storage-upserts-d1.test.ts
@@ -1,0 +1,179 @@
+import { env, exports as workerExports } from "cloudflare:workers";
+import { Kysely, sql } from "kysely";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { RawBindingD1Dialect } from "../../../cloudflare/src/db/d1-dialect.js";
+import { up } from "../../src/database/migrations/004_plugins.js";
+import type { Database } from "../../src/database/types.js";
+import { resetD1Schema } from "./d1-schema.js";
+
+declare global {
+	namespace Cloudflare {
+		interface Env {
+			DB: D1Database;
+		}
+		interface GlobalProps {
+			mainModule: typeof import("./fixtures/plugin-storage-worker.js");
+		}
+	}
+}
+
+let db: Kysely<Database>;
+
+beforeAll(() => {
+	db = new Kysely<Database>({ dialect: new RawBindingD1Dialect({ database: env.DB }) });
+});
+
+beforeEach(async () => {
+	await resetD1Schema(db);
+	await up(db);
+});
+
+afterAll(async () => {
+	await db.destroy();
+});
+
+function bridge(pluginId = "owner") {
+	return workerExports.PluginBridge({
+		props: {
+			pluginId,
+			pluginVersion: "1.0.0",
+			capabilities: [],
+			allowedHosts: [],
+			storageCollections: ["records", "settings"],
+		},
+	});
+}
+
+type WriteMethod = "kvSet" | "storagePut" | "storagePutMany";
+
+async function put(method: WriteMethod, id: string, data: unknown): Promise<void> {
+	const rpc = bridge();
+	if (method === "kvSet") {
+		await rpc.kvSet(id, data);
+	} else if (method === "storagePut") {
+		await rpc.storagePut("records", id, data);
+	} else {
+		await rpc.storagePutMany("records", [{ id, data }]);
+	}
+}
+
+interface StorageRow {
+	plugin_id: string;
+	collection: string;
+	id: string;
+	data: string;
+	created_at: string;
+	updated_at: string;
+}
+
+async function rows(): Promise<StorageRow[]> {
+	const result = await sql<StorageRow>`
+		SELECT plugin_id, collection, id, data, created_at, updated_at
+		FROM _plugin_storage
+		ORDER BY plugin_id, collection, id
+	`.execute(db);
+	return result.rows;
+}
+
+async function addUniqueValueIndex(): Promise<void> {
+	await sql`
+		CREATE UNIQUE INDEX unique_plugin_storage_value
+		ON _plugin_storage (plugin_id, collection, data)
+	`.execute(db);
+}
+
+describe("plugin storage upserts through Cloudflare RPC and D1", () => {
+	for (const method of ["kvSet", "storagePut", "storagePutMany"] as const) {
+		it(`${method} preserves created_at when overwriting a row`, async () => {
+			await put(method, "record", { value: "initial" });
+			await sql`
+				UPDATE _plugin_storage
+				SET created_at = '2020-01-01 00:00:00', updated_at = '2020-01-02 00:00:00'
+			`.execute(db);
+			const [before] = await rows();
+
+			await put(method, "record", { value: "updated" });
+
+			expect(await rows()).toEqual([
+				{
+					...before,
+					data: JSON.stringify({ value: "updated" }),
+					created_at: "2020-01-01 00:00:00",
+					updated_at: expect.any(String),
+				},
+			]);
+			expect((await rows())[0]?.updated_at).not.toBe(before?.updated_at);
+		});
+
+		it(`${method} rejects unique collisions and preserves existing rows`, async () => {
+			await addUniqueValueIndex();
+			await put(method, "first", "unique");
+			await put(method, "second", "other");
+			const before = await rows();
+
+			for (const id of ["third", "second"]) {
+				await expect(put(method, id, "unique")).rejects.toThrow();
+				expect(await rows()).toEqual(before);
+			}
+		});
+	}
+
+	it("storagePutMany inserts and overwrites items in order", async () => {
+		const rpc = bridge();
+		await rpc.storagePut("records", "existing", "initial");
+		await sql`UPDATE _plugin_storage SET created_at = '2020-01-01 00:00:00'`.execute(db);
+
+		await rpc.storagePutMany("records", [
+			{ id: "existing", data: "updated" },
+			{ id: "fresh", data: "first" },
+			{ id: "fresh", data: "last" },
+		]);
+
+		expect(await rpc.storageGet("records", "existing")).toBe("updated");
+		expect(await rpc.storageGet("records", "fresh")).toBe("last");
+		expect(await rows()).toEqual([
+			expect.objectContaining({ id: "existing", created_at: "2020-01-01 00:00:00" }),
+			expect.objectContaining({ id: "fresh" }),
+		]);
+	});
+
+	it("storagePutMany stops on a unique collision and keeps completed writes", async () => {
+		const rpc = bridge();
+		await addUniqueValueIndex();
+		await rpc.storagePut("records", "existing", "initial");
+		await rpc.storagePut("records", "reserved", "unique");
+		const before = await rows();
+
+		async function putMany(): Promise<void> {
+			await rpc.storagePutMany("records", [
+				{ id: "existing", data: "updated" },
+				{ id: "collision", data: "unique" },
+				{ id: "later", data: "unreached" },
+			]);
+		}
+		await expect(putMany()).rejects.toThrow();
+
+		expect(await rows()).toEqual([
+			{ ...before[0], data: JSON.stringify("updated"), updated_at: expect.any(String) },
+			before[1],
+		]);
+	});
+
+	it("writes only the matching plugin, collection, and key", async () => {
+		const owner = bridge();
+		const other = bridge("other");
+		await owner.kvSet("record", "kv");
+		await owner.storagePut("records", "record", "record");
+		await owner.storagePut("settings", "record", "setting");
+		await other.storagePut("records", "record", "other plugin");
+
+		await owner.storagePutMany("records", [{ id: "record", data: "updated record" }]);
+		await owner.kvSet("record", "updated kv");
+
+		expect(await owner.kvGet("record")).toBe("updated kv");
+		expect(await owner.storageGet("records", "record")).toBe("updated record");
+		expect(await owner.storageGet("settings", "record")).toBe("setting");
+		expect(await other.storageGet("records", "record")).toBe("other plugin");
+	});
+});

--- a/packages/core/vitest.workerd.config.ts
+++ b/packages/core/vitest.workerd.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
 			},
 		},
 		cloudflareTest({
+			main: "./tests/workerd/fixtures/plugin-storage-worker.ts",
 			miniflare: {
 				compatibilityDate: "2026-05-14",
 				compatibilityFlags: ["nodejs_compat"],


### PR DESCRIPTION
## What does this PR do?

Cloudflare plugin storage writes can delete another record when a value collides with a unique constraint. Overwriting an existing key also resets its creation timestamp.

This changes `ctx.kv.set()`, collection `put()` and `putMany()` to update only the matching plugin, collection and key. Unique conflicts reject the write and preserve existing records. Successful overwrites retain `created_at`. If an item in `putMany()` fails, earlier completed writes remain stored.

## Type of change

- [x] Bug fix
- [ ] Feature (requires maintainer approval through a Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md).
- [x] Workspace typechecks pass.
- [x] Full type-aware lint passes.
- [x] Targeted tests pass on the affected runtime.
- [x] Changed files have been formatted.
- [x] I have added tests for the changes.
- [ ] User-visible admin strings are wrapped for translation: not applicable; no admin UI changes.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md).
- [ ] New features link to an approved Discussion: not applicable; this fixes existing write behavior.
- [ ] Screenshots are included for UI changes: not applicable.

## AI-generated code disclosure

- [x] This PR includes AI-generated code. GPT-5.6.

## Screenshots / test output

Screenshots: not applicable; no UI changes.

Targeted D1 tests cover creation timestamps, unique conflicts, batch behavior and namespace isolation. The regression tests reproduce the failures on the unchanged base.
