### PR TITLE
feat(plugins): say why the sandbox runner is unavailable

### DIFF
--- a/.changeset/sandbox-unavailable-reason.md
+++ b/.changeset/sandbox-unavailable-reason.md
@@ -1,0 +1,9 @@
+---
+"emdash": minor
+"@emdash-cms/cloudflare": patch
+"@emdash-cms/sandbox-workerd": patch
+---
+
+Adds the cause to the `SANDBOX_NOT_AVAILABLE` error and to the "Plugin sandbox is configured but not available on this platform" startup warning when a configured sandbox runner cannot run plugins. On Cloudflare Workers the message names the missing `worker_loaders` binding or `PluginBridge` export; on Node.js it says that the `workerd` binary did not run.
+
+Sandbox runners report the cause through a new optional `unavailableReason()` method on `SandboxRunner`. Runners without it keep the previous messages.

--- a/docs/src/content/docs/deployment/plugin-sandbox.mdx
+++ b/docs/src/content/docs/deployment/plugin-sandbox.mdx
@@ -131,10 +131,10 @@ When a hook or route exceeds the wall-time limit, the invocation fails with `Plu
 
 ## When the runner is unavailable
 
-A configured runner can still be unavailable: on Cloudflare Workers when the `worker_loaders` binding or the `PluginBridge` export is missing, on Node.js when `workerd` is not installed or its binary does not run. EmDash then logs the following warning when the runtime starts:
+A configured runner can still be unavailable: on Cloudflare Workers when the `worker_loaders` binding or the `PluginBridge` export is missing, on Node.js when `workerd` is not installed or its binary does not run. EmDash then logs a warning when the runtime starts, with the cause the runner reports after the colon. The following warning is logged on Cloudflare Workers when the binding is missing:
 
 ```plain
-EmDash: Plugin sandbox is configured but not available on this platform. Sandboxed plugins will not be loaded. If using @emdash-cms/sandbox-workerd/sandbox, ensure workerd is installed.
+EmDash: Plugin sandbox is configured but not available on this platform: the worker has no worker_loaders binding named LOADER. Sandboxed plugins will not be loaded.
 ```
 
 Plugins under `sandboxed: []` are not loaded, installed marketplace and registry plugins do not run, and a new install from the admin fails with the error code `SANDBOX_NOT_AVAILABLE`. The rest of the site is unaffected.
@@ -158,9 +158,9 @@ Each entry is headed by the message as the server logs it, or by the error code 
 
 ### "Plugin sandbox is configured but not available on this platform"
 
-On Cloudflare Workers, check both requirements: `wrangler.jsonc` has a `worker_loaders` binding named `LOADER`, and `main` points to a file that exports `PluginBridge`. Deploying the binding needs the Workers Paid plan.
+The text after the colon names the cause. On Cloudflare Workers, `the worker has no worker_loaders binding named LOADER` means `wrangler.jsonc` needs a `worker_loaders` binding named `LOADER`, and `the worker entrypoint does not export PluginBridge` means the file `main` points to must export `PluginBridge`. Deploying the binding needs the Workers Paid plan.
 
-On Node.js, run the binary the runner uses:
+On Node.js, `workerd is missing or its binary does not run on this platform` means the runner could not run `workerd`. The following command runs the binary the runner uses:
 
 ```bash
 npx workerd --version
@@ -178,4 +178,4 @@ The runner has stopped restarting `workerd`. The `[emdash:workerd] workerd exite
 
 ### `SANDBOX_NOT_AVAILABLE` when installing a plugin
 
-The admin's install request was refused because the runner is missing or unavailable. Configure the runner for the platform, or fix the cause of the startup warning above, and redeploy.
+The admin's install request was refused because the runner is missing or unavailable. When a runner is configured, the error message ends with the same cause as the startup warning above. Configure the runner for the platform, or fix that cause, and redeploy.

--- a/packages/cloudflare/src/sandbox/runner.ts
+++ b/packages/cloudflare/src/sandbox/runner.ts
@@ -139,6 +139,13 @@ export class CloudflareSandboxRunner implements SandboxRunner {
 		return !!getLoader() && !!getPluginBridge();
 	}
 
+	unavailableReason(): string {
+		const missing: string[] = [];
+		if (!getLoader()) missing.push("the worker has no worker_loaders binding named LOADER");
+		if (!getPluginBridge()) missing.push("the worker entrypoint does not export PluginBridge");
+		return missing.join(", and ");
+	}
+
 	/**
 	 * Worker Loader runs in-process, always healthy if available.
 	 */

--- a/packages/cloudflare/tests/sandbox/runner-unavailable-reason.test.ts
+++ b/packages/cloudflare/tests/sandbox/runner-unavailable-reason.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const bindings = vi.hoisted(() => ({
+	env: {} as Record<string, unknown>,
+	exports: {} as Record<string, unknown>,
+}));
+
+vi.mock("cloudflare:workers", () => ({
+	WorkerEntrypoint: class {
+		ctx: unknown;
+		env: unknown;
+		constructor(ctx: unknown, env: unknown) {
+			this.ctx = ctx;
+			this.env = env;
+		}
+	},
+	env: bindings.env,
+	exports: bindings.exports,
+}));
+
+import { CloudflareSandboxRunner } from "../../src/sandbox/runner.js";
+
+describe("Cloudflare sandbox runner availability", () => {
+	beforeEach(() => {
+		bindings.env.LOADER = { get: vi.fn() };
+		bindings.exports.PluginBridge = vi.fn();
+	});
+
+	it("names the Worker Loader binding when it is missing", () => {
+		delete bindings.env.LOADER;
+		const runner = new CloudflareSandboxRunner({ db: null as never });
+
+		expect(runner.isAvailable()).toBe(false);
+		expect(runner.unavailableReason()).toContain("worker_loaders");
+		expect(runner.unavailableReason()).not.toContain("PluginBridge");
+	});
+
+	it("names the PluginBridge export when it is missing", () => {
+		delete bindings.exports.PluginBridge;
+		const runner = new CloudflareSandboxRunner({ db: null as never });
+
+		expect(runner.isAvailable()).toBe(false);
+		expect(runner.unavailableReason()).toContain("PluginBridge");
+		expect(runner.unavailableReason()).not.toContain("worker_loaders");
+	});
+
+	it("names both when both are missing", () => {
+		delete bindings.env.LOADER;
+		delete bindings.exports.PluginBridge;
+		const runner = new CloudflareSandboxRunner({ db: null as never });
+
+		expect(runner.unavailableReason()).toContain("worker_loaders");
+		expect(runner.unavailableReason()).toContain("PluginBridge");
+	});
+});

--- a/packages/core/src/api/handlers/marketplace.ts
+++ b/packages/core/src/api/handlers/marketplace.ts
@@ -22,6 +22,7 @@ import {
 	type MarketplaceVersionSummary,
 	type PluginBundle,
 } from "../../plugins/marketplace.js";
+import { withUnavailableReason } from "../../plugins/sandbox/types.js";
 import type { SandboxRunner } from "../../plugins/sandbox/types.js";
 import { PluginStateRepository } from "../../plugins/state.js";
 import {
@@ -363,7 +364,10 @@ export async function handleMarketplaceInstall(
 			success: false,
 			error: {
 				code: "SANDBOX_NOT_AVAILABLE",
-				message: "Sandbox runner is required for marketplace plugins",
+				message: withUnavailableReason(
+					"Sandbox runner is required for marketplace plugins",
+					sandboxRunner,
+				),
 			},
 		};
 	}
@@ -584,7 +588,10 @@ export async function handleMarketplaceUpdate(
 	if (!opts?.sandboxBypassed && (!sandboxRunner || !sandboxRunner.isAvailable())) {
 		return {
 			success: false,
-			error: { code: "SANDBOX_NOT_AVAILABLE", message: "Sandbox runner is required" },
+			error: {
+				code: "SANDBOX_NOT_AVAILABLE",
+				message: withUnavailableReason("Sandbox runner is required", sandboxRunner),
+			},
 		};
 	}
 

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -22,6 +22,7 @@ import {
 import type { Kysely } from "kysely";
 
 import type { Database } from "../../database/types.js";
+import { withUnavailableReason } from "../../plugins/sandbox/types.js";
 import type { SandboxRunner } from "../../plugins/sandbox/types.js";
 import { PluginStateRepository } from "../../plugins/state.js";
 import {
@@ -468,7 +469,10 @@ export async function handleRegistryInstall(
 			success: false,
 			error: {
 				code: "SANDBOX_NOT_AVAILABLE",
-				message: "Sandbox runner is required for registry plugins",
+				message: withUnavailableReason(
+					"Sandbox runner is required for registry plugins",
+					sandboxRunner,
+				),
 			},
 		};
 	}
@@ -1229,7 +1233,10 @@ export async function handleRegistryUpdate(
 	if (!sandboxRunner || !sandboxRunner.isAvailable()) {
 		return {
 			success: false,
-			error: { code: "SANDBOX_NOT_AVAILABLE", message: "Sandbox runner is required" },
+			error: {
+				code: "SANDBOX_NOT_AVAILABLE",
+				message: withUnavailableReason("Sandbox runner is required", sandboxRunner),
+			},
 		};
 	}
 	try {

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2057,10 +2057,14 @@ export class EmDashRuntime {
 		// Warn regardless of whether there are plugins to load, so operators
 		// see the issue even if no marketplace plugins are installed yet.
 		if (!sandboxRunner.isAvailable()) {
+			const reason = sandboxRunner.unavailableReason?.();
 			console.warn(
-				"EmDash: Plugin sandbox is configured but not available on this platform. " +
-					"Sandboxed plugins will not be loaded. " +
-					"If using @emdash-cms/sandbox-workerd/sandbox, ensure workerd is installed.",
+				reason
+					? `EmDash: Plugin sandbox is configured but not available on this platform: ${reason}. ` +
+							"Sandboxed plugins will not be loaded."
+					: "EmDash: Plugin sandbox is configured but not available on this platform. " +
+							"Sandboxed plugins will not be loaded. " +
+							"If using @emdash-cms/sandbox-workerd/sandbox, ensure workerd is installed.",
 			);
 			return sandboxedPluginCache;
 		}

--- a/packages/core/src/plugins/sandbox/types.ts
+++ b/packages/core/src/plugins/sandbox/types.ts
@@ -237,6 +237,15 @@ export interface SandboxRunner {
 	isHealthy(): boolean;
 
 	/**
+	 * Why the runner cannot run plugins, once isAvailable() or isHealthy()
+	 * has returned false. A lowercase clause without a final period: callers
+	 * append it to their own message after a colon.
+	 *
+	 * Making this required breaks runners implemented outside this repository.
+	 */
+	unavailableReason?(): string;
+
+	/**
 	 * Load a sandboxed plugin from code.
 	 *
 	 * @param manifest - Plugin manifest with metadata and capabilities
@@ -258,6 +267,11 @@ export interface SandboxRunner {
 	 * Called during shutdown or when reconfiguring.
 	 */
 	terminateAll(): Promise<void>;
+}
+
+export function withUnavailableReason(message: string, runner: SandboxRunner | null): string {
+	const reason = runner?.unavailableReason?.();
+	return reason ? `${message}: ${reason}` : message;
 }
 
 /**

--- a/packages/core/tests/integration/runtime/sandbox-unavailable-warning.test.ts
+++ b/packages/core/tests/integration/runtime/sandbox-unavailable-warning.test.ts
@@ -1,0 +1,55 @@
+/** Pins the startup warning for a configured sandbox runner that cannot run plugins. */
+
+import { randomUUID } from "node:crypto";
+
+import Database from "better-sqlite3";
+import { SqliteDialect } from "kysely";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { EmDashRuntime, type RuntimeDependencies } from "../../../src/emdash-runtime.js";
+import type { SandboxRunner } from "../../../src/plugins/sandbox/types.js";
+
+const REASON = "the worker has no worker_loaders binding named LOADER";
+
+describe("EmDashRuntime — unavailable sandbox runner", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("names the reason the runner gives in the startup warning", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const runner: SandboxRunner = {
+			isAvailable: () => false,
+			isHealthy: () => false,
+			unavailableReason: () => REASON,
+			load: () => Promise.reject(new Error("load is not reached")),
+			setEmailSend: () => {},
+			terminateAll: async () => {},
+		};
+		const deps: RuntimeDependencies = {
+			config: {
+				database: {
+					entrypoint: `test-sandbox-unavailable-${randomUUID()}`,
+					config: {},
+					type: "sqlite",
+				},
+			},
+			plugins: [],
+			createDialect: () => new SqliteDialect({ database: new Database(":memory:") }),
+			createStorage: null,
+			sandboxEnabled: true,
+			sandboxedPluginEntries: [],
+			createSandboxRunner: () => runner,
+		};
+
+		const runtime = await EmDashRuntime.create(deps);
+		try {
+			const warnings = warn.mock.calls.map((call) => String(call[0]));
+			expect(warnings).toContainEqual(
+				expect.stringContaining(`not available on this platform: ${REASON}.`),
+			);
+		} finally {
+			await runtime.stopCron();
+		}
+	});
+});

--- a/packages/core/tests/unit/api/sandbox-unavailable-handlers.test.ts
+++ b/packages/core/tests/unit/api/sandbox-unavailable-handlers.test.ts
@@ -1,0 +1,93 @@
+/** Pins what a refused install or update tells the operator about the sandbox runner. */
+
+import BetterSqlite3 from "better-sqlite3";
+import { Kysely, SqliteDialect } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	handleMarketplaceInstall,
+	handleMarketplaceUpdate,
+} from "../../../src/api/handlers/marketplace.js";
+import { handleRegistryInstall, handleRegistryUpdate } from "../../../src/api/handlers/registry.js";
+import type { ApiResult } from "../../../src/api/types.js";
+import { runMigrations } from "../../../src/database/migrations/runner.js";
+import type { Database as DbSchema } from "../../../src/database/types.js";
+import type { SandboxRunner } from "../../../src/plugins/sandbox/types.js";
+import type { Storage } from "../../../src/storage/types.js";
+
+const REASON = "the worker has no worker_loaders binding named LOADER";
+const MARKETPLACE_URL = "https://marketplace.example.com";
+const REGISTRY = { aggregatorUrl: "https://aggregator.test" };
+
+/** Present so the null-storage guard passes; the refusal comes before any storage call. */
+const stubStorage = {} as unknown as Storage;
+
+function unavailableRunner(reason?: string): SandboxRunner {
+	return {
+		isAvailable: () => false,
+		isHealthy: () => false,
+		...(reason === undefined ? {} : { unavailableReason: () => reason }),
+		load: () => Promise.reject(new Error("load is not reached")),
+		setEmailSend: () => {},
+		terminateAll: async () => {},
+	};
+}
+
+describe("install and update with an unavailable sandbox runner", () => {
+	let db: Kysely<DbSchema>;
+	let sqliteDb: BetterSqlite3.Database;
+
+	beforeEach(async () => {
+		sqliteDb = new BetterSqlite3(":memory:");
+		db = new Kysely<DbSchema>({ dialect: new SqliteDialect({ database: sqliteDb }) });
+		await runMigrations(db);
+	});
+
+	afterEach(async () => {
+		await db.destroy();
+		sqliteDb.close();
+	});
+
+	const refusals: Array<[string, (runner: SandboxRunner) => Promise<ApiResult<unknown>>]> = [
+		[
+			"marketplace install",
+			(runner) => handleMarketplaceInstall(db, stubStorage, runner, MARKETPLACE_URL, "test-seo"),
+		],
+		[
+			"marketplace update",
+			(runner) => handleMarketplaceUpdate(db, stubStorage, runner, MARKETPLACE_URL, "test-seo"),
+		],
+		[
+			"registry install",
+			(runner) =>
+				handleRegistryInstall(db, stubStorage, runner, REGISTRY, {
+					did: "did:plc:abc",
+					slug: "gallery",
+				}),
+		],
+		[
+			"registry update",
+			(runner) => handleRegistryUpdate(db, stubStorage, runner, REGISTRY, "r_dddddddddddddddd"),
+		],
+	];
+
+	it.each(refusals)("%s appends the reason the runner gives", async (_name, refuse) => {
+		const result = await refuse(unavailableRunner(REASON));
+
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe("SANDBOX_NOT_AVAILABLE");
+		expect(result.error?.message).toMatch(new RegExp(`: ${REASON}$`));
+	});
+
+	it("uses the plain message for a runner that gives no reason", async () => {
+		const result = await handleMarketplaceInstall(
+			db,
+			stubStorage,
+			unavailableRunner(),
+			MARKETPLACE_URL,
+			"test-seo",
+		);
+
+		expect(result.error?.message).toBe("Sandbox runner is required for marketplace plugins");
+	});
+});

--- a/packages/workerd/src/sandbox/runner.ts
+++ b/packages/workerd/src/sandbox/runner.ts
@@ -368,6 +368,9 @@ export class WorkerdSandboxRunner implements SandboxRunner {
 	 */
 	private gaveUp = false;
 
+	/** True when the last isAvailable() call could not run the workerd binary. */
+	private binaryFailed = false;
+
 	/**
 	 * True when stopWorkerd() is intentionally tearing down the child
 	 * (e.g., on intentional restart() to reload plugins). The exit handler
@@ -412,8 +415,10 @@ export class WorkerdSandboxRunner implements SandboxRunner {
 			// execFileSync (not execSync) so paths with spaces or shell
 			// metacharacters are passed verbatim, not shell-split.
 			execFileSync(bin, ["--version"], { stdio: "ignore", timeout: 5000 });
+			this.binaryFailed = false;
 			return true;
 		} catch {
+			this.binaryFailed = true;
 			return false;
 		}
 	}
@@ -454,14 +459,18 @@ export class WorkerdSandboxRunner implements SandboxRunner {
 	}
 
 	/**
-	 * Why an invocation cannot reach workerd, for the message carried by
-	 * SandboxUnavailableError.
+	 * Why the runner cannot run plugins: a binary the last isAvailable() call
+	 * could not run, or why an invocation cannot reach workerd, the message
+	 * SandboxUnavailableError carries.
 	 *
 	 * Giving up is the one state no invocation retries out of: needsRestart
 	 * stays false, so ensureRunning() returns without starting anything and
 	 * workerd waits for a server restart, an install or an update.
 	 */
 	unavailableReason(): string {
+		if (this.binaryFailed) {
+			return "workerd is missing or its binary does not run on this platform; reinstall with optional dependencies enabled";
+		}
 		if (this.gaveUp) {
 			return "workerd crashed 5 times in 60 seconds and the runner stopped retrying; restart the server";
 		}

--- a/packages/workerd/test/runner-binary-check.test.ts
+++ b/packages/workerd/test/runner-binary-check.test.ts
@@ -1,0 +1,32 @@
+/** Pins what the runner reports when the workerd binary does not run. */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { WorkerdSandboxRunner } from "../src/sandbox/runner.js";
+
+const MISSING_BINARY = "/nonexistent/bin/workerd";
+const RUNNABLE_BINARY = process.execPath;
+
+describe("workerd binary check", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("names the binary when it does not run", () => {
+		const runner = new WorkerdSandboxRunner({ db: null as any });
+		vi.spyOn(runner as any, "resolveWorkerdBinary").mockReturnValue(MISSING_BINARY);
+
+		expect(runner.isAvailable()).toBe(false);
+		expect(runner.unavailableReason()).toContain("binary");
+	});
+
+	it("drops the binary once a later check runs it", () => {
+		const runner = new WorkerdSandboxRunner({ db: null as any });
+		const resolve = vi.spyOn(runner as any, "resolveWorkerdBinary").mockReturnValue(MISSING_BINARY);
+		runner.isAvailable();
+		resolve.mockReturnValue(RUNNABLE_BINARY);
+
+		expect(runner.isAvailable()).toBe(true);
+		expect(runner.unavailableReason()).toBe("workerd is not running");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Names the cause when a configured sandbox runner cannot run plugins. `isAvailable()` answers only true or false, so a missing `worker_loaders` binding, a missing `PluginBridge` export and a `workerd` binary that does not run all produce the same startup warning and the same `SANDBOX_NOT_AVAILABLE` refusal.

`SandboxRunner` gets the optional `unavailableReason()` the workerd runner already had. The Cloudflare and workerd runners report their cause, and the warning and the four install and update refusals append it after a colon. Runners without the method keep today's text: the noop runner, whose "Sandbox runner is required" already names what is missing, and the Miniflare dev runner, which the factory returns only once Miniflare resolves. The sandbox guide maps each reason to its fix.

Part of #1686 and #1680.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) (the `emdash`, `@emdash-cms/cloudflare` and `@emdash-cms/sandbox-workerd` suites)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (n/a: server-side error and log text, no admin UI strings)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a: part of #1686 and #1680 on the 1.0 milestone; requested in https://github.com/emdash-cms/emdash/issues/1680#issuecomment-5620702247)
- [ ] I have included screenshots below if this PR changes the UI (n/a: no UI change)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5

## Screenshots / test output

Not applicable for screenshots. These new tests failed before the change:

```
 × marketplace install appends the reason the runner gives
 × marketplace update appends the reason the runner gives
 × registry install appends the reason the runner gives
 × registry update appends the reason the runner gives
 × names the reason the runner gives in the startup warning
 × names the Worker Loader binding when it is missing
 × names the PluginBridge export when it is missing
 × names both when both are missing
 × names the binary when it does not run

AssertionError: expected 'Sandbox runner is required for market…' to match
  /: the worker has no worker_loaders bi…/
TypeError: runner.unavailableReason is not a function
AssertionError: expected 'workerd is not running' to contain 'binary'
```

With the change:

```
pnpm --filter emdash test                        542 files, 6516 tests passed, 10 skipped
pnpm --filter @emdash-cms/cloudflare test         38 files, 422 tests passed, 2 skipped
pnpm --filter @emdash-cms/sandbox-workerd test    14 files, 92 tests passed
```

`pnpm typecheck`, `pnpm lint`, `pnpm format` and the docs build are clean. `pnpm test:e2e` was not run.
