### PR TITLE
docs: refresh site composition guides

### DIFF
--- a/docs/src/content/docs/guides/dark-mode.mdx
+++ b/docs/src/content/docs/guides/dark-mode.mdx
@@ -59,7 +59,7 @@ In the admin, open **Content Types**, edit the image field, and switch on **Dark
 
 In a seed file, set the `darkVariant` widget option on the field:
 
-```json title="seed/seed.json"
+```json title=".emdash/seed.json"
 {
 	"slug": "featured_image",
 	"label": "Featured Image",
@@ -88,13 +88,23 @@ The `Image` component renders both images when the value carries a `darkVariant`
 
 ```astro title="src/pages/posts/[slug].astro"
 ---
+import { decodeSlug, getEmDashEntry } from "emdash";
 import { Image } from "emdash/ui";
-import { getEmDashEntry } from "emdash";
 
-const { entry: post } = await getEmDashEntry("posts", Astro.params.slug);
+const slug = decodeSlug(Astro.params.slug);
+
+if (!slug) {
+  return Astro.redirect("/404");
+}
+
+const { entry: post } = await getEmDashEntry("posts", slug);
+
+if (!post) {
+  return Astro.redirect("/404");
+}
 ---
 
-{post?.data.featured_image && <Image image={post.data.featured_image} priority />}
+{post.data.featured_image && <Image image={post.data.featured_image} priority />}
 ```
 
 The output contains two `<img>` elements. The primary image gets the class `emdash-image--light` and the variant gets `emdash-image--dark`. Both use the primary image's `alt` text, width and height overrides, and loading attributes. Each keeps its own placeholder color.

--- a/docs/src/content/docs/guides/menus.mdx
+++ b/docs/src/content/docs/guides/menus.mdx
@@ -1,281 +1,128 @@
 ---
 title: Navigation Menus
-description: Create and manage navigation menus for headers, footers, and sidebars.
+description: Create menus in the admin and render locale-aware navigation in an Astro layout.
 ---
 
-import { Aside, Steps, Tabs, TabItem, Code } from "@astrojs/starlight/components";
+import { Aside, Steps } from "@astrojs/starlight/components";
 
-EmDash menus are ordered lists of links that you manage through the admin interface. Menus support nesting for dropdowns and can link to pages, posts, taxonomy terms, or external URLs.
+Menus let editors manage ordered links without changing a site template. A menu has a stable name, such as `primary` or `footer`, and a separate set of items for each translated menu.
 
-## Querying Menus
+## Create a menu
 
-Use `getMenu()` to fetch a menu by its unique name:
+Create and arrange menus in **Menus** in the EmDash admin.
+
+<Steps>
+
+1. Click **Create Menu** and enter a name and label. Templates query the name, while the label identifies the menu in the admin.
+
+2. Click **Add Content** to link an entry, or **Add Custom Link** to enter an external URL or a root-relative site path.
+
+3. Use **Move up** and **Move down** to set the order. Edit an item and choose a **Parent** to nest it.
+
+</Steps>
+
+Use the same menu name in every locale. On a multilingual site, open a menu and use its **Translations** panel to create and edit the other locale versions. EmDash keeps the translations of the same content or taxonomy term connected, so `getMenu()` can use the label and slug for the requested locale.
+
+## How menu links resolve
+
+Content and taxonomy menu items store a reference rather than a finished URL. When a template calls `getMenu()`, EmDash resolves that reference using the current collection and locale data.
+
+| Menu item kind | URL returned to the template |
+| -------------- | ---------------------------- |
+| Content entry | The collection's `urlPattern`, or `/{collection}/{slug}` when the collection has no pattern |
+| Taxonomy term | `/{taxonomy}/{slug}` using the resolved term translation |
+| Collection archive | `/{collection}/` |
+| Custom link | The external URL or root-relative path entered by the editor |
+
+Each returned item also contains its label, optional target, title attribute, CSS classes, and nested `children`. The rendering example below uses those values directly.
+
+## Render a menu
+
+Call `getMenu()` in a server-rendered Astro component. It returns `null` when the name does not exist.
+
+The following layout renders a primary menu and one level of nested items:
 
 ```astro title="src/layouts/Base.astro"
 ---
 import { getMenu } from "emdash";
+import { getRelativeLocaleUrl } from "astro:i18n";
 
-const primaryMenu = await getMenu("primary");
+const locale = Astro.currentLocale;
+const menu = await getMenu("primary", { locale });
+
+function menuHref(url: string) {
+  return locale && url.startsWith("/")
+    ? getRelativeLocaleUrl(locale, url)
+    : url;
+}
 ---
 
-{primaryMenu && (
-  <nav>
+{menu && menu.items.length > 0 && (
+  <nav aria-label="Primary navigation">
     <ul>
-      {primaryMenu.items.map(item => (
-        <li>
-          <a href={item.url}>{item.label}</a>
-        </li>
-      ))}
+      {menu.items.map((item) => {
+        const href = menuHref(item.url);
+
+        return (
+          <li class:list={item.cssClasses}>
+            <a
+              href={href}
+              target={item.target}
+              rel={item.target === "_blank" ? "noopener noreferrer" : undefined}
+              title={item.titleAttr}
+              aria-current={Astro.url.pathname === href ? "page" : undefined}
+            >
+              {item.label}
+            </a>
+
+            {item.children.length > 0 && (
+              <ul>
+                {item.children.map((child) => {
+                  const childHref = menuHref(child.url);
+
+                  return (
+                    <li class:list={child.cssClasses}>
+                      <a
+                        href={childHref}
+                        target={child.target}
+                        rel={child.target === "_blank" ? "noopener noreferrer" : undefined}
+                        title={child.titleAttr}
+                        aria-current={Astro.url.pathname === childHref ? "page" : undefined}
+                      >
+                        {child.label}
+                      </a>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </li>
+        );
+      })}
     </ul>
   </nav>
 )}
 ```
 
-The function returns `null` if no menu exists with that name.
+`getMenu()` chooses the explicit `locale` first, then the current request locale, then the configured default locale. If a menu or referenced entry is missing in that locale, lookup follows the configured fallback chain.
 
-## Menu Structure
+Menu item URLs contain the collection URL pattern or taxonomy path, but they do not contain Astro's locale prefix. The `menuHref()` helper adds that prefix to root-relative links and leaves external links unchanged.
 
-A menu contains metadata and an array of items:
+The example renders one child level, which covers a typical dropdown. If editors can create deeper navigation, move the item markup into a recursive component that renders each item's `children` with the same rules.
 
-```ts
-interface Menu {
-	id: string;
-	name: string; // Unique identifier ("primary", "footer")
-	label: string; // Display name ("Primary Navigation")
-	items: MenuItem[];
-}
-
-interface MenuItem {
-	id: string;
-	label: string;
-	url: string; // Resolved URL
-	target?: string; // "_blank" for new window
-	titleAttr?: string; // HTML title attribute
-	cssClasses?: string; // Custom CSS classes
-	children: MenuItem[]; // Nested items for dropdowns
-}
-```
-
-URLs are resolved automatically based on the item type:
-
-- **Page/Post items** resolve to `/{collection}/{slug}`
-- **Taxonomy items** resolve to `/{taxonomy}/{slug}`
-- **Collection items** resolve to `/{collection}/`
-- **Custom links** use the URL as-is
-
-## Rendering Nested Menus
-
-Menu items can have children for dropdown navigation. Handle nesting by recursively rendering the `children` array:
-
-```astro title="src/components/Navigation.astro"
----
-import { getMenu } from "emdash";
-import type { MenuItem } from "emdash";
-
-interface Props {
-  name: string;
-}
-
-const menu = await getMenu(Astro.props.name);
----
-
-{menu && (
-  <nav class="nav">
-    <ul class="nav-list">
-      {menu.items.map(item => (
-        <li class:list={["nav-item", item.cssClasses]}>
-          <a
-            href={item.url}
-            target={item.target}
-            title={item.titleAttr}
-            aria-current={Astro.url.pathname === item.url ? "page" : undefined}
-          >
-            {item.label}
-          </a>
-          {item.children.length > 0 && (
-            <ul class="submenu">
-              {item.children.map(child => (
-                <li>
-                  <a href={child.url} target={child.target}>
-                    {child.label}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          )}
-        </li>
-      ))}
-    </ul>
-  </nav>
-)}
-```
-
-<Aside>
-	Use `aria-current="page"` to indicate the current page in navigation. Screen readers announce
-	this, and the `[aria-current="page"]` CSS selector enables styling the active link.
+<Aside type="tip">
+	Use `aria-current="page"` on the active link. Screen readers announce the current page, and the
+	attribute also provides a stable styling hook.
 </Aside>
 
-## Menu Item Types
+## Use menus in widget areas
 
-The admin supports five types of menu items:
+A menu widget places an existing menu inside a [widget area](/guides/widgets/). The widget reads the menu for the current request locale. Use the direct rendering pattern above when the site needs custom nested markup or explicit locale URL handling.
 
-| Type         | Description                  | URL Resolution         |
-| ------------ | ---------------------------- | ---------------------- |
-| `page`       | Link to a page               | `/{collection}/{slug}` |
-| `post`       | Link to a post               | `/{collection}/{slug}` |
-| `taxonomy`   | Link to a category or tag    | `/{taxonomy}/{slug}`   |
-| `collection` | Link to a collection archive | `/{collection}/`       |
-| `custom`     | External or custom URL       | Used as-is             |
+## Query menu data directly
 
-## Listing All Menus
+Use `getMenus()` when a template needs the available menu definitions rather than one menu's items. The [runtime API reference](/reference/api/#menus) documents the query signatures and return values.
 
-Use `getMenus()` to retrieve all menu definitions (without items):
+For programmatic menu changes, authenticate with a Bearer token and add `X-EmDash-Request: 1` to every state-changing request. See the [menu endpoints](/reference/rest-api/#menu-endpoints) for request bodies and responses.
 
-```ts
-import { getMenus } from "emdash";
-
-const menus = await getMenus();
-// Returns: [{ id, name, label, locale }, ...]
-```
-
-This is primarily useful for admin interfaces or debugging.
-
-## Creating Menus
-
-Create menus through the admin interface at `/_emdash/admin/menus`, or use the admin API:
-
-```http
-POST /_emdash/api/menus
-Content-Type: application/json
-
-{
-  "name": "footer",
-  "label": "Footer Navigation"
-}
-```
-
-Add items to a menu:
-
-```http
-POST /_emdash/api/menus/footer/items
-Content-Type: application/json
-
-{
-  "type": "page",
-  "referenceCollection": "pages",
-  "referenceId": "page_privacy",
-  "label": "Privacy Policy"
-}
-```
-
-Add a custom external link:
-
-```http
-POST /_emdash/api/menus/footer/items
-Content-Type: application/json
-
-{
-  "type": "custom",
-  "customUrl": "https://github.com/example",
-  "label": "GitHub",
-  "target": "_blank"
-}
-```
-
-## Reordering and Nesting
-
-Update item order and parent-child relationships with the reorder endpoint:
-
-```http
-POST /_emdash/api/menus/primary/reorder
-Content-Type: application/json
-
-{
-  "items": [
-    { "id": "item_1", "parentId": null, "sortOrder": 0 },
-    { "id": "item_2", "parentId": null, "sortOrder": 1 },
-    { "id": "item_3", "parentId": "item_2", "sortOrder": 0 }
-  ]
-}
-```
-
-This makes `item_3` a child of `item_2`, creating a dropdown.
-
-## Complete Example
-
-The following example shows a responsive header with primary navigation:
-
-```astro title="src/layouts/Base.astro"
----
-import { getMenu, getSiteSettings } from "emdash";
-
-const settings = await getSiteSettings();
-const primaryMenu = await getMenu("primary");
----
-
-<html lang="en">
-  <head>
-    <title>{settings.title}</title>
-  </head>
-  <body>
-    <header class="header">
-      <a href="/" class="logo">
-        {settings.logo ? (
-          <img src={settings.logo.url} alt={settings.logo.alt || settings.title} />
-        ) : (
-          settings.title
-        )}
-      </a>
-
-      {primaryMenu && (
-        <nav class="main-nav" aria-label="Main navigation">
-          <ul>
-            {primaryMenu.items.map(item => (
-              <li class:list={[item.cssClasses, { "has-children": item.children.length > 0 }]}>
-                <a
-                  href={item.url}
-                  target={item.target}
-                  aria-current={Astro.url.pathname === item.url ? "page" : undefined}
-                >
-                  {item.label}
-                </a>
-                {item.children.length > 0 && (
-                  <ul class="dropdown">
-                    {item.children.map(child => (
-                      <li>
-                        <a href={child.url} target={child.target}>{child.label}</a>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </li>
-            ))}
-          </ul>
-        </nav>
-      )}
-    </header>
-
-    <main>
-      <slot />
-    </main>
-  </body>
-</html>
-```
-
-## API Reference
-
-### `getMenu(name)`
-
-Fetch a menu by name with all items and resolved URLs.
-
-**Parameters:**
-
-- `name` — The menu's unique identifier (string)
-
-**Returns:** `Promise<Menu | null>`
-
-### `getMenus()`
-
-List all menu definitions without items.
-
-**Returns:** `Promise<Array<{ id: string; name: string; label: string; locale: string }>>`
+See [Internationalization](/guides/internationalization/) for locale routing and fallback configuration.

--- a/docs/src/content/docs/guides/page-layouts.mdx
+++ b/docs/src/content/docs/guides/page-layouts.mdx
@@ -3,9 +3,9 @@ title: Page Layouts
 description: Let editors choose different layouts for individual pages using a template field.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Aside } from "@astrojs/starlight/components";
 
-Let editors pick a layout per page (e.g. Default, Full Width, Landing Page) from a dropdown in the editor, using a `select` field mapped to layout components in your page route.
+Let editors pick a layout per page, for example Default, Full Width, or Landing Page. A `select` field stores the choice, and the page route maps that value to an Astro layout component.
 
 ## How it works
 
@@ -17,7 +17,7 @@ This uses EmDash's select field and Astro's component model.
 
 ## Add the field
 
-In the admin UI, add a select field to your pages collection with slug `template` and your layout options (e.g. "Default", "Full Width"). Or include it in your seed data:
+In the admin UI, add a select field to your pages collection with slug `template` and your layout options (for example, "Default" and "Full Width"). To define the same field in seed data, add the following object to the collection's `fields` array:
 
 ```json title=".emdash/seed.json"
 {
@@ -37,12 +37,12 @@ Each layout wraps content in your base layout with different styling:
 
 ```astro title="src/layouts/PageDefault.astro"
 ---
-import type { ContentEntry } from "emdash";
+import type { ContentEntry, InferCollectionData } from "emdash";
 import { PortableText } from "emdash/ui";
 import Base from "./Base.astro";
 
 interface Props {
-  page: ContentEntry<any>;
+  page: ContentEntry<InferCollectionData<"pages">>;
 }
 
 const { page } = Astro.props;
@@ -66,12 +66,12 @@ const { page } = Astro.props;
 
 ```astro title="src/layouts/PageFullWidth.astro"
 ---
-import type { ContentEntry } from "emdash";
+import type { ContentEntry, InferCollectionData } from "emdash";
 import { PortableText } from "emdash/ui";
 import Base from "./Base.astro";
 
 interface Props {
-  page: ContentEntry<any>;
+  page: ContentEntry<InferCollectionData<"pages">>;
 }
 
 const { page } = Astro.props;
@@ -99,11 +99,11 @@ In your page route, import each layout and map the template value:
 
 ```astro title="src/pages/pages/[slug].astro"
 ---
-import { getEmDashEntry } from "emdash";
+import { decodeSlug, getEmDashEntry } from "emdash";
 import PageDefault from "../../layouts/PageDefault.astro";
 import PageFullWidth from "../../layouts/PageFullWidth.astro";
 
-const { slug } = Astro.params;
+const slug = decodeSlug(Astro.params.slug);
 
 if (!slug) {
   return Astro.redirect("/404");
@@ -115,12 +115,12 @@ if (!page) {
   return Astro.redirect("/404");
 }
 
-const layouts = {
-  "Default": PageDefault,
-  "Full Width": PageFullWidth,
-};
+const layouts = new Map([
+  ["Default", PageDefault],
+  ["Full Width", PageFullWidth],
+]);
 
-const Layout = layouts[page.data.template as keyof typeof layouts] ?? PageDefault;
+const Layout = layouts.get(page.data.template ?? "") ?? PageDefault;
 ---
 
 <Layout page={page} />
@@ -129,7 +129,8 @@ const Layout = layouts[page.data.template as keyof typeof layouts] ?? PageDefaul
 The route stays small. Each layout component owns its own markup and styling. Adding a layout is: create a component, add the option to the select field, add a line to the map.
 
 <Aside type="tip">
-Use human-readable option names like "Full Width" rather than slugs like "full-width". The value is both the stored value and the admin dropdown label.
+	Use human-readable option names like "Full Width" rather than slugs like "full-width". The value
+	is both the stored value and the admin dropdown label.
 </Aside>
 
 ## Adding more layouts
@@ -139,6 +140,6 @@ Common layout choices:
 - **Default** — narrow content column, good for reading
 - **Full Width** — wider content area, no sidebar
 - **Landing Page** — no header/footer, hero sections
-- **Sidebar** — content with a sidebar widget area
+- **Sidebar** — content with a [widget area](/guides/widgets/) beside it
 
 Each is just another Astro component in your `src/layouts/` directory and another entry in the route's layout map.

--- a/docs/src/content/docs/guides/sections.mdx
+++ b/docs/src/content/docs/guides/sections.mdx
@@ -1,146 +1,88 @@
 ---
 title: Sections
-description: Create and use reusable content blocks across your site.
+description: Create reusable Portable Text blocks and insert independent copies into content.
 ---
 
-import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Steps } from "@astrojs/starlight/components";
 
-Sections are reusable content blocks that editors can insert into any content via slash commands. Use them for common patterns like CTAs, testimonials, feature grids, or any content that appears across multiple pages.
+Sections are reusable groups of Portable Text blocks. Editors can insert them into any Portable Text field, then change the inserted blocks without changing the source section.
 
-## Querying Sections
+Use sections for repeatable starting points such as a call to action, an author biography, or a standard notice. Use a [widget area](/guides/widgets/) when one centrally managed value should update everywhere it appears.
 
-### getSection
+## Create a section
 
-The following example fetches a single section by slug:
-
-```typescript
-import { getSection } from "emdash";
-
-const cta = await getSection("newsletter-cta");
-
-if (cta) {
-  console.log(cta.title);    // "Newsletter CTA"
-  console.log(cta.content);  // PortableTextBlock[]
-}
-```
-
-### getSections
-
-The following example fetches multiple sections with optional filters:
-
-```typescript
-import { getSections } from "emdash";
-
-// Get all sections
-const { items: all } = await getSections();
-
-// Filter by source
-const { items: themeSections } = await getSections({ source: "theme" });
-
-// Search by title/keywords
-const { items: results } = await getSections({ search: "newsletter" });
-```
-
-`getSections` returns `{ items: Section[], nextCursor?: string }` following the standard pagination pattern.
-
-## Section Structure
-
-A section has the following shape:
-
-```typescript
-interface Section {
-  id: string;
-  slug: string;
-  title: string;
-  description?: string;
-  keywords: string[];
-  content: PortableTextBlock[];
-  previewUrl?: string;
-  source: "theme" | "user" | "import";
-  themeId?: string;
-  createdAt: string;
-  updatedAt: string;
-}
-```
-
-### Source Types
-
-| Source   | Description                                      |
-| -------- | ------------------------------------------------ |
-| `theme`  | Defined in seed file, managed by theme           |
-| `user`   | Created by editors in admin                      |
-| `import` | Imported from WordPress (reusable blocks)        |
-
-## Using Sections in Content
-
-Editors insert sections using the `/section` slash command in the rich text editor.
+Create and manage sections in **Sections** in the EmDash admin.
 
 <Steps>
 
-1. Type `/section` (or `/pattern`, `/block`, `/template`)
+1. Click **New Section** and enter a title, slug, and optional description.
 
-2. Search or browse available sections
+2. Add the content that editors should receive when they insert the section.
 
-3. Click to insert the section's content at the cursor position
+3. Add search keywords for terms that editors may use when looking for the section.
+
+4. Save the section.
 
 </Steps>
 
-The section's Portable Text content is copied into the document. The inserted content is self-contained: editors can customize it, and later changes to the section do not affect copies already placed in content.
+Section slugs contain lowercase letters, numbers, and hyphens. The slug identifies the section in templates and in the API; it is not a public page URL.
 
-<Aside type="tip">
-  For content that should stay synchronized, consider using [Widget Areas](/guides/widgets/) with component widgets instead.
-</Aside>
+## Insert a section into content
 
-## Creating Sections
+<Steps>
 
-### In the Admin UI
+1. Put the cursor in a Portable Text field and type `/section`.
 
-1. Navigate to **Sections** in the admin sidebar
+2. Search for the section by title, description, or keyword.
 
-2. Click **New Section**
+3. Select the section to insert its blocks at the cursor.
 
-3. Fill in:
-   - **Title** - Display name for the section
-   - **Slug** - URL identifier (auto-generated from title)
-   - **Description** - Help text for editors
+4. Edit the inserted content as needed, then save the entry.
 
-4. Add content using the rich text editor
+</Steps>
 
-5. Optionally set keywords for easier discovery
+The editor copies the section's Portable Text into the entry. Later edits to the library section do not change copies that have already been inserted.
 
-### Via Seed Files
+## Provide sections in a seed file
 
-The following seed file defines two sections for a theme:
+A theme or starter can provide sections in its seed file. Give every Portable Text block and span a stable `_key`, as in other seeded content.
+
+The following seed file adds a newsletter section:
 
 ```json title=".emdash/seed.json"
 {
+  "version": "1",
   "sections": [
     {
-      "slug": "hero-centered",
-      "title": "Centered Hero",
-      "description": "Full-width hero with centered heading and CTA",
-      "keywords": ["hero", "banner", "header"],
+      "slug": "newsletter-signup",
+      "title": "Newsletter signup",
+      "description": "A short newsletter call to action",
+      "keywords": ["newsletter", "subscribe", "email"],
+      "source": "theme",
       "content": [
         {
           "_type": "block",
-          "style": "h1",
-          "children": [{ "_type": "span", "text": "Welcome to Our Site" }]
+          "_key": "newsletter-heading",
+          "style": "h3",
+          "children": [
+            {
+              "_type": "span",
+              "_key": "newsletter-heading-text",
+              "text": "Receive new articles by email"
+            }
+          ]
         },
         {
           "_type": "block",
-          "children": [{ "_type": "span", "text": "Your tagline goes here." }]
-        }
-      ]
-    },
-    {
-      "slug": "newsletter-cta",
-      "title": "Newsletter CTA",
-      "keywords": ["newsletter", "subscribe", "email"],
-      "content": [
-        {
-          "_type": "block",
-          "style": "h3",
-          "children": [{ "_type": "span", "text": "Subscribe to our newsletter" }]
+          "_key": "newsletter-body",
+          "style": "normal",
+          "children": [
+            {
+              "_type": "span",
+              "_key": "newsletter-body-text",
+              "text": "Subscribe for occasional updates."
+            }
+          ]
         }
       ]
     }
@@ -148,127 +90,36 @@ The following seed file defines two sections for a theme:
 }
 ```
 
-### Via WordPress Import
+Run `emdash seed --validate` before applying a hand-written seed file. See [Seed Files](/themes/seed-files/) for application and conflict-handling options.
 
-WordPress reusable blocks (`wp_block` post type) are automatically imported as sections:
+Theme-provided sections use the `theme` source. Sections created in the admin use `user`, and WordPress reusable blocks imported by EmDash use `import`. See [Content Import](/migration/content-import/) for the import workflow.
 
-- Source is set to `"import"`
-- Gutenberg content converted to Portable Text
+## Render a section in a template
 
-## Rendering Sections Programmatically
+Most sites render section content as part of the entry into which it was copied. To render the current library value directly, fetch the section by slug and pass its content to `PortableText`.
 
-The following example renders a section's content server-side, outside the editor:
+The following component renders a centrally queried newsletter section:
 
-```astro
+```astro title="src/components/NewsletterSection.astro"
 ---
 import { getSection } from "emdash";
 import { PortableText } from "emdash/ui";
 
-const newsletter = await getSection("newsletter-cta");
+const section = await getSection("newsletter-signup");
 ---
 
-{newsletter && (
-  <aside class="cta-box">
-    <PortableText value={newsletter.content} />
+{section && (
+  <aside aria-label={section.title}>
+    <PortableText value={section.content} />
   </aside>
 )}
 ```
 
-## Admin UI Features
+This direct rendering path reads the library value on every render, so a later edit to the section affects every place that uses this component.
 
-The Sections library (`/_emdash/admin/sections`) provides:
+<Aside type="tip">
+	Use the direct rendering path only when synchronized output is the intended behavior. Inserting a
+	section in the editor is the better fit when each entry needs its own editable copy.
+</Aside>
 
-- **Grid view** with section previews
-- **Search** by title and keywords  
-- **Filter** by source
-- **Quick copy** slug to clipboard
-- **Edit** section content and metadata
-- **Delete** with confirmation (warns for theme sections)
-
-## API Reference
-
-### `getSection(slug)`
-
-Fetch a section by slug.
-
-**Parameters:**
-- `slug` — The section's unique identifier (string)
-
-**Returns:** `Promise<Section | null>`
-
-### `getSections(options?)`
-
-List sections with optional filters.
-
-**Parameters:**
-- `options.source` — Filter by source: `"theme"`, `"user"`, or `"import"`
-- `options.search` — Search title, description, and keywords
-- `options.limit` — Page size (default 50, max 100)
-- `options.cursor` — Pagination cursor from a previous `nextCursor`
-
-**Returns:** `Promise<{ items: Section[]; nextCursor?: string }>`
-
-## REST API
-
-### List Sections
-
-List sections, optionally filtered by source or search term:
-
-```http
-GET /_emdash/api/sections
-GET /_emdash/api/sections?source=theme
-GET /_emdash/api/sections?search=newsletter
-```
-
-### Get Section
-
-Fetch a single section by slug:
-
-```http
-GET /_emdash/api/sections/newsletter-cta
-```
-
-### Create Section
-
-Create a section with a POST request:
-
-```http
-POST /_emdash/api/sections
-Content-Type: application/json
-
-{
-  "slug": "my-section",
-  "title": "My Section",
-  "description": "Optional description",
-  "keywords": ["keyword1", "keyword2"],
-  "content": [...]
-}
-```
-
-### Update Section
-
-Update a section with a PUT request:
-
-```http
-PUT /_emdash/api/sections/my-section
-Content-Type: application/json
-
-{
-  "title": "Updated Title",
-  "content": [...]
-}
-```
-
-### Delete Section
-
-Delete a section by slug:
-
-```http
-DELETE /_emdash/api/sections/my-section
-```
-
-## Next Steps
-
-- [Working with Content](/guides/working-with-content/) - Learn about the rich text editor
-- [Widget Areas](/guides/widgets/) - For synchronized dynamic content
-- [Content Import](/migration/content-import/) - Import WordPress reusable blocks
+The [runtime API reference](/reference/api/#sections) documents section queries and pagination. For programmatic changes, authenticate with a Bearer token and add `X-EmDash-Request: 1` to every state-changing request. See the [section endpoints](/reference/rest-api/#section-endpoints) for request bodies and responses.

--- a/docs/src/content/docs/guides/site-settings.mdx
+++ b/docs/src/content/docs/guides/site-settings.mdx
@@ -1,343 +1,180 @@
 ---
 title: Site Settings
-description: Configure global settings like site title, logo, and social links.
+description: Read site identity, display, social, and SEO settings in Astro templates.
 ---
 
-import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Steps } from "@astrojs/starlight/components";
 
-Site settings are global configuration values for your site: title, tagline, logo, social links, and display preferences. Administrators manage these through the admin interface, and you access them in your templates.
+Site settings hold values that apply across the site. Templates can use them for site identity, pagination, date handling, social profiles, and search metadata.
 
-## Querying Settings
+## Configure settings
 
-Use `getSiteSettings()` to fetch all site settings:
+Open **Settings** in the EmDash admin, then choose the page for the values you need:
+
+- **General** contains the site title, tagline, logo, favicon, public URL, posts per page, date format, and timezone.
+- **Social** contains profile handles for the supported social services.
+- **SEO** contains the title separator, default social image, verification values, and `robots.txt` content.
+
+<Steps>
+
+1. Open the relevant settings page.
+
+2. Enter the values used by the site's templates and metadata.
+
+3. Save the page, then reload a public page that renders those settings.
+
+</Steps>
+
+Settings are optional until configured. A template should provide a suitable fallback for any value it requires.
+
+## Read settings in a layout
+
+Use `getSiteSettings()` when a layout needs several values. It returns the configured keys as a partial object and resolves media references before returning them.
+
+The following base layout uses site identity settings and lets `EmDashHead` apply the configured favicon, default social image, and site-wide verification metadata:
 
 ```astro title="src/layouts/Base.astro"
 ---
 import { getSiteSettings } from "emdash";
-
-const settings = await getSiteSettings();
----
-
-<html lang="en">
-  <head>
-    <title>{settings.title}</title>
-    {settings.favicon && (
-      <link rel="icon" href={settings.favicon.url} />
-    )}
-  </head>
-  <body>
-    <header>
-      {settings.logo ? (
-        <img src={settings.logo.url} alt={settings.logo.alt || settings.title} />
-      ) : (
-        <span class="site-title">{settings.title}</span>
-      )}
-      {settings.tagline && <p class="tagline">{settings.tagline}</p>}
-    </header>
-    <slot />
-  </body>
-</html>
-```
-
-## Available Settings
-
-EmDash provides these core settings:
-
-```ts
-interface SiteSettings {
-	// Identity
-	title: string;
-	tagline?: string;
-	logo?: MediaReference;
-	favicon?: MediaReference;
-
-	// URLs
-	url?: string;
-
-	// Display
-	postsPerPage: number;
-	dateFormat: string;
-	timezone: string;
-
-	// Social
-	social?: {
-		twitter?: string;
-		github?: string;
-		facebook?: string;
-		instagram?: string;
-		linkedin?: string;
-		youtube?: string;
-	};
-}
-
-interface MediaReference {
-	mediaId: string;
-	alt?: string;
-	url?: string; // Resolved URL (read-only)
-}
-```
-
-## Fetching Individual Settings
-
-Use `getSiteSetting()` to fetch a single setting by key:
-
-```ts
-import { getSiteSetting } from "emdash";
-
-const title = await getSiteSetting("title");
-// Returns: "My Site" or undefined
-
-const logo = await getSiteSetting("logo");
-// Returns: { mediaId: "...", url: "/_emdash/api/media/file/..." }
-```
-
-This is useful when you only need one or two values and want to avoid fetching everything.
-
-## Using Settings in Components
-
-### Site Header
-
-The following component renders a header with the site logo and primary menu:
-
-```astro title="src/components/Header.astro"
----
-import { getSiteSettings, getMenu } from "emdash";
-
-const settings = await getSiteSettings();
-const menu = await getMenu("primary");
----
-
-<header class="header">
-  <a href="/" class="logo">
-    {settings.logo ? (
-      <img
-        src={settings.logo.url}
-        alt={settings.logo.alt || settings.title}
-        width="150"
-        height="50"
-      />
-    ) : (
-      <span class="site-name">{settings.title}</span>
-    )}
-  </a>
-
-  {menu && (
-    <nav>
-      {menu.items.map(item => (
-        <a href={item.url}>{item.label}</a>
-      ))}
-    </nav>
-  )}
-</header>
-```
-
-### Social Links
-
-The following component renders links for each configured social platform:
-
-```astro title="src/components/SocialLinks.astro"
----
-import { getSiteSetting } from "emdash";
-
-const social = await getSiteSetting("social");
-
-const platforms = [
-  { key: "twitter", label: "Twitter", baseUrl: "https://twitter.com/" },
-  { key: "github", label: "GitHub", baseUrl: "https://github.com/" },
-  { key: "facebook", label: "Facebook", baseUrl: "https://facebook.com/" },
-  { key: "instagram", label: "Instagram", baseUrl: "https://instagram.com/" },
-  { key: "linkedin", label: "LinkedIn", baseUrl: "https://linkedin.com/in/" },
-  { key: "youtube", label: "YouTube", baseUrl: "https://youtube.com/@" },
-] as const;
----
-
-{social && (
-  <div class="social-links">
-    {platforms.map(({ key, label, baseUrl }) => (
-      social[key] && (
-        <a
-          href={baseUrl + social[key]}
-          rel="noopener noreferrer"
-          target="_blank"
-          aria-label={label}
-        >
-          {label}
-        </a>
-      )
-    ))}
-  </div>
-)}
-```
-
-### SEO Meta Tags
-
-<Aside>
-	On server-rendered content pages that include the `<EmDashHead>` component and fetch their entry
-	through `getEmDashEntry()`, values from the entry's
-	SEO panel (description, image, canonical, noindex — and the title, which feeds
-	`og:title`/`twitter:title` but not the `<title>` element, which stays with the template) are
-	applied automatically. Editors' panel settings override whatever the template passed into the
-	page context, at no additional query cost. Hand-rolled meta tags like the component below bypass
-	that behavior, so prefer `<EmDashHead>` for content pages. Prerendered pages keep using
-	`getSeoMeta()`.
-</Aside>
-
-The following component builds document and Open Graph meta tags from site settings:
-
-```astro title="src/components/SEO.astro"
----
-import { getSiteSettings } from "emdash";
+import { createPublicPageContext } from "emdash/page";
+import { EmDashHead } from "emdash/ui";
 
 interface Props {
   title?: string;
   description?: string;
-  image?: string;
 }
 
+const { title, description } = Astro.props;
 const settings = await getSiteSettings();
-const {
-  title,
-  description = settings.tagline,
-  image,
-} = Astro.props;
+const siteTitle = settings.title ?? "My site";
+const fullTitle = title ? `${title} — ${siteTitle}` : siteTitle;
+const pageDescription = description ?? settings.tagline;
 
-const documentTitle = title
-  ? `${title} | ${settings.title}`
-  : settings.title;
-const ogTitle = title ?? settings.title;
+const page = createPublicPageContext({
+  Astro,
+  kind: "custom",
+  pageType: "website",
+  title: fullTitle,
+  pageTitle: title ?? siteTitle,
+  description: pageDescription,
+  siteName: siteTitle,
+});
 ---
 
-<title>{documentTitle}</title>
-{description && <meta name="description" content={description} />}
+<!doctype html>
+<html lang={Astro.currentLocale ?? "en"}>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>{fullTitle}</title>
+    <EmDashHead page={page} />
+  </head>
+  <body>
+    <header>
+      <a href="/" aria-label={siteTitle}>
+        {settings.logo?.url ? (
+          <img
+            src={settings.logo.url}
+            alt={settings.logo.alt ?? siteTitle}
+            width={settings.logo.width}
+            height={settings.logo.height}
+          />
+        ) : (
+          siteTitle
+        )}
+      </a>
+      {settings.tagline && <p>{settings.tagline}</p>}
+    </header>
 
-<!-- Open Graph -->
-<meta property="og:title" content={ogTitle} />
-{description && <meta property="og:description" content={description} />}
-{image && <meta property="og:image" content={image} />}
-{settings.url && <meta property="og:url" content={settings.url + Astro.url.pathname} />}
-
-<!-- Twitter -->
-{settings.social?.twitter && (
-  <meta name="twitter:site" content={settings.social.twitter} />
-)}
-<meta name="twitter:card" content={image ? "summary_large_image" : "summary"} />
+    <main>
+      <slot />
+    </main>
+  </body>
+</html>
 ```
 
-## Date Formatting
+`EmDashHead` also calls `getSiteSettings()`. Request caching makes that call reuse the layout's result rather than run another settings query.
 
-Use the `dateFormat` and `timezone` settings for consistent date display:
+On a server-rendered content page, pass the content reference to `createPublicPageContext()` and fetch the entry with `getEmDashEntry()`. `EmDashHead` then applies the entry's SEO panel values over site defaults. See [Rendering SEO panel data](/guides/querying-content/#rendering-seo-panel-data) for the complete content-page pattern.
+
+## Read one setting
+
+Use `getSiteSetting()` when a component needs one value and its parent has not already fetched the settings object.
+
+The following component formats a timestamp in the configured timezone:
 
 ```astro title="src/components/PostDate.astro"
 ---
 import { getSiteSetting } from "emdash";
 
 interface Props {
-  date: string;
+  date: Date;
 }
 
 const { date } = Astro.props;
-const dateFormat = await getSiteSetting("dateFormat") || "MMMM d, yyyy";
-const timezone = await getSiteSetting("timezone") || "UTC";
-
-// Format using Intl.DateTimeFormat or a library like date-fns
-const formatted = new Intl.DateTimeFormat("en-US", {
-  timeZone: timezone,
+const timezone = await getSiteSetting("timezone") ?? "UTC";
+const formatted = new Intl.DateTimeFormat(Astro.currentLocale, {
   dateStyle: "long",
-}).format(new Date(date));
+  timeZone: timezone,
+}).format(date);
 ---
 
-<time datetime={date}>{formatted}</time>
+<time datetime={date.toISOString()}>{formatted}</time>
 ```
 
-<Aside>
-	The `dateFormat` setting uses a pattern string (e.g., "MMMM d, yyyy"). You may need a library like
-	`date-fns` to parse and apply these patterns.
+The `dateFormat` setting is a pattern string such as `MMMM d, yyyy`. `Intl.DateTimeFormat` does not consume that syntax; use a formatting library that supports pattern strings when the template needs to apply it exactly.
+
+## Render social profiles
+
+Social settings store handles or usernames rather than complete links. The template decides which profiles to show and turns each configured value into the service's URL.
+
+The following component renders the configured X and GitHub profiles:
+
+```astro title="src/components/SocialLinks.astro"
+---
+import { getSiteSetting } from "emdash";
+
+const social = await getSiteSetting("social");
+const xHandle = social?.twitter?.replace(/^@/, "");
+---
+
+{(xHandle || social?.github) && (
+  <nav aria-label="Social profiles">
+    <ul>
+      {xHandle && (
+        <li>
+          <a href={`https://x.com/${xHandle}`} rel="me noopener" target="_blank">
+            X
+          </a>
+        </li>
+      )}
+      {social?.github && (
+        <li>
+          <a
+            href={`https://github.com/${social.github}`}
+            rel="me noopener"
+            target="_blank"
+          >
+            GitHub
+          </a>
+        </li>
+      )}
+    </ul>
+  </nav>
+)}
+```
+
+Apply the same pattern to the configured Facebook, Instagram, LinkedIn, and YouTube values. Those fields store the page, profile, channel, or handle value entered in the admin; the theme remains responsible for the public URL format.
+
+## Use media settings
+
+The logo, favicon, and default social image are stored as media references. On read, EmDash adds the current URL and any known content type, width, and height. If the referenced media item has been deleted, those resolved values can be absent, so check `url` before rendering an image.
+
+Site settings hold one logo and one favicon. A dark image variant belongs to an EmDash image field, where the editor can choose the counterpart and the `Image` component can switch between them. See [Dark Mode](/guides/dark-mode/#dark-image-variants) for that pattern.
+
+<Aside type="tip">
+	Read the settings object once in a base layout when several nested components need it. Calls made
+	later in the same request reuse the cached result.
 </Aside>
 
-## Admin API
-
-Fetch settings programmatically with a GET request:
-
-```http
-GET /_emdash/api/settings
-```
-
-The response is a JSON object of the settings:
-
-```json
-{
-	"title": "My EmDash Site",
-	"tagline": "A modern CMS",
-	"logo": {
-		"mediaId": "med_123",
-		"url": "/_emdash/api/media/file/abc123"
-	},
-	"postsPerPage": 10,
-	"dateFormat": "MMMM d, yyyy",
-	"timezone": "America/New_York",
-	"social": {
-		"twitter": "@handle",
-		"github": "username"
-	}
-}
-```
-
-Update settings (partial updates supported):
-
-```http
-POST /_emdash/api/settings
-Content-Type: application/json
-
-{
-  "title": "New Site Title",
-  "tagline": "Updated tagline"
-}
-```
-
-Only the provided fields are changed. Omitted fields retain their current values.
-
-## Media References
-
-The `logo` and `favicon` settings store media references. When you read them, EmDash resolves the `url` property automatically:
-
-```ts
-const logo = await getSiteSetting("logo");
-// {
-//   mediaId: "med_123",
-//   alt: "Site logo",
-//   url: "/_emdash/api/media/file/abc123"
-// }
-```
-
-When updating via the API, provide only the `mediaId`:
-
-```json
-{
-	"logo": {
-		"mediaId": "med_456",
-		"alt": "New logo"
-	}
-}
-```
-
-## API Reference
-
-### `getSiteSettings()`
-
-Fetch all site settings with resolved media URLs.
-
-**Returns:** `Promise<Partial<SiteSettings>>`
-
-Returns a partial object. Unset values are `undefined`.
-
-### `getSiteSetting(key)`
-
-Fetch a single setting by key.
-
-**Parameters:**
-
-- `key` — The setting key (e.g., `"title"`, `"logo"`, `"social"`)
-
-**Returns:** `Promise<SiteSettings[K] | undefined>`
-
-Type-safe: the return type matches the key you request.
+The [runtime API reference](/reference/api/#site-settings) documents the setting keys and query return types. For programmatic changes, authenticate with a Bearer token and add `X-EmDash-Request: 1` to every state-changing request. See the [settings endpoints](/reference/rest-api/#settings-endpoints) for request bodies and responses.

--- a/docs/src/content/docs/guides/taxonomies.mdx
+++ b/docs/src/content/docs/guides/taxonomies.mdx
@@ -1,313 +1,99 @@
 ---
 title: Taxonomies
-description: Organize content with categories, tags, and custom taxonomies.
+description: Classify content, query locale-aware terms, and build taxonomy archive pages.
 ---
 
-import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Steps } from "@astrojs/starlight/components";
 
-Taxonomies are classification systems for organizing content. EmDash includes built-in categories and tags, and supports custom taxonomies for specialized classification needs.
+A taxonomy is a named classification applied to one or more collections. EmDash starts with the hierarchical `category` taxonomy and the flat `tag` taxonomy for posts. A site can also define taxonomies such as `genre`, `topic`, or `difficulty`.
 
-## Built-in Taxonomies
+Terms belong to a taxonomy. A category such as “Guides” can have child categories, while tags and other flat taxonomies have one level.
 
-EmDash provides two default taxonomies:
+## Manage terms
 
-| Taxonomy       | Type         | Description                                           |
-| -------------- | ------------ | ----------------------------------------------------- |
-| **Categories** | Hierarchical | Nested classification with parent-child relationships |
-| **Tags**       | Flat         | Simple labels without hierarchy                       |
+Open a taxonomy from **Taxonomies** in the EmDash admin.
 
-Both are available for the posts collection by default.
+<Steps>
 
-## Managing Terms
+1. Click **Add Category**, **Add Tag**, or the equivalent action for the current taxonomy.
 
-### Create a Term
+2. Enter the label and slug. For a hierarchical taxonomy, choose a parent when the term belongs below another term.
 
-<Tabs>
-  <TabItem label="Admin Dashboard">
+3. Add an optional description, then create the term.
 
-1. Go to the taxonomy page (e.g., `/_emdash/admin/taxonomies/category`)
+4. Use the move controls in the term list to set the order within the current parent group.
 
-2. Enter the term name in the **Add New** form
+</Steps>
 
-3. Optionally set:
-   - **Slug** - URL identifier (auto-generated from name)
-   - **Parent** - For hierarchical taxonomies
-   - **Description** - Term description
+Editors assign terms from the taxonomy panels in a content entry. The taxonomy definition controls which collections show each panel.
 
-4. Click **Add**
+Deleting a term removes its assignments from content. It does not delete the content entries.
 
-  </TabItem>
-  <TabItem label="Content Editor">
+## Add a custom taxonomy
 
-1. Open a content entry in the editor
+Create a taxonomy when an existing collection needs a separate classification.
 
-2. Find the taxonomy panel in the sidebar
+<Steps>
 
-3. For categories, check the boxes for applicable terms, or click **+ Add New**
+1. Open **Taxonomies** and click **New Taxonomy**.
 
-4. For tags, type tag names separated by commas
+2. Enter a label and a stable name. Names start with a lowercase letter and contain only lowercase letters, numbers, and underscores.
 
-5. Save the content
+3. Enable **Hierarchical** if terms need parent and child relationships.
 
-  </TabItem>
-  <TabItem label="API">
+4. Select every collection that can use the taxonomy, then click **Create Taxonomy**.
 
-The following request creates a term in the `category` taxonomy:
+5. Add the initial terms and assign them to content.
 
-```bash
-POST /_emdash/api/taxonomies/category/terms
-Content-Type: application/json
-Authorization: Bearer YOUR_API_TOKEN
+</Steps>
 
-{
-  "slug": "tutorials",
-  "label": "Tutorials",
-  "parentId": "term_abc",
-  "description": "How-to guides and tutorials"
-}
-```
+Templates query the stable name. Changing a display label does not require a template change.
 
-  </TabItem>
-</Tabs>
-
-### Edit a Term
-
-1. Go to the taxonomy terms page
-
-2. Click **Edit** next to the term
-
-3. Update the name, slug, parent, or description
-
-4. Click **Save**
-
-### Delete a Term
-
-1. Go to the taxonomy terms page
-
-2. Click **Delete** next to the term
-
-3. Confirm the deletion
-
-<Aside type="caution">
-	Deleting a term removes it from all associated content. Content is not deleted, only the term
-	assignment.
-</Aside>
-
-## Querying Taxonomies
-
-EmDash provides functions to query taxonomy terms and filter content by term.
-
-### Get All Terms
-
-Retrieve all terms for a taxonomy:
+Custom taxonomies use the same query and filter helpers as categories and tags. The following example reads the `genre` terms and filters books by one of their slugs:
 
 ```ts
-import { getTaxonomyTerms } from "emdash";
+import { getEmDashCollection, getTaxonomyTerms } from "emdash";
 
-// Get all categories (returns tree structure)
-const categories = await getTaxonomyTerms("category");
-
-// Get all tags (returns flat list)
-const tags = await getTaxonomyTerms("tag");
-```
-
-For hierarchical taxonomies, terms include a `children` array:
-
-```ts
-interface TaxonomyTerm {
-	id: string;
-	name: string; // Taxonomy name ("category")
-	slug: string; // Term slug ("news")
-	label: string; // Display label ("News")
-	parentId?: string;
-	description?: string;
-	children: TaxonomyTerm[];
-	count?: number; // Number of entries with this term
-}
-```
-
-Computing `count` aggregates every content–term assignment in the taxonomy's
-collections, which is the most expensive part of the call. If you only need
-labels and slugs, skip it — `count` is then omitted from the returned terms:
-
-```ts
-const tags = await getTaxonomyTerms("tag", { includeCounts: false });
-```
-
-### Get a Single Term
-
-The following example fetches one term by taxonomy and slug:
-
-```ts
-import { getTerm } from "emdash";
-
-const category = await getTerm("category", "news");
-// Returns TaxonomyTerm or null
-```
-
-`getTerm()` computes `count` the same way and takes the same option. A term page
-that only needs the label can skip the aggregate — `count` is then omitted:
-
-```ts
-const category = await getTerm("category", "news", { includeCounts: false });
-```
-
-### Get Terms for an Entry
-
-The following example retrieves the categories and tags assigned to a single entry:
-
-```ts
-import { getEntryTerms } from "emdash";
-
-// Get all categories for a post
-const categories = await getEntryTerms("posts", "post-123", "category");
-
-// Get all tags for a post
-const tags = await getEntryTerms("posts", "post-123", "tag");
-```
-
-### Filter Content by Term
-
-Use `getEmDashCollection` with the `where` filter:
-
-```ts
-import { getEmDashCollection } from "emdash";
-
-// Posts in the "news" category
-const { entries: newsPosts } = await getEmDashCollection("posts", {
-	status: "published",
-	where: { category: "news" },
-});
-
-// Posts with the "javascript" tag
-const { entries: jsPosts } = await getEmDashCollection("posts", {
-	status: "published",
-	where: { tag: "javascript" },
+const genres = await getTaxonomyTerms("genre", { includeCounts: false });
+const { entries: scienceFictionBooks } = await getEmDashCollection("books", {
+  where: { genre: "science-fiction" },
 });
 ```
 
-Or use the convenience function:
+## Query a term list
 
-```ts
-import { getEntriesByTerm } from "emdash";
+Use `getTaxonomyTerms()` to render a taxonomy index, navigation list, or set of filters. Hierarchical taxonomies return a tree through each term's `children` array.
 
-const newsPosts = await getEntriesByTerm("posts", "category", "news");
-```
+Term counts are included by default and require an aggregate across the taxonomy's assigned collections. Skip that work when the component does not display counts.
 
-## Building Taxonomy Pages
-
-### Category Archive
-
-Create a page that lists posts in a category:
-
-```astro title="src/pages/category/[slug].astro"
----
-import { getTaxonomyTerms, getTerm, getEmDashCollection } from "emdash";
-import Base from "../../layouts/Base.astro";
-
-export async function getStaticPaths() {
-  const categories = await getTaxonomyTerms("category");
-
-  // Flatten hierarchical tree for routing
-  function flatten(terms) {
-    return terms.flatMap((term) => [term, ...flatten(term.children)]);
-  }
-
-  return flatten(categories).map((cat) => ({
-    params: { slug: cat.slug },
-    props: { category: cat },
-  }));
-}
-
-const { category } = Astro.props;
-
-const { entries: posts } = await getEmDashCollection("posts", {
-  status: "published",
-  where: { category: category.slug },
-});
----
-
-<Base title={category.label}>
-  <h1>{category.label}</h1>
-  {category.description && <p>{category.description}</p>}
-  <p>{category.count} posts</p>
-
-  <ul>
-    {posts.map((post) => (
-      <li>
-        <a href={`/blog/${post.data.slug}`}>{post.data.title}</a>
-      </li>
-    ))}
-  </ul>
-</Base>
-```
-
-### Tag Archive
-
-Create a page that lists posts with a tag:
-
-```astro title="src/pages/tag/[slug].astro"
----
-import { getTaxonomyTerms, getEmDashCollection } from "emdash";
-import Base from "../../layouts/Base.astro";
-
-export async function getStaticPaths() {
-  const tags = await getTaxonomyTerms("tag");
-
-  return tags.map((tag) => ({
-    params: { slug: tag.slug },
-    props: { tag },
-  }));
-}
-
-const { tag } = Astro.props;
-
-const { entries: posts } = await getEmDashCollection("posts", {
-  status: "published",
-  where: { tag: tag.slug },
-});
----
-
-<Base title={`Posts tagged "${tag.label}"`}>
-  <h1>#{tag.label}</h1>
-
-  <ul>
-    {posts.map((post) => (
-      <li>
-        <a href={`/blog/${post.data.slug}`}>{post.data.title}</a>
-      </li>
-    ))}
-  </ul>
-</Base>
-```
-
-### Category List Widget
-
-Display a list of categories with post counts:
+The following component renders category links without counts:
 
 ```astro title="src/components/CategoryList.astro"
 ---
 import { getTaxonomyTerms } from "emdash";
+import { getRelativeLocaleUrl } from "astro:i18n";
 
-const categories = await getTaxonomyTerms("category");
+const locale = Astro.currentLocale;
+const categories = await getTaxonomyTerms("category", {
+  locale,
+  includeCounts: false,
+});
+
+function categoryHref(slug: string) {
+  const path = `/category/${slug}`;
+  return locale ? getRelativeLocaleUrl(locale, path) : path;
+}
 ---
 
-<nav class="category-list">
-  <h3>Categories</h3>
+<nav aria-label="Categories">
   <ul>
-    {categories.map((cat) => (
+    {categories.map((category) => (
       <li>
-        <a href={`/category/${cat.slug}`}>
-          {cat.label} ({cat.count})
-        </a>
-        {cat.children.length > 0 && (
+        <a href={categoryHref(category.slug)}>{category.label}</a>
+        {category.children.length > 0 && (
           <ul>
-            {cat.children.map((child) => (
-              <li>
-                <a href={`/category/${child.slug}`}>
-                  {child.label} ({child.count})
-                </a>
-              </li>
+            {category.children.map((child) => (
+              <li><a href={categoryHref(child.slug)}>{child.label}</a></li>
             ))}
           </ul>
         )}
@@ -317,165 +103,127 @@ const categories = await getTaxonomyTerms("category");
 </nav>
 ```
 
-### Tag Cloud
+When a component displays usage, omit `includeCounts: false` and render `term.count`. The count includes publicly visible entries in the locale used for the query.
 
-Display tags with size based on usage:
+## Build a taxonomy archive
 
-```astro title="src/components/TagCloud.astro"
+Decode a dynamic route parameter before looking up a term. Query the term and content with the same locale, and pass generated paths through Astro's locale URL helper.
+
+The following route lists published posts in one category:
+
+```astro title="src/pages/category/[slug].astro"
 ---
-import { getTaxonomyTerms } from "emdash";
+import { decodeSlug, getEmDashCollection, getTerm } from "emdash";
+import { getRelativeLocaleUrl } from "astro:i18n";
+import Base from "../../layouts/Base.astro";
 
-const tags = await getTaxonomyTerms("tag");
+const locale = Astro.currentLocale;
+const slug = decodeSlug(Astro.params.slug);
+const category = slug
+  ? await getTerm("category", slug, { locale, includeCounts: false })
+  : null;
 
-// Calculate font sizes based on count
-const counts = tags.map((t) => t.count ?? 0);
-const maxCount = Math.max(...counts, 1);
-const minSize = 0.8;
-const maxSize = 2;
+if (!category) {
+  return Astro.redirect("/404");
+}
 
-function getSize(count: number) {
-  const ratio = count / maxCount;
-  return minSize + ratio * (maxSize - minSize);
+const { entries: posts } = await getEmDashCollection("posts", {
+  status: "published",
+  locale,
+  where: { category: category.slug },
+  orderBy: { published_at: "desc" },
+});
+
+function postHref(postSlug: string) {
+  const path = `/posts/${postSlug}`;
+  return locale ? getRelativeLocaleUrl(locale, path) : path;
 }
 ---
 
-<div class="tag-cloud">
-  {tags.map((tag) => (
-    <a
-      href={`/tag/${tag.slug}`}
-      style={`font-size: ${getSize(tag.count ?? 0)}rem`}
-    >
-      {tag.label}
-    </a>
-  ))}
-</div>
+<Base title={`${category.label} posts`}>
+  <h1>{category.label}</h1>
+  {category.description && <p>{category.description}</p>}
+
+  {posts.length > 0 ? (
+    <ul>
+      {posts.map((post) => (
+        post.data.slug && (
+          <li>
+            <a href={postHref(post.data.slug)}>{post.data.title}</a>
+          </li>
+        )
+      ))}
+    </ul>
+  ) : (
+    <p>No posts in this category.</p>
+  )}
+</Base>
 ```
 
-## Displaying Terms on Content
+`where` uses the taxonomy name as its key and a term slug as its value. Query sort identifiers use database field names such as `published_at`; entry data exposes the corresponding value as `publishedAt`.
 
-Show categories and tags on a post:
+Use the collection's actual public route in `postHref()`. If the collection uses a custom `urlPattern`, build links from that pattern rather than assuming `/posts/{slug}`.
+
+## Display an entry's terms
+
+`getEmDashEntry()` and `getEmDashCollection()` hydrate assigned terms onto `entry.data.terms`. Read that value instead of running one `getEntryTerms()` query for every entry in a list.
+
+The following component renders categories and tags already loaded with a post:
 
 ```astro title="src/components/PostTerms.astro"
 ---
-import { getEntryTerms } from "emdash";
+import type { ContentEntry, InferCollectionData } from "emdash";
+import { getRelativeLocaleUrl } from "astro:i18n";
 
 interface Props {
-  collection: string;
-  entryId: string;
+  post: ContentEntry<InferCollectionData<"posts">>;
 }
 
-const { collection, entryId } = Astro.props;
+const { post } = Astro.props;
+const locale = Astro.currentLocale;
+const categories = post.data.terms?.category ?? [];
+const tags = post.data.terms?.tag ?? [];
 
-const categories = await getEntryTerms(collection, entryId, "category");
-const tags = await getEntryTerms(collection, entryId, "tag");
+function termHref(taxonomy: string, slug: string) {
+  const path = `/${taxonomy}/${slug}`;
+  return locale ? getRelativeLocaleUrl(locale, path) : path;
+}
 ---
 
-<div class="post-terms">
-  {categories.length > 0 && (
-    <div class="categories">
-      <span>Posted in:</span>
-      {categories.map((cat, i) => (
-        <>
-          {i > 0 && ", "}
-          <a href={`/category/${cat.slug}`}>{cat.label}</a>
-        </>
-      ))}
-    </div>
-  )}
+{categories.length > 0 && (
+  <ul aria-label="Categories">
+    {categories.map((category) => (
+      <li>
+        <a href={termHref("category", category.slug)}>{category.label}</a>
+      </li>
+    ))}
+  </ul>
+)}
 
-  {tags.length > 0 && (
-    <div class="tags">
-      {tags.map((tag) => (
-        <a href={`/tag/${tag.slug}`} class="tag">
-          #{tag.label}
-        </a>
-      ))}
-    </div>
-  )}
-</div>
+{tags.length > 0 && (
+  <ul aria-label="Tags">
+    {tags.map((tag) => (
+      <li>
+        <a href={termHref("tag", tag.slug)}>{tag.label}</a>
+      </li>
+    ))}
+  </ul>
+)}
 ```
 
-## Custom Taxonomies
+Use `getEntryTerms()` when all you have is a collection name and entry ID. Use `getTermsForEntries()` to batch terms for several entries when they were not hydrated by the content query.
 
-Create taxonomies beyond categories and tags for specialized needs.
+## Translate taxonomies and terms
 
-### Create a Custom Taxonomy
+Taxonomy definitions and terms have one row per locale. EmDash records which rows are translations of the same taxonomy or term. Content assignments use that shared identity, so an assignment made in one locale resolves to the translated term in another locale when one exists.
 
-Use the admin API to create a taxonomy:
+Use the locale switcher on a taxonomy page to manage terms in each configured locale. Open a term's edit dialog and use its **Translations** panel to add or open another locale. A translated term can use a different slug and label.
 
-```bash
-POST /_emdash/api/taxonomies
-Content-Type: application/json
-Authorization: Bearer YOUR_API_TOKEN
+The query helpers use an explicit locale when supplied. Otherwise they use the current request locale, then the configured default. Single-term lookups follow the configured fallback chain when the requested translation is absent.
 
-{
-  "name": "genre",
-  "label": "Genres",
-  "labelSingular": "Genre",
-  "hierarchical": true,
-  "collections": ["books", "movies"]
-}
-```
+<Aside type="tip">
+	Keep taxonomy names stable across locales. Translate the definition label, term labels, and term
+	slugs; templates continue to query the same name, such as `category`.
+</Aside>
 
-### Use Custom Taxonomies
-
-Query and display custom taxonomies the same way as built-in ones:
-
-```ts
-import { getTaxonomyTerms, getEmDashCollection } from "emdash";
-
-// Get all genres
-const genres = await getTaxonomyTerms("genre");
-
-// Get books in a genre
-const { entries: sciFiBooks } = await getEmDashCollection("books", {
-	where: { genre: "science-fiction" },
-});
-```
-
-### Assign to Collections
-
-Taxonomies specify which collections they apply to:
-
-```ts
-{
-  "name": "difficulty",
-  "label": "Difficulty Levels",
-  "hierarchical": false,
-  "collections": ["recipes", "tutorials"]
-}
-```
-
-## Taxonomy API Reference
-
-### REST Endpoints
-
-| Endpoint                                      | Method | Description               |
-| --------------------------------------------- | ------ | ------------------------- |
-| `/_emdash/api/taxonomies`                   | GET    | List taxonomy definitions |
-| `/_emdash/api/taxonomies`                   | POST   | Create taxonomy           |
-| `/_emdash/api/taxonomies/:name/terms`       | GET    | List terms                |
-| `/_emdash/api/taxonomies/:name/terms`       | POST   | Create term               |
-| `/_emdash/api/taxonomies/:name/terms/:slug` | GET    | Get term                  |
-| `/_emdash/api/taxonomies/:name/terms/:slug` | PUT    | Update term               |
-| `/_emdash/api/taxonomies/:name/terms/:slug` | DELETE | Delete term               |
-
-### Assign Terms to Content
-
-The following request assigns category terms to a post:
-
-```bash
-POST /_emdash/api/content/posts/post-123/terms/category
-Content-Type: application/json
-Authorization: Bearer YOUR_API_TOKEN
-
-{
-  "termIds": ["term_news", "term_featured"]
-}
-```
-
-## Next Steps
-
-- [Create a Blog](/guides/create-a-blog/) - Use categories and tags in a blog
-- [Querying Content](/guides/querying-content/) - Filter by taxonomy terms
-- [Working with Content](/guides/working-with-content/) - Assign terms in the editor
+See [Internationalization](/guides/internationalization/) for locale routing and fallback configuration and [Working with Content](/guides/working-with-content/) for editing entries. The [runtime API reference](/reference/api/#taxonomies) documents taxonomy query helpers. For programmatic changes, authenticate with a Bearer token and add `X-EmDash-Request: 1` to every state-changing request. See the [taxonomy endpoints](/reference/rest-api/#taxonomy-endpoints) for request bodies and responses.

--- a/docs/src/content/docs/guides/widgets.mdx
+++ b/docs/src/content/docs/guides/widgets.mdx
@@ -1,368 +1,190 @@
 ---
 title: Widget Areas
-description: Add dynamic content blocks to sidebars, footers, and other template regions.
+description: Place editor-managed content, menus, and built-in widgets in an Astro template.
 ---
 
-import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Steps } from "@astrojs/starlight/components";
 
-Widget areas are named regions in your templates where administrators can place content blocks. Use them for sidebars, footer columns, promotional banners, or any section that editors should control without touching code.
+A widget area is a named position in a site template. Editors choose what appears there, while the template controls where the area sits and how its output is styled.
 
-## Querying Widget Areas
+Use a widget area for content that should stay synchronized wherever the area appears, such as a sidebar, a footer column, or a promotional message. Use a [section](/guides/sections/) when an editor should insert and then customize an independent copy inside an entry.
 
-Use `getWidgetArea()` to fetch a widget area by name:
+## Add a widget area
 
-```astro title="src/layouts/Base.astro"
----
-import { getWidgetArea } from "emdash";
+Create and fill widget areas in **Widgets** in the EmDash admin.
 
-const sidebar = await getWidgetArea("sidebar");
----
+<Steps>
 
-{sidebar && sidebar.widgets.length > 0 && (
-  <aside class="sidebar">
-    {sidebar.widgets.map(widget => (
-      <div class="widget">
-        {widget.title && <h3>{widget.title}</h3>}
-        <!-- Render widget content -->
-      </div>
-    ))}
-  </aside>
-)}
-```
+1. Click **Add Widget Area**. Enter the name the template will query, a label for the admin, and an optional description of where it appears.
 
-The function returns `null` if the widget area does not exist.
+2. Drag a widget from **Available Widgets** into the new area.
 
-## Widget Area Structure
+3. Configure the widget, then drag the widgets within the area to set their order.
 
-A widget area contains metadata and an array of widgets:
+</Steps>
 
-```ts
-interface WidgetArea {
-	id: string;
-	name: string; // Unique identifier ("sidebar", "footer-1")
-	label: string; // Display name ("Main Sidebar")
-	description?: string;
-	widgets: Widget[];
-}
+The available widget types are:
 
-interface Widget {
-	id: string;
-	type: "content" | "menu" | "component";
-	title?: string;
-	// Type-specific fields
-	content?: PortableTextBlock[]; // For content widgets
-	menuName?: string; // For menu widgets
-	componentId?: string; // For component widgets
-	componentProps?: Record<string, unknown>;
-}
-```
+- **Content** renders Portable Text entered by an editor.
+- **Menu** renders a menu selected by name.
+- **Component** renders one of the built-in components: recent posts, categories, tags, search, or archives.
 
-## Widget Types
+The component settings in the admin control details such as item limits, dates, counts, and search placeholder text.
 
-EmDash supports three widget types:
+The following built-in component widgets are available:
 
-### Content Widgets
+| Component | What it renders |
+| --------- | --------------- |
+| `core:recent-posts` | Recent posts, with optional dates and thumbnails |
+| `core:categories` | Category links and optional entry counts |
+| `core:tags` | A limited list of tag links and optional counts |
+| `core:search` | A search form that submits to `/search` |
+| `core:archives` | Monthly or yearly post archive links |
 
-Rich text content stored as Portable Text. Render using the `PortableText` component:
+## Place the area in a template
 
-```astro
----
-import { PortableText } from "emdash/ui";
----
+Import `WidgetArea` from `emdash/ui`. The component fetches the named area, preserves the configured order, and renders nothing when the area is missing or empty.
 
-{widget.type === "content" && widget.content && (
-  <div class="widget-content">
-    <PortableText value={widget.content} />
-  </div>
-)}
-```
-
-### Menu Widgets
-
-Display a navigation menu within a widget area:
-
-```astro
----
-import { getMenu } from "emdash";
-
-const menu = widget.menuName ? await getMenu(widget.menuName) : null;
----
-
-{widget.type === "menu" && menu && (
-  <nav class="widget-nav">
-    <ul>
-      {menu.items.map(item => (
-        <li><a href={item.url}>{item.label}</a></li>
-      ))}
-    </ul>
-  </nav>
-)}
-```
-
-### Component Widgets
-
-Render a registered component with configurable props. EmDash includes these core components:
-
-| Component ID        | Description             | Props                                 |
-| ------------------- | ----------------------- | ------------------------------------- |
-| `core:recent-posts` | List of recent posts    | `count`, `showThumbnails`, `showDate` |
-| `core:categories`   | Category list           | `showCount`, `hierarchical`           |
-| `core:tags`         | Tag cloud               | `showCount`, `limit`                  |
-| `core:search`       | Search form             | `placeholder`                         |
-| `core:archives`     | Monthly/yearly archives | `type`, `limit`                       |
-
-## Rendering Widgets
-
-Create a reusable widget renderer component:
-
-```astro title="src/components/WidgetRenderer.astro"
----
-import { PortableText } from "emdash/ui";
-import { getMenu } from "emdash";
-import type { Widget } from "emdash";
-
-// Import your widget components
-import RecentPosts from "./widgets/RecentPosts.astro";
-import Categories from "./widgets/Categories.astro";
-import TagCloud from "./widgets/TagCloud.astro";
-import SearchForm from "./widgets/SearchForm.astro";
-import Archives from "./widgets/Archives.astro";
-
-interface Props {
-  widget: Widget;
-}
-
-const { widget } = Astro.props;
-
-const componentMap: Record<string, any> = {
-  "core:recent-posts": RecentPosts,
-  "core:categories": Categories,
-  "core:tags": TagCloud,
-  "core:search": SearchForm,
-  "core:archives": Archives,
-};
-
-const menu = widget.type === "menu" && widget.menuName
-  ? await getMenu(widget.menuName)
-  : null;
----
-
-<div class="widget">
-  {widget.title && <h3 class="widget-title">{widget.title}</h3>}
-
-  {widget.type === "content" && widget.content && (
-    <div class="widget-content">
-      <PortableText value={widget.content} />
-    </div>
-  )}
-
-  {widget.type === "menu" && menu && (
-    <nav class="widget-menu">
-      <ul>
-        {menu.items.map(item => (
-          <li><a href={item.url}>{item.label}</a></li>
-        ))}
-      </ul>
-    </nav>
-  )}
-
-  {widget.type === "component" && widget.componentId && componentMap[widget.componentId] && (
-    <Fragment>
-      {(() => {
-        const Component = componentMap[widget.componentId!];
-        return <Component {...widget.componentProps} />;
-      })()}
-    </Fragment>
-  )}
-</div>
-```
-
-## Example Widget Components
-
-### Recent Posts Widget
-
-The following component renders the most recent posts, with optional thumbnails and dates:
-
-```astro title="src/components/widgets/RecentPosts.astro"
----
-import { getEmDashCollection } from "emdash";
-import { Image } from "emdash/ui";
-
-interface Props {
-  count?: number;
-  showThumbnails?: boolean;
-  showDate?: boolean;
-}
-
-const { count = 5, showThumbnails = false, showDate = true } = Astro.props;
-
-const { entries: posts } = await getEmDashCollection("posts", {
-  limit: count,
-  orderBy: { publishedAt: "desc" },
-});
----
-
-<ul class="recent-posts">
-  {posts.map(post => (
-    <li>
-      {showThumbnails && post.data.featured_image && (
-        <Image image={post.data.featured_image} alt="" class="thumbnail" />
-      )}
-      <a href={`/posts/${post.data.slug}`}>{post.data.title}</a>
-      {showDate && post.data.publishedAt && (
-        <time datetime={post.data.publishedAt.toISOString()}>
-          {post.data.publishedAt.toLocaleDateString()}
-        </time>
-      )}
-    </li>
-  ))}
-</ul>
-```
-
-### Search Widget
-
-The following component renders a search form that submits to a search page:
-
-```astro title="src/components/widgets/SearchForm.astro"
----
-interface Props {
-  placeholder?: string;
-}
-
-const { placeholder = "Search..." } = Astro.props;
----
-
-<form action="/search" method="get" class="search-form">
-  <input
-    type="search"
-    name="q"
-    placeholder={placeholder}
-    aria-label="Search"
-  />
-  <button type="submit">Search</button>
-</form>
-```
-
-## Using Widget Areas in Layouts
-
-The following example shows a blog layout with a sidebar widget area:
+The following layout places a sidebar area beside the page content:
 
 ```astro title="src/layouts/BlogPost.astro"
 ---
-import { getWidgetArea } from "emdash";
-import WidgetRenderer from "../components/WidgetRenderer.astro";
-
-const sidebar = await getWidgetArea("sidebar");
+import { WidgetArea } from "emdash/ui";
 ---
 
-<div class="layout">
-  <main class="content">
+<div class="page-with-sidebar">
+  <main>
     <slot />
   </main>
 
-  {sidebar && sidebar.widgets.length > 0 && (
-    <aside class="sidebar">
-      {sidebar.widgets.map(widget => (
-        <WidgetRenderer widget={widget} />
-      ))}
-    </aside>
-  )}
+  <aside aria-label="Sidebar">
+    <WidgetArea name="sidebar" class="sidebar-widgets" />
+  </aside>
 </div>
+```
 
-<style>
-  .layout {
+`WidgetArea` adds `widget-area` and the supplied `class` to its wrapper. Each item uses the `widget`, `widget__title`, and `widget__content` classes. Content, menu, and built-in component widgets add more specific classes beneath them.
+
+Astro component styles are scoped by default. Use a global style block when styling the markup rendered inside `WidgetArea`:
+
+```astro title="src/layouts/BlogPost.astro"
+<style is:global>
+  .page-with-sidebar {
     display: grid;
-    grid-template-columns: 1fr 300px;
+    grid-template-columns: minmax(0, 1fr) 18rem;
     gap: 2rem;
   }
 
-  @media (max-width: 768px) {
-    .layout {
+  .sidebar-widgets {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  .sidebar-widgets .widget__title {
+    margin-block-end: 0.75rem;
+  }
+
+  @media (max-width: 48rem) {
+    .page-with-sidebar {
       grid-template-columns: 1fr;
     }
   }
 </style>
 ```
 
-## Listing All Widget Areas
+## Menus and taxonomies in widgets
 
-Use `getWidgetAreas()` to retrieve all widget areas with their widgets:
+Menu, category, and tag widgets query data in the current request locale. Menu references also resolve to the translated content or term when one exists.
 
-```ts
-import { getWidgetAreas } from "emdash";
+The built-in widget renderer uses the root-relative URL returned by the menu or taxonomy helper. It does not add Astro's locale prefix. On a multilingual site, render navigation and taxonomy lists with the [menu rendering pattern](/guides/menus/#render-a-menu) or [taxonomy list pattern](/guides/taxonomies/#query-a-term-list) when those links need locale prefixes. Content, search, recent-post, and archive widgets can still use the standard `WidgetArea` component.
 
-const areas = await getWidgetAreas();
-// Returns all areas with widgets populated
-```
+<Aside type="tip">
+	A content widget is rendered as Portable Text. Use a component widget when the output needs to
+	query content or apply custom Astro markup.
+</Aside>
 
-## Creating Widget Areas
+## Render an area yourself
 
-Create widget areas through the admin interface at `/_emdash/admin/widgets`, or use the admin API:
+Call `getWidgetArea()` when the site needs markup that the built-in renderer does not provide. The following example renders an area containing content and menu widgets, and adds Astro's locale prefix to menu links.
 
-```http
-POST /_emdash/api/widget-areas
-Content-Type: application/json
+First, fetch the area and pass each configured widget to a renderer:
 
-{
-  "name": "footer-1",
-  "label": "Footer Column 1",
-  "description": "First column in the footer"
+```astro title="src/components/LocalizedWidgetArea.astro"
+---
+import { getWidgetArea } from "emdash";
+import LocalizedWidget from "./LocalizedWidget.astro";
+
+interface Props {
+  name: string;
 }
+
+const area = await getWidgetArea(Astro.props.name);
+---
+
+{area && area.widgets.length > 0 && (
+  <div class="widget-area" data-widget-area={area.name}>
+    {area.widgets.map((widget) => (
+      <LocalizedWidget widget={widget} />
+    ))}
+  </div>
+)}
 ```
 
-Add a content widget:
+Then handle content and menu widgets explicitly:
 
-```http
-POST /_emdash/api/widget-areas/footer-1/widgets
-Content-Type: application/json
+```astro title="src/components/LocalizedWidget.astro"
+---
+import { getMenu } from "emdash";
+import type { Widget } from "emdash";
+import { PortableText } from "emdash/ui";
+import { getRelativeLocaleUrl } from "astro:i18n";
 
-{
-  "type": "content",
-  "title": "About Us",
-  "content": [
-    {
-      "_type": "block",
-      "style": "normal",
-      "children": [{ "_type": "span", "text": "Welcome to our site." }]
-    }
-  ]
+interface Props {
+  widget: Widget;
 }
-```
 
-Add a component widget:
+const { widget } = Astro.props;
+const locale = Astro.currentLocale;
+const menu = widget.type === "menu" && widget.menuName
+  ? await getMenu(widget.menuName, { locale })
+  : null;
 
-```http
-POST /_emdash/api/widget-areas/sidebar/widgets
-Content-Type: application/json
-
-{
-  "type": "component",
-  "title": "Recent Posts",
-  "componentId": "core:recent-posts",
-  "componentProps": { "count": 5, "showDate": true }
+function menuHref(url: string) {
+  return locale && url.startsWith("/")
+    ? getRelativeLocaleUrl(locale, url)
+    : url;
 }
+---
+
+{widget.type !== "component" && (
+  <section class="widget" data-widget-id={widget.id}>
+    {widget.title && <h3>{widget.title}</h3>}
+
+    {widget.type === "content" && widget.content && (
+      <PortableText value={widget.content} />
+    )}
+
+    {widget.type === "menu" && menu && (
+      <nav aria-label={widget.title}>
+        <ul>
+          {menu.items.map((item) => (
+            <li>
+              <a
+                href={menuHref(item.url)}
+                target={item.target}
+                rel={item.target === "_blank" ? "noopener noreferrer" : undefined}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    )}
+  </section>
+)}
 ```
 
-## API Reference
+This focused renderer produces no output for component widgets. Keep component widgets in the standard `WidgetArea`, or add explicit component-ID cases for the site components you support.
 
-### `getWidgetArea(name)`
-
-Fetch a widget area by name with all widgets.
-
-**Parameters:**
-
-- `name` — The widget area's unique identifier (string)
-
-**Returns:** `Promise<WidgetArea | null>`
-
-### `getWidgetAreas()`
-
-List all widget areas with their widgets.
-
-**Returns:** `Promise<WidgetArea[]>`
-
-### `getWidgetComponents()`
-
-List available widget component definitions for the admin UI.
-
-**Returns:** `WidgetComponentDef[]`
+The [runtime API reference](/reference/api/#widget-areas) documents `getWidgetArea()` and `getWidgetAreas()`. For programmatic changes, authenticate with a Bearer token and add `X-EmDash-Request: 1` to every state-changing request. See the [widget area endpoints](/reference/rest-api/#widget-area-endpoints) for request bodies and responses.


### PR DESCRIPTION
## What does this PR do?

Reworks the guides for menus, widget areas, sections, site settings, taxonomies, page layouts, and dark-mode images as a consistent set of site-composition tasks.

The examples now use current query identifiers and decoded route slugs, show locale-aware menu and taxonomy links, use the shipped widget-area renderer, and distinguish copied sections from synchronized widget content. Repeated type and endpoint reference material is replaced with links to the canonical runtime and REST references.

Closes: N/A — documentation correction.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

`pnpm typecheck` was not run because this PR changes MDX only. Targeted Prettier formatting was run on all changed files. Test files, admin localization, changesets, feature discussion, and UI screenshots are not applicable; the documentation site build and seed validation cover the changed examples.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Not applicable — no product UI changes.

Verified with:

- `pnpm build`
- `pnpm lint`
- `pnpm lint:quick`
- `pnpm --dir docs build`
- `emdash seed --validate` against the combined section, layout-field, and dark-image examples
- `git diff --check`
