### PR TITLE
Clarify locale, preview, authentication, and integration guides

### DIFF
--- a/docs/src/content/docs/docs-mcp.mdx
+++ b/docs/src/content/docs/docs-mcp.mdx
@@ -5,9 +5,9 @@ description: Connect your AI coding assistant to the EmDash documentation so it 
 
 import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
-The EmDash documentation site exposes a [Model Context Protocol](https://modelcontextprotocol.io) server at `https://docs.emdashcms.com/mcp`. Connect your coding assistant to it and the assistant can search the docs as you work, instead of guessing from training data that may be out of date.
+The EmDash documentation site exposes a public [Model Context Protocol](https://modelcontextprotocol.io) server at `https://docs.emdashcms.com/mcp`. Connect a coding assistant to search the published docs while you work.
 
-This is **separate from your site's MCP server** (covered in the [AI Tools guide](/guides/ai-tools)). The docs MCP only knows about EmDash's documentation -- it cannot read or modify your content. Most developers want both: the docs MCP to look things up, and the site MCP to manage content.
+This is **separate from your site's MCP server** (covered in the [AI Tools guide](/guides/ai-tools)). The docs MCP only knows about EmDash's documentation -- it cannot read or modify your content. Connect the docs MCP for documentation lookup, the site MCP for content management, or both when the assistant needs both kinds of access.
 
 ## What it does
 
@@ -17,7 +17,7 @@ The docs MCP exposes a single tool:
 | ------------- | --------------------------------------------------------------------------------------------- |
 | `search_docs` | Search the EmDash documentation. Returns relevant chunks with source URLs and match scores. |
 
-Behind the scenes it uses [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/) over an index built from `docs.emdashcms.com`. The crawler keeps the index in sync with the published site, so answers reflect the docs you're reading.
+The server uses [Cloudflare AI Search](https://developers.cloudflare.com/ai-search/) over an index of `docs.emdashcms.com`. Results contain source URLs and matching passages; the AI client decides how to use them in its answer.
 
 ## Connect it
 
@@ -44,6 +44,22 @@ Open the project and accept the workspace-trust prompt the tool shows on first r
 If you're not using a template, or you use a different tool, add it once with the snippet for your client:
 
 <Tabs>
+<TabItem label="Codex">
+
+Add the public remote server with the Codex CLI:
+
+```bash
+codex mcp add emdash-docs --url https://docs.emdashcms.com/mcp
+```
+
+The ChatGPT desktop app, Codex CLI, and IDE extension share MCP configuration for the same Codex host. The [official Codex MCP documentation](https://learn.chatgpt.com/docs/extend/mcp) covers the CLI, `config.toml`, and current transport support.
+
+</TabItem>
+<TabItem label="ChatGPT">
+
+ChatGPT developer mode can create an app from a remote MCP server with no authentication. Use the docs MCP endpoint when creating the app. Follow the [official ChatGPT developer mode guide](https://developers.openai.com/api/docs/guides/developer-mode) for current eligibility and controls instead of relying on a copied settings path.
+
+</TabItem>
 <TabItem label="Claude Code">
 
 The following command adds the server with the Claude Code CLI:
@@ -52,7 +68,7 @@ The following command adds the server with the Claude Code CLI:
 claude mcp add --transport http emdash-docs https://docs.emdashcms.com/mcp
 ```
 
-Alternatively, commit a `.mcp.json` file at the project root with the following contents:
+Alternatively, commit the same `.mcp.json` file that EmDash templates provide:
 
 ```json title=".mcp.json"
 {
@@ -84,7 +100,7 @@ Add the following entry to `opencode.jsonc`:
 </TabItem>
 <TabItem label="Cursor">
 
-Commit a `.cursor/mcp.json` file at the project root with the following contents, or add the server via **Cursor Settings -> MCP -> Add new MCP server**:
+Commit a `.cursor/mcp.json` file at the project root with the following contents. For user-level or interface setup, follow [Cursor's MCP documentation](https://docs.cursor.com/context/model-context-protocol):
 
 ```json title=".cursor/mcp.json"
 {
@@ -100,7 +116,7 @@ Commit a `.cursor/mcp.json` file at the project root with the following contents
 </TabItem>
 <TabItem label="VS Code">
 
-Add the following entry to `.vscode/mcp.json` in the project, or to user settings:
+Add the following entry to `.vscode/mcp.json` in the project. For user-level configuration and trust controls, follow [Visual Studio Code's MCP documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers):
 
 ```json title=".vscode/mcp.json"
 {
@@ -114,20 +130,9 @@ Add the following entry to `.vscode/mcp.json` in the project, or to user setting
 ```
 
 </TabItem>
-<TabItem label="Claude Desktop">
+<TabItem label="Claude">
 
-Claude Desktop only supports stdio MCP servers natively, so use [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) as a bridge. Add the following entry to `claude_desktop_config.json`:
-
-```json title="claude_desktop_config.json"
-{
-  "mcpServers": {
-    "emdash-docs": {
-      "command": "npx",
-      "args": ["mcp-remote", "https://docs.emdashcms.com/mcp"]
-    }
-  }
-}
-```
+Add the endpoint as a remote custom connector. Connector screens and plan requirements are controlled by Anthropic, so follow its [current remote MCP connector instructions](https://support.claude.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp).
 
 </TabItem>
 </Tabs>
@@ -139,7 +144,7 @@ Claude Desktop only supports stdio MCP servers natively, so use [`mcp-remote`](h
 - You're porting a WordPress theme and want examples of seed file patterns.
 - You're stuck on an error and want to search release notes and concepts.
 
-## Recommend it in your AGENTS.md
+## Recommend it in `AGENTS.md`
 
 If your project uses `AGENTS.md` (or `CLAUDE.md`, `.cursorrules`, etc.) to instruct AI tools, point them at the docs MCP so they prefer real documentation over assumptions:
 

--- a/docs/src/content/docs/guides/ai-tools.mdx
+++ b/docs/src/content/docs/guides/ai-tools.mdx
@@ -3,27 +3,27 @@ title: AI Tools
 description: Connect Claude, ChatGPT, and other AI assistants to your EmDash site.
 ---
 
-import { Aside, Steps, Tabs, TabItem, LinkCard } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
-EmDash has a built-in [MCP server](https://modelcontextprotocol.io) that lets AI assistants work directly with your site's content. You can ask Claude, ChatGPT, or other tools to draft posts, update pages, manage media, search your content, and more -- all through natural conversation.
+EmDash has a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that lets AI assistants work directly with your site's content. You can ask Claude, ChatGPT, or other tools to draft posts, update pages, manage media, search your content, and more -- all through natural conversation.
 
 <Aside>
-	This guide covers your **site's** MCP server -- for managing the content of an EmDash site. If you want to give an AI coding assistant access to the EmDash documentation itself (so it can answer questions about EmDash as you build), see [Docs MCP for AI Tools](/docs-mcp) instead. Most developers connect both.
+	This guide covers your **site's** MCP server -- for managing the content of an EmDash site. If you want to give an AI coding assistant access to the EmDash documentation itself (so it can answer questions about EmDash as you build), see [Docs MCP for AI Tools](/docs-mcp) instead. You can connect either server or both, depending on whether the assistant needs documentation, site content, or both.
 </Aside>
 
-## The MCP Server
+## Your site's MCP server
 
-The MCP server is enabled by default -- the route at `/_emdash/api/mcp` is mounted unless you explicitly turn it off. It always requires authentication, so no content is exposed without valid credentials.
+The MCP server is enabled by default. EmDash mounts `/_emdash/api/mcp` unless you turn it off. The endpoint accepts OAuth or personal access bearer tokens; an admin browser session by itself does not authenticate an MCP request. OAuth lets the person connecting the client choose scopes before EmDash issues the token.
 
 To disable it, set `mcp: false` in your Astro configuration:
 
 ```js title="astro.config.mjs"
 emdash({
-  mcp: false,
-})
+	mcp: false,
+});
 ```
 
-## Setting Up
+## Connect an AI client
 
 Your site's MCP server URL is:
 
@@ -36,42 +36,24 @@ Replace `example.com` with your domain. For local development, use `http://local
 <Tabs>
 <TabItem label="Claude">
 
-Connectors added in [claude.ai](https://claude.ai) work in both the web app and Claude Desktop.
-
-<Steps>
-
-1. Go to [Settings > Connectors](https://claude.ai/settings/connectors)
-
-2. Click **Add custom connector**
-
-3. Enter your site's MCP server URL
-
-4. Click **Add** -- your browser opens for you to log in and approve access
-
-5. Start a new conversation, click **+** in the chat input, then **Connectors**, and toggle your site on
-
-</Steps>
-
-For Team and Enterprise plans, an Owner first adds the connector from [Admin Settings > Connectors](https://claude.ai/admin-settings/connectors). Members then connect individually from their own settings.
+Add the URL as a remote custom connector. Claude opens the EmDash OAuth flow so you can sign in and choose permissions. Anthropic changes the connector screens independently of EmDash, so follow its [current custom connector instructions](https://support.claude.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp) for the exact controls and plan requirements.
 
 </TabItem>
 <TabItem label="ChatGPT">
 
-ChatGPT supports MCP servers on Pro, Business, and Enterprise plans.
+ChatGPT developer mode can connect a remote MCP server and supports OAuth-authenticated tools. Eligibility and the settings screens can change, so follow the [official ChatGPT developer mode guide](https://developers.openai.com/api/docs/guides/developer-mode) and use your site's MCP URL when creating the app. Review each write call before approving it.
 
-<Steps>
+</TabItem>
+<TabItem label="Codex">
 
-1. Go to **Settings > Apps & Connectors > Advanced settings** and enable **Developer Mode**
+Add the remote server from the Codex CLI, then start its OAuth login:
 
-2. Go to **Settings > Connectors > Create**
+```bash
+codex mcp add emdash-site --url https://example.com/_emdash/api/mcp
+codex mcp login emdash-site
+```
 
-3. Enter a name, description, and your site's MCP server URL
-
-4. Click **Create**
-
-5. In a conversation, click **+** near the composer, then **More**, and select your connector
-
-</Steps>
+The ChatGPT desktop app, Codex CLI, and IDE extension share MCP configuration for the same Codex host. See the [official Codex MCP documentation](https://learn.chatgpt.com/docs/extend/mcp) for configuration files, OAuth, and supported transports.
 
 </TabItem>
 </Tabs>
@@ -80,7 +62,7 @@ ChatGPT supports MCP servers on Pro, Business, and Enterprise plans.
 	Using a coding tool like VS Code, Cursor, or Windsurf? See the [MCP Server Reference](/reference/mcp-server) for configuration details.
 </Aside>
 
-## What You Can Do
+## Work with site content
 
 Once connected, you can ask the AI assistant to perform any of these operations in natural language. You don't need to know the tool names -- just describe what you want.
 
@@ -93,19 +75,29 @@ Once connected, you can ask the AI assistant to perform any of these operations 
 - **Publish and schedule** -- "Publish the summer sale post", "Schedule the announcement for June 1st at 9am", or "Cancel the schedule on the launch post"
 - **Compare versions** -- "Show me what changed in the homepage since it was last published"
 - **Manage drafts** -- "Discard the draft changes on the about page" or "Duplicate the newsletter template"
-- **Translations** -- "What translations exist for the welcome post?" (when i18n is enabled)
+- **Translations** -- "What translations exist for the welcome post?" or "Create a French draft linked to this English post" (when i18n is enabled)
+
+### Bylines
+
+- **Browse bylines** -- "List the guest contributors whose names contain 'Lee'"
+- **Credit content** -- "Add Priya Shah as the primary byline on this post"
+- **Manage bylines** -- "Create a guest byline for Sam Rivera" or "Update this contributor's bio"
+- **Translate bylines** -- "Show the locale variants of this byline"
+
+Creating, updating, deleting, and translating bylines requires the Editor role. Content write tools accept existing byline IDs when the caller has permission to create or edit that content.
 
 ### Media
 
 - **Browse media** -- "List all uploaded images" or "Show me PDFs in the media library"
 - **Check details** -- "Get the details for this media item"
-- **Register uploads** -- "Register the file I just uploaded to `media/2026/banner.png` as a media item"
+- **Upload files** -- "Upload this base64 image as `banner.png`" or "Import the image at this public URL"
+- **Register existing storage objects** -- "Register `media/2026/banner.png` as a media item"
 - **Update metadata** -- "Set the alt text on the hero image to 'Mountain sunset'"
 - **Remove files** -- "Delete the old banner image"
 
-<Aside>
-	The MCP transport can't carry binary uploads. To add a new image, upload the bytes via the admin UI (or your own signed-upload flow) and then ask the AI to register the metadata.
-</Aside>
+`media_upload` accepts either base64-encoded bytes or a public HTTP(S) URL. It stores the file, registers the media item, and returns the ID and URL. `media_create` only registers metadata for a file that is already in storage. URL imports reject private network targets and re-check redirects; both paths enforce the site's MIME-type and upload-size limits.
+
+Contributors can use `media_upload`. Registering an existing storage object with `media_create` requires Author or a higher role.
 
 ### Search
 
@@ -127,13 +119,13 @@ Once connected, you can ask the AI assistant to perform any of these operations 
 - **Set items** -- "Replace the items in the main menu with Home, Blog, About, and Contact"
 - **Delete menus** -- "Delete the unused 'mobile' menu"
 
-### Site Settings
+### Site settings
 
 - **Inspect** -- "What's the current site title?" or "Show me the social links"
 - **Update identity** -- "Set the site title to 'Acme Blog' and tagline to 'Stories from the team'"
 - **Set logo / favicon** -- "Use this image as the site logo" (after uploading it with `media_upload`)
 - **SEO defaults** -- "Set the default OG image to the new banner" or "Update the title separator to a vertical bar"
-- **Social handles** -- "Add our Mastodon and YouTube links to the social settings"
+- **Social handles** -- "Add our GitHub and YouTube links to the social settings"
 
 <Aside>
 	Reading site settings requires the Editor role; updating them requires Admin.
@@ -146,7 +138,8 @@ Once connected, you can ask the AI assistant to perform any of these operations 
 - **Modify schema** -- "Add a 'featured' boolean field to posts"
 
 <Aside type="caution">
-	Schema changes (creating/deleting collections and fields) modify your database structure and require Admin permissions. The AI will tell you if you don't have sufficient access.
+	Schema changes modify the database structure and can delete stored field data. They require Admin
+	permissions, and EmDash rejects the tool call when the connected user or token lacks them.
 </Aside>
 
 ### Revisions
@@ -161,11 +154,11 @@ When an MCP client opens the OAuth consent page, every permission it requested i
 | Role | What the AI can do |
 | --- | --- |
 | **Admin** | Everything, including schema changes and updating site settings |
-| **Editor** | All content, media, taxonomies, and menus. Can view schema and read settings. |
-| **Author** | Own content and media |
-| **Contributor** | Own content (no publishing) and media |
+| **Editor** | Manage all content, media, bylines, taxonomies, and menus. View schema and read settings. |
+| **Author** | Create content; edit and publish owned content; upload media and manage owned media. |
+| **Contributor** | Create draft content and upload media, without publishing. |
 
-If you try something you don't have access to, the AI will let you know.
+EmDash rejects a tool call when either the token scope or the user's role is insufficient. A client may explain that error, but EmDash remains the authority that enforces it.
 
 ## Tips
 
@@ -175,6 +168,6 @@ If you try something you don't have access to, the AI will let you know.
 - **Use compare for review.** Before publishing, ask "Compare the live and draft versions of this post" to see exactly what will change.
 - **Rich text fields use Portable Text.** The AI can write content for rich text fields, but complex formatting is best done in the admin editor.
 
-## For Developers
+## For developers
 
 The MCP server endpoint, authentication methods, OAuth discovery, tool parameters, and error handling are documented in the [MCP Server Reference](/reference/mcp-server).

--- a/docs/src/content/docs/guides/atmosphere-auth.mdx
+++ b/docs/src/content/docs/guides/atmosphere-auth.mdx
@@ -29,12 +29,12 @@ import emdash from "emdash/astro";
 import { atproto } from "@emdash-cms/auth-atproto";
 
 export default defineConfig({
+	server: {
+		host: "127.0.0.1", // required for local development; see below
+	},
 	integrations: [
 		emdash({
 			authProviders: [atproto()],
-			server: {
-				host: "127.0.0.1", // required for local dev — see "Local development" below
-			},
 		}),
 	],
 });
@@ -44,7 +44,7 @@ That's enough to put **Sign in with Atmosphere** on the login page and the setup
 
 The provider is a public OAuth client and serves its own metadata document at `/.well-known/atproto-client-metadata.json`, so it works with the configuration above alone — no environment variables, client secret, or OAuth-app registration to set up.
 
-## Configuration
+## Configure access
 
 The `atproto()` provider accepts an allowlist and a default role:
 
@@ -58,22 +58,22 @@ atproto({
 
 | Option           | Type       | Default                   | Description                                                                  |
 | ---------------- | ---------- | ------------------------- | ---------------------------------------------------------------------------- |
-| `allowedDIDs`    | `string[]` | none (allow all on first) | DID allowlist. DIDs are permanent and can't be spoofed.                      |
-| `allowedHandles` | `string[]` | none (allow all on first) | Handle allowlist. Supports wildcards (`*.example.com`).                      |
+| `allowedDIDs`    | `string[]` | none                      | Exact DID allowlist.                                                         |
+| `allowedHandles` | `string[]` | none                      | Handle allowlist. Supports leading wildcards (`*.example.com`).              |
 | `defaultRole`    | `number`   | `10` (Subscriber)         | Role assigned to allowed users after the first. First user is always Admin. |
 
 The full role ladder is documented in the main [authentication guide](/guides/authentication/#user-roles).
 
 ### Allowlists
 
-If neither `allowedDIDs` nor `allowedHandles` is set, only the **first user** can sign up — anyone else attempting to log in will be rejected with `signup_not_allowed`. Existing users can always sign back in regardless of the allowlist (so removing yourself from the list won't lock you out, but won't let new people in either).
+If neither `allowedDIDs` nor `allowedHandles` is set, only the **first user** can sign up. Accounts already linked to an EmDash user can continue to sign in, while a new account is rejected with `signup_not_allowed`.
 
-When at least one allowlist is configured, a user is admitted if **either** list matches:
+When at least one allowlist is configured, every login must match it, including logins for existing users. Removing an existing user's DID and handle from the configured lists prevents that account from signing in. A user is admitted if **either** list matches:
 
-- **DID match.** The user's DID is in `allowedDIDs`. DIDs are cryptographic identifiers that can't be moved or impersonated, so this is the strictest form of gating.
+- **DID match.** The user's stable account identifier exactly matches a value in `allowedDIDs`.
 - **Handle match.** The user's handle matches an entry in `allowedHandles`, exactly or via a leading-wildcard pattern (`*.example.com` matches `alice.example.com` and `bob.team.example.com`).
 
-Handle allowlists are safe even though handles are mutable. Before admitting a user via a handle match, EmDash independently resolves the handle's DNS/HTTP record and verifies that it points at the same DID the provider claims. A misbehaving provider can't simply assert it owns `you@yourcompany.com`.
+Handle allowlists are safe even though handles are mutable. Before admitting a user via a handle match, EmDash independently resolves the handle's DNS/HTTP record and verifies that it points at the same DID the provider claims. A misbehaving provider cannot simply assert that it owns `you.yourcompany.com`.
 
 <Aside>
 	Use `allowedDIDs` for individuals and `allowedHandles` with a wildcard for org-level access. The
@@ -84,29 +84,31 @@ Handle allowlists are safe even though handles are mutable. Before admitting a u
 
 Allowed users land on the role you set in `defaultRole`. Only the first user — the one who completes setup — is forced to Admin. There's no group/role mapping for Atmosphere accounts; if you need finer-grained roles, change the user's role from **Settings → Users** after they've logged in once.
 
-## First-user setup
+## Set up the first user
 
 When you start a fresh site with the Atmosphere provider configured, the setup wizard offers it as an option for creating the initial admin account.
 
 <Steps>
 
-1. Visit `/_emdash/admin`. The setup wizard takes you through site title, tagline, and admin email.
+1. Visit `/_emdash/admin`. On **Set up your site**, enter the site title and optional tagline, then continue.
 
-2. On the "Create admin account" step, choose **Atmosphere** and enter your handle (e.g. `alice.bsky.social`).
+2. On **Create your account**, enter the email address and optional name to store on the EmDash user.
 
-3. You'll be redirected to your account's authorization page, where you sign in however your provider supports — password, passkey, or whatever else.
+3. On **Secure your account**, choose **Atmosphere**, enter your handle (for example, `alice.bsky.social`), and continue.
 
-4. After approval you're sent back to EmDash, the admin user is created with role 50 (Admin), and the email you entered in step 1 is stored against your account.
+4. Your account provider opens its authorization page. Sign in using the method that provider supports and approve the request.
+
+5. The provider redirects you to EmDash. EmDash creates the first user as Admin, stores the email from step 2, establishes an EmDash session, and opens the dashboard.
 
 </Steps>
 
-The same flow runs for every subsequent login: enter your handle, authenticate at your provider, and return to EmDash signed in.
+Later logins begin with the handle, continue at the account provider, and return with an EmDash session. The provider's OAuth state and tokens are stored separately from that EmDash session so the OAuth callback can complete and the provider can refresh its own session.
 
 ## Local development
 
 The AT Protocol OAuth profile requires loopback redirect URIs to use an **IP literal** (`127.0.0.1` or `[::1]`), not `localhost`. EmDash transparently rewrites `://localhost` to `://127.0.0.1` when generating the redirect URI, but that means your dev session needs to start on `127.0.0.1` too — otherwise the session cookie set on `localhost` won't be visible after the redirect lands you on `127.0.0.1`.
 
-Astro's dev server is Vite's dev server, and Vite binds to `localhost` by default. Tell it to listen on the loopback IP as well:
+Astro's dev server uses Vite, which binds to `localhost` by default. Set Astro's top-level `server.host` option to the loopback IP:
 
 ```js title="astro.config.mjs"
 export default defineConfig({
@@ -145,7 +147,7 @@ The handle or DID you signed in with isn't in `allowedDIDs` / `allowedHandles`. 
 
 ### "Self-signup is not allowed"
 
-You hit the callback successfully but no allowlist is configured and you aren't the first user. Either add yourself to `allowedDIDs`/`allowedHandles`, or have an existing admin invite you so the user already exists when you log in.
+You reached the callback successfully, but no allowlist is configured and you are not the first user. Add the account's DID to `allowedDIDs` or its verified handle to `allowedHandles`. An email invite does not link an Atmosphere DID to an EmDash user.
 
 ### Login redirects to the login page with no error
 

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -3,26 +3,30 @@ title: Authentication
 description: Passkey-first authentication with pluggable providers for GitHub, Google, and the Atmosphere.
 ---
 
-import { Aside, Steps, Tabs, TabItem, Code } from "@astrojs/starlight/components";
+import { Aside, Steps } from "@astrojs/starlight/components";
 
 EmDash uses passkey authentication as its primary login method. Passkeys are phishing-resistant, don't require passwords, and work across devices through your browser or password manager.
 
-Beyond passkeys, you can add **pluggable login providers** — GitHub, Google, and [the Atmosphere](/guides/atmosphere-auth/) (AT Protocol) ship out of the box, and the same provider interface is open for third-party packages. Any configured provider can be used to create the first admin account, log in, or link to an existing user.
+Beyond passkeys, you can add **pluggable login providers**. GitHub and Google are included with EmDash. The separately installed [Atmosphere provider](/guides/atmosphere-auth/) adds AT Protocol accounts, and the same provider interface is open to other packages. The documented GitHub, Google, and Atmosphere providers can create the first admin account or sign in a linked EmDash user.
 
-For Cloudflare deployments, [Cloudflare Access](#cloudflare-access) is also available as an exclusive auth method that takes over the entire login flow.
+For Cloudflare deployments, [Cloudflare Access](#cloudflare-access) is a separate, exclusive authentication mode in production. It validates Access credentials on protected EmDash routes rather than showing the EmDash login methods.
 
-## How It Works
+## Choose an authentication mode
 
 Passkeys use WebAuthn, a web standard that creates public-key credentials stored on your device or synced through your password manager. When you log in, your device proves possession of the credential without ever sending a password over the network.
 
-Benefits of passkey authentication:
+Passkeys are the default. GitHub, Google, and Atmosphere providers are additional login methods: each one authenticates the user, links or creates an EmDash account, and establishes the same EmDash session used by a passkey login.
+
+Passkey authentication provides:
 
 - **No passwords to remember or leak**
 - **Phishing-resistant** — credentials are bound to your site's domain
 - **Cross-device sync** — works with iCloud Keychain, Google Password Manager, 1Password, etc.
 - **Fast login** — one tap with biometrics or PIN
 
-## First User Setup
+Cloudflare Access uses the `auth` option instead of `authProviders`. In production it becomes the authority for protected `/_emdash` routes. EmDash still stores a local user so roles, ownership, and disabled-user checks continue to work.
+
+## Set up the first user
 
 The first time you access the admin panel, the Setup Wizard guides you through creating your admin account.
 
@@ -30,28 +34,25 @@ The first time you access the admin panel, the Setup Wizard guides you through c
 
 1. Navigate to `http://localhost:4321/_emdash/admin`
 
-2. You'll be redirected to the Setup Wizard. Enter:
-   - **Site Title** — Your site's name
-   - **Tagline** — A short description
-   - **Admin Email** — Your email address
+2. On **Set up your site**, enter the site title and optional tagline. A template can also offer sample content. Select **Continue**.
 
-3. Click **Create Site** to register your passkey
+3. On **Create your account**, enter your email address and optional name. Select **Continue**.
 
-4. Your browser will prompt you to create a passkey:
+4. On **Secure your account**, create a passkey or choose one of the configured login providers. If you choose a passkey, your browser asks where to save it:
    - On macOS: Touch ID, device password, or security key
    - On Windows: Windows Hello or security key
    - On mobile: Face ID, fingerprint, or PIN
 
-5. Once your passkey is registered, you're logged in and redirected to the admin dashboard.
+5. Complete the browser or provider flow. EmDash creates the first user as Admin and opens the dashboard.
 
 </Steps>
 
 <Aside>
-	Your email is stored but not verified during initial setup. You can configure email later to
-	enable features like invites and magic link login.
+	When a passkey creates the first account, EmDash stores the email entered in the wizard without
+	verifying it. Configure an email provider before using invites or magic-link login.
 </Aside>
 
-## Logging In
+## Log in with a passkey
 
 After setup, returning to the admin panel triggers passkey authentication:
 
@@ -69,9 +70,9 @@ After setup, returning to the admin panel triggers passkey authentication:
 
 </Steps>
 
-## Magic Link Fallback
+## Log in with a magic link
 
-If you can't use your passkey (e.g., lost device), magic links provide an alternative. This requires email to be configured.
+If you cannot use your passkey, a magic link provides an alternative. The site must have an email provider configured before EmDash can send the link.
 
 <Steps>
 
@@ -89,13 +90,13 @@ If you can't use your passkey (e.g., lost device), magic links provide an altern
 	Magic links are single-use and expire after 15 minutes. Request a new link if yours has expired.
 </Aside>
 
-## Login Providers
+## Configure login providers
 
-In addition to passkeys, EmDash supports pluggable login providers that appear on the login page and in the setup wizard. GitHub, Google, and Atmosphere providers ship in the box; third-party packages can register their own using the same interface.
+In addition to passkeys, EmDash supports pluggable login providers that appear on the login page and in the setup wizard. GitHub and Google are included with EmDash. Atmosphere and third-party providers are separate packages that register through the same interface.
 
-Providers are additive — passkeys keep working when providers are enabled, and users can link a provider to an existing passkey-only account. The first user can also be created through any configured provider, so a fresh install can skip passkeys entirely if you prefer.
+Providers are additive — passkeys keep working when providers are enabled. GitHub and Google automatically link an existing EmDash user only when the provider supplies the same verified email address. Atmosphere accounts are linked by their decentralized identifier (DID), because EmDash's Atmosphere flow does not receive an email address. Each included provider can create the first user, so a fresh install can skip passkeys entirely.
 
-### Configuring providers
+### Add providers to Astro
 
 Pass providers to the `authProviders` array on the EmDash integration. The following example enables GitHub, Google, and Atmosphere:
 
@@ -179,9 +180,9 @@ emdash({
 
 No client secret or environment variable is needed. See the [Atmosphere login guide](/guides/atmosphere-auth/) for handle/DID allowlists, role mapping, and the local-development setup that the AT Protocol OAuth profile requires.
 
-### Building your own provider
+### Build a provider
 
-A provider is just an `AuthProviderDescriptor` — an `id`, a human label, and any combination of admin-side React components, route handlers, public route prefixes, and storage collections. The shape is exported from `emdash`:
+A provider is an `AuthProviderDescriptor`: an `id`, a human label, and the admin components, route handlers, public route prefixes, and storage collections that its login flow needs. Export a `SetupStep` from `adminEntry` if the provider should appear during first-user setup. The shape is exported from `emdash`:
 
 ```ts
 import type { AuthProviderDescriptor } from "emdash";
@@ -205,7 +206,7 @@ export function myProvider(): AuthProviderDescriptor {
 
 The Atmosphere package (`@emdash-cms/auth-atproto`) is the most complete real-world reference for a provider that needs a custom login form, OAuth route handlers, and persistent storage.
 
-## User Roles
+## User roles
 
 EmDash uses role-based access control with five levels:
 
@@ -223,7 +224,7 @@ Each role inherits permissions from all lower levels. The first user is always c
 
 Subscribers hold the `content:read` permission so member-only published content can be served to authenticated readers. They cannot see drafts, scheduled items, trashed items, revisions, or preview URLs — those are gated on `content:read_drafts`, granted to Contributor and above. The list and get endpoints transparently filter to `status=published` for Subscribers; editor-only views (`/compare`, `/revisions`, `/trash`, `/preview-url`) reject Subscriber requests outright.
 
-## Inviting Users
+## Invite users
 
 Admins can invite new users via the admin panel:
 
@@ -237,15 +238,15 @@ Admins can invite new users via the admin panel:
 
 4. Click **Send Invite**
 
-5. The user receives an email with an invite link
+5. If email is configured, EmDash sends the invite. Otherwise, copy the generated link and send it to the user yourself.
 
-6. They click the link and register their passkey
+6. They open the link and create the account with a passkey or a login provider offered on the invite page.
 
 </Steps>
 
-Invites are valid for 7 days. Admins can resend or revoke invites from the Users page.
+Invite links are single-use and expire after 7 days.
 
-## Managing Passkeys
+## Manage passkeys
 
 Users can manage their passkeys from the account settings:
 
@@ -255,6 +256,8 @@ Users can manage their passkeys from the account settings:
 
 Each user can have up to 10 passkeys registered.
 
+EmDash does not let a user remove their last passkey. Add a replacement before deleting the old one.
+
 <Aside type="tip">
 	Register passkeys on multiple devices (e.g., laptop and phone) to ensure you always have a way to
 	log in.
@@ -262,65 +265,71 @@ Each user can have up to 10 passkeys registered.
 
 ## Letting a group sign in without invites
 
-To let a group sign in without inviting each user, configure a [login provider](#login-providers) with an allowlist. The Atmosphere provider accepts `allowedHandles` and `allowedDIDs` (see [Atmosphere login](/guides/atmosphere-auth/)); the [Cloudflare Access](#cloudflare-access) adapter provisions users from your identity provider via `autoProvision` and `roleMapping`. Any configured provider can also create the initial admin account.
+To let a group sign in without inviting each user, configure a [login provider](#configure-login-providers) with an allowlist. The Atmosphere provider accepts `allowedHandles` and `allowedDIDs` (see [Atmosphere login](/guides/atmosphere-auth/)); the [Cloudflare Access](#cloudflare-access) adapter provisions users from your identity provider via `autoProvision` and `roleMapping`. The documented GitHub, Google, and Atmosphere providers can also create the initial admin account.
 
 ## Sessions
 
-Sessions use secure, HttpOnly, SameSite=Lax cookies and last 30 days with sliding expiration — the expiry resets on activity.
+Passkey, magic-link, invite, and login-provider callbacks store the EmDash user ID in Astro's session store. The browser receives Astro's opaque `astro-session` identifier; user and credential records remain in the EmDash database.
 
-## Security Notes
+Cloudflare Access also writes the resolved EmDash user to the Astro session. That lets public pages identify a signed-in user when they read `Astro.locals.user`. The session does not replace Access authentication on protected `/_emdash` routes: EmDash validates the Access JSON Web Token (JWT) again on those requests.
 
-- **Passkeys are stored as public keys** — the private key never leaves your device
-- **Challenge verification** prevents replay attacks
-- **Rate limiting** protects against brute force (5 attempts/minute/IP)
-- **Sessions are HttpOnly, Secure, SameSite=Lax** for cookie security
-- **Magic link tokens are SHA-256 hashed** — raw tokens are never stored
+## Authentication rate limits
+
+EmDash limits the endpoints that begin unauthenticated login or signup flows. The limits are separate for each endpoint and trusted client IP:
+
+| Endpoint | Limit |
+| --- | --- |
+| `POST /_emdash/api/auth/passkey/options` | 10 requests per minute |
+| `POST /_emdash/api/auth/magic-link/send` | 3 requests per 5 minutes |
+| `POST /_emdash/api/auth/signup/request` | 3 requests per 5 minutes |
+
+On Cloudflare, EmDash reads the client IP from Cloudflare's request metadata. A self-hosted site behind a reverse proxy must configure [`trustedProxyHeaders`](/reference/configuration/#trustedproxyheaders) before EmDash can use the proxy's client-IP header. When no trusted IP is available, these per-IP checks are skipped because there is no safe key to count.
+
+Passkeys store public-key credentials; the private key stays with the user's authenticator. Magic-link tokens are stored as SHA-256 hashes and deleted after use.
 
 ## Troubleshooting
 
 ### "No passkeys registered"
 
-If you see this error on login, your passkey may have been deleted from your password manager. Ask an admin to send you a magic link or new invite.
+If you see this error on login, your passkey may have been deleted from your password manager. Ask an admin to send a recovery magic link; the site must have email configured.
 
 ### "Passkey authentication failed"
 
 This usually means the passkey was created for a different domain. Passkeys are domain-bound — a passkey for `localhost:4321` won't work on `example.com`. Register a new passkey for each domain.
 
-### "Session expired"
-
-Sessions last 30 days by default with sliding expiration. If you're logged out unexpectedly, clear your cookies and log in again.
-
 ### Lost all passkeys
 
 If you've lost access to all your registered passkeys:
 
-1. Ask another admin to send you a magic link (requires email configuration)
-2. Use the magic link to log in
-3. Register a new passkey in account settings
+1. Ask another admin to send a recovery magic link. The site must have email configured.
+2. Use the link within 15 minutes to log in.
+3. Register a new passkey in account settings.
 
 If you're the only admin and email isn't configured, you'll need to reset your site's authentication through the database.
 
 ## Cloudflare Access
 
-When deploying to Cloudflare, you can use [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/applications/) as your authentication provider instead of passkeys. Access handles authentication at the edge using your existing identity provider.
+When deploying to Cloudflare, you can use [Cloudflare Access](https://developers.cloudflare.com/workers/configuration/cloudflare-access/) instead of the built-in login methods. Access authenticates the user at the edge with your identity provider. EmDash validates the signed Access JWT, loads the person's identity and groups, and maps that identity to a local EmDash user.
 
 <Aside>
-	When Cloudflare Access is configured, it becomes the **exclusive** authentication method.
-	Passkeys, OAuth, magic links, and self-signup are all disabled.
+	In production, Cloudflare Access is the exclusive authentication method. Passkeys, login providers,
+	magic links, invites, and self-signup are unavailable. During local development, EmDash falls back
+	to passkey authentication because a development request does not carry an Access JWT.
 </Aside>
 
-### Why Use Cloudflare Access
+### When to use Cloudflare Access
 
 - **Single Sign-On** — Users authenticate with your company's IdP
 - **Centralized access control** — Manage who can access the admin in the Cloudflare dashboard
 - **No passkey management** — No need to register or manage passkeys
 - **Group-based roles** — Map IdP groups to EmDash roles automatically
 
-### Setup
+### Set up Access
 
-1. Create a [Cloudflare Access application](https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/self-hosted-apps/) for your EmDash site
-2. Note the **Application Audience (AUD) Tag** from the application settings
-3. Configure EmDash to use Access:
+1. Create a Cloudflare Access application and policy for your site's `/_emdash/*` path. Protecting only `/_emdash/admin/*` leaves the REST API without the JWT that EmDash expects.
+2. Copy the application's **Application Audience (AUD) Tag**.
+3. Store the tag in the `CF_ACCESS_AUDIENCE` runtime environment variable. Follow the [EmDash secrets guide](/deployment/secrets/) for local and deployed values.
+4. Configure EmDash to read that value at runtime:
 
 ```js title="astro.config.mjs"
 import { defineConfig } from "astro/config";
@@ -336,26 +345,30 @@ export default defineConfig({
 			database: d1({ binding: "DB" }),
 			auth: access({
 				teamDomain: "myteam.cloudflareaccess.com",
-				audience: "abc123def456...", // From Access app settings
+				audienceEnvVar: "CF_ACCESS_AUDIENCE",
 			}),
 		}),
 	],
 });
 ```
 
-### Configuration Options
+The application audience identifies which Access application issued the JWT. EmDash verifies it together with the issuer and signature; a token for another Access application is rejected.
+
+### Configuration options
 
 | Option          | Type      | Default  | Description                                                   |
 | --------------- | --------- | -------- | ------------------------------------------------------------- |
 | `teamDomain`    | `string`  | required | Your Access team domain (e.g., `myteam.cloudflareaccess.com`) |
-| `audience`      | `string`  | required | Application Audience (AUD) tag from Access settings           |
+| `audience`      | `string`  | —        | Application Audience (AUD) tag supplied directly. Prefer `audienceEnvVar` on Workers. |
 | `autoProvision` | `boolean` | `true`   | Create EmDash users on first Access login                   |
 | `defaultRole`   | `number`  | `30`     | Role for users not matching any group (30 = Author)           |
 | `syncRoles`     | `boolean` | `false`  | Update role on each login based on IdP groups                 |
 | `roleMapping`   | `object`  | —        | Map IdP group names to role levels                            |
-| `audienceEnvVar`| `string`  | `"CF_ACCESS_AUDIENCE"` | Environment variable name for the audience tag (alternative to hardcoding) |
+| `audienceEnvVar`| `string`  | `"CF_ACCESS_AUDIENCE"` | Environment variable containing the audience tag. Used when `audience` is omitted. |
 
-### Role Mapping
+Provide either `audience` or an environment value under `audienceEnvVar`.
+
+### Role mapping
 
 Map your IdP groups to EmDash roles:
 
@@ -363,7 +376,7 @@ Map your IdP groups to EmDash roles:
 emdash({
 	auth: access({
 		teamDomain: "myteam.cloudflareaccess.com",
-		audience: "abc123...",
+		audienceEnvVar: "CF_ACCESS_AUDIENCE",
 		roleMapping: {
 			Admins: 50, // Admin
 			"Content Editors": 40, // Editor
@@ -376,37 +389,38 @@ emdash({
 
 The first matching group wins if a user belongs to multiple groups. The **first user** to access the site always becomes Admin, regardless of groups.
 
-### Role Sync Behavior
+### Role sync behavior
 
 By default (`syncRoles: false`), a user's role is set when they first log in and doesn't change afterward. This allows admins to manually adjust roles in EmDash.
 
 Set `syncRoles: true` if you want IdP groups to be authoritative — the user's role will update on every login based on their current groups.
 
-### How It Works
+### Request and session flow
 
-1. User visits `/_emdash/admin`
-2. Cloudflare Access intercepts and redirects to your IdP
-3. User authenticates (SSO, MFA, etc.)
-4. Access sets a signed JWT in the request
-5. EmDash validates the JWT and creates/authenticates the user
+1. The user visits a path protected by the Access application.
+2. Cloudflare Access redirects the user to your identity provider when no Access session exists.
+3. After authentication, Access sends a signed JWT to the origin in `Cf-Access-Jwt-Assertion`.
+4. EmDash validates the token's signature, issuer, and audience, then reads the Access identity and groups.
+5. EmDash finds or provisions the local user, applies the configured role behavior, and records the user in the Astro session.
+6. Later requests to protected EmDash routes repeat Access validation. Public pages can use the EmDash session to identify the user without treating it as proof of a new Access request.
 
 <Aside type="tip">
 	You can still disable users locally in EmDash. A disabled user will be rejected even if Access
 	allows them through.
 </Aside>
 
-### Disabled Features
+### Features replaced by Access
 
 When Access is enabled, these features are unavailable:
 
 - Login page (`/_emdash/admin/login`)
 - Passkey registration and management
-- OAuth login
+- GitHub, Google, and Atmosphere login
 - Magic link login
 - Self-signup
 - User invites
 
-User management is done entirely through your Cloudflare Access policies.
+Access policies decide who reaches EmDash. EmDash still owns local roles, content ownership, and the disabled-user flag. With `syncRoles: false`, administrators can change a provisioned user's role in EmDash. With `syncRoles: true`, the mapped Access groups replace that role on each login.
 
 ### Troubleshooting
 
@@ -417,7 +431,7 @@ The request reached EmDash without an Access JWT. This means:
 - Access isn't configured to protect your application
 - The Access policy isn't matching the admin routes
 
-Verify your Access application covers `/_emdash/admin/*`.
+Verify that the Access application covers the full `/_emdash/*` path and that its policy includes the user.
 
 #### "JWT audience mismatch"
 

--- a/docs/src/content/docs/guides/internationalization.mdx
+++ b/docs/src/content/docs/guides/internationalization.mdx
@@ -3,13 +3,13 @@ title: Internationalization (i18n)
 description: Translate content into multiple languages with per-locale publishing, slugs, and automatic fallback.
 ---
 
-import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside } from "@astrojs/starlight/components";
 
 EmDash integrates with [Astro's built-in i18n routing](https://docs.astro.build/en/guides/internationalization/) to provide multilingual content management. Astro handles URL routing and locale detection; EmDash handles translated content storage and retrieval.
 
 Each translation is a full, independent content entry with its own slug, status, and revision history. The French version of a post can be in draft while the English version is published.
 
-## Configuration
+## Configure locales
 
 Enable i18n by adding an `i18n` block to your Astro config. EmDash reads this same configuration for its locale list, default locale, and fallback chain.
 
@@ -39,7 +39,7 @@ export default defineConfig({
 When `i18n` is not present in the Astro config, all i18n features are disabled and EmDash behaves as a single-language CMS.
 
 <Aside type="caution" title="Do not prefix the default locale">
-Any Astro routing strategy that prefixes the default locale breaks the EmDash admin — that includes `routing: { prefixDefaultLocale: true }` and `routing: "prefix-always"`. With either enabled, every page route — including routes injected by integrations — requires a locale prefix, so `/_emdash/admin` and all its sub-paths (`/setup`, `/login`, `/content`, …) return **404**. The locale-prefixed variant (`/es/_emdash/admin/...`) does not work either, because the admin's client-side router expects to live at `/_emdash/admin`. API routes under `/_emdash/api/*` are unaffected — only injected page routes with spread parameters break. This is an upstream Astro limitation in how i18n routing interacts with `injectRoute` (see [#369](https://github.com/emdash-cms/emdash/issues/369)).
+Any Astro routing strategy that prefixes the default locale breaks the EmDash admin. This includes `routing: { prefixDefaultLocale: true }` and `routing: "prefix-always"`. These strategies require a locale prefix on page routes injected by integrations, so `/_emdash/admin` and its setup, login, and content pages return **404**. A locale-prefixed path such as `/en/_emdash/admin` does not work because the admin router is mounted at `/_emdash/admin`. API routes under `/_emdash/api/*` are unaffected.
 
 Use Astro's default routing strategy (`prefix-other-locales`) instead, which serves the default locale unprefixed and works with the admin:
 
@@ -52,10 +52,10 @@ i18n: {
 },
 ```
 
-If you need the default locale prefixed for public pages, handle it with a redirect or rewrite in front of the site (e.g. `/` → `/en/` at the edge) rather than `prefixDefaultLocale`.
+If public URLs must include the default locale, add a redirect or rewrite in front of the site (for example, `/` to `/en/`) rather than enabling `prefixDefaultLocale`.
 </Aside>
 
-## How Translations Work
+## How translations work
 
 EmDash uses a **row-per-locale** model. Each translation is its own row in the database with its own ID, slug, and status, linked to other translations via a shared `translation_group` identifier. A posts table with three translations looks like this:
 
@@ -75,11 +75,20 @@ This design means:
 - **Per-locale revisions** — each translation has its own revision history
 - **Single-locale queries** — list queries return entries for one locale only
 
-## Querying Translated Content
+### Slugs, entry IDs, and database IDs
+
+An entry has two identifiers with different purposes:
+
+- `entry.id` is the entry's slug. Use it when building the public URL.
+- `entry.data.id` is the database ID. Use it for API operations and helpers that refer to a stored content row, including `getTranslations()` and `getEntryTerms()`.
+
+Translations have different database IDs because each locale is a separate row. Their shared `translation_group` records that the rows are translations of the same content. EmDash manages that group when you create a translation; templates normally only need the database ID of any row in the group.
+
+## Query translated content
 
 ### Single entry
 
-Pass `locale` to `getEmDashEntry` to retrieve a specific translation. When omitted, it defaults to the request's current locale (set by Astro's i18n middleware).
+Pass `Astro.currentLocale` to `getEmDashEntry` on a multilingual route. Astro knows the locale selected by its router, while EmDash needs the explicit value to disambiguate slugs that can exist in more than one locale. Do the same for collection queries.
 
 ```astro title="src/pages/[...slug].astro"
 ---
@@ -100,16 +109,18 @@ if (!post) return Astro.redirect("/404");
 
 ### Fallback chain
 
-When no content exists for the requested locale, EmDash follows the fallback chain defined in your Astro config. Given `fallback: { fr: "en" }`:
+When a matching published entry does not exist in the requested locale, `getEmDashEntry` follows the fallback chain from the Astro config. In preview or visual-editing mode, the same lookup can return a draft. Given `fallback: { fr: "en" }`:
 
 1. Try the requested locale (`fr`)
 2. Try the fallback locale (`en`)
-3. Try the default locale
+3. Try the default locale if it is not already in the chain
 
 Fallback only applies to single-entry queries. List queries return entries for the requested locale only.
 
+Each fallback lookup uses the same `id` argument. For example, a request for the slug `about` can fall back from French to an English entry whose slug is also `about`. A request for `a-propos` cannot discover an English entry whose slug is `about`; the two rows use different public identifiers. Use `getTranslations()` to find and link locale variants with different slugs.
+
 <Aside>
-  When a fallback is used, the response metadata includes `fallbackLocale` so your template can display a "this content is not yet translated" notice.
+  When a fallback is used, `fallbackLocale` contains the locale that supplied the entry. Use it to explain that the requested translation is unavailable.
 </Aside>
 
 ### Menus
@@ -158,7 +169,7 @@ import { getTaxonomyTerms, getEntryTerms } from "emdash";
 const categories = await getTaxonomyTerms("category", {
   locale: Astro.currentLocale,
 });
-const terms = await getEntryTerms("posts", post.id, undefined, {
+const terms = await getEntryTerms("posts", post.data.id, undefined, {
   locale: Astro.currentLocale,
 });
 ---
@@ -212,12 +223,12 @@ const { entries: posts } = await getEmDashCollection("posts", {
 
 <ul>
   {posts.map((post) => (
-    <li><a href={`/${post.data.slug}`}>{post.data.title}</a></li>
+    <li><a href={`/${post.id}`}>{post.data.title}</a></li>
   ))}
 </ul>
 ```
 
-## Language Switcher
+## Build a language switcher
 
 Use `getTranslations` to build a language switcher that links to existing translations of the current entry:
 
@@ -233,17 +244,21 @@ interface Props {
 
 const { collection, entryId } = Astro.props;
 const { translations } = await getTranslations(collection, entryId);
+const publishedTranslations = translations.filter(
+  (translation): translation is typeof translation & { slug: string } =>
+    translation.status === "published" && translation.slug !== null
+);
 ---
 
 <nav aria-label="Language">
   <ul>
-    {translations.map((t) => (
+    {publishedTranslations.map((translation) => (
       <li>
         <a
-          href={getRelativeLocaleUrl(t.locale, `/blog/${t.slug}`)}
-          aria-current={t.locale === Astro.currentLocale ? "page" : undefined}
+          href={getRelativeLocaleUrl(translation.locale, `/blog/${translation.slug}`)}
+          aria-current={translation.locale === Astro.currentLocale ? "page" : undefined}
         >
-          {t.locale.toUpperCase()}
+          {translation.locale.toUpperCase()}
         </a>
       </li>
     ))}
@@ -254,7 +269,7 @@ const { translations } = await getTranslations(collection, entryId);
 The `getTranslations` function returns all locale variants in the same translation group:
 
 ```ts
-const { translationGroup, translations } = await getTranslations("posts", post.entry.id);
+const { translationGroup, translations } = await getTranslations("posts", post.data.id);
 // translations: [
 //   { locale: "en", id: "01ABC...", slug: "my-post", status: "published" },
 //   { locale: "fr", id: "01DEF...", slug: "mon-article", status: "draft" },
@@ -262,10 +277,10 @@ const { translationGroup, translations } = await getTranslations("posts", post.e
 ```
 
 <Aside type="tip">
-  Use `getRelativeLocaleUrl` from `astro:i18n` to build locale-prefixed URLs. This respects your Astro routing strategy (`prefix-other-locales` or `prefix-always`).
+  `getTranslations()` returns draft and scheduled siblings as well as published ones. Filter the result before rendering a public language switcher so it does not link to an unpublished route.
 </Aside>
 
-## Managing Translations in the Admin
+## Manage translations in the admin
 
 ### Content list
 
@@ -288,18 +303,18 @@ When creating a translation, the new entry is pre-filled with data from the sour
 
 Each translation has its own status. Publish, unpublish, or schedule translations independently. The French version can be in draft while the English version is live.
 
-## Content API
+## Use the content API
 
 ### Locale parameter
 
-All content API routes accept an optional `locale` query parameter:
+Content API routes require an authenticated session or bearer token. List routes accept an optional `locale` query parameter. A single-entry route also accepts it when the path uses a slug; database IDs are globally unique and do not need locale disambiguation.
 
 ```http
 GET /_emdash/api/content/posts?locale=fr
 GET /_emdash/api/content/posts/my-post?locale=fr
 ```
 
-When omitted, defaults to the configured default locale.
+When a list request omits `locale`, it uses the configured default locale.
 
 ### Creating translations via API
 
@@ -308,18 +323,19 @@ Create a translation by passing `locale` and `translationOf` to the content crea
 ```http
 POST /_emdash/api/content/posts
 Content-Type: application/json
+X-EmDash-Request: 1
 
 {
   "locale": "fr",
   "translationOf": "01ABC...",
+  "slug": "mon-article",
   "data": {
-    "title": "Mon Article",
-    "slug": "mon-article"
+    "title": "Mon Article"
   }
 }
 ```
 
-The new entry shares the source entry's `translation_group` and starts as a draft.
+`translationOf` is the source row's database ID, such as `entry.data.id`. The new entry shares the source entry's `translation_group` and starts as a draft.
 
 ### Listing translations
 
@@ -331,9 +347,9 @@ GET /_emdash/api/content/posts/01ABC.../translations
 
 Returns the translation group ID and an array of locale variants with their IDs, slugs, and statuses.
 
-## CLI
+## Use the CLI
 
-The CLI supports `--locale` flags on content commands:
+After authenticating the CLI, use its `--locale` flags on content commands:
 
 ```bash
 # List French posts
@@ -342,11 +358,18 @@ emdash content list posts --locale fr
 # Get a specific entry in French
 emdash content get posts my-post --locale fr
 
-# Create a French translation of an existing entry
-emdash content create posts --locale fr --translation-of 01ABC...
+# Create a French translation as a draft
+emdash content create posts \
+  --locale fr \
+  --translation-of 01ABC... \
+  --slug mon-article \
+  --data '{"title":"Mon article"}' \
+  --draft
 ```
 
-## Seeding Multilingual Content
+`content create` requires input from `--data`, `--file`, or `--stdin`. It publishes after creation unless you pass `--draft`.
+
+## Seed multilingual content
 
 Seed files express translations using `locale` and `translationOf`:
 
@@ -376,7 +399,7 @@ Seed files express translations using `locale` and `translationOf`:
 
 The source locale entry must appear before its translations in the seed file so that `translationOf` references resolve correctly.
 
-## Field Translatability
+## Choose which fields are translatable
 
 Each field has a `translatable` setting (default: `true`). When creating a translation:
 
@@ -389,25 +412,21 @@ System fields like `status`, `published_at`, and `author_id` are always per-loca
   Non-translatable fields are useful for values that should stay consistent across locales, such as a product SKU or a sort order number.
 </Aside>
 
-## URL Strategy
+## Build locale URLs
 
-EmDash does not manage locale URLs — Astro handles routing. Common patterns:
+EmDash stores the locale; Astro handles public routing. The supported EmDash configuration leaves the default locale unprefixed:
 
 ```
 # prefix-other-locales (Astro default)
 /blog/my-post          → en (default locale, no prefix)
 /fr/blog/mon-article   → fr
-
-# prefix-always
-/en/blog/my-post       → en
-/fr/blog/mon-article   → fr
 ```
 
-Use `getRelativeLocaleUrl` from `astro:i18n` to build correct URLs regardless of routing mode.
+Use `getRelativeLocaleUrl` from `astro:i18n` to add the correct prefix and any custom locale path mapping. Do not enable a default-locale prefix; as described in [Configure locales](#configure-locales), that routing strategy prevents the injected admin pages from loading.
 
 ## Sitemaps
 
-The per-collection sitemap at `/sitemap-{collection}.xml` is locale-aware. When i18n is enabled, each translation is emitted as its own `<url>` entry, with the locale prefix resolved through Astro's `getRelativeLocaleUrl`. Your `prefixDefaultLocale` setting and any custom locale `path` mappings are honoured automatically.
+The per-collection sitemap at `/sitemap-{collection}.xml` is locale-aware. It includes published entries from routable, SEO-enabled collections. Deleted entries, entries without a slug, and entries marked `noindex` are excluded. Each included translation becomes its own `<url>` entry. EmDash builds its path from the collection's `urlPattern`, then applies Astro's locale prefix and any custom locale `path` mapping.
 
 Translation siblings are cross-linked with `xhtml:link` alternates so search engines can serve the correct language to each user:
 
@@ -421,9 +440,9 @@ Translation siblings are cross-linked with `xhtml:link` alternates so search eng
 </url>
 ```
 
-Siblings are grouped by `translation_group`, so a row added later (a new locale variant of an existing post) automatically appears as an alternate on every other variant. Sites with a single locale produce a plain sitemap with no `xhtml` namespace.
+Siblings are grouped by `translation_group`, so a published locale variant appears as an alternate on every other published, indexable variant. Locales missing from `i18n.locales` are omitted because Astro has no route for them. Sites with a single locale produce a plain sitemap with no `xhtml` namespace.
 
-## hreflang Alternates in the Page Head
+## Add `hreflang` links to the page head
 
 The same alternates belong in the `<head>` of every content page. If your layout uses [`<EmDashHead>`](/plugins/creating-plugins/hooks/#pagemetadata), this is automatic: when i18n is enabled and the page context includes `content`, it emits one `<link rel="alternate">` per published translation sibling — including a self-referencing link, as Google recommends — plus `x-default`:
 
@@ -439,7 +458,12 @@ For hand-rolled heads, resolve the alternates with `getHreflangAlternates`:
 ---
 import { getEmDashEntry, getHreflangAlternates } from "emdash";
 
-const { entry } = await getEmDashEntry("posts", Astro.params.slug);
+const { entry, error } = await getEmDashEntry("posts", Astro.params.slug, {
+	locale: Astro.currentLocale,
+});
+if (error) return new Response("Server error", { status: 500 });
+if (!entry) return Astro.redirect("/404");
+
 const alternates = await getHreflangAlternates("posts", entry.data.id, {
 	siteUrl: Astro.url.origin,
 });
@@ -450,29 +474,35 @@ const alternates = await getHreflangAlternates("posts", entry.data.id, {
 </head>
 ```
 
-Behaviour matches the sitemap exactly:
+Behaviour matches the sitemap:
 
 - **`x-default`** points at the default-locale variant. When the default locale has no published translation, it falls back to the first routable variant, so the set never lacks an `x-default`.
 - **Unpublished siblings are excluded** — draft translations never leak into alternates.
+- **`noindex` siblings are excluded.** If the current entry is `noindex`, no alternates are returned.
 - **Unroutable locales are dropped.** A row whose locale isn't in your configured `i18n.locales` can't be served, and linking search engines to a 404 is worse than no link.
 - **Untranslated entries** still get a self-referencing alternate and `x-default` when i18n is enabled, mirroring the sitemap.
 - With **i18n disabled**, the result is empty and no queries run.
 
-URLs are built from the collection's `urlPattern` and localized through your Astro i18n routing config (`prefixDefaultLocale`, custom locale `path` mappings), so head and sitemap always agree.
+URLs are built from the collection's `urlPattern` and localized through the Astro i18n configuration. `getHreflangAlternates()` needs an absolute site URL. It uses `siteUrl` from the call or the site settings URL; without either, it returns an empty array because `hreflang` links must be absolute.
 
-## Importing Multilingual Content
+## Import multilingual content
 
 Import WordPress content through the admin migration tool — see [Content Import](/migration/content-import/) and [Migrate from WordPress](/migration/from-wordpress/). A WXR export does not carry the locale and translation-group structure that WPML or Polylang add, so imported content lands in your default locale.
 
-To build translations from imported content, create the translated entry and link it to the original:
+To build translations from imported content, create the translated entry as a draft and link it to the original database ID:
 
 ```bash
-emdash content create posts --locale fr --translation-of 01ABC...
+emdash content create posts \
+  --locale fr \
+  --translation-of 01ABC... \
+  --slug mon-article \
+  --data '{"title":"Mon article"}' \
+  --draft
 ```
 
-This is the same `--locale` / `--translation-of` workflow shown in [Seeding multilingual content](#seeding-multilingual-content) above, applied after the import completes.
+This is the same `--locale` and `--translation-of` relationship used by [seed files](#seed-multilingual-content), applied after the import completes.
 
-## Next Steps
+## Next steps
 
 - [Querying Content](/guides/querying-content/) — Full query API reference
 - [Working with Content](/guides/working-with-content/) — Admin content management

--- a/docs/src/content/docs/guides/preview.mdx
+++ b/docs/src/content/docs/guides/preview.mdx
@@ -3,20 +3,20 @@ title: Preview Mode
 description: Enable secure previews of draft content before publishing.
 ---
 
-import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside } from "@astrojs/starlight/components";
 
 EmDash's preview system lets editors view unpublished content through secure, time-limited URLs. Preview links use HMAC-SHA256 signed tokens that you can share with reviewers without exposing your entire draft content.
 
-## How It Works
+## How preview requests work
 
 1. The admin generates a preview URL for a draft post
 2. The URL contains a signed `_preview` query parameter with an expiration time
 3. EmDash's middleware automatically verifies the token and sets up the request context
 4. Your template code calls `getEmDashEntry()` as normal — draft content is served automatically
 
-Preview is **implicit**. The middleware verifies the token and the query functions read it through `AsyncLocalStorage`, so the same template code serves draft content during a preview and published content otherwise.
+The middleware verifies the token before rendering the page and records which content entry it authorizes. `getEmDashEntry()` reads that request context automatically. The same template therefore serves the draft for a valid, matching preview link and the published entry for an ordinary request. A token for another collection or entry never grants draft access to the requested page.
 
-## Setting Up Preview
+## Set up preview
 
 Preview works as soon as EmDash is installed. On first use, EmDash
 generates a per-site preview secret and stores it in the database, so
@@ -29,7 +29,7 @@ Set `EMDASH_PREVIEW_SECRET` in your environment only if you need to:
 - Pin the secret to a value you control for compliance/audit reasons
 - Migrate to a known value when restoring from a backup
 
-```bash title=".env"
+```dotenv title=".env"
 # Optional: override the auto-generated secret
 EMDASH_PREVIEW_SECRET="your-random-secret-key-here"
 ```
@@ -44,8 +44,6 @@ import { getEmDashEntry } from "emdash";
 
 const { slug } = Astro.params;
 
-// No special preview handling needed — the middleware
-// detects _preview tokens and serves draft content automatically
 const { entry, isPreview, error } = await getEmDashEntry("posts", slug);
 
 if (error) {
@@ -59,7 +57,7 @@ if (!entry) {
 
 {isPreview && (
   <div class="preview-banner">
-    You are viewing a preview. This content is not published.
+    You are viewing the preview version of this page.
   </div>
 )}
 
@@ -68,31 +66,32 @@ if (!entry) {
 </article>
 ```
 
-The `isPreview` flag is `true` when draft content is being served via a valid preview token.
+The `isPreview` flag is `true` when a valid preview token matches the entry returned by the query. Invalid, expired, and non-matching tokens do not expose draft content.
 
-## Generating Preview URLs
+## Generate preview URLs
 
-Use `getPreviewUrl()` to create preview links. The function takes the
-secret as an explicit argument:
+Most editors use **View on site** in the admin. That action calls the preview URL endpoint, which resolves the site secret without exposing it to the browser.
+
+Use `getPreviewUrl()` when server-side application code must create a link. The helper requires the signing secret explicitly. Read secrets from `process.env`, and fail before generating a link if the variable is missing:
 
 ```ts
 import { getPreviewUrl } from "emdash";
 
+const secret = process.env.EMDASH_PREVIEW_SECRET;
+if (!secret) throw new Error("EMDASH_PREVIEW_SECRET is required");
+
 const previewUrl = await getPreviewUrl({
 	collection: "posts",
 	id: "my-draft-post",
-	secret: import.meta.env.EMDASH_PREVIEW_SECRET,
+	secret,
 	expiresIn: "1h",
 });
 // Returns: /posts/my-draft-post?_preview=eyJjaWQ...
 ```
 
-When `EMDASH_PREVIEW_SECRET` isn't set, EmDash auto-generates and stores
-a per-site secret in the database for token verification. The
-`getPreviewUrl()` template helper still requires you to pass the secret
-explicitly — pin your env var if you call it from page templates. Most
-sites use the admin UI's "Generate preview link" button instead, which
-goes through the API and uses the resolved secret automatically.
+When `EMDASH_PREVIEW_SECRET` is unset, the EmDash endpoint generates and stores a per-site secret in the database. The standalone helper cannot read that stored value, so configure the environment variable if application code calls the helper.
+
+The `id` value identifies the authorized content and also replaces `{id}` in the URL path. It can be a database ID or a slug. Use the same identifier that the destination page passes to `getEmDashEntry()`.
 
 Pass `baseUrl` to generate an absolute URL:
 
@@ -100,7 +99,7 @@ Pass `baseUrl` to generate an absolute URL:
 const fullUrl = await getPreviewUrl({
 	collection: "posts",
 	id: "my-draft-post",
-	secret: import.meta.env.EMDASH_PREVIEW_SECRET,
+	secret,
 	baseUrl: "https://example.com",
 });
 // Returns: https://example.com/posts/my-draft-post?_preview=eyJjaWQ...
@@ -112,7 +111,7 @@ Pass `pathPattern` to generate a URL with a custom path:
 const blogUrl = await getPreviewUrl({
 	collection: "posts",
 	id: "my-draft-post",
-	secret: import.meta.env.EMDASH_PREVIEW_SECRET,
+	secret,
 	pathPattern: "/blog/{id}",
 });
 // Returns: /blog/my-draft-post?_preview=eyJjaWQ...
@@ -146,66 +145,72 @@ await getPreviewUrl({
 // Returns: /hello?_preview=...
 ```
 
-The admin's "View on site" link goes through `POST /_emdash/api/content/{collection}/{id}/preview-url`,
-which reads the entry's locale, looks up the site's i18n config and supplies
-the `locale` automatically. To change the default pattern used by that
-endpoint, set `EMDASH_PREVIEW_PATH_PATTERN` (e.g. `/{locale}/{id}`) — request
-bodies still win when they include their own `pathPattern`.
+The admin's **View on site** link goes through `POST /_emdash/api/content/{collection}/{id}/preview-url`. The endpoint uses the entry's database ID and supplies its locale automatically. Set `EMDASH_PREVIEW_PATH_PATTERN` when your public route differs from the default `/{collection}/{id}` pattern. For example, `/{locale}/posts/{id}` produces `/pt-br/posts/01ABC...` for a Portuguese entry and `/posts/01ABC...` for an unprefixed default-locale entry. The destination route can pass that database ID to `getEmDashEntry()`. A `pathPattern` in the request body overrides the environment value.
 
-## Token Expiration
+The endpoint cannot substitute the entry's slug separately from its database ID. If a preview URL must use the slug, generate it in server-side application code with `getPreviewUrl()` and pass the slug as `id`.
+
+The `{locale}` placeholder receives the configured locale code. It does not apply Astro's custom locale `path` mappings. If the public route uses a different segment, call the helper with that segment or provide a route that accepts the locale code used by the admin endpoint.
+
+## Set token expiration
 
 Control how long preview links remain valid:
 
 ```ts
+const preview = {
+	collection: "posts",
+	id: "my-draft-post",
+	secret,
+};
+
 // Valid for 1 hour (default)
-await getPreviewUrl({ ..., expiresIn: "1h" });
+await getPreviewUrl(preview);
 
 // Valid for 30 minutes
-await getPreviewUrl({ ..., expiresIn: "30m" });
+await getPreviewUrl({ ...preview, expiresIn: "30m" });
 
 // Valid for 1 day
-await getPreviewUrl({ ..., expiresIn: "1d" });
+await getPreviewUrl({ ...preview, expiresIn: "1d" });
 
 // Valid for 2 weeks
-await getPreviewUrl({ ..., expiresIn: "2w" });
+await getPreviewUrl({ ...preview, expiresIn: "2w" });
 
 // Valid for 3600 seconds
-await getPreviewUrl({ ..., expiresIn: 3600 });
+await getPreviewUrl({ ...preview, expiresIn: 3600 });
 ```
 
 Supported units: `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks).
 
-## Verifying Tokens
+## Verify tokens in a custom flow
 
-Use `verifyPreviewToken()` to validate incoming preview requests:
+Normal Astro pages do not call `verifyPreviewToken()`; the EmDash middleware already verifies `_preview`. Use this helper only when code outside that middleware must validate a token:
 
 ```ts
 import { verifyPreviewToken } from "emdash";
 
 // From a URL (extracts _preview query parameter)
-const result = await verifyPreviewToken({
+const fromUrl = await verifyPreviewToken({
 	url: Astro.url,
-	secret: import.meta.env.EMDASH_PREVIEW_SECRET,
+	secret,
 });
 
 // Or with a token directly
-const result = await verifyPreviewToken({
-	token: someTokenString,
-	secret: import.meta.env.EMDASH_PREVIEW_SECRET,
+const fromToken = await verifyPreviewToken({
+	token: Astro.url.searchParams.get("_preview"),
+	secret,
 });
 ```
 
 The result indicates whether the token is valid:
 
 ```ts
-if (result.valid) {
+if (fromUrl.valid) {
 	// Token is valid
-	console.log(result.payload.cid); // "posts:my-draft-post"
-	console.log(result.payload.exp); // Expiry timestamp
-	console.log(result.payload.iat); // Issued-at timestamp
+	console.log(fromUrl.payload.cid); // "posts:my-draft-post"
+	console.log(fromUrl.payload.exp); // Expiry timestamp
+	console.log(fromUrl.payload.iat); // Issued-at timestamp
 } else {
 	// Token is invalid
-	console.log(result.error);
+	console.log(fromUrl.error);
 	// "none" - no token present
 	// "malformed" - token structure is invalid
 	// "invalid" - signature verification failed
@@ -213,14 +218,14 @@ if (result.valid) {
 }
 ```
 
-## Preview Indicator
+## Show a preview indicator
 
-You can show a visual indicator when content is being previewed. The `isPreview` flag returned by `getEmDashEntry` tells you when draft content is being served:
+Use the `isPreview` flag returned by `getEmDashEntry` to show that the page came from a preview request:
 
 ```astro
 {isPreview && (
   <div class="preview-banner" role="alert">
-    <strong>Preview</strong> — You are viewing unpublished content.
+    <strong>Preview</strong> — You are viewing the preview version of this page.
     <a href={Astro.url.pathname}>Exit preview</a>
   </div>
 )}
@@ -231,11 +236,11 @@ You can show a visual indicator when content is being previewed. The `isPreview`
 	that indicates edit/preview mode. You only need a custom preview banner for shared preview links.
 </Aside>
 
-## Helper Functions
+## Inspect preview URLs
 
 ### `isPreviewRequest(url)`
 
-Check if a URL contains a preview token:
+Check whether a URL contains a `_preview` parameter. This does not verify the token:
 
 ```ts
 import { isPreviewRequest } from "emdash";
@@ -269,14 +274,14 @@ const { collection, id } = parseContentId("posts:my-draft-post");
 
 ## Token security
 
-Preview tokens are signed and time-limited. The CLI and the helper functions generate and verify them for you; you do not construct or parse them by hand. A token identifies one entry and stops working after it expires.
+Preview tokens are signed and time-limited. The admin endpoint and helper functions generate and verify them for you; you do not construct or parse them by hand. A token identifies one entry and stops working after it expires.
 
 <Aside type="caution">
 	Keep your `EMDASH_PREVIEW_SECRET` secret. Anyone who has it can generate a
 	valid preview token for any content.
 </Aside>
 
-## Complete Example
+## Complete example
 
 The following page combines preview and visual editing support in a full blog post template:
 
@@ -288,7 +293,6 @@ import { PortableText } from "emdash/ui";
 
 const { slug } = Astro.params;
 
-// Preview is automatic — middleware handles token verification
 const { entry, isPreview, error } = await getEmDashEntry("posts", slug);
 
 if (error) {
@@ -303,7 +307,7 @@ if (!entry) {
 <BaseLayout title={entry.data.title}>
   {isPreview && (
     <div class="preview-banner" role="alert">
-      <strong>Preview</strong> — This content is not published.
+      <strong>Preview</strong> — You are viewing the preview version of this page.
     </div>
   )}
 
@@ -329,7 +333,7 @@ if (!entry) {
 
 Note the `{...entry.edit}` and `{...entry.edit.title}` spreads — these add `data-emdash-ref` attributes that enable visual editing for authenticated editors. In production, they produce no output.
 
-## API Reference
+## API reference
 
 ### `getPreviewUrl(options)`
 

--- a/docs/src/content/docs/guides/x402-payments.mdx
+++ b/docs/src/content/docs/guides/x402-payments.mdx
@@ -1,21 +1,23 @@
 ---
 title: x402 Payments
-description: Monetize content with the x402 payment protocol — charge bots, not humans.
+description: Require x402 payments for server-rendered Astro routes.
 ---
 
-import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
-The `@emdash-cms/x402` package adds [x402 payment protocol](https://www.x402.org/) support to any Astro site on Cloudflare. It runs as a standalone Astro integration, and pairs with EmDash's CMS fields for per-page pricing when you use EmDash.
+The `@emdash-cms/x402` package adds [x402 payment protocol](https://www.x402.org/) support to server-rendered Astro sites. It is a standalone Astro integration, so payment enforcement does not require EmDash. When the site also uses EmDash, a content field can supply the price for each entry.
 
 x402 is an HTTP-native payment protocol. When a client requests a paid resource without payment, the server responds with `402 Payment Required` and machine-readable payment instructions. Agents and browsers that understand x402 can complete payment automatically and retry the request.
 
-## When to Use This
+## Choose an enforcement mode
 
-The most common use case is **bot-only mode**: charge AI agents and scrapers for content access while letting human visitors read for free. This uses Cloudflare Bot Management to distinguish bots from humans.
+Use normal enforcement when every request to the route must present a valid payment. This mode does not depend on Cloudflare-specific request metadata.
 
-You can also enforce payment for all visitors, or check for payment headers without enforcing (conditional rendering).
+Use **bot-only mode** when the site runs on Cloudflare Workers with Bot Management enabled and only low-score requests should pay. The package reads `request.cf.botManagement.score`; when that value is absent, it treats the request as human and skips enforcement. Do not use bot-only mode when missing bot data must fail closed.
 
-## Installation
+`hasPayment()` provides a third behavior for presentation only. It reports whether the request has a payment header but does not verify or settle the payment.
+
+## Install the package
 
 Install the package with your package manager:
 
@@ -37,9 +39,9 @@ yarn add @emdash-cms/x402
 </TabItem>
 </Tabs>
 
-## Setup
+## Configure the integration
 
-Add the integration to your Astro config:
+Choose a wallet, network, and facilitator that work together. The integration supports Ethereum Virtual Machine (EVM) networks by default, but the facilitator must also support the configured network and asset. The following example uses Base mainnet and enforces payment for every request:
 
 ```js title="astro.config.mjs"
 import { defineConfig } from "astro/config";
@@ -51,8 +53,6 @@ export default defineConfig({
 			payTo: "0xYourWalletAddress",
 			network: "eip155:8453", // Base mainnet
 			defaultPrice: "$0.01",
-			botOnly: true,
-			botScoreThreshold: 30,
 		}),
 	],
 });
@@ -64,7 +64,7 @@ Add the type reference so TypeScript knows about `Astro.locals.x402`:
 /// <reference types="@emdash-cms/x402/locals" />
 ```
 
-## Basic Usage
+## Enforce payment on a route
 
 The integration puts an enforcer on `Astro.locals.x402`. Call `enforce()` in your page frontmatter to gate content behind payment:
 
@@ -96,9 +96,21 @@ The `enforce()` method returns either:
 - A **`Response`** (402) — the client needs to pay. Return it directly.
 - An **`EnforceResult`** — the request should proceed. The content was paid for, or enforcement was skipped (human in botOnly mode).
 
-## Bot-Only Mode
+## Enable bot-only mode
 
-When `botOnly` is `true`, the integration reads `request.cf.botManagement.score` to classify requests:
+Enable `botOnly` in the integration configuration:
+
+```js title="astro.config.mjs"
+x402({
+	payTo: "0xYourWalletAddress",
+	network: "eip155:8453",
+	defaultPrice: "$0.01",
+	botOnly: true,
+	botScoreThreshold: 30,
+});
+```
+
+The integration reads Cloudflare's `request.cf.botManagement.score` to classify requests:
 
 - **Score below threshold** (default 30) -> treated as bot, payment enforced
 - **Score at or above threshold** -> treated as human, enforcement skipped
@@ -119,12 +131,12 @@ x402.applyHeaders(result, Astro.response);
 ---
 ```
 
-<Aside>
-	Bot-only mode requires a Cloudflare deployment with Bot Management enabled. In local development,
-	all requests are treated as human and enforcement is skipped.
+<Aside type="caution">
+	Bot-only mode requires a Cloudflare Workers deployment with Bot Management enabled. Local,
+	non-Cloudflare, and Cloudflare requests without Bot Management data all skip enforcement.
 </Aside>
 
-## Per-Page Pricing with EmDash
+## Read a price from EmDash
 
 When using EmDash, add a regular `number` field to your collection for per-page pricing and read it at request time:
 
@@ -139,9 +151,9 @@ if (!entry) return Astro.redirect("/404");
 
 const { x402 } = Astro.locals;
 
-// Use the price from the CMS, falling back to a default
+// Use the price from the CMS, falling back only when it is absent.
 const result = await x402.enforce(Astro.request, {
-  price: entry.data.price || "$0.01",
+  price: entry.data.price ?? "$0.01",
   description: entry.data.title,
 });
 if (result instanceof Response) return result;
@@ -154,30 +166,30 @@ x402.applyHeaders(result, Astro.response);
 </article>
 ```
 
-## Checking for Payment Without Enforcing
+## Check for a payment header without enforcing
 
-Use `hasPayment()` to check if a request includes payment headers without verifying or enforcing. This is useful for conditional rendering — showing different content to paying vs non-paying visitors:
+Use `hasPayment()` to check whether a request includes a payment header without verifying or enforcing it. This can change a prompt or sign-in message, but it must not unlock protected content:
 
 ```astro
 ---
 const { x402 } = Astro.locals;
 
-const hasPaid = x402.hasPayment(Astro.request);
+const hasPaymentHeader = x402.hasPayment(Astro.request);
 ---
 
-{hasPaid ? (
-  <p>Full premium content here.</p>
+{hasPaymentHeader ? (
+  <p>Payment supplied. Verification is still required.</p>
 ) : (
-  <p>Subscribe for the full article.</p>
+  <p>This page requires payment.</p>
 )}
 ```
 
 <Aside type="caution">
-	`hasPayment()` only checks for the presence of a payment header. It does not verify the payment
-	is valid. Use `enforce()` when you need verified payment.
+	`hasPayment()` only checks for the presence of a payment header. An attacker can send an invalid
+	header. Use `enforce()` before returning paid content.
 </Aside>
 
-## Configuration Reference
+## Configuration reference
 
 | Option              | Type      | Default                          | Description                                      |
 | ------------------- | --------- | -------------------------------- | ------------------------------------------------ |
@@ -187,12 +199,12 @@ const hasPaid = x402.hasPayment(Astro.request);
 | `facilitatorUrl`    | `string`  | `https://x402.org/facilitator`   | Payment facilitator URL                           |
 | `scheme`            | `string`  | `"exact"`                        | Payment scheme                                    |
 | `maxTimeoutSeconds` | `number`  | `60`                             | Maximum timeout for payment signatures            |
-| `evm`               | `boolean` | `true`                           | Enable EVM chain support                          |
-| `svm`               | `boolean` | `false`                          | Enable Solana chain support (requires `@x402/svm`) |
+| `evm`               | `boolean` | `true`                           | Enable Ethereum Virtual Machine network support  |
+| `svm`               | `boolean` | `false`                          | Enable Solana Virtual Machine support (requires `@x402/svm`) |
 | `botOnly`           | `boolean` | `false`                          | Only enforce payment for bots                     |
 | `botScoreThreshold` | `number`  | `30`                             | Bot score threshold (1-99, lower = more likely bot) |
 
-### Price Format
+### Price format
 
 Prices can be specified in several formats:
 
@@ -201,18 +213,11 @@ Prices can be specified in several formats:
 - **Number** — `0.10`
 - **Object** — `{ amount: "100000", asset: "0x...", extra: {} }` for explicit asset/amount
 
-### Network Identifiers
+### Network identifiers
 
-Networks use [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) format:
+[CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) gives blockchain networks unambiguous identifiers such as `eip155:8453` for Base mainnet. Use the exact identifier advertised by the facilitator. The package accepts the `eip155:*` family when EVM support is enabled and the `solana:*` family when Solana Virtual Machine (SVM) support is enabled; this does not guarantee that a facilitator accepts every network in that family.
 
-| Network       | Identifier       |
-| ------------- | ---------------- |
-| Base mainnet  | `eip155:8453`    |
-| Base Sepolia  | `eip155:84532`   |
-| Ethereum      | `eip155:1`       |
-| Solana        | `solana:mainnet` |
-
-## Enforce Options
+## Override one request
 
 Override config defaults for a specific page:
 
@@ -226,7 +231,7 @@ await x402.enforce(Astro.request, {
 });
 ```
 
-## Solana Support
+## Enable Solana support
 
 Solana is opt-in. Install `@x402/svm` and enable it in config:
 
@@ -234,24 +239,21 @@ Solana is opt-in. Install `@x402/svm` and enable it in config:
 pnpm add @x402/svm
 ```
 
-Set the network to a Solana identifier and disable EVM if you only use Solana:
+Set `svm: true`, use the CAIP-2 Solana identifier supported by the facilitator, and disable EVM if the site only accepts Solana payments. For example, the Solana mainnet identifier used by `@x402/svm` 2.8 is `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`:
 
 ```js title="astro.config.mjs"
 x402({
 	payTo: "YourSolanaAddress",
-	network: "solana:mainnet",
+	network: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
 	svm: true,
 	evm: false, // Disable EVM if only using Solana
 });
 ```
 
-## How It Works
+## Request flow
 
-1. The `x402()` integration registers middleware that creates an enforcer and places it on `Astro.locals.x402`
-2. Configuration is passed to the middleware via a Vite virtual module (`virtual:x402/config`)
-3. When `enforce()` is called, it checks for a `payment-signature` header on the request
-4. If no payment header is present, a `402 Payment Required` response is returned with payment instructions in the `PAYMENT-REQUIRED` header
-5. If a payment header is present, it's verified through the facilitator service and settled
-6. After settlement, `PAYMENT-RESPONSE` headers are set on the response via `applyHeaders()`
-
-The resource server is initialized lazily on first request and cached for the worker lifetime.
+1. The integration puts the payment enforcer on `Astro.locals.x402` before the page runs.
+2. `enforce()` checks for a `payment-signature` header.
+3. Without a payment header, `enforce()` returns a `402 Payment Required` response whose body and `PAYMENT-REQUIRED` header describe the accepted payment.
+4. With a matching payment, the configured facilitator verifies and settles it.
+5. `enforce()` returns the payer and settlement result. Call `applyHeaders()` so the page response includes the facilitator's `PAYMENT-RESPONSE` proof.


### PR DESCRIPTION
## What does this PR do?

Clarifies the guides where locale, preview, and authentication behavior meet external integrations:

- explains the difference between public slugs and database IDs, the exact locale fallback boundary, and how sitemap and `hreflang` output treat unpublished, unroutable, and `noindex` translations
- documents automatic preview request handling, admin-generated preview URL identifiers, the current first-user setup flow, provider/session boundaries, endpoint-specific auth limits, and the correct Astro placement for `server.host`
- distinguishes the public docs MCP from a site's authenticated CMS MCP, covers the current media upload, byline, and translation tools, and updates ChatGPT, Codex, and third-party client guidance
- aligns the x402 guide with the current package, including normal versus Cloudflare bot-only enforcement and the current Solana network identifier format

Related issue: None.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

`pnpm typecheck`, tests for documentation text, admin localization, a changeset, a feature Discussion, and UI screenshots are not applicable to this documentation-only change. The seven changed MDX files were formatted with scoped Prettier and verified with `prettier --check`.

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: GPT-5.6 Sol (Codex)

## Screenshots / test output

Screenshots: Not applicable; this changes documentation content only.

Validation:

- `pnpm lint`
- `pnpm lint:quick`
- `pnpm --dir docs build`
- `git diff --check`
- `pnpm --dir packages/x402 test -- --run` (17 tests)
- `pnpm --dir packages/core exec vitest run tests/unit/preview/urls.test.ts tests/unit/preview/tokens.test.ts tests/integration/seo/hreflang.test.ts tests/integration/seo/sitemap-route.test.ts` (61 tests)
- `pnpm --dir packages/auth-atproto exec vitest run tests/auth.test.ts tests/oauth-client.test.ts tests/resolve-handle.test.ts` (27 tests)
- `pnpm --dir packages/core exec vitest run tests/integration/auth/rate-limit.test.ts tests/integration/astro/setup-admin-nonce-success.test.ts tests/unit/astro/signup-rate-limit.test.ts tests/unit/auth/magic-link.test.ts tests/unit/auth/mcp-discovery-post.test.ts` (39 tests)
- `pnpm --dir packages/core exec vitest run tests/unit/mcp/authorization.test.ts tests/unit/api/handlers/media-upload.test.ts` (57 tests)
