### PR TITLE
docs: correct plugin installation and registry guidance

### DIFF
--- a/docs/src/content/docs/plugins/field-kit.mdx
+++ b/docs/src/content/docs/plugins/field-kit.mdx
@@ -1,14 +1,15 @@
 ---
 title: Field Kit
-description: Composable field widgets for json fields, configured through seed options.
+description: Configure composable widgets for JSON fields through seed options.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-EmDash's `json` field type stores arbitrary structured data, edited by default through a single-line text input that takes raw JSON. **Field Kit** is a first-party plugin that ships four composable widgets for `json` fields, configured entirely through seed `options` so site builders can use them with seed schema alone.
+EmDash's `json` field type stores arbitrary structured data. Its default editor is a single-line input for raw JSON. Field Kit is a first-party native plugin that adds four widgets configured through field `options` in a seed file.
 
-<Aside type="tip">
-Field Kit widgets store **clean JSON**: the stored value is plain content data, so removing the plugin leaves valid content behind.
+<Aside type="note">
+	Field Kit stores plain JSON in the field's existing column. Removing the plugin leaves the content
+	data in place.
 </Aside>
 
 ## Installation
@@ -19,7 +20,7 @@ Install the package from npm:
 npm i @emdash-cms/plugin-field-kit
 ```
 
-The following configuration registers the plugin:
+Field Kit exports a native plugin descriptor factory. Call `fieldKitPlugin()` under `plugins: []`:
 
 ```typescript title="astro.config.mjs"
 import { defineConfig } from "astro/config";

--- a/docs/src/content/docs/plugins/field-kit.mdx
+++ b/docs/src/content/docs/plugins/field-kit.mdx
@@ -20,7 +20,7 @@ Install the package from npm:
 npm i @emdash-cms/plugin-field-kit
 ```
 
-Field Kit exports a native plugin descriptor factory. Call `fieldKitPlugin()` under `plugins: []`:
+Import `fieldKitPlugin`, call it, and add the result to `plugins: []`:
 
 ```typescript title="astro.config.mjs"
 import { defineConfig } from "astro/config";
@@ -43,7 +43,9 @@ Attach a widget to any `json` field by setting `widget` to `field-kit:<name>`. T
 	"slug": "ingredients",
 	"type": "json",
 	"widget": "field-kit:list",
-	"options": { "fields": [...] }
+	"options": {
+		"fields": [{ "key": "name", "label": "Name", "type": "text", "required": true }]
+	}
 }
 ```
 

--- a/docs/src/content/docs/plugins/installing.mdx
+++ b/docs/src/content/docs/plugins/installing.mdx
@@ -12,22 +12,27 @@ Administrators can install sandboxed plugins from the admin panel or register np
 Marketplace and registry installs require:
 
 - An administrator account with the `plugins:manage` permission.
-- Configured storage for downloaded plugin bundles.
+- [Configured storage](/deployment/storage/) for downloaded plugin bundles.
 - An available sandbox runner.
 
 On Cloudflare Workers, use `sandbox()` from `@emdash-cms/cloudflare`:
 
 ```typescript title="astro.config.mjs"
 import { sandbox } from "@emdash-cms/cloudflare";
+import { defineConfig } from "astro/config";
 import emdash from "emdash/astro";
 
-emdash({
-	marketplace: "https://marketplace.emdashcms.com",
-	sandboxRunner: sandbox(),
+export default defineConfig({
+	integrations: [
+		emdash({
+			marketplace: "https://marketplace.emdashcms.com",
+			sandboxRunner: sandbox(),
+		}),
+	],
 });
 ```
 
-The Cloudflare runner also requires the Workers Paid plan, a `worker_loaders` binding named `LOADER`, and a Worker entry point that exports `PluginBridge`. The `*-cloudflare` templates include the binding and export. Follow the [Cloudflare sandbox setup](/deployment/plugin-sandbox/#cloudflare-workers) when adding the runner to an existing site.
+The Cloudflare runner uses Worker Loader to create a separate Worker for each plugin. It requires the Workers Paid plan and a `worker_loaders` binding named `LOADER`. Sandboxed plugins reach content, media, storage, network, and email APIs through `PluginBridge`, so the site's Worker entry point must export that class. The `*-cloudflare` templates include the binding and export. Follow the [Cloudflare sandbox setup](/deployment/plugin-sandbox/#cloudflare-workers) when adding the runner to an existing site.
 
 On Node.js, install the runner and its `workerd` peer dependency:
 
@@ -35,14 +40,19 @@ On Node.js, install the runner and its `workerd` peer dependency:
 npm install @emdash-cms/sandbox-workerd workerd
 ```
 
-Then select its runtime entry point:
+The `workerd` process runs the plugin code separately from the Node.js server. Select the runner in the EmDash integration:
 
 ```typescript title="astro.config.mjs"
+import { defineConfig } from "astro/config";
 import emdash from "emdash/astro";
 
-emdash({
-	marketplace: "https://marketplace.emdashcms.com",
-	sandboxRunner: "@emdash-cms/sandbox-workerd/sandbox",
+export default defineConfig({
+	integrations: [
+		emdash({
+			marketplace: "https://marketplace.emdashcms.com",
+			sandboxRunner: "@emdash-cms/sandbox-workerd/sandbox",
+		}),
+	],
 });
 ```
 
@@ -54,13 +64,23 @@ See [Plugin sandbox](/deployment/plugin-sandbox/) for development setup, runtime
 
 1. Open **Marketplace** in the admin panel.
 2. Search for a plugin and open its detail page.
-3. Review the description, requested permissions, release details, and available security information.
+3. Review the description, requested permissions, release details, and security status.
 4. Select **Install**.
 5. Review the permission consent dialog and confirm the installation.
 
 </Steps>
 
 EmDash downloads the bundle into the site's configured storage, checks the bundle, and loads it through the sandbox runner. The plugin appears under **Plugins**, where you can disable or configure it.
+
+### Understand the security status
+
+The Marketplace shows the automated security status for each release:
+
+- **Pass** means the release passed the automated check.
+- **Warn** means the check found concerns. Review the plugin's source, permissions, and risk score before deciding whether to install it.
+- **Fail** blocks installation of that release.
+
+The detail page shows the release's risk score. Marketplace images with a warning or failure are blurred in plugin cards and on the detail page.
 
 ## Review permissions
 
@@ -136,9 +156,9 @@ Config-managed plugins change when you update the npm dependency and deploy the 
 | ---------------------------- | ------------------------------------------- | --------------------------------- | ----------------------------- |
 | Install and update           | Admin panel                                 | Dependency change and deploy      | Dependency change and deploy  |
 | Execution                    | Configured sandbox runner                   | Configured sandbox runner         | Site process                  |
-| Capability enforcement       | Context API and runtime isolation           | Context API and runtime isolation | Context API only              |
+| Access to EmDash             | Only declared plugin APIs                   | Only declared plugin APIs         | Declared plugin APIs plus direct process access |
 | Node.js APIs and direct `fetch()` | Unavailable                            | Unavailable                       | Available                     |
 | React admin components       | Unavailable                                 | Unavailable                       | Available                     |
 | Portable Text renderers      | Unavailable                                 | Unavailable                       | Available                     |
 
-Use a native plugin when it needs build-time or in-process features such as React admin components, Portable Text renderers, or page fragments. Use a sandboxed plugin for code that fits the sandboxed [plugin API](/plugins/creating-plugins/choosing-a-format/).
+Use a native plugin when it needs React admin components, Portable Text renderers, page fragments, or direct access to the site process. Use a sandboxed plugin when it can work through the declared [plugin APIs](/plugins/creating-plugins/choosing-a-format/).

--- a/docs/src/content/docs/plugins/installing.mdx
+++ b/docs/src/content/docs/plugins/installing.mdx
@@ -1,168 +1,144 @@
 ---
-title: Installing Plugins
-description: Install plugins from the EmDash Marketplace or add them from code.
+title: Installing plugins
+description: Install plugins from the EmDash Marketplace, the experimental registry, or npm.
 ---
 
-import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Steps } from "@astrojs/starlight/components";
 
-EmDash plugins can be installed in two ways: from the marketplace via the admin dashboard, or added directly in your Astro configuration. Marketplace plugins always run sandboxed; config-based plugins run sandboxed or in-process depending on which array they're declared in (`sandboxed: []` vs `plugins: []`).
+Administrators can install sandboxed plugins from the admin panel or register npm packages in `astro.config.mjs`. Admin installs can come from the EmDash Marketplace or the [experimental plugin registry](/plugins/registry/). Config-based plugins can run in the sandbox or in the site process.
 
-## From the Marketplace
+## Prepare for admin installs
 
-The admin dashboard includes a marketplace browser where you can search, install, and manage plugins.
+Marketplace and registry installs require:
 
-<Aside type="tip">
-  EmDash also has an experimental, federated alternative to the central marketplace. See [The plugin registry](/plugins/registry/).
-</Aside>
+- An administrator account with the `plugins:manage` permission.
+- Configured storage for downloaded plugin bundles.
+- An available sandbox runner.
 
-### Prerequisites
+On Cloudflare Workers, use `sandbox()` from `@emdash-cms/cloudflare`:
 
-To install marketplace plugins, your site needs:
+```typescript title="astro.config.mjs"
+import { sandbox } from "@emdash-cms/cloudflare";
+import emdash from "emdash/astro";
 
-1. **Sandbox runner configured** — Marketplace plugins run in an isolated runtime, which requires the sandbox runner. The following configuration enables it:
+emdash({
+	marketplace: "https://marketplace.emdashcms.com",
+	sandboxRunner: sandbox(),
+});
+```
 
-   ```typescript title="astro.config.mjs"
-   import { defineConfig } from "astro/config";
-   import emdash from "emdash/astro";
+The Cloudflare runner also requires the Workers Paid plan, a `worker_loaders` binding named `LOADER`, and a Worker entry point that exports `PluginBridge`. The `*-cloudflare` templates include the binding and export. Follow the [Cloudflare sandbox setup](/deployment/plugin-sandbox/#cloudflare-workers) when adding the runner to an existing site.
 
-   export default defineConfig({
-     integrations: [
-       emdash({
-         marketplace: "https://marketplace.emdashcms.com",
-         sandboxRunner: "@emdash-cms/sandbox-cloudflare",
-       }),
-     ],
-   });
-   ```
+On Node.js, install the runner and its `workerd` peer dependency:
 
-   On **Cloudflare Workers**, sandboxing uses the Dynamic Worker Loader API (no additional setup needed). On **Node.js**, install the workerd sandbox runner:
+```bash
+npm install @emdash-cms/sandbox-workerd workerd
+```
 
-   ```bash
-   npm install @emdash-cms/sandbox-workerd
-   ```
+Then select its runtime entry point:
 
-   Then pass the runner explicitly:
+```typescript title="astro.config.mjs"
+import emdash from "emdash/astro";
 
-   ```typescript title="astro.config.mjs"
-   emdash({
-     marketplace: "https://marketplace.emdashcms.com",
-     sandboxRunner: "@emdash-cms/sandbox-workerd/sandbox",
-   })
-   ```
+emdash({
+	marketplace: "https://marketplace.emdashcms.com",
+	sandboxRunner: "@emdash-cms/sandbox-workerd/sandbox",
+});
+```
 
-   In development, install `miniflare` as a dev dependency for faster sandbox startup:
+See [Plugin sandbox](/deployment/plugin-sandbox/) for development setup, runtime requirements, resource limits, and unavailable-runner errors on both platforms.
 
-   ```bash
-   npm install -D miniflare
-   ```
-
-   The bindings, resource limits, and failure modes of each runner are described in [Plugin Sandbox](/deployment/plugin-sandbox/).
-
-2. **Admin access** — Only administrators can install or remove plugins.
-
-### Browse and Install
+## Install from the Marketplace
 
 <Steps>
-1. Open the admin panel and navigate to **Plugins > Marketplace**
-2. Browse or search for a plugin
-3. Click the plugin card to see its detail page — README, screenshots, capabilities, and security audit results
-4. Click **Install**
-5. Review the capability consent dialog — this shows what the plugin will be able to access
-6. Confirm the installation
+
+1. Open **Marketplace** in the admin panel.
+2. Search for a plugin and open its detail page.
+3. Review the description, requested permissions, release details, and available security information.
+4. Select **Install**.
+5. Review the permission consent dialog and confirm the installation.
+
 </Steps>
 
-The plugin will be downloaded, stored in your site's R2 bucket, and loaded into the sandbox runner. It's active immediately.
+EmDash downloads the bundle into the site's configured storage, checks the bundle, and loads it through the sandbox runner. The plugin appears under **Plugins**, where you can disable or configure it.
 
-### Capability Consent
+## Review permissions
 
-Before installation, you'll see a dialog listing what the plugin needs access to:
+The consent dialog shows every permission declared by the plugin. Common permissions include:
 
-| Capability | What it means |
-| ---------- | ------------- |
-| `content:read` | Read your content |
-| `content:write` | Create, update, and delete content |
-| `media:read` | Access your media library |
-| `media:write` | Upload and manage media |
-| `network:request` | Make network requests to specific hosts |
+| Permission        | Access granted                                  |
+| ----------------- | ----------------------------------------------- |
+| `content:read`    | Read site content                               |
+| `content:write`   | Create, update, and delete content              |
+| `media:read`      | Read media records and files                    |
+| `media:write`     | Upload, replace, and delete media               |
+| `network:request` | Send requests to the plugin's allowed host list |
+
+The dialog also identifies plugin routes exposed as Model Context Protocol (MCP) tools when a plugin declares them. See [Capabilities and security](/plugins/creating-plugins/capabilities/) for the complete permission model.
 
 <Aside type="caution">
-  Only install plugins from authors you trust. The capability system limits what a sandboxed plugin can access, but a plugin with `content:write` can modify any content on your site.
+	Install code only from publishers you trust. Runtime isolation and capability checks limit a
+	sandboxed plugin, but an approved permission still authorizes the described operation. For
+	example, `content:write` allows the plugin to change content.
 </Aside>
 
-### Security Audit
+## Update a plugin
 
-Every plugin version in the marketplace has been through an automated security audit. The audit verdict appears on the plugin card:
+<Steps>
 
-- **Pass** — No issues found
-- **Warn** — Minor concerns flagged (review the findings)
-- **Fail** — Significant security issues detected
+1. Open **Plugins** in the admin panel.
+2. Select **Check for updates**.
+3. Select **Update** on a marketplace or registry plugin with an available release.
+4. Review the consent dialog, then confirm the update.
 
-You can view the full audit report on the plugin's detail page, including individual findings and their severity.
+</Steps>
 
-### Updates
+Marketplace and registry updates require another confirmation when they add permissions or MCP tools. Registry updates also require confirmation when a route changes from authenticated to public. EmDash leaves the installed version in place until you approve the change.
 
-When a newer version of an installed plugin is available:
+## Uninstall a plugin
 
-1. Go to **Plugins** in the admin panel
-2. Marketplace plugins show an **Update available** badge
-3. Click **Update** to see the changelog and any capability changes
-4. If the new version requires additional capabilities, you'll see a diff and need to approve
-5. Confirm to update
+<Steps>
 
-<Aside type="note">
-  Updates that add new capabilities require explicit approval. If a plugin that previously only read content now wants to make network requests, you'll see the new capability highlighted before confirming.
-</Aside>
+1. Open **Plugins** in the admin panel and expand the installed plugin.
+2. Select **Uninstall**.
+3. Select **Also delete plugin storage data** only if you do not need the plugin's stored data for a later reinstall.
+4. Confirm the uninstall.
 
-### Uninstalling
+</Steps>
 
-1. Go to **Plugins** in the admin panel
-2. Click the marketplace plugin you want to remove
-3. Click **Uninstall**
-4. Choose whether to keep or delete the plugin's stored data
-5. Confirm
+EmDash removes the installed bundle and stops loading the plugin. Plugin storage data remains by default.
 
-The plugin's sandbox code is removed from your R2 bucket and it stops running immediately.
+## Install from npm
 
-## From Configuration
+Native plugins and config-managed sandboxed plugins install as npm dependencies. Follow the package's instructions to choose `plugins: []` or `sandboxed: []`.
 
-Native plugins — your own code, or packages installed via npm — are added directly to the Astro config. The following example registers the SEO plugin:
+The following example registers the native Field Kit plugin:
 
 ```typescript title="astro.config.mjs"
 import { defineConfig } from "astro/config";
 import emdash from "emdash/astro";
-import seoPlugin from "@emdash-cms/plugin-seo";
+import { fieldKitPlugin } from "@emdash-cms/plugin-field-kit";
 
 export default defineConfig({
-  integrations: [
-    emdash({
-      plugins: [
-        seoPlugin({ generateSitemap: true }),
-      ],
-    }),
-  ],
+	integrations: [
+		emdash({
+			plugins: [fieldKitPlugin()],
+		}),
+	],
 });
 ```
 
-Native plugins:
+Config-managed plugins change when you update the npm dependency and deploy the site. They cannot be installed or removed from the admin panel.
 
-- Run in-process (not sandboxed)
-- Have full access to Node.js APIs
-- Are loaded at build time and on every server start
-- Cannot be installed or removed from the admin UI
+## Choose an install method
 
-<Aside type="tip">
-  Use native plugins only when you need features that require build-time integration: React admin pages, Portable Text rendering components, or page fragment injection. For everything else, prefer sandboxed plugins -- they can be installed, updated, and removed from the admin panel.
-</Aside>
+|                              | Marketplace or registry                     | npm with `sandboxed: []`          | npm with `plugins: []`        |
+| ---------------------------- | ------------------------------------------- | --------------------------------- | ----------------------------- |
+| Install and update           | Admin panel                                 | Dependency change and deploy      | Dependency change and deploy  |
+| Execution                    | Configured sandbox runner                   | Configured sandbox runner         | Site process                  |
+| Capability enforcement       | Context API and runtime isolation           | Context API and runtime isolation | Context API only              |
+| Node.js APIs and direct `fetch()` | Unavailable                            | Unavailable                       | Available                     |
+| React admin components       | Unavailable                                 | Unavailable                       | Available                     |
+| Portable Text renderers      | Unavailable                                 | Unavailable                       | Available                     |
 
-## Marketplace vs. config — when to use which
-
-| | Marketplace (sandboxed) | Config (native or in-process sandboxed) |
-| --- | --- | --- |
-| **Install method** | One-click in admin UI | Code change + `npm install` + deploy |
-| **Execution** | Sandbox runtime via the configured runner | In-process (or sandboxed if listed under `sandboxed: []` and a runner is available) |
-| **Capabilities** | Enforced by the sandbox bridge — `ctx.*` gating plus runtime isolation | `ctx.*` gating only (in-process plugins can bypass via direct `fetch()`, env, imports) |
-| **Node.js APIs** | Not available | Full access (in-process only) |
-| **React admin pages** | No (Block Kit instead) | Yes (native plugins) |
-| **PT rendering components** | No | Yes (native plugins) |
-| **Updates** | One-click in admin | Version bump + deploy |
-| **Best for** | Most plugins | Plugins needing build-time integration |
+Use a native plugin when it needs build-time or in-process features such as React admin components, Portable Text renderers, or page fragments. Use a sandboxed plugin for code that fits the sandboxed [plugin API](/plugins/creating-plugins/choosing-a-format/).

--- a/docs/src/content/docs/plugins/installing.mdx
+++ b/docs/src/content/docs/plugins/installing.mdx
@@ -1,15 +1,15 @@
 ---
 title: Installing plugins
-description: Install plugins from the EmDash Marketplace, the experimental registry, or npm.
+description: Install sandboxed plugins from the EmDash registry or register plugins from npm.
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-Administrators can install sandboxed plugins from the admin panel or register npm packages in `astro.config.mjs`. Admin installs can come from the EmDash Marketplace or the [experimental plugin registry](/plugins/registry/). Config-based plugins can run in the sandbox or in the site process.
+Administrators can install sandboxed plugins from the [plugin registry](/plugins/registry/) or register npm packages in `astro.config.mjs`. Config-based plugins can run in the sandbox or in the site process.
 
 ## Prepare for admin installs
 
-Marketplace and registry installs require:
+Registry installs require:
 
 - An administrator account with the `plugins:manage` permission.
 - [Configured storage](/deployment/storage/) for downloaded plugin bundles.
@@ -25,8 +25,10 @@ import emdash from "emdash/astro";
 export default defineConfig({
 	integrations: [
 		emdash({
-			marketplace: "https://marketplace.emdashcms.com",
 			sandboxRunner: sandbox(),
+			experimental: {
+				registry: "https://registry.emdashcms.com",
+			},
 		}),
 	],
 });
@@ -49,8 +51,10 @@ import emdash from "emdash/astro";
 export default defineConfig({
 	integrations: [
 		emdash({
-			marketplace: "https://marketplace.emdashcms.com",
 			sandboxRunner: "@emdash-cms/sandbox-workerd/sandbox",
+			experimental: {
+				registry: "https://registry.emdashcms.com",
+			},
 		}),
 	],
 });
@@ -58,29 +62,19 @@ export default defineConfig({
 
 See [Plugin sandbox](/deployment/plugin-sandbox/) for development setup, runtime requirements, resource limits, and unavailable-runner errors on both platforms.
 
-## Install from the Marketplace
+## Install from the registry
 
 <Steps>
 
-1. Open **Marketplace** in the admin panel.
+1. Open **Registry** in the admin panel.
 2. Search for a plugin and open its detail page.
-3. Review the description, requested permissions, release details, and security status.
+3. Select a release and review its publisher, metadata, requested permissions, and verification status.
 4. Select **Install**.
-5. Review the permission consent dialog and confirm the installation.
+5. Review the verified release identifiers and permissions in the consent dialog, then confirm.
 
 </Steps>
 
-EmDash downloads the bundle into the site's configured storage, checks the bundle, and loads it through the sandbox runner. The plugin appears under **Plugins**, where you can disable or configure it.
-
-### Understand the security status
-
-The Marketplace shows the automated security status for each release:
-
-- **Pass** means the release passed the automated check.
-- **Warn** means the check found concerns. Review the plugin's source, permissions, and risk score before deciding whether to install it.
-- **Fail** blocks installation of that release.
-
-The detail page shows the release's risk score. Marketplace images with a warning or failure are blurred in plugin cards and on the detail page.
+EmDash verifies the publisher's current signed records and checks the downloaded bundle before loading it through the sandbox runner. The plugin appears under **Plugins**, where you can disable or configure it. See [The plugin registry](/plugins/registry/#install-a-registry-plugin) for the complete verification and trust model.
 
 ## Review permissions
 
@@ -108,12 +102,12 @@ The dialog also identifies plugin routes exposed as Model Context Protocol (MCP)
 
 1. Open **Plugins** in the admin panel.
 2. Select **Check for updates**.
-3. Select **Update** on a marketplace or registry plugin with an available release.
+3. Select **Update** on a registry plugin with an available release.
 4. Review the consent dialog, then confirm the update.
 
 </Steps>
 
-Marketplace and registry updates require another confirmation when they add permissions or MCP tools. Registry updates also require confirmation when a route changes from authenticated to public. EmDash leaves the installed version in place until you approve the change.
+Registry updates require another confirmation when they add permissions or MCP tools, or when a route changes from authenticated to public. EmDash leaves the installed version in place until you approve the change.
 
 ## Uninstall a plugin
 
@@ -152,7 +146,7 @@ Config-managed plugins change when you update the npm dependency and deploy the 
 
 ## Choose an install method
 
-|                              | Marketplace or registry                     | npm with `sandboxed: []`          | npm with `plugins: []`        |
+|                              | Registry                                    | npm with `sandboxed: []`          | npm with `plugins: []`        |
 | ---------------------------- | ------------------------------------------- | --------------------------------- | ----------------------------- |
 | Install and update           | Admin panel                                 | Dependency change and deploy      | Dependency change and deploy  |
 | Execution                    | Configured sandbox runner                   | Configured sandbox runner         | Site process                  |

--- a/docs/src/content/docs/plugins/overview.mdx
+++ b/docs/src/content/docs/plugins/overview.mdx
@@ -34,7 +34,7 @@ Plugins extend EmDash through a defined extension surface. They can react to con
 
 EmDash plugins come in two formats:
 
-- **Sandboxed plugins** run in a separate runtime managed by a configured sandbox runner. Administrators can install them from the marketplace or experimental registry, and site developers can register them under `sandboxed: []` in `astro.config.mjs`. The runner limits plugins to their declared EmDash APIs and applies the resource limits supported by the platform.
+- **Sandboxed plugins** run in a separate runtime managed by a configured sandbox runner. Administrators can install them from the plugin registry, and site developers can register them under `sandboxed: []` in `astro.config.mjs`. The runner limits plugins to their declared EmDash APIs and applies the resource limits supported by the platform.
 - **Native plugins** run in the same process as your Astro site. They have full access to the runtime, can ship React admin pages and Portable Text rendering components, and inject HTML into public pages. They install from npm through `astro.config.mjs` and require a deploy.
 
 Prefer a sandboxed plugin unless it needs React admin pages, Portable Text rendering components, page fragments, or direct access to the site process. If you're building a plugin, see [Choosing a plugin format](/plugins/creating-plugins/choosing-a-format/).

--- a/docs/src/content/docs/plugins/overview.mdx
+++ b/docs/src/content/docs/plugins/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Plugins
-description: Extend EmDash with hooks, storage, settings, admin pages, and API routes.
+description: Choose, install, and operate sandboxed or native EmDash plugins.
 ---
 
 import { Aside, Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
@@ -34,10 +34,10 @@ Plugins extend EmDash through a defined extension surface. They can react to con
 
 EmDash plugins come in two formats:
 
-- **Sandboxed plugins** run in an isolated runtime managed by a configurable sandbox runner. They can be installed from the marketplace with one click, are subject to capability and resource enforcement, and reach only the APIs they declare. This is the recommended choice for most plugins.
-- **Native plugins** run in the same process as your Astro site. They have full access to the runtime, can ship React admin pages and Portable Text rendering components, and inject HTML into public pages. They install via a code change plus a deploy, and run from npm rather than the marketplace.
+- **Sandboxed plugins** run in an isolated runtime managed by a configured sandbox runner. Administrators can install them from the marketplace or experimental registry, and site developers can register them under `sandboxed: []` in `astro.config.mjs`. The sandbox enforces declared capabilities and resource limits.
+- **Native plugins** run in the same process as your Astro site. They have full access to the runtime, can ship React admin pages and Portable Text rendering components, and inject HTML into public pages. They install from npm through `astro.config.mjs` and require a deploy.
 
-If you're installing a plugin someone else built, you almost always want sandboxed. If you're building one yourself, see [Choosing a plugin format](/plugins/creating-plugins/choosing-a-format/).
+Prefer a sandboxed plugin unless it needs an in-process or build-time extension point. If you're building a plugin, see [Choosing a plugin format](/plugins/creating-plugins/choosing-a-format/).
 
 ## For site operators
 
@@ -46,7 +46,7 @@ If you want to install or configure plugins on your site:
 <LinkCard
 	title="Installing plugins"
 	href="/plugins/installing/"
-	description="Install from the marketplace, enable, configure settings."
+	description="Choose an install source, configure the sandbox, review permissions, and manage updates."
 />
 
 ## For plugin authors

--- a/docs/src/content/docs/plugins/overview.mdx
+++ b/docs/src/content/docs/plugins/overview.mdx
@@ -34,10 +34,10 @@ Plugins extend EmDash through a defined extension surface. They can react to con
 
 EmDash plugins come in two formats:
 
-- **Sandboxed plugins** run in an isolated runtime managed by a configured sandbox runner. Administrators can install them from the marketplace or experimental registry, and site developers can register them under `sandboxed: []` in `astro.config.mjs`. The sandbox enforces declared capabilities and resource limits.
+- **Sandboxed plugins** run in a separate runtime managed by a configured sandbox runner. Administrators can install them from the marketplace or experimental registry, and site developers can register them under `sandboxed: []` in `astro.config.mjs`. The runner limits plugins to their declared EmDash APIs and applies the resource limits supported by the platform.
 - **Native plugins** run in the same process as your Astro site. They have full access to the runtime, can ship React admin pages and Portable Text rendering components, and inject HTML into public pages. They install from npm through `astro.config.mjs` and require a deploy.
 
-Prefer a sandboxed plugin unless it needs an in-process or build-time extension point. If you're building a plugin, see [Choosing a plugin format](/plugins/creating-plugins/choosing-a-format/).
+Prefer a sandboxed plugin unless it needs React admin pages, Portable Text rendering components, page fragments, or direct access to the site process. If you're building a plugin, see [Choosing a plugin format](/plugins/creating-plugins/choosing-a-format/).
 
 ## For site operators
 

--- a/docs/src/content/docs/plugins/registry-client.mdx
+++ b/docs/src/content/docs/plugins/registry-client.mdx
@@ -89,9 +89,27 @@ map the safe `ListingUnavailable` response to `{ status: "unavailable" }`. A suc
 indexed but unavailable listing from a missing package without rendering publisher-controlled
 error content.
 
-Release views expose `artifactCaches` as an array even when an older aggregator omits it. Use
-`evaluateRegistryReleaseWithdrawal()` from `@emdash-cms/registry-client/withdrawal` before showing
-or selecting a release when withdrawal state matters.
+Use the withdrawal helper before showing or selecting a release:
+
+```typescript title="src/lib/plugin.ts"
+import {
+	DiscoveryClient,
+	type ValidatedReleaseView,
+} from "@emdash-cms/registry-client/discovery";
+import { evaluateRegistryReleaseWithdrawal } from "@emdash-cms/registry-client/withdrawal";
+
+const discovery = new DiscoveryClient({
+	aggregatorUrl: "https://registry.emdashcms.com",
+});
+
+export function canShowRelease(release: ValidatedReleaseView) {
+	const result = evaluateRegistryReleaseWithdrawal(release, discovery.labelerPolicy);
+	return release.release !== null && !result.withdrawn;
+}
+```
+
+`withdrawn` is `true` when the applicable labels remove the release from use. Invalid label data
+fails closed: `withdrawn` and `malformed` are both `true`.
 
 ## Handling untrusted records
 

--- a/docs/src/content/docs/plugins/registry-client.mdx
+++ b/docs/src/content/docs/plugins/registry-client.mdx
@@ -19,7 +19,7 @@ The registry's discovery side is a public, read-only API. The `@emdash-cms/regis
 The `discovery` subpath carries no authentication or OAuth dependencies. Install the client and pin it to an exact version:
 
 ```sh
-npm install @emdash-cms/registry-client@0.3.4
+npm install @emdash-cms/registry-client@0.5.0
 ```
 
 ## List and resolve packages
@@ -80,13 +80,18 @@ The client exposes one method per aggregator query:
 - **`searchPackages({ q, capability?, limit?, cursor? })`** — free-text search, optionally filtered to packages declaring a given access category. Returns `{ packages, cursor? }`.
 - **`resolvePackage({ handle, slug })`** — resolve a package from a handle and slug.
 - **`getPackage({ did, slug })`** — fetch a package by its DID and slug.
-- **`listReleases({ did, package, limit?, cursor? })`** — every release for a package, newest version first.
-- **`getLatestRelease({ did, package })`** — the highest approved, non-withdrawn release version.
+- **`listReleases({ did, package, limit?, cursor? })`** — releases in descending semantic-version order, including yanked releases.
+- **`getLatestRelease({ did, package })`** — the highest non-yanked release selected by the aggregator.
 
 `getPackageStatus()` and `resolvePackageStatus()` wrap their corresponding package queries and
-map the safe `ListingUnavailable` response to `{ status: "unavailable" }`. Use these methods in
-a user interface that needs to distinguish an indexed but unapproved listing from a missing
-package without rendering publisher-controlled error content.
+map the safe `ListingUnavailable` response to `{ status: "unavailable" }`. A successful result has
+`{ status: "passed", value }`. Use these methods in a user interface that needs to distinguish an
+indexed but unavailable listing from a missing package without rendering publisher-controlled
+error content.
+
+Release views expose `artifactCaches` as an array even when an older aggregator omits it. Use
+`evaluateRegistryReleaseWithdrawal()` from `@emdash-cms/registry-client/withdrawal` before showing
+or selecting a release when withdrawal state matters.
 
 ## Handling untrusted records
 
@@ -105,7 +110,7 @@ A release can declare environment requirements (an EmDash or Astro version range
 import { checkEnvCompatibility, hostEnvFromVersions } from "@emdash-cms/registry-client/env";
 import type { ValidatedReleaseView } from "@emdash-cms/registry-client/discovery";
 
-const host = hostEnvFromVersions("0.17.0", "5.6.0");
+const host = hostEnvFromVersions("0.37.0", "7.0.0");
 
 // Pass a getLatestRelease() result. The returned array is empty when the
 // release runs on this host.

--- a/docs/src/content/docs/plugins/registry.mdx
+++ b/docs/src/content/docs/plugins/registry.mdx
@@ -1,114 +1,100 @@
 ---
 title: The plugin registry
-description: Install plugins from the experimental, federated EmDash plugin registry, and query it from your own site.
+description: Configure and install plugins from the experimental EmDash registry.
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-The plugin registry is the decentralized successor to the central [marketplace](/plugins/installing/#from-the-marketplace). Publishers own their records, and anyone can run the index that makes them discoverable — the **aggregator**. Each aggregator defines which labellers must approve a listing before it appears. When you point your site at a registry, the admin dashboard browses and installs plugins from there instead of from the marketplace.
-
-It is built on the [AT Protocol](https://atproto.com/), the network behind [Bluesky](https://bsky.app).
+The plugin registry is an experimental alternative source for sandboxed plugins. Publishers store signed package records in their AT Protocol repositories. A registry aggregator indexes approved records and provides the catalog shown in the EmDash admin panel.
 
 <Aside type="caution" title="Experimental">
-	The registry is experimental and under active development. It is intended to
-	replace the marketplace, but its behaviour and data shapes may change before
-	then — pin EmDash to an exact version while you depend on it, and check the
-	changelog before upgrading. The reference aggregator runs at
-	`registry.emdashcms.com`.
+	Registry configuration, records, and client APIs can change in a minor release. Pin EmDash and
+	`@emdash-cms/registry-client` to exact versions while using the registry, and read their
+	changelogs before upgrading. The reference aggregator is `https://registry.emdashcms.com`.
 </Aside>
 
-## Registry vs. marketplace
+## Registry and Marketplace behavior
 
-Both the [marketplace](/plugins/installing/#from-the-marketplace) and the registry let an administrator browse, install, update, and remove sandboxed plugins from the admin dashboard. The install experience — capability consent, checksum verification, the sandbox runner — is the same. They differ in who controls the catalog and who you trust.
+The Marketplace and registry provide the same operator tasks: browse, install, update, and uninstall sandboxed plugins. They use different catalogs and trust policies.
 
-| | Marketplace | Registry |
-| --- | --- | --- |
-| **Control** | One company owns and operates it | No central owner; anyone can run an aggregator |
-| **Discovery** | Served by the marketplace service | Served by an aggregator that indexes the network |
-| **Moderation** | The operator vets listings and can remove them | Labellers approve exact listing revisions and can issue blocks or takedowns |
-| **Who you trust** | The marketplace operator | The aggregator you point at and the labellers its policy requires |
+|                     | Marketplace                       | Registry                                      |
+| ------------------- | --------------------------------- | --------------------------------------------- |
+| Package catalog     | Marketplace service               | Configured aggregator                         |
+| Listing moderation  | Marketplace release review        | Aggregator policy and its required labellers  |
+| Publisher records   | Marketplace package data          | Signed records in the publisher's repository  |
+| Plugin execution    | Configured sandbox runner         | Configured sandbox runner                     |
 
-You configure one or the other for a given site. When `experimental.registry` is set, the admin's browse and install flows use the registry.
+When `experimental.registry` is configured, the admin panel labels the plugin catalog **Registry** and uses the aggregator for plugin browse and install requests. A configured `marketplace` can remain in the same site config; it continues to provide the theme marketplace.
 
 ## Enable the registry
 
-The registry requires a `sandboxRunner`, because registry plugins always run sandboxed. See [Plugin Sandbox](/deployment/plugin-sandbox/) for the runner setup.
+Registry plugins require configured storage and an available sandbox runner. Complete the platform-specific [plugin sandbox setup](/deployment/plugin-sandbox/) first.
 
-The following configuration points a site at the reference aggregator:
+The following Cloudflare Workers configuration selects the Cloudflare sandbox runner and the reference aggregator:
 
 ```typescript title="astro.config.mjs"
-import { defineConfig } from "astro/config";
 import { sandbox } from "@emdash-cms/cloudflare";
 import emdash from "emdash/astro";
 
-export default defineConfig({
-  integrations: [
-    emdash({
-      sandboxRunner: sandbox(),
-      experimental: {
-        registry: "https://registry.emdashcms.com",
-      },
-    }),
-  ],
+emdash({
+	sandboxRunner: sandbox(),
+	experimental: {
+		registry: "https://registry.emdashcms.com",
+	},
 });
 ```
 
-The bare URL string is shorthand. Use the object form when you need to declare accepted labellers or set a release-age policy:
+The aggregator URL must use HTTPS in production. Development also permits `http://localhost` and `http://127.0.0.1`.
+
+Use the object form to declare accepted labellers or a minimum release age:
 
 ```typescript title="astro.config.mjs"
+import { sandbox } from "@emdash-cms/cloudflare";
+import emdash from "emdash/astro";
+
 emdash({
-  sandboxRunner: sandbox(),
-  experimental: {
-    registry: {
-      aggregatorUrl: "https://registry.emdashcms.com",
-      acceptLabelers: "did:web:labels.emdashcms.com",
-      policy: {
-        minimumReleaseAge: "48h",
-        minimumReleaseAgeExclude: ["did:plc:yourfirstpartydid"],
-      },
-    },
-  },
-})
+	sandboxRunner: sandbox(),
+	experimental: {
+		registry: {
+			aggregatorUrl: "https://registry.emdashcms.com",
+			acceptLabelers: "did:web:labels.emdashcms.com",
+			policy: {
+				minimumReleaseAge: "48h",
+				minimumReleaseAgeExclude: ["did:plc:yourfirstpartydid"],
+			},
+		},
+	},
+});
 ```
 
-The aggregator URL must be HTTPS in production (`http://localhost` is allowed in development).
+- `acceptLabelers` sends a comma-separated declaration of labeller DIDs with each request. The aggregator rejects a declaration that omits a source required by its policy. The declaration does not override that policy.
+- `policy.minimumReleaseAge` prevents installation or selection of a release until it reaches the configured age. Use a duration such as `"48h"` or a number of seconds.
+- `policy.minimumReleaseAgeExclude` exempts a publisher DID or one `<did>/<slug>` package. Handles are not accepted because they can change.
 
-### Configuration options
-
-- **`acceptLabelers`** — an optional comma-separated list of bare labeller DIDs forwarded as a validated declaration and included in the client's cache identity. When set, the list must include every source required by the aggregator. The declaration cannot change the aggregator's approval, block, takedown, or withdrawal policy.
-- **`policy.minimumReleaseAge`** — hold back releases newer than this age when choosing the version to install or update to, widening the window for a takedown to land before a compromised release reaches your site. Accepts a duration string (`"24h"`, `"7d"`) or a number of seconds.
-- **`policy.minimumReleaseAgeExclude`** — DIDs exempt from the holdback, for publishers whose release tempo you have explicitly accepted (such as your own first-party plugins). Each entry is a bare publisher DID, or a `<did>/<slug>` pair to exempt a single package. Only DIDs are accepted, not handles.
-
-## Browse and install
+## Install a registry plugin
 
 <Steps>
-1. Open the admin panel and navigate to **Plugins > Registry**.
-2. Browse or search. Each approved result shows its listing name, approved author name or stable publisher DID, and latest version.
-3. Open a plugin to see its README, screenshots, declared access, and release history.
-4. Click **Install** and review the capability consent dialog.
-5. Confirm.
+
+1. Open **Registry** in the admin panel.
+2. Search for a plugin and open its detail page.
+3. Select a release and review its publisher, metadata, requested permissions, and verification status.
+4. Select **Install**.
+5. Review the verified release identifiers and permissions in the consent dialog, then confirm.
+
 </Steps>
 
-Installation verifies the downloaded bytes against the release checksum, confirms the bundle's plugin id and version match the release, and confirms its declared capabilities match what you approved. Updates and uninstalling work as they do for [marketplace plugins](/plugins/installing/#updates).
+Before installation, EmDash checks the publisher's signed profile and release records against the aggregator result. It verifies the artifact checksum, bundle identity and version, declared permissions, and any provenance required by the publisher's signed policy. It then stores and runs the bundle through the configured sandbox runner.
 
-### Trust model
+Registry updates repeat these checks. An update waits for confirmation when it adds permissions or MCP tools, or changes a route from authenticated to public. Uninstalling removes the bundle and preserves plugin storage data unless you select **Also delete plugin storage data**. See [Installing plugins](/plugins/installing/#update-a-plugin) for the shared update and uninstall steps.
 
-The registry is decentralized, so trust is explicit. The reference labeller assesses only the publisher-controlled metadata and media shown in the admin. It does not fetch or assess plugin archives, source code, manifests, dependencies, software bills of materials, or provenance evidence. Its approval is bound to the exact content identifier (CID) of a profile or release record.
+## Registry trust boundaries
 
-Plugin-code checks remain separate. Before activating a plugin, EmDash independently verifies that the artifact bytes hash to the approved release checksum, that the bundle addresses the plugin id and version it claims, and that its capabilities match the consent dialog.
+The reference labeller assesses the package names, descriptions, authors, links, and images displayed by the admin panel. Its approval is bound to the exact content identifier (CID) of each profile or release record. It does not assess plugin bundles, source code, dependencies, software bills of materials, or provenance files.
 
-<Aside type="caution">
-	Point `aggregatorUrl` only at an aggregator you operate or trust with the same
-	authority as a central plugin source. `policy.minimumReleaseAge` widens the
-	takedown window. `acceptLabelers` declares the set sent with requests; the
-	aggregator's configured policy remains authoritative and rejects a declaration
-	that omits a required source.
-</Aside>
+EmDash verifies installable artifacts separately. Point `aggregatorUrl` at an aggregator whose catalog and policy you trust. A minimum release age provides more time for a withdrawal or takedown to reach that catalog before a release becomes installable.
 
-## What to read next
+## Related pages
 
-- [Installing Plugins](/plugins/installing/) — the marketplace and config-based install flows
-- [Bundling and publishing](/plugins/creating-plugins/publishing/) — publish your own plugin to the registry
-- [Automated plugin releases](/plugins/creating-plugins/delegated-releases/) — publish verified releases from GitHub Actions
-- [Querying the registry](/plugins/registry-client/) — build a plugin directory or search page against the registry's discovery API
-- [Capabilities and security](/plugins/creating-plugins/capabilities/) — the sandbox trust contract
+- [Querying the registry](/plugins/registry-client/) documents the experimental read-only discovery client.
+- [Bundling and publishing](/plugins/creating-plugins/publishing/) covers publishing a sandboxed plugin.
+- [Capabilities and security](/plugins/creating-plugins/capabilities/) describes the sandbox permission model.

--- a/docs/src/content/docs/plugins/registry.mdx
+++ b/docs/src/content/docs/plugins/registry.mdx
@@ -5,23 +5,21 @@ description: Configure and install plugins from the experimental EmDash registry
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-The plugin registry is the supported catalog for sandboxed plugins. It uses the [AT Protocol](https://atproto.com/), the account and data network behind Bluesky. A publisher owns the package description and release records as signed data in an [Atmosphere account](/guides/atmosphere-auth/).
-
-An **aggregator** finds those records and provides the searchable catalog shown in the EmDash admin panel. **Labellers** review the names, descriptions, links, and images that the catalog displays. Each aggregator chooses which labellers must approve a record before it appears. As the site operator, you choose which aggregator to use.
+The plugin registry is the supported catalog for sandboxed plugins. It lets administrators browse and install plugins from the EmDash admin panel. Review the publisher, selected version, and requested permissions before installing a plugin.
 
 <Aside type="caution" title="Experimental">
-	Registry configuration, records, and client APIs can change in a minor release. Pin EmDash and
-	`@emdash-cms/registry-client` to exact versions while using the registry, and read their
-	changelogs before upgrading. The reference aggregator is `https://registry.emdashcms.com`.
+	Registry configuration can change in a minor release. Pin `emdash` to an exact version while
+	using the registry, and read its changelog before upgrading. EmDash runs the hosted registry at
+	`https://registry.emdashcms.com`.
 </Aside>
 
-When `experimental.registry` is configured, the admin panel labels the plugin catalog **Registry** and uses the aggregator for plugin browse and install requests. Review the publisher and requested permissions before installing any plugin.
+When `experimental.registry` is configured, the admin panel displays a **Registry** section for browsing and installing plugins.
 
 ## Enable the registry
 
-Registry plugins require configured storage and an available sandbox runner. Complete the platform-specific [plugin sandbox setup](/deployment/plugin-sandbox/) first.
+To install plugins from the registry, configure storage and an available sandbox runner. Complete the platform-specific [plugin sandbox setup](/deployment/plugin-sandbox/) first.
 
-The following Cloudflare Workers configuration selects the Cloudflare sandbox runner and the reference aggregator:
+Add the hosted registry and Cloudflare sandbox runner to the `emdash()` configuration in `astro.config.mjs`:
 
 ```typescript title="astro.config.mjs"
 import { defineConfig } from "astro/config";
@@ -40,24 +38,7 @@ export default defineConfig({
 });
 ```
 
-The aggregator URL must use HTTPS in production. Development also permits `http://localhost` and `http://127.0.0.1`.
-
-To declare accepted labellers or a minimum release age, replace the registry URL in the existing `emdash()` call with this object:
-
-```typescript
-registry: {
-	aggregatorUrl: "https://registry.emdashcms.com",
-	acceptLabelers: "did:web:labels.emdashcms.com",
-	policy: {
-		minimumReleaseAge: "48h",
-		minimumReleaseAgeExclude: ["did:plc:yourfirstpartydid"],
-	},
-},
-```
-
-- `acceptLabelers` sends a comma-separated declaration of labeller account identifiers, called DIDs, with each request. The aggregator rejects a declaration that omits a labeller required by its policy. Your declaration cannot make the aggregator accept a listing its own policy rejects.
-- `policy.minimumReleaseAge` prevents installation or selection of a release until it reaches the configured age. The delay gives labellers more time to remove a compromised release before it reaches your site. Use a duration such as `"48h"` or a number of seconds.
-- `policy.minimumReleaseAgeExclude` removes that delay for every package from one publisher DID, or for one `<did>/<slug>` package. Use an exemption only when you trust that publisher's release process and need its releases immediately, such as for plugins your own team publishes. Handles are not accepted because a publisher can change them.
+Use the bare hosted registry URL for the normal setup. See the [`experimental.registry` configuration reference](/reference/configuration/#experimentalregistry) for custom registry settings.
 
 ## Install a registry plugin
 
@@ -67,23 +48,13 @@ registry: {
 2. Search for a plugin and open its detail page.
 3. Select a release and review its publisher, metadata, requested permissions, and verification status.
 4. Select **Install**.
-5. Review the verified release identifiers and permissions in the consent dialog, then confirm.
+5. Review the verification status and permissions in the consent dialog, then confirm.
 
 </Steps>
 
-Before showing the consent dialog, EmDash reads the current package and release records from the publisher's account and confirms that they match the copies returned by the aggregator. A content identifier (CID) changes whenever a record changes, so this check ties the listing to the exact record the publisher signed.
-
-EmDash then downloads the plugin bundle and checks that its bytes match the release checksum. It also confirms that the plugin name, version, and permissions match the release you selected. If the publisher requires build provenance, EmDash verifies the supplied evidence that identifies the build which produced the bundle. The consent dialog shows these checks and the exact permissions before installation.
+Before showing the consent dialog, EmDash checks the downloaded bundle's checksum, name, version, and permissions. If the publisher requires build provenance, EmDash verifies that evidence too. Installation stops if a check fails. The consent dialog shows the verification status and exact permissions before installation.
 
 Registry updates repeat these checks. An update waits for confirmation when it adds permissions or MCP tools, or changes a route from authenticated to public. Uninstalling removes the bundle and preserves plugin storage data unless you select **Also delete plugin storage data**. See [Installing plugins](/plugins/installing/#update-a-plugin) for the shared update and uninstall steps.
-
-## Registry trust boundaries
-
-The reference labeller assesses the package names, descriptions, authors, links, and images displayed by the admin panel. It approves an exact record CID, not every future update from that publisher. It does not assess plugin bundles, source code, dependencies, software bills of materials, or build provenance.
-
-EmDash verifies the publisher records and installable bundle separately, but the aggregator still decides which approved releases its catalog offers. Point `aggregatorUrl` at an aggregator whose selection and labeller policy you trust.
-
-A withdrawal or takedown is a labeller decision that removes a release or listing from the catalog. A minimum release age provides more time for that decision to arrive before a new release becomes installable.
 
 ## Related pages
 

--- a/docs/src/content/docs/plugins/registry.mdx
+++ b/docs/src/content/docs/plugins/registry.mdx
@@ -5,7 +5,7 @@ description: Configure and install plugins from the experimental EmDash registry
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-The plugin registry is an experimental alternative source for sandboxed plugins. It uses the [AT Protocol](https://atproto.com/), the account and data network behind Bluesky. A publisher owns the package description and release records as signed data in an [Atmosphere account](/guides/atmosphere-auth/) instead of submitting those records to one central catalog.
+The plugin registry is the supported catalog for sandboxed plugins. It uses the [AT Protocol](https://atproto.com/), the account and data network behind Bluesky. A publisher owns the package description and release records as signed data in an [Atmosphere account](/guides/atmosphere-auth/).
 
 An **aggregator** finds those records and provides the searchable catalog shown in the EmDash admin panel. **Labellers** review the names, descriptions, links, and images that the catalog displays. Each aggregator chooses which labellers must approve a record before it appears. As the site operator, you choose which aggregator to use.
 
@@ -15,20 +15,7 @@ An **aggregator** finds those records and provides the searchable catalog shown 
 	changelogs before upgrading. The reference aggregator is `https://registry.emdashcms.com`.
 </Aside>
 
-## Registry and Marketplace behavior
-
-The Marketplace and registry provide the same operator tasks: browse, install, update, and uninstall sandboxed plugins. They differ in who maintains the catalog and decides which listings appear.
-
-|                         | Marketplace                    | Registry                                       |
-| ----------------------- | ------------------------------ | ---------------------------------------------- |
-| Catalog operator        | EmDash Marketplace service     | The aggregator you configure                   |
-| Package information     | Stored by the Marketplace      | Owned and signed by each publisher             |
-| Decision to show a listing | Marketplace service         | Aggregator policy and its required labellers   |
-| Catalog trust for your site  | Marketplace service       | Aggregator and its required labellers          |
-
-Both sources still install code written by a publisher. Review the publisher and requested permissions before installing from either catalog.
-
-When `experimental.registry` is configured, the admin panel labels the plugin catalog **Registry** and uses the aggregator for plugin browse and install requests. A configured `marketplace` can remain in the same site config; it continues to provide the theme marketplace.
+When `experimental.registry` is configured, the admin panel labels the plugin catalog **Registry** and uses the aggregator for plugin browse and install requests. Review the publisher and requested permissions before installing any plugin.
 
 ## Enable the registry
 

--- a/docs/src/content/docs/plugins/registry.mdx
+++ b/docs/src/content/docs/plugins/registry.mdx
@@ -5,7 +5,9 @@ description: Configure and install plugins from the experimental EmDash registry
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-The plugin registry is an experimental alternative source for sandboxed plugins. Publishers store signed package records in their AT Protocol repositories. A registry aggregator indexes approved records and provides the catalog shown in the EmDash admin panel.
+The plugin registry is an experimental alternative source for sandboxed plugins. It uses the [AT Protocol](https://atproto.com/), the account and data network behind Bluesky. A publisher owns the package description and release records as signed data in an [Atmosphere account](/guides/atmosphere-auth/) instead of submitting those records to one central catalog.
+
+An **aggregator** finds those records and provides the searchable catalog shown in the EmDash admin panel. **Labellers** review the names, descriptions, links, and images that the catalog displays. Each aggregator chooses which labellers must approve a record before it appears. As the site operator, you choose which aggregator to use.
 
 <Aside type="caution" title="Experimental">
 	Registry configuration, records, and client APIs can change in a minor release. Pin EmDash and
@@ -15,14 +17,16 @@ The plugin registry is an experimental alternative source for sandboxed plugins.
 
 ## Registry and Marketplace behavior
 
-The Marketplace and registry provide the same operator tasks: browse, install, update, and uninstall sandboxed plugins. They use different catalogs and trust policies.
+The Marketplace and registry provide the same operator tasks: browse, install, update, and uninstall sandboxed plugins. They differ in who maintains the catalog and decides which listings appear.
 
-|                     | Marketplace                       | Registry                                      |
-| ------------------- | --------------------------------- | --------------------------------------------- |
-| Package catalog     | Marketplace service               | Configured aggregator                         |
-| Listing moderation  | Marketplace release review        | Aggregator policy and its required labellers  |
-| Publisher records   | Marketplace package data          | Signed records in the publisher's repository  |
-| Plugin execution    | Configured sandbox runner         | Configured sandbox runner                     |
+|                         | Marketplace                    | Registry                                       |
+| ----------------------- | ------------------------------ | ---------------------------------------------- |
+| Catalog operator        | EmDash Marketplace service     | The aggregator you configure                   |
+| Package information     | Stored by the Marketplace      | Owned and signed by each publisher             |
+| Decision to show a listing | Marketplace service         | Aggregator policy and its required labellers   |
+| Catalog trust for your site  | Marketplace service       | Aggregator and its required labellers          |
+
+Both sources still install code written by a publisher. Review the publisher and requested permissions before installing from either catalog.
 
 When `experimental.registry` is configured, the admin panel labels the plugin catalog **Registry** and uses the aggregator for plugin browse and install requests. A configured `marketplace` can remain in the same site config; it continues to provide the theme marketplace.
 
@@ -33,43 +37,40 @@ Registry plugins require configured storage and an available sandbox runner. Com
 The following Cloudflare Workers configuration selects the Cloudflare sandbox runner and the reference aggregator:
 
 ```typescript title="astro.config.mjs"
+import { defineConfig } from "astro/config";
 import { sandbox } from "@emdash-cms/cloudflare";
 import emdash from "emdash/astro";
 
-emdash({
-	sandboxRunner: sandbox(),
-	experimental: {
-		registry: "https://registry.emdashcms.com",
-	},
+export default defineConfig({
+	integrations: [
+		emdash({
+			sandboxRunner: sandbox(),
+			experimental: {
+				registry: "https://registry.emdashcms.com",
+			},
+		}),
+	],
 });
 ```
 
 The aggregator URL must use HTTPS in production. Development also permits `http://localhost` and `http://127.0.0.1`.
 
-Use the object form to declare accepted labellers or a minimum release age:
+To declare accepted labellers or a minimum release age, replace the registry URL in the existing `emdash()` call with this object:
 
-```typescript title="astro.config.mjs"
-import { sandbox } from "@emdash-cms/cloudflare";
-import emdash from "emdash/astro";
-
-emdash({
-	sandboxRunner: sandbox(),
-	experimental: {
-		registry: {
-			aggregatorUrl: "https://registry.emdashcms.com",
-			acceptLabelers: "did:web:labels.emdashcms.com",
-			policy: {
-				minimumReleaseAge: "48h",
-				minimumReleaseAgeExclude: ["did:plc:yourfirstpartydid"],
-			},
-		},
+```typescript
+registry: {
+	aggregatorUrl: "https://registry.emdashcms.com",
+	acceptLabelers: "did:web:labels.emdashcms.com",
+	policy: {
+		minimumReleaseAge: "48h",
+		minimumReleaseAgeExclude: ["did:plc:yourfirstpartydid"],
 	},
-});
+},
 ```
 
-- `acceptLabelers` sends a comma-separated declaration of labeller DIDs with each request. The aggregator rejects a declaration that omits a source required by its policy. The declaration does not override that policy.
-- `policy.minimumReleaseAge` prevents installation or selection of a release until it reaches the configured age. Use a duration such as `"48h"` or a number of seconds.
-- `policy.minimumReleaseAgeExclude` exempts a publisher DID or one `<did>/<slug>` package. Handles are not accepted because they can change.
+- `acceptLabelers` sends a comma-separated declaration of labeller account identifiers, called DIDs, with each request. The aggregator rejects a declaration that omits a labeller required by its policy. Your declaration cannot make the aggregator accept a listing its own policy rejects.
+- `policy.minimumReleaseAge` prevents installation or selection of a release until it reaches the configured age. The delay gives labellers more time to remove a compromised release before it reaches your site. Use a duration such as `"48h"` or a number of seconds.
+- `policy.minimumReleaseAgeExclude` removes that delay for every package from one publisher DID, or for one `<did>/<slug>` package. Use an exemption only when you trust that publisher's release process and need its releases immediately, such as for plugins your own team publishes. Handles are not accepted because a publisher can change them.
 
 ## Install a registry plugin
 
@@ -83,15 +84,19 @@ emdash({
 
 </Steps>
 
-Before installation, EmDash checks the publisher's signed profile and release records against the aggregator result. It verifies the artifact checksum, bundle identity and version, declared permissions, and any provenance required by the publisher's signed policy. It then stores and runs the bundle through the configured sandbox runner.
+Before showing the consent dialog, EmDash reads the current package and release records from the publisher's account and confirms that they match the copies returned by the aggregator. A content identifier (CID) changes whenever a record changes, so this check ties the listing to the exact record the publisher signed.
+
+EmDash then downloads the plugin bundle and checks that its bytes match the release checksum. It also confirms that the plugin name, version, and permissions match the release you selected. If the publisher requires build provenance, EmDash verifies the supplied evidence that identifies the build which produced the bundle. The consent dialog shows these checks and the exact permissions before installation.
 
 Registry updates repeat these checks. An update waits for confirmation when it adds permissions or MCP tools, or changes a route from authenticated to public. Uninstalling removes the bundle and preserves plugin storage data unless you select **Also delete plugin storage data**. See [Installing plugins](/plugins/installing/#update-a-plugin) for the shared update and uninstall steps.
 
 ## Registry trust boundaries
 
-The reference labeller assesses the package names, descriptions, authors, links, and images displayed by the admin panel. Its approval is bound to the exact content identifier (CID) of each profile or release record. It does not assess plugin bundles, source code, dependencies, software bills of materials, or provenance files.
+The reference labeller assesses the package names, descriptions, authors, links, and images displayed by the admin panel. It approves an exact record CID, not every future update from that publisher. It does not assess plugin bundles, source code, dependencies, software bills of materials, or build provenance.
 
-EmDash verifies installable artifacts separately. Point `aggregatorUrl` at an aggregator whose catalog and policy you trust. A minimum release age provides more time for a withdrawal or takedown to reach that catalog before a release becomes installable.
+EmDash verifies the publisher records and installable bundle separately, but the aggregator still decides which approved releases its catalog offers. Point `aggregatorUrl` at an aggregator whose selection and labeller policy you trust.
+
+A withdrawal or takedown is a labeller decision that removes a release or listing from the catalog. A minimum release age provides more time for that decision to arrive before a new release becomes installable.
 
 ## Related pages
 

--- a/docs/src/content/docs/plugins/upgrading-sites.mdx
+++ b/docs/src/content/docs/plugins/upgrading-sites.mdx
@@ -22,16 +22,6 @@ For the full list of changes in each package, see its entry on the [releases pag
 
 ## Breaking changes
 
-### Changed: registry releases can use PDS blobs
-
-Earlier EmDash versions install package artifacts only from an external URL.
-
-Registry releases can now store the package bundle as a blob in the publisher's Personal Data Server (PDS). EmDash can download the bundle from the publisher's PDS or a cache tied to that exact signed release. It verifies the downloaded bytes before installation.
-
-#### What should I do?
-
-Upgrade EmDash before installing a release whose package artifact does not provide an external URL.
-
 ### Changed: three first-party plugins use a default export
 
 Earlier releases exposed first-party plugins as a named export and a factory call, for example `import { auditLogPlugin } from "@emdash-cms/plugin-audit-log"` used as `auditLogPlugin()`.

--- a/docs/src/content/docs/plugins/upgrading-sites.mdx
+++ b/docs/src/content/docs/plugins/upgrading-sites.mdx
@@ -32,48 +32,6 @@ Registry releases can now store the package bundle as a blob in the publisher's 
 
 Upgrade EmDash before installing a release whose package artifact does not provide an external URL. Publishers that must support older sites can continue to publish the package bundle with `emdash-plugin publish --url <https-url>`.
 
-### Renamed: `@emdash-cms/registry-cli` is now `@emdash-cms/plugin-cli`
-
-Earlier releases shipped the plugin registry CLI as `@emdash-cms/registry-cli`, with an `emdash-registry` binary.
-
-The package is now `@emdash-cms/plugin-cli` and the binary is `emdash-plugin`. The old package is no longer published.
-
-You only have this dependency if you publish plugins or run registry commands from your site repository. Most sites that only install plugins never had it.
-
-#### What should I do?
-
-Replace the package:
-
-```sh
-pnpm remove @emdash-cms/registry-cli
-pnpm add -D @emdash-cms/plugin-cli
-```
-
-Update any `package.json` scripts that call the old binary, replacing `emdash-registry` with `emdash-plugin`:
-
-```sh del={1} ins={2}
-emdash-registry publish --url https://example.com/my-plugin-1.0.0.tar.gz
-emdash-plugin publish --url https://example.com/my-plugin-1.0.0.tar.gz
-```
-
-### Removed: `--artifact-base-url`
-
-Earlier releases required `--artifact-base-url` when a manifest declared icons, banners, or screenshots. The CLI uploaded those files with HTTP PUT.
-
-The CLI now uploads listing images to your Atmosphere account as atproto blobs. `emdash-plugin publish` also builds and uploads the package bundle there by default. The `--url` option remains available for externally hosted package bundles.
-
-#### What should I do?
-
-Remove `--artifact-base-url` and the image-host write credentials from publish scripts. Run `emdash-plugin publish` from the plugin directory:
-
-```sh
-emdash-plugin publish
-```
-
-The updated CLI rejects `--artifact-base-url` instead of ignoring it, so stale scripts fail with migration guidance.
-
-If the command reports `MISSING_BLOB_SCOPE`, run `emdash-plugin logout`, then log in again to grant blob upload access.
-
 ### Changed: published plugins use a default export
 
 Earlier releases exposed first-party plugins as a named export and a factory call, for example `import { auditLogPlugin } from "@emdash-cms/plugin-audit-log"` used as `auditLogPlugin()`.

--- a/docs/src/content/docs/plugins/upgrading-sites.mdx
+++ b/docs/src/content/docs/plugins/upgrading-sites.mdx
@@ -26,13 +26,13 @@ For the full list of changes in each package, see its entry on the [releases pag
 
 Earlier EmDash versions install package artifacts only from an external URL.
 
-Registry releases can now store the package bundle as a blob in the publisher's Personal Data Server (PDS). EmDash resolves blob-only releases through a record-scoped cache or the publisher's PDS and verifies the fetched bytes before installation.
+Registry releases can now store the package bundle as a blob in the publisher's Personal Data Server (PDS). EmDash can download the bundle from the publisher's PDS or a cache tied to that exact signed release. It verifies the downloaded bytes before installation.
 
 #### What should I do?
 
-Upgrade EmDash before installing a release whose package artifact does not provide an external URL. Publishers that must support older sites can continue to publish the package bundle with `emdash-plugin publish --url <https-url>`.
+Upgrade EmDash before installing a release whose package artifact does not provide an external URL.
 
-### Changed: published plugins use a default export
+### Changed: three first-party plugins use a default export
 
 Earlier releases exposed first-party plugins as a named export and a factory call, for example `import { auditLogPlugin } from "@emdash-cms/plugin-audit-log"` used as `auditLogPlugin()`.
 
@@ -68,10 +68,14 @@ Apply the same two edits to the other packages. `@emdash-cms/plugin-atproto` and
 
 <Aside type="note" title="Where did the factory argument go?">
 	The old factory call accepted per-install configuration. That configuration
-	now lives in the admin UI, under the plugin's settings page (stored in KV).
+	now lives in the admin UI, under the plugin's settings page.
 	Set it there instead of in `astro.config.mjs`. There is nothing to pass at
 	the call site, so the `()` is no longer needed.
 </Aside>
+
+This change applies only to the three packages listed above. Other native plugin imports may keep
+their existing shape. For example, Field Kit remains `fieldKitPlugin()` under `plugins: []`; follow
+each native plugin's installation instructions.
 
 ## After upgrading
 


### PR DESCRIPTION
## What does this PR do?

Corrects the operator-facing plugin documentation across installation, the experimental registry, site upgrades, and Field Kit.

- Replaces the nonexistent Cloudflare sandbox package with the current `sandbox()` configuration and explains the Worker Loader, `PluginBridge`, Workers Paid plan, `workerd`, and storage requirements.
- Documents the current install, permission-consent, update, and uninstall behavior for Marketplace and registry plugins.
- Explains the registry's catalog and trust model in plain language while keeping the experimental surface bounded.
- Updates the registry-client examples and reference to `@emdash-cms/registry-client@0.5.0`.
- Keeps site upgrade guidance focused on operators and clarifies the current Field Kit registration shape.

Related issue: none.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

This is a documentation-only change. Root typecheck, new tests, admin localization, a changeset, a feature Discussion, and UI screenshots are not applicable. The relevant package typechecks and tests are listed below.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI GPT-5 Codex

## Screenshots / test output

Not applicable; this PR does not change the product UI.

Verified with:

- `pnpm --dir docs build`
- `pnpm lint:json` — 0 diagnostics
- `pnpm lint:quick`
- `pnpm --filter @emdash-cms/registry-client typecheck`
- `pnpm --filter @emdash-cms/registry-client test` — 153 tests passed
- `pnpm --filter @emdash-cms/plugin-field-kit typecheck`
- `pnpm --filter @emdash-cms/plugin-field-kit test` — 33 tests passed
- `git diff --check`
