### PR TITLE
docs: rewrite native plugin authoring guides

### DIFF
--- a/docs/src/content/docs/plugins/creating-native-plugins/distributing.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/distributing.mdx
@@ -1,141 +1,257 @@
 ---
 title: Distributing native plugins
-description: Package and ship a native plugin via npm.
+description: Build, inspect, publish, and install a native plugin package from npm.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Steps } from "@astrojs/starlight/components";
 
-Native plugins distribute via npm. A native plugin is a regular npm package that exports a descriptor factory plus `createPlugin`. Site operators install it with `npm install` and register it in `astro.config.mjs`.
+Native plugins are npm packages installed in the host project and registered in `astro.config.mjs`. The package needs a built server entry for its descriptor and `createPlugin()`. If it also ships React or Astro components, export those as separate source entrypoints so the host can compile them for the correct environment.
 
 ## Package layout
 
-A typical native plugin package has the following layout:
+The following layout separates the server runtime from browser and Astro source:
 
-```
-@my-org/plugin-analytics/
+```text
+plugin-activity/
 ├── src/
-│   ├── index.ts          # Descriptor + createPlugin
-│   ├── admin.tsx         # React admin components (optional)
-│   └── astro/            # Astro components for PT block rendering (optional)
-│       └── index.ts
-├── dist/                 # build output
+│   ├── index.ts
+│   ├── admin/
+│   │   ├── index.tsx
+│   │   └── ActivityPage.tsx
+│   └── astro/
+│       ├── index.ts
+│       └── ActivityBlock.astro
+├── dist/
+│   ├── index.mjs
+│   └── index.d.mts
 ├── package.json
 ├── tsconfig.json
 └── README.md
 ```
 
-## package.json
+`dist/` is generated. Keep `src/admin/` and `src/astro/` in the published tarball because the host's Vite and Astro build must process those entrypoints.
 
-The following `package.json` declares the build scripts, exports, and peer dependencies a distributable plugin needs:
+## Package exports
+
+The following `package.json` builds the server entry and publishes all three entrypoints:
 
 ```json title="package.json"
 {
-	"name": "@my-org/plugin-analytics",
+	"name": "@example/plugin-activity",
 	"version": "0.1.0",
 	"type": "module",
-	"main": "dist/index.js",
+	"main": "./dist/index.mjs",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
+			"types": "./dist/index.d.mts",
+			"import": "./dist/index.mjs"
 		},
-		"./admin": {
-			"types": "./dist/admin.d.ts",
-			"import": "./dist/admin.js"
-		},
-		"./astro": {
-			"types": "./dist/astro/index.d.ts",
-			"import": "./dist/astro/index.js"
-		}
+		"./admin": "./src/admin/index.tsx",
+		"./astro": "./src/astro/index.ts"
 	},
-	"files": ["dist"],
+	"files": ["dist", "src/admin", "src/astro"],
 	"scripts": {
-		"build": "tsdown src/index.ts src/admin.tsx --format esm --dts --clean",
-		"prepublishOnly": "pnpm build"
+		"build": "tsdown src/index.ts --format esm --dts --clean",
+		"dev": "tsdown src/index.ts --format esm --dts --watch",
+		"typecheck": "tsc --noEmit",
+		"prepublishOnly": "pnpm typecheck && pnpm build"
 	},
 	"peerDependencies": {
+		"@cloudflare/kumo": "*",
+		"@emdash-cms/admin": "*",
+		"@lingui/core": "*",
+		"@lingui/react": "*",
+		"@tanstack/react-query": "*",
+		"astro": ">=6.0.0-beta.0",
 		"emdash": "*",
-		"react": "^18.0.0"
-	}
+		"react": "^18.0.0 || ^19.0.0"
+	},
+	"devDependencies": {
+		"@types/react": "^19.0.0",
+		"tsdown": "^0.20.0",
+		"typescript": "^5.9.0"
+	},
+	"keywords": ["emdash", "emdash-plugin"],
+	"license": "MIT"
 }
 ```
 
-| Export      | Required if you use…                          | Built for |
-| ----------- | --------------------------------------------- | --------- |
-| `"."`       | Always                                        | Server    |
-| `"./admin"` | React admin pages or widgets                  | Browser   |
-| `"./astro"` | Portable Text rendering components            | Server (SSR) |
+Remove `./admin`, `src/admin`, and the admin-only peer dependencies when the plugin has no trusted React UI. Remove `./astro`, `src/astro`, and the `astro` peer when it has no Portable Text renderer. Add a peer dependency for every host-owned library imported by an exported source entrypoint; this prevents a second React, Kumo, Lingui, or React Query instance from entering the admin bundle.
 
-Skip the `./admin` and `./astro` exports if your plugin doesn't need them.
+The entrypoints have different consumers:
 
-<Aside type="tip">
-	Keep `emdash` and `react` as peer dependencies, not regular dependencies. The host site provides the actual versions; bundling your own copy causes version conflicts and duplicate React copies in the admin UI.
-</Aside>
+| Export | Required when | Consumer |
+| --- | --- | --- |
+| `.` | Always | Astro configuration imports the descriptor factory; EmDash imports the named `createPlugin()` at runtime. |
+| `./admin` | `adminEntry` is set | The host's browser build imports the React component maps. |
+| `./astro` | `componentsEntry` is set | The host's Astro build imports `blockComponents`. |
 
-## Build configuration
+The module specifiers in the descriptor and runtime must match these exports:
 
-Native plugins ship as ES modules. Most authors use `tsdown` (or `tsup`) with TypeScript. Externalise `react`, `emdash`, and `@emdash-cms/admin` so they aren't bundled into your output:
+```typescript title="src/index.ts"
+export function activityPlugin(): PluginDescriptor {
+	return {
+		id: "plugin-activity",
+		version: "0.1.0",
+		format: "native",
+		entrypoint: "@example/plugin-activity",
+		adminEntry: "@example/plugin-activity/admin",
+		componentsEntry: "@example/plugin-activity/astro",
+	};
+}
 
-```typescript title="tsdown.config.ts"
-export default {
-	entry: {
-		index: "src/index.ts",
-		admin: "src/admin.tsx",
-	},
-	format: "esm",
-	dts: true,
-	external: ["react", "react-dom", "emdash", "@emdash-cms/admin"],
-};
+export function createPlugin() {
+	return definePlugin({
+		id: "plugin-activity",
+		version: "0.1.0",
+		admin: {
+			entry: "@example/plugin-activity/admin",
+		},
+	});
+}
 ```
 
-If you ship Astro components for Portable Text rendering, those don't need bundling — Astro consumes the `.astro` source files directly. List the `astro/` directory under `files` so they're included in the npm tarball.
+Keep the npm package version, descriptor version, and `definePlugin()` version synchronized. The version shown to a site administrator comes from the plugin definition, not automatically from `package.json`.
 
-## Versioning
+## Plugin identity and version
 
-Use semantic versioning. Bumping a major version is a signal to operators that they may need to make changes when upgrading. The shape of `definePlugin()` and the plugin context API are stable, but if you change your plugin's hook behaviour, capability requirements, or settings schema in a way that affects existing installs, that's a breaking change.
+`definePlugin()` accepts either an unscoped ID containing lowercase letters, digits, and hyphens, or a scoped ID in the form `@scope/name`. Use an unscoped, kebab-case ID for a site plugin because the ID also occupies one path segment in `/_emdash/api/plugins/<plugin-id>/<route>`.
 
-Capabilities are part of the plugin's surface contract. Adding one in a non-major release means existing operators upgrade and silently grant a new capability — that's fine for a sandboxed plugin where the consent dialog re-prompts, but native plugins don't have a consent flow. Treat capability additions as a major version bump for native plugins, or document them very prominently in release notes.
+The following values show the accepted forms and the recommended separation between plugin ID and npm package name:
 
-## README and documentation
+```typescript
+id: "plugin-activity"; // Recommended: valid in plugin route URLs
+id: "@example/plugin-activity"; // Accepted by definePlugin(), but not one URL segment
 
-A good plugin README covers:
+entrypoint: "@example/plugin-activity"; // The npm package may stay scoped
+```
 
-- What the plugin does, in one sentence.
-- How to install it (`npm install ...` and the `astro.config.mjs` snippet with the import).
-- What capabilities it declares and what it uses them for.
-- Any required Astro template changes (e.g. `<EmDashHead />` for `page:metadata`, `<EmDashBodyEnd />` for `page:fragments`).
-- Settings and what each one controls.
-- Migration notes between major versions.
+Versions must begin with a semantic `major.minor.patch` sequence. Use a complete semantic version for both the descriptor and runtime:
 
-## Publishing to npm
+```typescript
+version: "1.0.0"; // Valid
+version: "1.2.3-beta.1"; // Valid prerelease
+version: "1.0"; // Invalid: missing patch version
+```
 
-Bump the version and publish the package:
+## TypeScript configuration
+
+The native scaffold creates a suitable `tsconfig.json`. If the plugin adds React and Astro source after scaffolding, include both JSX environments:
+
+```json title="tsconfig.json"
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "preserve",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"declaration": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"jsx": "react-jsx",
+		"types": ["astro/client"]
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}
+```
+
+Run `pnpm typecheck` against the source entrypoints before packaging. The `build` script compiles only `src/index.ts`; the host compiles the exported admin and Astro source when it consumes the package.
+
+## Inspect the package
+
+Test the exact tarball contents before publishing. The commands below assume a disposable site named `my-emdash-site` sits beside the plugin directory.
+
+<Steps>
+
+1. Build and type-check the package.
+
+   ```bash
+   pnpm typecheck
+   pnpm build
+   ```
+
+2. Create the npm tarball and review the file list printed by npm.
+
+   ```bash
+   npm pack
+   ```
+
+   For the example package, npm creates `example-plugin-activity-0.1.0.tgz`.
+
+3. Confirm that the output contains `dist/index.mjs`, `dist/index.d.mts`, and every source file reachable from the exported `./admin` and `./astro` modules.
+
+4. Install the produced tarball in the disposable EmDash site.
+
+   ```bash
+   cd ../my-emdash-site
+   pnpm add ../plugin-activity/example-plugin-activity-0.1.0.tgz
+   ```
+
+5. Import and register the descriptor factory in the disposable site's `astro.config.mjs`, following [Create and register the package](/plugins/creating-native-plugins/your-first-native-plugin/#create-and-register-the-package). Then build the host site.
+
+   ```bash
+   pnpm build
+   ```
+
+   Open every plugin admin surface and render every contributed Portable Text block. Registering before the build makes Astro resolve the tarball's `./admin` and `./astro` exports; a server-only package test cannot catch a missing browser or `.astro` source file.
+
+</Steps>
+
+## README contents
+
+Give an operator enough information to install and evaluate the package without reading its source. Include:
+
+- a one-sentence description and the supported EmDash version
+- the install command and complete `astro.config.mjs` registration
+- the native trust boundary and why the plugin needs native execution
+- every declared capability and allowed host, with the feature that uses it
+- settings and their defaults
+- required layout components, such as `EmDashBodyEnd` for a body-end fragment
+- upgrade steps for changes that require operator action
+
+Do not describe capability declarations as an isolation boundary. They gate `ctx` APIs, but native code can still use imports, environment variables, and direct network calls available to the host process.
+
+## Publish to npm
+
+Publish after the tarball test passes:
 
 ```bash
-npm version patch     # or minor/major
 npm publish --access public
 ```
 
-For scoped packages, `--access public` is required on the first publish (npm defaults scoped packages to private).
+The first public release of a scoped package needs `--access public`. Use semantic versioning for later releases. Treat changes to constructor options, stored data, required host changes, package exports, or the plugin's trust requirements as compatibility decisions. If an upgrade requires a new capability or allowed host, call it out in the release notes even though native installs do not have a capability-consent prompt.
 
-## Local development against a host site
+## Install from npm
 
-When iterating on a plugin, link it into a test site rather than republishing on every change:
+An operator installs the published package in the EmDash site:
 
 ```bash
-# In the plugin package
-pnpm build --watch
-
-# In the test site
-pnpm add file:../plugins/my-plugin
-# or with workspaces:
-pnpm add @my-org/plugin-analytics --workspace
+pnpm add @example/plugin-activity
 ```
 
-Then register the plugin in the test site's `astro.config.mjs` and run the dev server. Hook handlers run on the next request after `pnpm build` finishes.
+Then import and register its descriptor factory in `astro.config.mjs` as shown in [Create and register the package](/plugins/creating-native-plugins/your-first-native-plugin/#create-and-register-the-package). Installing the dependency alone does not activate the plugin; changing the Astro configuration and deploying the site completes the installation.
 
-## Marketplace availability
+## Develop against a host site
 
-Native plugins can't be published to the EmDash marketplace. The marketplace is sandboxed-only: every published plugin runs through `emdash plugin bundle` (which validates that the backend code is self-contained, doesn't import Node.js built-ins, and stays under size limits), gets a security audit, and runs in the sandbox runtime when installed.
+Build the plugin in watch mode:
 
-A plugin that uses native-only features can sometimes drop them and become sandboxable — for example, by removing `page:fragments` or converting `settingsSchema` to a Block Kit settings page. See [Choosing a plugin format](/plugins/creating-plugins/choosing-a-format/) for the trade-offs.
+```bash
+pnpm dev
+```
+
+Install the local directory from the host site:
+
+```bash
+pnpm add ../plugin-activity
+```
+
+Register the plugin's descriptor factory in `astro.config.mjs`, then start the host development server. Restart the server after changing descriptor metadata or package exports. If a package-manager file dependency copies files instead of linking them in your setup, reinstall it after rebuilding; a workspace dependency or `pnpm link` keeps the local package connected during development.
+
+## Marketplace boundary
+
+Native packages cannot be published to the EmDash marketplace. Marketplace plugins use the sandboxed package format, bundle workflow, and installation consent flow. If the plugin no longer needs React admin code, Astro renderers, trusted fragments, or another in-process dependency, [convert it to the sandboxed format](/plugins/creating-plugins/choosing-a-format/) before publishing through the marketplace.
+
+<Aside type="note">
+	A package may publish a sandboxed plugin and a separate native rendering companion. Keep the split explicit in both READMEs: installing the marketplace plugin does not install or trust the npm companion automatically.
+</Aside>

--- a/docs/src/content/docs/plugins/creating-native-plugins/page-fragments.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/page-fragments.mdx
@@ -1,183 +1,175 @@
 ---
 title: Page fragments
-description: Inject scripts, stylesheets, or HTML into rendered public pages — native plugins only.
+description: Add trusted scripts or HTML to public page insertion points.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Steps } from "@astrojs/starlight/components";
 
-The `page:fragments` hook lets a plugin contribute raw HTML, scripts, or stylesheets to public pages. It's the right tool for analytics tags, third-party widgets, custom CSS, and anything else that needs to ship JavaScript or markup directly into the visitor's browser.
+The `page:fragments` hook contributes scripts or raw HTML to the head or body of a rendered public page. Use it for browser code that structured metadata cannot express, such as an analytics loader with a `<noscript>` fallback.
 
-It's restricted to native plugins because its output runs as first-party code in the browser, outside any sandbox boundary. If you only need to contribute structured metadata — meta tags, OpenGraph, JSON-LD, allowlisted `<link>` rels — use `page:metadata` instead, which is available to both sandboxed and native plugins. See [Hooks: page:metadata](/plugins/creating-plugins/hooks/#pagemetadata).
+Fragment output runs as first-party page code. EmDash invokes this hook only for trusted, in-process plugins; sandboxed plugins never contribute fragments. If the page needs meta tags, canonical or alternate links, or JSON-LD, use the sandbox-compatible [`page:metadata` hook](/plugins/creating-plugins/hooks/#pagemetadata) instead.
 
-## Capability
+## Declare the capability and hook
 
-`page:fragments` requires the `hooks.page-fragments:register` capability:
+`page:fragments` requires `hooks.page-fragments:register` in the native runtime definition. The following hook adds an external script and an HTML fallback only when a configured analytics ID exists:
 
 ```typescript title="src/index.ts"
 return definePlugin({
-	id: "analytics-gtm",
-	version: "1.0.0",
+	id: "plugin-analytics",
+	version: "0.1.0",
 	capabilities: ["hooks.page-fragments:register"],
-	// ...
+	hooks: {
+		"page:fragments": async (event, ctx) => {
+			const analyticsId = await ctx.kv.get<string>("settings:analyticsId");
+			if (!analyticsId || event.page.path.startsWith("/_emdash/")) return null;
+
+			const encodedId = encodeURIComponent(analyticsId);
+			return [
+				{
+					kind: "external-script",
+					placement: "head",
+					src: `https://analytics.example.com/client.js?id=${encodedId}`,
+					async: true,
+					key: "analytics-client",
+				},
+				{
+					kind: "html",
+					placement: "body:end",
+					html: "<noscript>Analytics requires JavaScript.</noscript>",
+					key: "analytics-fallback",
+				},
+			];
+		},
+	},
 });
 ```
 
-The capability must also appear on the descriptor.
+Raw HTML contributions are inserted verbatim. Keep the fragment static when possible; otherwise escape every value that can come from settings, content, request data, or an external service.
 
-## Where fragments render
+For native plugins, declare the capability in `definePlugin()`. The descriptor does not need a second copy because `createPlugin()` supplies the runtime capability list.
 
-Templates opt into receiving fragments by including the relevant components from `emdash/ui`:
+If the capability is missing, EmDash logs a warning and does not register the hook. Hook errors are logged and do not prevent the page from rendering.
 
-- `<EmDashHead />` — renders fragments with `placement: "head"` plus all `page:metadata` contributions.
-- `<EmDashBodyStart />` — renders fragments with `placement: "body:start"`.
-- `<EmDashBodyEnd />` — renders fragments with `placement: "body:end"`.
+## Add the layout insertion points
 
-Templates that omit one of these components silently ignore fragments targeting that placement — your plugin doesn't break, the fragments just don't appear. Document your placement requirement in the plugin's README.
+The host theme chooses which placements it supports. It must pass the same `PublicPageContext` to the corresponding EmDash components:
 
-## Contribution kinds
+<Steps>
 
-A hook can return one of three contribution kinds:
+1. Build the page context once in the layout.
 
-```typescript
-type PageFragmentContribution =
-	| {
-			kind: "external-script";
-			placement: PagePlacement;
-			src: string;
-			async?: boolean;
-			defer?: boolean;
-			attributes?: Record<string, string>;
-			key?: string;
-	  }
-	| {
-			kind: "inline-script";
-			placement: PagePlacement;
-			code: string;
-			attributes?: Record<string, string>;
-			key?: string;
-	  }
-	| {
-			kind: "html";
-			placement: PagePlacement;
-			html: string;
-			key?: string;
-	  };
-```
+   ```astro title="src/layouts/Base.astro"
+   ---
+   import { createPublicPageContext } from "emdash/page";
+   import {
+       EmDashBodyEnd,
+       EmDashBodyStart,
+       EmDashHead,
+   } from "emdash/ui";
 
-`PagePlacement` is `"head" | "body:start" | "body:end"`.
+   interface Props {
+       title: string;
+       description?: string;
+       content?: { collection: string; id: string; slug?: string | null };
+   }
 
-## Examples
+   const { title, description, content } = Astro.props;
+   const page = createPublicPageContext({
+       Astro,
+       kind: content ? "content" : "custom",
+       pageType: content ? "article" : "website",
+       title,
+       description,
+       content,
+   });
+   ---
+   ```
 
-### External script
+2. Render each supported placement in the matching part of the document.
 
-The following hook injects a third-party tag manager into `<head>`:
+   ```astro title="src/layouts/Base.astro"
+   <html lang="en">
+       <head>
+           <title>{title}</title>
+           <EmDashHead page={page} />
+       </head>
+       <body>
+           <EmDashBodyStart page={page} />
+           <slot />
+           <EmDashBodyEnd page={page} />
+       </body>
+   </html>
+   ```
 
-```typescript
-"page:fragments": async (event, ctx) => {
-	const containerId = await ctx.kv.get<string>("settings:gtmContainerId");
-	if (!containerId) return null;
+</Steps>
 
-	return {
-		kind: "external-script",
-		placement: "head",
-		src: `https://www.googletagmanager.com/gtm.js?id=${containerId}`,
-		async: true,
-	};
-},
-```
+`EmDashHead` renders `head` fragments as well as EmDash and plugin metadata. `EmDashBodyStart` renders `body:start` fragments immediately after the opening `<body>`, and `EmDashBodyEnd` renders `body:end` fragments after the page content. A theme that omits a component does not render fragments for that placement. Document any required insertion point in the plugin README.
 
-### Inline script
+## Contribution reference
 
-The following hook runs a small piece of JavaScript at the top of `<body>` on content pages:
+A hook can return one contribution, an array, or `null`. The supported contribution shapes are:
 
-```typescript
-"page:fragments": async (event, ctx) => {
-	if (event.page.kind !== "content") return null;
+| `kind` | Required fields | Optional fields | Output behavior |
+| --- | --- | --- | --- |
+| `external-script` | `placement`, `src` | `async`, `defer`, `attributes`, `key` | Renders a `<script src="…">` element. |
+| `inline-script` | `placement`, `code` | `attributes`, `key` | Renders `code` inside a `<script>` element. |
+| `html` | `placement`, `html` | `key` | Inserts `html` without sanitizing it. |
+
+`placement` accepts `head`, `body:start`, or `body:end`.
+
+EmDash HTML-escapes attribute names and values and removes attributes whose names begin with `on`. For inline scripts, it escapes `</` so a value cannot close the script element. These renderer checks do not make untrusted HTML or JavaScript safe; the plugin must still encode interpolated data for the language and context where it is inserted.
+
+The following hook safely places a JSON value in an inline script:
+
+```typescript title="src/index.ts"
+"page:fragments": async (event) => {
+	if (event.page.kind !== "content" || !event.page.content) return null;
+
 	return {
 		kind: "inline-script",
 		placement: "body:start",
-		code: `window.contentId = ${JSON.stringify(event.page.content?.id)};`,
+		code: `window.currentContent = ${JSON.stringify({
+			collection: event.page.content.collection,
+			id: event.page.content.id,
+		})};`,
+		key: "current-content",
 	};
 },
 ```
+
+Within one placement, contributions with the same `key` keep the first value. External scripts without a key are also deduplicated by `src`. Use a stable key when two hooks could describe the same logical fragment.
+
+## Page context reference
+
+The hook receives `{ page }`. The page object comes from the host layout, with optional SEO-panel values overlaid for a content entry that was loaded during the request.
+
+| Field | Type and meaning |
+| --- | --- |
+| `url` | Absolute page URL. |
+| `path` | URL pathname. |
+| `locale` | Active locale, or `null`. |
+| `kind` | `content` for an EmDash entry or `custom` for another page. |
+| `pageType` | Theme-defined type, commonly `article` or `website`. |
+| `title`, `pageTitle` | Full document title and optional page-only title. |
+| `description`, `canonical`, `image` | Page metadata values, each nullable. |
+| `content` | Optional `{ collection, id, slug }` reference for the rendered entry. |
+| `seo` | Optional Open Graph title, description, image, and robots overrides. |
+| `articleMeta` | Optional published time, modified time, and author. |
+| `siteName`, `siteUrl` | Optional public site identity and origin. |
+| `breadcrumbs` | Optional root-first `{ name, url }` items. An empty array explicitly means no breadcrumbs. |
+
+Use `kind`, `pageType`, `path`, `locale`, or `content` to limit where a fragment appears. Do not fetch an entry again when the page context already carries the identity needed for the decision.
+
+## Prefer structured metadata when possible
+
+Use `page:metadata` for the following output:
+
+- `<meta name="…">` and `<meta property="…">` tags
+- canonical, alternate, author, license, `nlweb`, and `site.standard.document` links
+- JSON-LD graphs
+
+`page:metadata` validates its structured contributions, deduplicates them with the page's base metadata, and works in both native and sandboxed plugins. Use `page:fragments` when the browser must receive executable code or markup that the structured hook cannot represent.
 
 <Aside type="caution">
-	Inline script content is inserted verbatim. Treat any value you interpolate as untrusted output and use `JSON.stringify()` (or equivalent) to escape it. Never concatenate raw user input into inline JS.
+	A native fragment can read secrets from the host process and send data to the browser or another origin. Review the package as first-party application code, and never place a server-side secret in a fragment.
 </Aside>
-
-### HTML fragment
-
-The following hook appends a noscript fallback at the end of `<body>`:
-
-```typescript
-"page:fragments": async (event, ctx) => {
-	const containerId = await ctx.kv.get<string>("settings:gtmContainerId");
-	if (!containerId) return null;
-
-	return {
-		kind: "html",
-		placement: "body:end",
-		html: `<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${containerId}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>`,
-	};
-},
-```
-
-### Multiple fragments
-
-A hook can return an array to contribute multiple fragments at once. The following hook adds both a script and a noscript fallback:
-
-```typescript
-"page:fragments": async (event, ctx) => {
-	const id = await ctx.kv.get<string>("settings:gtmContainerId");
-	if (!id) return null;
-
-	return [
-		{
-			kind: "external-script",
-			placement: "head",
-			src: `https://www.googletagmanager.com/gtm.js?id=${id}`,
-			async: true,
-		},
-		{
-			kind: "html",
-			placement: "body:end",
-			html: `<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${id}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>`,
-		},
-	];
-},
-```
-
-## Page event
-
-The `page:fragments` hook receives the same event shape as `page:metadata`:
-
-```typescript
-{
-	page: {
-		url: string;
-		path: string;
-		locale: string | null;
-		kind: "content" | "custom";
-		pageType: string;
-		title: string | null;
-		pageTitle?: string | null;
-		description: string | null;
-		canonical: string | null;
-		image: string | null;
-		content?: { collection: string; id: string; slug: string | null };
-	}
-}
-```
-
-Use `event.page.kind` and `event.page.pageType` to decide whether to contribute on a given page — for example, skipping analytics on admin previews or only injecting JSON-LD on blog posts.
-
-## When to use `page:metadata` instead
-
-If what you actually need is:
-
-- A meta description, robots directive, or Twitter card → `page:metadata` with `kind: "meta"`.
-- An OpenGraph property → `page:metadata` with `kind: "property"`.
-- A canonical or alternate `<link>` → `page:metadata` with `kind: "link"`.
-- A JSON-LD graph → `page:metadata` with `kind: "jsonld"`.
-
-`page:metadata` works in sandboxed plugins, gets validation and deduplication for free, and avoids the trust burden of shipping raw HTML to visitors. Reach for `page:fragments` only when you need to ship JavaScript or HTML.

--- a/docs/src/content/docs/plugins/creating-native-plugins/portable-text-components.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/portable-text-components.mdx
@@ -1,100 +1,173 @@
 ---
 title: Portable Text rendering components
-description: Provide Astro components that render plugin-defined Portable Text block types on the public site.
+description: Define a plugin block in the editor and provide its Astro renderer on the public site.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Steps } from "@astrojs/starlight/components";
 
-Plugins can add custom block types to the Portable Text editor — YouTube embeds, code snippets, image galleries, anything that isn't covered by the default block set. Sandboxed plugins can declare the editing UI for these blocks (using Block Kit fields), but the Astro components that **render** them on the public site have to be loaded at build time from npm. That's the part that requires a native plugin.
+A plugin-defined Portable Text block has two parts:
 
-If your plugin only needs editing-side fields and someone else is providing the rendering components (or the site is providing them locally), you can stay sandboxed. If the plugin should ship the rendering components too, you need to be native.
+- A declarative block definition tells the EmDash editor how to insert and edit the block.
+- An Astro component renders the saved block on the public site.
 
-## Declaring block types
+The block definition uses the shared plugin runtime and is compatible with sandboxed plugins. Loading an Astro component from the package requires a native descriptor because Astro must import it while building the host site.
 
-Both sandboxed and native plugins can declare block types. Native plugins do it inside `definePlugin()` under `admin.portableTextBlocks`:
+## Define the editor block
 
-```typescript title="src/index.ts"
-admin: {
-	portableTextBlocks: [
-		{
-			type: "youtube",
-			label: "YouTube Video",
-			icon: "video",                       // video, code, link, link-external
-			placeholder: "Paste YouTube URL...",
-			fields: [                            // Block Kit fields for the editing UI
-				{ type: "text_input", action_id: "id", label: "YouTube URL" },
-				{ type: "text_input", action_id: "title", label: "Title" },
-				{ type: "text_input", action_id: "poster", label: "Poster Image URL" },
-			],
-		},
-	],
-},
-```
-
-Each block type defines:
-
-- **`type`** — block type name (used in Portable Text `_type`).
-- **`label`** — display name in the editor's slash command menu.
-- **`icon`** — `video`, `code`, `link`, or `link-external`. Falls back to a generic cube.
-- **`placeholder`** — input placeholder text.
-- **`fields`** — Block Kit form fields for editing. If omitted, a simple URL input is shown.
-
-## Rendering on the public site
-
-To render block types on the public site, export Astro components from a `componentsEntry`. The export name is **required** to be `blockComponents`:
-
-```typescript title="src/astro/index.ts"
-import YouTube from "./YouTube.astro";
-import CodePen from "./CodePen.astro";
-
-export const blockComponents = {
-	youtube: YouTube,
-	codepen: CodePen,
-};
-```
-
-Set `componentsEntry` on the descriptor:
+Declare blocks in `admin.portableTextBlocks` inside `definePlugin()`. The following definition adds a callout with a heading, body, and tone:
 
 ```typescript title="src/index.ts"
-export function myPlugin(): PluginDescriptor {
-	return {
-		id: "embeds",
-		version: "1.0.0",
-		format: "native",
-		entrypoint: "@my-org/embeds",
-		componentsEntry: "@my-org/embeds/astro",
-	};
-}
+return definePlugin({
+	id: "plugin-callout",
+	version: "0.1.0",
+	admin: {
+		portableTextBlocks: [
+			{
+				type: "callout",
+				label: "Callout",
+				icon: "info",
+				description: "Highlight supporting information",
+				category: "Sections",
+				fields: [
+					{
+						type: "text_input",
+						action_id: "heading",
+						label: "Heading",
+					},
+					{
+						type: "text_input",
+						action_id: "body",
+						label: "Body",
+						multiline: true,
+					},
+					{
+						type: "select",
+						action_id: "tone",
+						label: "Tone",
+						options: [
+							{ value: "note", label: "Note" },
+							{ value: "warning", label: "Warning" },
+						],
+						initial_value: "note",
+					},
+				],
+			},
+		],
+	},
+});
 ```
 
-EmDash merges plugin block components into `<PortableText>` automatically — site authors don't need to import anything. User-provided components (declared in the site's `components` prop on `<PortableText>`) take precedence over plugin defaults.
+The block fields control how the block appears in the slash menu and edit dialog:
 
-## Package exports
+| Field | Required | Behavior |
+| --- | --- | --- |
+| `type` | Yes | Becomes the saved Portable Text block's `_type` and the renderer-map key. Keep it unique across the enabled plugins. |
+| `label` | Yes | Names the block in the editor. |
+| `icon` | No | Uses the editor's supported icon key when one matches; otherwise the editor shows its generic block icon. |
+| `description` | No | Adds supporting text in the slash menu. |
+| `category` | No | Groups the block in the slash menu. The default category is `Embeds`. |
+| `placeholder` | No | Sets the simple URL input's placeholder when `fields` is omitted. |
+| `fields` | No | Replaces the simple URL input with Block Kit form elements. Each `action_id` becomes a property on the saved block. |
 
-Add the `./astro` export to `package.json`:
+Use the Block Kit element shapes documented in [Block Kit](/plugins/creating-plugins/block-kit/) for `fields`. The example stores a block shaped like the following value:
 
-```json title="package.json"
+```json
 {
-	"exports": {
-		".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
-		"./admin": { "types": "./dist/admin.d.ts", "import": "./dist/admin.js" },
-		"./astro": { "types": "./dist/astro/index.d.ts", "import": "./dist/astro/index.js" }
-	}
+	"_type": "callout",
+	"_key": "01JEXAMPLEKEY",
+	"heading": "Before you publish",
+	"body": "Check the preview on a small screen.",
+	"tone": "warning"
 }
 ```
 
-The `./astro` export is server-side (Astro SSR), the `./admin` export is browser-side (React), and the `"."` export is the descriptor + `createPlugin`. Keep them in separate files because they bundle for different environments.
+## Add the Astro component
 
-<Aside type="tip">
-	The bundled `@emdash-cms/plugin-embeds` plugin is a complete example of this pattern — YouTube, Vimeo, Tweet, Bluesky, Mastodon, Gist, and Link Preview block types with both admin editing fields and site-side Astro rendering components.
+<Steps>
+
+1. Create an Astro component that accepts the saved block as `node`.
+
+   ```astro title="src/astro/Callout.astro"
+   ---
+   interface CalloutNode {
+       _type: "callout";
+       _key: string;
+       heading?: string;
+       body?: string;
+       tone?: "note" | "warning";
+   }
+
+   interface Props {
+       node: CalloutNode;
+   }
+
+   const { node } = Astro.props;
+   ---
+
+   <aside class:list={["callout", `callout--${node.tone ?? "note"}`]}>
+       {node.heading && <p class="callout__heading"><strong>{node.heading}</strong></p>}
+       {node.body && <p>{node.body}</p>}
+   </aside>
+   ```
+
+   `astro-portabletext` passes custom type components a `node` prop. It does not pass the block as `value`. The renderer uses styled text for the optional heading because the block can appear at any depth in the document; a fixed heading element could skip or repeat a heading level.
+
+2. Export the component in a map named `blockComponents`.
+
+   ```typescript title="src/astro/index.ts"
+   import Callout from "./Callout.astro";
+
+   export const blockComponents = {
+       callout: Callout,
+   };
+   ```
+
+   Each key must match the block definition's `type`.
+
+3. Add `componentsEntry` to the descriptor factory.
+
+   ```typescript title="src/index.ts"
+   export function calloutPlugin(): PluginDescriptor {
+       return {
+           id: "plugin-callout",
+           version: "0.1.0",
+           format: "native",
+           entrypoint: "@example/plugin-callout",
+           componentsEntry: "@example/plugin-callout/astro",
+       };
+   }
+   ```
+
+4. Export the `./astro` entry from the npm package. The entry must resolve to the module that exports `blockComponents`. [Distributing native plugins](/plugins/creating-native-plugins/distributing/#package-exports) shows a complete package definition.
+
+</Steps>
+
+## Rendering order and overrides
+
+EmDash automatically adds plugin components to its `<PortableText>` component. Components merge in the following order:
+
+1. EmDash built-in components
+2. Plugin `blockComponents`
+3. Components passed by the site to `<PortableText>`
+
+Later entries override earlier ones with the same type key. A site can therefore replace only the callout renderer while leaving the plugin's editor definition enabled:
+
+```astro title="src/pages/article.astro"
+---
+import { PortableText } from "emdash/ui";
+import SiteCallout from "../components/SiteCallout.astro";
+---
+
+<PortableText
+	value={entry.body}
+	components={{
+		type: {
+			callout: SiteCallout,
+		},
+	}}
+/>
+```
+
+<Aside type="note">
+	A sandboxed plugin can contribute the editor definition because it is declarative data. A sandboxed descriptor cannot use `componentsEntry`, so the site must supply the renderer itself or install a separate trusted package that provides it. Keep that split only when the sandbox boundary is worth the extra installation step.
 </Aside>
-
-## Sandbox-friendly variants
-
-If you want a plugin to be sandboxed but still ship a default rendering experience, the usual pattern is:
-
-1. Ship the sandboxed plugin (editing fields only) on the marketplace.
-2. Ship a separate companion native package on npm that provides the Astro rendering components.
-3. Document both: end users install the sandboxed plugin from the marketplace and `npm install` the companion package for rendering.
-
-This trades a one-step install for keeping the editor side sandboxed. Going fully native is simpler when block rendering is involved, but this split remains an option.

--- a/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
@@ -1,555 +1,453 @@
 ---
-title: React admin pages and widgets
-description: Ship custom React components for plugin admin pages and dashboard widgets.
+title: React admin extensions
+description: Add generated settings, React pages and widgets, editor panels, and content-list columns to a native plugin.
 ---
 
-import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside } from "@astrojs/starlight/components";
 
-Native plugins can extend the admin panel with custom React pages, dashboard widgets, field widgets, and content-list columns — sandboxed plugins describe their UI as [Block Kit](/plugins/creating-plugins/block-kit/) instead, because shipping plugin JavaScript into the admin would break sandbox isolation.
+Native plugins can load trusted React components into the EmDash admin. The host keeps control of navigation, page routing, dashboard cards, editor layout, content tables, authentication, and error boundaries. The plugin supplies the components and the metadata needed to place them.
 
-If your plugin only needs a settings form, the auto-generated `admin.settingsSchema` form (see [Your first native plugin](/plugins/creating-native-plugins/your-first-native-plugin/#settings-ui)) covers most cases without writing any React. Reach for custom components when you need richer UI than `settingsSchema` provides.
+If the plugin only needs a settings form, start with `admin.settingsSchema`. It uses the host's form components and does not require a React entrypoint. Sandboxed plugins can also use this generated form; the custom React extensions on this page require a native plugin.
 
-## Admin entry point
+## Generated settings form
 
-Plugins with admin UI export `pages` and `widgets` objects from an `admin` entrypoint:
-
-```typescript title="src/admin.tsx"
-import { SEOSettingsPage } from "./components/SEOSettingsPage";
-import { SEODashboardWidget } from "./components/SEODashboardWidget";
-
-export const widgets = {
-	"seo-overview": SEODashboardWidget,
-};
-
-export const pages = {
-	"/settings": SEOSettingsPage,
-};
-```
-
-Configure the entry point in `package.json`:
-
-```json title="package.json"
-{
-	"exports": {
-		".": "./dist/index.js",
-		"./admin": "./dist/admin.js"
-	}
-}
-```
-
-Reference it from `definePlugin()`:
+Declare `settingsSchema` inside the runtime definition. The following schema produces a multiline text field, a select, a number input, a switch, and a write-only secret input:
 
 ```typescript title="src/index.ts"
-definePlugin({
-	id: "seo",
-	version: "1.0.0",
-
+return definePlugin({
+	id: "plugin-activity",
+	version: "0.1.0",
 	admin: {
-		entry: "@my-org/plugin-seo/admin",
-		pages: [{ path: "/settings", label: "SEO Settings", icon: "settings" }],
-		widgets: [{ id: "seo-overview", title: "SEO Overview", size: "half" }],
+		settingsSchema: {
+			projectName: {
+				type: "string",
+				label: "Project name",
+				description: "Name shown in activity exports",
+			},
+			notes: {
+				type: "string",
+				label: "Internal notes",
+				multiline: true,
+			},
+			mode: {
+				type: "select",
+				label: "Recording mode",
+				options: [
+					{ value: "creates", label: "New entries only" },
+					{ value: "all", label: "New and updated entries" },
+				],
+				default: "all",
+			},
+			retentionDays: {
+				type: "number",
+				label: "Retention in days",
+				min: 1,
+				max: 365,
+				default: 30,
+			},
+			enabled: {
+				type: "boolean",
+				label: "Record activity",
+				default: true,
+			},
+			exportToken: {
+				type: "secret",
+				label: "Export token",
+			},
+		},
 	},
 });
 ```
 
-The descriptor needs a matching `adminEntry` so EmDash knows where to find the components at build time:
+The available fields have the following options. `label` is required and `description` is optional for every type.
 
-```typescript
-adminEntry: "@my-org/plugin-seo/admin",
+| `type` | Value | Additional fields |
+| --- | --- | --- |
+| `string` | string | `default`, `multiline` |
+| `number` | number | `default`, `min`, `max` |
+| `boolean` | boolean | `default` |
+| `select` | string | required `options: Array<{ value, label }>` and optional `default` |
+| `secret` | string | no additional fields; the stored value is never returned to the browser |
+| `url` | string | `default`, `placeholder` |
+| `email` | string | `default`, `placeholder` |
+
+The form is available from the settings control on the plugin's card in **Plugins**. Reading or changing it requires `plugins:manage`.
+
+Settings use the plugin's namespaced KV store. A field named `retentionDays` is available to the plugin as `settings:retentionDays`:
+
+```typescript title="src/index.ts"
+const retentionDays =
+	(await ctx.kv.get<number>("settings:retentionDays")) ?? 30;
 ```
+
+Schema defaults fill the generated form when no value is stored, but EmDash does not write those defaults to KV. Apply the same fallback when the runtime reads the setting. Clearing a non-secret field deletes its stored value and returns the form to its default. Secret values are never sent back to the browser; the form reports only whether a secret is set and lets an administrator replace or clear it.
+
+Settings labels and descriptions render as declared. If those strings must change with the admin locale, build a custom React settings page instead.
+
+## React entrypoint
+
+A trusted React extension has three connected declarations:
+
+1. The descriptor's `adminEntry` tells Astro which module to bundle into the admin.
+2. The runtime's `admin.entry`, `admin.pages`, and `admin.widgets` describe the visible admin surfaces.
+3. The admin module exports component maps whose keys match the declared page paths and widget IDs.
+
+The descriptor only needs the module specifier. Page and widget metadata belongs in the runtime definition:
+
+```typescript title="src/index.ts"
+export function activityPlugin(): PluginDescriptor {
+	return {
+		id: "plugin-activity",
+		version: "0.1.0",
+		format: "native",
+		entrypoint: "@example/plugin-activity",
+		adminEntry: "@example/plugin-activity/admin",
+	};
+}
+
+export function createPlugin() {
+	return definePlugin({
+		id: "plugin-activity",
+		version: "0.1.0",
+		storage: {
+			events: { indexes: ["createdAt"] },
+		},
+		admin: {
+			entry: "@example/plugin-activity/admin",
+			pages: [{ path: "/activity", label: "Activity", icon: "clock" }],
+			widgets: [{ id: "recent-activity", title: "Recent activity" }],
+		},
+	});
+}
+```
+
+Keep `adminEntry` and `admin.entry` identical. The first is a build-time import; the second tells the runtime that the plugin uses trusted React admin components.
 
 ## Admin pages
 
-Admin pages are React components that mount under `/_emdash/admin/plugins/<plugin-id>/<path>`.
+Each page declaration has the following fields:
 
-### Page definition
+| Field | Required | Behavior |
+| --- | --- | --- |
+| `path` | Yes | Mounts the page at `/_emdash/admin/plugins/<plugin-id><path>`. Use a leading slash. |
+| `label` | Yes | Supplies the sidebar and command-palette label. |
+| `icon` | No | Names a Phosphor icon in kebab, snake, space-separated, or PascalCase form. Unknown names fall back to the plugin icon. |
 
-Declare each page under `admin.pages` with a path, label, and icon:
+The admin module maps each declared path to a React component. A trailing slash is treated as equivalent, and the plugin root opens the first exported page when no `/` page exists.
 
-```typescript
-admin: {
-	pages: [
-		{
-			path: "/settings",
-			label: "Settings",
-			icon: "settings",
-		},
-		{
-			path: "/reports",
-			label: "Reports",
-			icon: "chart",
-		},
-	],
-}
-```
+The following page loads a private plugin route. Use Kumo for controls and `apiFetch()` for plugin API requests; `apiFetch()` adds the `X-EmDash-Request: 1` header required by cookie-authenticated private routes.
 
-Declare labels in English. The admin runs them through its shared [Lingui](https://lingui.dev/) instance before rendering the sidebar and command palette, so a plugin that loads its own message catalog — with the English label as the message id — gets localized navigation for free. Labels that match one of the admin's own messages (`Settings`, `Dashboard`, …) pick up the admin's translations even without a plugin catalog; labels with no catalog entry anywhere render as declared.
+```tsx title="src/admin/ActivityPage.tsx"
+import { Button, Loader } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react";
+import { apiFetch, parseApiResponse } from "emdash/plugin-utils";
+import * as React from "react";
 
-```typescript title="src/admin.tsx"
-import { i18n } from "@lingui/core";
-
-// Merge the plugin's compiled catalog into the admin's i18n instance.
-// "Reports" now renders as "Berichte" when the admin locale is German.
-const catalogs: Record<string, Record<string, string>> = {
-	de: { Reports: "Berichte", Settings: "Einstellungen" },
-};
-
-function mergeCatalog() {
-	const messages = catalogs[i18n.locale];
-	if (messages && !("Reports" in i18n.messages)) i18n.load(i18n.locale, messages);
+interface ActivitySummary {
+	count: number;
 }
 
-mergeCatalog();
-// The admin's locale switcher *replaces* the catalog on change, so re-merge.
-// The sentinel check above keeps this from recursing (load() fires "change").
-i18n.on("change", mergeCatalog);
-```
+export function ActivityPage() {
+	const { i18n } = useLingui();
+	const [summary, setSummary] = React.useState<ActivitySummary>();
+	const [error, setError] = React.useState<string>();
 
-### Page component
+	const load = React.useCallback(async () => {
+		setError(undefined);
+		try {
+			const response = await apiFetch(
+				"/_emdash/api/plugins/plugin-activity/summary",
+			);
+			setSummary(
+				await parseApiResponse<ActivitySummary>(
+					response,
+					i18n._({ id: "activity.load-error", message: "Could not load activity" }),
+				),
+			);
+		} catch (cause) {
+			setError(cause instanceof Error ? cause.message : String(cause));
+		}
+	}, [i18n]);
 
-The following component reads and saves settings through the plugin API hook:
-
-```typescript title="src/components/SettingsPage.tsx"
-import { useState, useEffect } from "react";
-import { usePluginAPI } from "@emdash-cms/admin";
-
-export function SettingsPage() {
-	const api = usePluginAPI();
-	const [settings, setSettings] = useState<Record<string, unknown>>({});
-	const [saving, setSaving] = useState(false);
-
-	useEffect(() => {
-		api.get("settings").then(setSettings);
-	}, []);
-
-	const handleSave = async () => {
-		setSaving(true);
-		await api.post("settings/save", settings);
-		setSaving(false);
-	};
+	React.useEffect(() => {
+		void load();
+	}, [load]);
 
 	return (
-		<div>
-			<h1>Plugin Settings</h1>
-
-			<label>
-				Site Title
-				<input
-					type="text"
-					value={(settings.siteTitle as string) || ""}
-					onChange={(e) => setSettings({ ...settings, siteTitle: e.target.value })}
-				/>
-			</label>
-
-			<button onClick={handleSave} disabled={saving}>
-				{saving ? "Saving..." : "Save Settings"}
-			</button>
-		</div>
+		<section className="space-y-4">
+			<h1 className="text-2xl font-semibold">
+				{i18n._({ id: "activity.title", message: "Activity" })}
+			</h1>
+			{summary ? (
+				<p>
+					{i18n._({ id: "activity.count", message: "Event count" })}: {summary.count}
+				</p>
+			) : error ? (
+				<p role="alert" className="text-kumo-danger">{error}</p>
+			) : (
+				<Loader />
+			)}
+			<Button type="button" onClick={() => void load()}>
+				{i18n._({ id: "activity.refresh", message: "Refresh" })}
+			</Button>
+		</section>
 	);
 }
 ```
 
-### Plugin API hook
+Define the corresponding route in the native runtime. Native handlers receive one context argument:
 
-`usePluginAPI()` calls your plugin's routes with the plugin id prefix and the `X-EmDash-Request: 1` CSRF header added automatically:
-
-```typescript
-import { usePluginAPI } from "@emdash-cms/admin";
-
-function MyComponent() {
-	const api = usePluginAPI();
-
-	const data = await api.get("status");                       // GET /_emdash/api/plugins/<id>/status
-	await api.post("settings/save", { enabled: true });          // POST with JSON body
-	const result = await api.get("history?limit=50");            // query params supported
-}
+```typescript title="src/index.ts"
+routes: {
+	summary: {
+		permission: "plugins:read",
+		handler: async (ctx) => ({
+			count: await ctx.storage.events.count(),
+		}),
+	},
+},
 ```
+
+Private routes default to the administrator-only `plugins:manage` permission. Declare the narrowest existing permission that matches the operation. Use `public: true` only for an endpoint intended for unauthenticated internet traffic.
+
+Export the page from the admin entrypoint:
+
+```tsx title="src/admin/index.tsx"
+import type { PluginAdminExports } from "emdash";
+
+import { ActivityPage } from "./ActivityPage.js";
+
+export const pages: PluginAdminExports["pages"] = {
+	"/activity": ActivityPage,
+};
+```
+
+Page labels are passed through the admin's shared Lingui instance. A label such as `Settings` uses the admin's translation when one exists. A plugin can load its own message catalog into the shared instance for plugin-specific labels and component messages; otherwise the declared English message is the fallback.
+
+Load the plugin catalog when the admin entrypoint is imported, then load it again after the administrator changes locale. The following small German catalog uses the same IDs as the page and widget examples:
+
+```typescript title="src/admin/i18n.ts"
+import { i18n } from "@lingui/core";
+
+const catalogs: Record<string, Record<string, string>> = {
+	de: {
+		Activity: "Aktivität",
+		"activity.title": "Aktivität",
+		"activity.count": "Ereignisanzahl",
+		"activity.refresh": "Aktualisieren",
+		"activity.load-error": "Aktivität konnte nicht geladen werden",
+		"activity.unavailable": "Nicht verfügbar",
+		"activity.default-locale": "Standardsprache",
+	},
+};
+
+function loadPluginCatalog() {
+	const messages = catalogs[i18n.locale];
+	if (!messages || "activity.title" in i18n.messages) return;
+	i18n.load(i18n.locale, messages);
+}
+
+loadPluginCatalog();
+i18n.on("change", loadPluginCatalog);
+```
+
+Import the loader for its registration side effect before exporting components:
+
+```tsx title="src/admin/index.tsx"
+import "./i18n.js";
+
+// Page, widget, panel, and column exports follow.
+```
+
+The admin replaces its active catalog when the locale changes. The `change` listener restores the plugin messages, and the message-ID check prevents `i18n.load()` from triggering a loop. For more locales, generate the message objects with the plugin's Lingui build instead of maintaining them by hand. Keep `@lingui/core` and `@lingui/react` as peer dependencies so the plugin uses the host's shared instance.
 
 ## Dashboard widgets
 
-Widgets appear on the admin dashboard and provide at-a-glance information.
+A widget declaration has a required `id` and optional `title` and `size`:
 
-### Widget definition
-
-Declare each widget under `admin.widgets` with an id, title, and size:
-
-```typescript
+```typescript title="src/index.ts"
 admin: {
+	entry: "@example/plugin-activity/admin",
 	widgets: [
-		{
-			id: "seo-overview",
-			title: "SEO Overview",
-			size: "half",   // "full" | "half" | "third"
-		},
+		{ id: "recent-activity", title: "Recent activity", size: "half" },
 	],
-}
+},
 ```
 
-### Widget component
+Export a component under the same ID. This widget reads the same summary route as the page and supplies only the card content; EmDash supplies the surrounding dashboard card and heading.
 
-The following component fetches its data on mount and renders a compact summary:
+```tsx title="src/admin/index.tsx"
+import { useLingui } from "@lingui/react";
+import { useQuery } from "@tanstack/react-query";
+import type { PluginAdminExports } from "emdash";
+import { apiFetch, parseApiResponse } from "emdash/plugin-utils";
 
-```typescript title="src/components/SEOWidget.tsx"
-import { useState, useEffect } from "react";
-import { usePluginAPI } from "@emdash-cms/admin";
+interface ActivitySummary {
+	count: number;
+}
 
-export function SEOWidget() {
-	const api = usePluginAPI();
-	const [data, setData] = useState({ score: 0, issues: [] });
-
-	useEffect(() => {
-		api.get("analyze").then(setData);
-	}, []);
-
-	return (
-		<div className="widget-content">
-			<div className="score">{data.score}%</div>
-			<ul>
-				{data.issues.map((issue, i) => (
-					<li key={i}>{(issue as { message: string }).message}</li>
-				))}
-			</ul>
-		</div>
+async function loadSummary(fallbackMessage: string) {
+	const response = await apiFetch(
+		"/_emdash/api/plugins/plugin-activity/summary",
+	);
+	return parseApiResponse<ActivitySummary>(
+		response,
+		fallbackMessage,
 	);
 }
+
+function RecentActivityWidget() {
+	const { i18n } = useLingui();
+	const { data, isLoading, isError } = useQuery({
+		queryKey: ["plugin-activity", "summary"],
+		queryFn: () =>
+			loadSummary(
+				i18n._({ id: "activity.load-error", message: "Could not load activity" }),
+			),
+	});
+
+	return (
+		<p>
+			{i18n._({ id: "activity.count", message: "Event count" })}:{" "}
+			{isLoading
+				? "…"
+				: isError
+					? i18n._({ id: "activity.unavailable", message: "Unavailable" })
+					: (data?.count ?? 0)}
+		</p>
+	);
+}
+
+export const widgets: PluginAdminExports["widgets"] = {
+	"recent-activity": RecentActivityWidget,
+};
 ```
 
-### Widget sizes
-
-| Size    | Description               |
-| ------- | ------------------------- |
-| `full`  | Full dashboard width      |
-| `half`  | Half dashboard width      |
-| `third` | One-third dashboard width |
-
-Widgets wrap automatically based on screen width.
+The host places the component inside a dashboard card and renders `title` as its heading. Keep the component compact and do not add a second card shell. `size` accepts `full`, `half`, or `third`; it is stored as a layout hint, but the current dashboard renders plugin widgets in its responsive two-column grid without applying that hint.
 
 ## Content editor panels
 
-A trusted React plugin can add host-framed sections to the settings sidebar for saved content entries. EmDash owns the section heading and placement, applies collection and role filters, and isolates rendering failures so one plugin panel cannot unmount the editor.
+An editor panel adds a host-framed section to the settings sidebar of a saved entry. It does not mount for a new entry because no saved `entry` exists yet.
 
-Export a `contentEditorPanels` array from the plugin admin entry:
+Panels and content-list columns are discovered directly from the trusted admin module. They need `adminEntry` and `admin.entry` so the module loads, but they do not need entries in `admin.pages` or `admin.widgets`.
 
-```tsx title="src/admin.tsx"
-import type { ContentEditorPanelContext } from "@emdash-cms/admin";
+```tsx title="src/admin/index.tsx"
+import type {
+	ContentEditorPanelContext,
+	ContentEditorPanelExtension,
+} from "@emdash-cms/admin";
+import { useLingui } from "@lingui/react";
 
-function ContentInsights({ entry, locale }: ContentEditorPanelContext) {
+function ActivityPanel({ entry, collection, locale }: ContentEditorPanelContext) {
+	const { i18n } = useLingui();
+	const displayLocale =
+		locale ??
+		i18n._({ id: "activity.default-locale", message: "Default locale" });
+
 	return (
-		<p>
-			Analysis for {entry.slug} in {locale ?? "the default locale"}
+		<p className="text-sm text-kumo-subtle">
+			{collection}/{entry.slug} ({displayLocale})
 		</p>
 	);
 }
 
 export const contentEditorPanels = [
 	{
-		id: "content-insights",
-		title: "Content insights",
-		component: ContentInsights,
+		id: "activity-summary",
+		title: "Activity summary",
+		component: ActivityPanel,
 		collections: ["posts", "pages"],
-		minRole: 40,
 		order: 10,
 	},
-];
+] satisfies readonly ContentEditorPanelExtension[];
 ```
 
-Each panel receives the saved `entry`, its `collection`, and resolved `locale`. Panels are not mounted for new, unsaved entries. `collections` may be an array or a predicate and can be omitted to support every collection. Lower `order` values render first among contributed panels; ties are resolved deterministically by plugin and panel ID.
+Panel fields have the following behavior:
 
-Panel IDs must be unique within the plugin. Keep panel content responsive to the narrow settings sidebar and perform authorization in plugin API routes rather than relying on `minRole`, which only controls visibility.
+- `id`, `title`, and `component` are required. The ID must be unique among this plugin's panels.
+- `collections` is an array of collection names or a predicate. Omit it to show the panel for every collection.
+- `minRole` is a numeric visibility threshold. It does not authorize API calls.
+- `order` sorts lower values first. Ties use plugin ID and panel ID.
 
-<Aside type="note">
-	This extension point is available only to trusted React plugins. Sandboxed plugins cannot execute React components inside the host admin.
-</Aside>
+The component receives the saved `entry`, its `collection`, and the resolved `locale`. Keep its layout responsive to the narrow sidebar. EmDash isolates component and collection-predicate failures so one panel cannot unmount the editor.
 
 ## Content-list columns
 
-Trusted React plugins can add read-only columns to active content collection lists. EmDash keeps ownership of the table, pagination, row actions, and loading and empty states; the plugin supplies only the header metadata and cell content.
+A content-list column adds read-only cells to active collection lists. The host still owns pagination, row actions, loading and empty states, and the table itself. Columns are not shown in Trash.
 
-```typescript title="src/admin.tsx"
+The following column uses `visibleItems` to fetch one page of statuses. Every cell uses the same React Query key, so the requests share one result instead of issuing one request per row.
+
+```tsx title="src/admin/index.tsx"
+import { useQuery } from "@tanstack/react-query";
 import type {
 	ContentListColumnCellContext,
 	ContentListColumnExtension,
 } from "@emdash-cms/admin";
-import { useQuery } from "@tanstack/react-query";
 import { apiFetch, parseApiResponse } from "emdash/plugin-utils";
 
-async function fetchReviewStatuses(
+async function loadStatuses(
 	collection: string,
 	locale: string | undefined,
 	ids: readonly string[],
 ) {
 	const response = await apiFetch(
-		"/_emdash/api/plugins/editorial-workflow/review-statuses/batch",
+		"/_emdash/api/plugins/plugin-activity/statuses",
 		{
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ collection, locale, ids }),
 		},
 	);
-	return parseApiResponse<Record<string, string>>(response, "Failed to load review statuses");
+	return parseApiResponse<Record<string, string>>(
+		response,
+		"Could not load activity statuses",
+	);
 }
 
-function ReviewStatusCell({
+function ActivityCell({
 	item,
 	visibleItems,
 	collection,
 	locale,
 }: ContentListColumnCellContext) {
-	const itemIds = visibleItems.map((visibleItem) => visibleItem.id);
-	const { data: reviewStatuses } = useQuery({
-		queryKey: ["editorial-workflow", "review-statuses", collection, locale ?? null, itemIds],
-		queryFn: () => fetchReviewStatuses(collection, locale, itemIds),
+	const ids = visibleItems.map((visibleItem) => visibleItem.id);
+	const { data } = useQuery({
+		queryKey: ["plugin-activity", "statuses", collection, locale ?? null, ids],
+		queryFn: () => loadStatuses(collection, locale, ids),
 	});
-	const reviewStatus = reviewStatuses?.[item.id];
-	return reviewStatus ? <span>{reviewStatus}</span> : <span>-</span>;
+
+	return <span>{data?.[item.id] ?? "-"}</span>;
 }
 
 export const contentListColumns = [
 	{
-		id: "review-status",
-		label: "Review status",
+		id: "activity",
+		label: "Activity",
+		cell: ActivityCell,
 		collections: ["posts", "pages"],
-		order: 10,
 		align: "end",
-		cell: ReviewStatusCell,
+		order: 10,
 	},
 ] satisfies readonly ContentListColumnExtension[];
 ```
 
-Every cell component mounts once per visible row. When a column needs data that is not already on `item`, use `visibleItems` to request the whole page in one batch. All cells in the example share the same React Query key, so they reuse one request instead of issuing one request per item.
-
 <Aside type="caution">
-	Do not fetch metadata using only `item.id` from inside a cell. A 20-row page would issue 20 requests. Add a batch plugin route and key the shared query by the visible item ids, collection, and locale.
+	Do not key remote data by only `item.id` inside a cell. Each visible row mounts a cell component, so that pattern creates one request per row. Batch the visible IDs in a plugin route and include the IDs, collection, and locale in the shared query key.
 </Aside>
 
-Column ids only need to be unique within the plugin. Contributions are ordered by `order`, then plugin id and column id. A plugin can also provide:
+Column fields have the following behavior:
 
-- `header`: a custom header component; `label` remains the host-rendered fallback.
-- `collections`: an array or predicate restricting where the column appears.
-- `minRole`: a visibility filter for the admin UI. This is not authorization; plugin API routes must still enforce access.
+- `id`, `label`, and `cell` are required. The ID must be unique among this plugin's columns.
+- `header` replaces the header content with a component; `label` remains the host fallback.
+- `collections`, `minRole`, and `order` behave like their panel equivalents.
+- `align` accepts `start` or `end` and uses logical alignment for left-to-right and right-to-left locales.
 
-Disabled or missing plugins are omitted. Invalid definitions, collection predicates that throw, and render failures are isolated so the host content list remains usable. Columns are not shown in Trash.
+Columns cannot add browser-only sorting or filtering. Those controls would affect only the loaded cursor page, not the full server-backed collection.
 
-Content-list columns are display-only. Server-backed sorting and filtering require a separate host data-provider contract; a browser comparator would only sort the currently loaded cursor pages and is therefore not supported by this API.
+## Disabled plugins
 
-## Export structure
+When an administrator disables the plugin, EmDash removes its pages, widgets, panels, and columns from the admin. Its private routes return not found, and its hooks stop running. Re-enabling the plugin rebuilds the hook pipeline and makes its trusted admin exports available again.
 
-The admin entry point exports each contribution directly:
+## Package the entrypoint
 
-```typescript title="src/admin.tsx"
-import { SettingsPage } from "./components/SettingsPage";
-import { ReportsPage } from "./components/ReportsPage";
-import { StatusWidget } from "./components/StatusWidget";
-import { OverviewWidget } from "./components/OverviewWidget";
-import { ReviewStatusCell } from "./components/ReviewStatusCell";
-
-export const pages = {
-	"/settings": SettingsPage,
-	"/reports": ReportsPage,
-};
-
-export const widgets = {
-	status: StatusWidget,
-	overview: OverviewWidget,
-};
-
-export const contentListColumns = [
-	{
-		id: "review-status",
-		label: "Review status",
-		collections: ["posts"],
-		cell: ReviewStatusCell,
-	},
-];
-```
-
-<Aside type="caution">
-	Page paths in `pages` should match the `path` values in `admin.pages`. A trailing slash is treated as equivalent, so `/settings` and `/settings/` resolve to the same page. Opening a plugin at its root resolves to the first registered page. Widget keys must match the `id` values in `admin.widgets`. Content-list columns are discovered directly from the trusted admin entry point and do not need a separate descriptor entry.
-</Aside>
-
-## Using admin components
-
-EmDash provides pre-built components for common patterns:
-
-```typescript
-import {
-	Card,
-	Button,
-	Input,
-	Select,
-	Toggle,
-	Table,
-	Pagination,
-	Alert,
-	Loading,
-} from "@emdash-cms/admin";
-
-function SettingsPage() {
-	return (
-		<Card title="Settings">
-			<Input label="API Key" type="password" />
-			<Toggle label="Enabled" defaultChecked />
-			<Button variant="primary">Save</Button>
-		</Card>
-	);
-}
-```
-
-## Auto-generated settings UI
-
-If your plugin only needs a settings form, use `admin.settingsSchema` without custom components:
-
-```typescript
-admin: {
-	settingsSchema: {
-		apiKey: { type: "secret", label: "API Key" },
-		enabled: { type: "boolean", label: "Enabled", default: true },
-	},
-},
-```
-
-EmDash generates a settings page automatically. Reach for custom React pages only when you need behaviour beyond a basic form.
-
-## Navigation
-
-Plugin pages appear in the admin sidebar under the plugin's name. The order matches the `admin.pages` array, as shown below:
-
-```typescript
-admin: {
-	pages: [
-		{ path: "/settings", label: "Settings", icon: "settings" },  // first
-		{ path: "/history", label: "History", icon: "history" },     // second
-		{ path: "/reports", label: "Reports", icon: "chart" },        // third
-	],
-}
-```
-
-## Build configuration
-
-Admin components need a separate build entry point. The following bundler configuration builds both the server and admin entrypoints:
-
-<Tabs>
-<TabItem label="tsdown">
-```typescript title="tsdown.config.ts"
-export default {
-	entry: {
-		index: "src/index.ts",
-		admin: "src/admin.tsx",
-	},
-	format: "esm",
-	dts: true,
-	external: ["react", "react-dom", "emdash", "@emdash-cms/admin"],
-};
-```
-</TabItem>
-<TabItem label="tsup">
-```typescript title="tsup.config.ts"
-export default {
-	entry: ["src/index.ts", "src/admin.tsx"],
-	format: "esm",
-	dts: true,
-	external: ["react", "react-dom", "emdash", "@emdash-cms/admin"],
-};
-```
-</TabItem>
-</Tabs>
-
-Keep React and EmDash admin as external dependencies to avoid bundling duplicates.
-
-## Plugin enable/disable
-
-When a plugin is disabled in the admin:
-
-- Sidebar links are hidden.
-- Dashboard widgets are not rendered.
-- Content-list columns are not rendered.
-- Admin pages return 404.
-- Backend hooks still execute (for data safety).
-
-Plugins can check their enabled state:
-
-```typescript
-const enabled = await ctx.kv.get<boolean>("_emdash:enabled");
-```
-
-## Complete example
-
-The following plugin defines a dashboard page, a settings page, and a widget, with the runtime and admin entrypoints in separate files. The `src/index.ts` file holds the descriptor and runtime:
-
-```typescript title="src/index.ts"
-import { definePlugin } from "emdash";
-import type { PluginDescriptor } from "emdash";
-
-export function analyticsPlugin(): PluginDescriptor {
-	return {
-		id: "analytics",
-		version: "1.0.0",
-		format: "native",
-		entrypoint: "@my-org/plugin-analytics",
-		adminEntry: "@my-org/plugin-analytics/admin",
-		adminPages: [
-			{ path: "/dashboard", label: "Dashboard", icon: "chart" },
-			{ path: "/settings", label: "Settings", icon: "settings" },
-		],
-		adminWidgets: [{ id: "events-today", title: "Events Today", size: "third" }],
-	};
-}
-
-export function createPlugin() {
-	return definePlugin({
-		id: "analytics",
-		version: "1.0.0",
-
-		capabilities: ["network:request"],
-		allowedHosts: ["api.analytics.example.com"],
-
-		storage: {
-			events: { indexes: ["type", "createdAt"] },
-		},
-
-		admin: {
-			entry: "@my-org/plugin-analytics/admin",
-			settingsSchema: {
-				trackingId: { type: "string", label: "Tracking ID" },
-				enabled: { type: "boolean", label: "Enabled", default: true },
-			},
-			pages: [
-				{ path: "/dashboard", label: "Dashboard", icon: "chart" },
-				{ path: "/settings", label: "Settings", icon: "settings" },
-			],
-			widgets: [{ id: "events-today", title: "Events Today", size: "third" }],
-		},
-
-		routes: {
-			stats: {
-				handler: async (ctx) => {
-					const today = new Date().toISOString().split("T")[0];
-					const count = await ctx.storage.events.count({
-						createdAt: { gte: today },
-					});
-					return { today: count };
-				},
-			},
-		},
-	});
-}
-
-export default createPlugin;
-```
-
-The `src/admin.tsx` file maps page paths and widget ids to their React components:
-
-```typescript title="src/admin.tsx"
-import { EventsWidget } from "./components/EventsWidget";
-import { DashboardPage } from "./components/DashboardPage";
-import { SettingsPage } from "./components/SettingsPage";
-
-export const widgets = {
-	"events-today": EventsWidget,
-};
-
-export const pages = {
-	"/dashboard": DashboardPage,
-	"/settings": SettingsPage,
-};
-```
+Export the admin module separately from the server runtime so Astro can bundle it for the browser with the host's React, Kumo, and Lingui instances. [Distributing native plugins](/plugins/creating-native-plugins/distributing/) provides the complete package layout, exports, peer dependencies, and build commands.

--- a/docs/src/content/docs/plugins/creating-native-plugins/your-first-native-plugin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/your-first-native-plugin.mdx
@@ -1,348 +1,173 @@
 ---
 title: Your first native plugin
-description: Build a native EmDash plugin with the descriptor + createPlugin pattern.
+description: Scaffold, register, and run an in-process EmDash plugin.
 ---
 
-import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Steps } from "@astrojs/starlight/components";
 
-This guide walks through building a native plugin from scratch. Native plugins run in the same process as your Astro site with full access to the runtime, including React admin pages, Portable Text components, and page fragments.
+A native plugin is an npm package that EmDash imports into the same process as the Astro site. This tutorial creates a plugin that logs content saves, installs it in a site, and registers it in `astro.config.mjs`.
 
-If you haven't decided yet whether you want a native plugin instead of a sandboxed one, read [Choosing a plugin format](/plugins/creating-plugins/choosing-a-format/) first. Native is the format for plugins that need React admin pages, Portable Text rendering components, or page fragments.
+Use the native format when the plugin needs an in-process feature such as React admin components, Astro rendering components, or trusted page fragments. If hooks, routes, storage, and Block Kit cover the feature, start with a sandboxed plugin. [Choosing a plugin format](/plugins/creating-plugins/choosing-a-format/) compares the formats.
 
-## Two pieces, in one or two files
+## Prerequisites
 
-Like sandboxed plugins, native plugins ship two pieces:
+Start with an EmDash site that uses pnpm and can run its development server. The site must already depend on `emdash`, which provides the `emdash` command used below.
 
-1. **A descriptor factory** — returns a `PluginDescriptor` with `format: "native"` plus admin-related entrypoints. Imported by `astro.config.mjs` at build time.
-2. **A `createPlugin(options)` function** — the runtime side. Returns a `definePlugin({ id, version, capabilities, hooks, routes, admin })` result.
+The commands call the site directory `my-emdash-site` and create `plugin-activity` beside it. Replace `my-emdash-site` with your site's directory name.
 
-Unlike sandboxed plugins, both pieces can live in the same file because they don't run in different environments — the whole plugin runs in-process. The package's `"."` export points at a file that exports both the descriptor factory and a `createPlugin` (or `default`) function:
+## Create and register the package
 
-```
-my-native-plugin/
-├── src/
-│   ├── index.ts          # Descriptor factory + createPlugin
-│   ├── admin.tsx         # React admin components (optional)
-│   └── astro/            # Astro components for PT block rendering (optional)
-│       └── index.ts
-├── package.json
-└── tsconfig.json
-```
+<Steps>
 
-## Set up the package
+1. Scaffold a native package next to the site.
 
-The following `package.json` declares the entrypoints and peer dependencies a native plugin needs:
+   ```bash
+   pnpm exec emdash plugin init --native --name @example/plugin-activity --dir ../plugin-activity
+   ```
 
-```json title="package.json"
-{
-	"name": "@my-org/plugin-analytics",
-	"version": "0.1.0",
-	"type": "module",
-	"main": "dist/index.js",
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
-		},
-		"./admin": {
-			"types": "./dist/admin.d.ts",
-			"import": "./dist/admin.js"
-		}
-	},
-	"files": ["dist"],
-	"peerDependencies": {
-		"emdash": "*",
-		"react": "^18.0.0"
-	}
-}
-```
+   The command removes the npm scope when it creates the plugin ID. The package name is `@example/plugin-activity`, while the plugin ID is `plugin-activity`.
 
-Keep `emdash` and `react` as peer dependencies so the host site provides the actual versions and you don't ship duplicates.
+2. Install the package dependencies.
 
-## Write the descriptor and runtime
+   ```bash
+   cd ../plugin-activity
+   pnpm install
+   ```
 
-The following `src/index.ts` defines the descriptor factory and the `createPlugin` runtime in one file:
+3. Replace the generated `src/index.ts` with a content-save hook.
+
+   ```typescript title="src/index.ts"
+   import { definePlugin } from "emdash";
+   import type { PluginDescriptor } from "emdash";
+
+   export interface ActivityPluginOptions {
+       logUpdates?: boolean;
+   }
+
+   export function activityPlugin(
+       options: ActivityPluginOptions = {},
+   ): PluginDescriptor<ActivityPluginOptions> {
+       return {
+           id: "plugin-activity",
+           version: "0.1.0",
+           format: "native",
+           entrypoint: "@example/plugin-activity",
+           options,
+       };
+   }
+
+   export function createPlugin(options: ActivityPluginOptions = {}) {
+       return definePlugin({
+           id: "plugin-activity",
+           version: "0.1.0",
+           capabilities: ["content:read"],
+           hooks: {
+               "content:afterSave": async (event, ctx) => {
+                   if (!event.isNew && options.logUpdates === false) return;
+
+                   ctx.log.info("Content saved", {
+                       collection: event.collection,
+                       contentId: event.content.id,
+                       isNew: event.isNew,
+                   });
+               },
+           },
+       });
+   }
+
+   export default createPlugin;
+   ```
+
+   `content:afterSave` requires the `content:read` capability. EmDash skips the hook when that capability is missing.
+
+4. Build the package.
+
+   ```bash
+   pnpm build
+   ```
+
+5. Install the local package in the site.
+
+   ```bash
+   cd ../my-emdash-site
+   pnpm add ../plugin-activity
+   ```
+
+6. Register the descriptor factory in the EmDash integration.
+
+   ```typescript title="astro.config.mjs"
+   import { defineConfig } from "astro/config";
+   import emdash from "emdash/astro";
+   import { activityPlugin } from "@example/plugin-activity";
+
+   export default defineConfig({
+       integrations: [
+           emdash({
+               plugins: [activityPlugin({ logUpdates: true })],
+           }),
+       ],
+   });
+   ```
+
+   Native descriptors belong in `plugins`, not `sandboxed`. EmDash rejects a native descriptor in the `sandboxed` array.
+
+7. Start the site and save an entry in the admin panel.
+
+   ```bash
+   pnpm dev
+   ```
+
+   The server log includes `Content saved` with the collection, content ID, and whether the entry was created.
+
+</Steps>
+
+## Descriptor and runtime boundary
+
+The package export has two jobs. EmDash uses each at a different stage:
+
+- The descriptor factory, `activityPlugin()`, runs while Astro evaluates its configuration. It returns serializable build-time metadata: `id`, `version`, `format`, `entrypoint`, and `options`. React and Astro entrypoints also belong on this descriptor.
+- The named `createPlugin()` export runs when EmDash initializes. EmDash imports it from `entrypoint`, passes the serialized `options`, and expects a resolved plugin from `definePlugin()`.
+
+The named `createPlugin` export is required. A default export may be useful to package consumers, but EmDash's native loader imports `createPlugin` by name.
+
+Keep `id` and `version` identical in the descriptor and `definePlugin()`. Use an unscoped, kebab-case plugin ID such as `plugin-activity`; keep the npm scope in the package name and `entrypoint`. This keeps the ID usable as the single plugin segment in API route URLs.
+
+[Plugin identity and versioning](/plugins/creating-native-plugins/distributing/#plugin-identity-and-version) lists the accepted ID and version forms.
+
+Runtime behavior belongs in `definePlugin()`:
+
+- `capabilities` and `allowedHosts`
+- `storage`
+- `hooks` and `routes`
+- `admin` settings, page, widget, and Portable Text declarations
+
+The descriptor carries the static entries that Astro must import or expose at build time. The focused guides show which admin fields need matching descriptor and runtime declarations.
+
+## Native route handlers
+
+Native route handlers receive one `RouteContext`. It combines validated input and request data with the regular `PluginContext`:
 
 ```typescript title="src/index.ts"
-import { definePlugin } from "emdash";
-import type { PluginDescriptor } from "emdash";
-
-export interface AnalyticsOptions {
-	enabled?: boolean;
-	maxEvents?: number;
-}
-
-export function analyticsPlugin(options: AnalyticsOptions = {}): PluginDescriptor {
-	return {
-		id: "analytics",
-		version: "0.1.0",
-		format: "native",
-		entrypoint: "@my-org/plugin-analytics",
-		options,
-		adminEntry: "@my-org/plugin-analytics/admin",
-		adminPages: [{ path: "/dashboard", label: "Dashboard", icon: "chart" }],
-		adminWidgets: [{ id: "events-today", title: "Events Today", size: "third" }],
-	};
-}
-
-export function createPlugin(options: AnalyticsOptions = {}) {
-	const maxEvents = options.maxEvents ?? 100;
-
-	return definePlugin({
-		id: "analytics",
-		version: "0.1.0",
-
-		capabilities: ["network:request"],
-		allowedHosts: ["api.analytics.example.com"],
-
-		storage: {
-			events: { indexes: ["type", "createdAt"] },
-		},
-
-		admin: {
-			entry: "@my-org/plugin-analytics/admin",
-			settingsSchema: {
-				trackingId: { type: "string", label: "Tracking ID" },
-				enabled: { type: "boolean", label: "Enabled", default: options.enabled ?? true },
-			},
-			pages: [{ path: "/dashboard", label: "Dashboard", icon: "chart" }],
-			widgets: [{ id: "events-today", title: "Events Today", size: "third" }],
-		},
-
-		hooks: {
-			"plugin:install": async (_event, ctx) => {
-				ctx.log.info("Analytics plugin installed", { maxEvents });
-			},
-
-			"content:afterSave": async (event, ctx) => {
-				const enabled = await ctx.kv.get<boolean>("settings:enabled");
-				if (enabled === false) return;
-
-				await ctx.storage.events.put(`evt_${Date.now()}`, {
-					type: "content:save",
-					contentId: event.content.id,
-					createdAt: new Date().toISOString(),
-				});
-			},
-		},
-
-		routes: {
-			stats: {
-				handler: async (ctx) => {
-					const today = new Date().toISOString().split("T")[0];
-					const count = await ctx.storage.events.count({
-						createdAt: { gte: today },
-					});
-					return { today: count };
-				},
-			},
-		},
-	});
-}
-
-export default createPlugin;
-```
-
-Key details of this configuration:
-
-- **`format: "native"` is required.** `"native"` is also the default, but stating it explicitly on every descriptor makes the format easy to spot.
-- **`entrypoint` is the package's main export.** EmDash imports it at runtime and calls the default export to construct the resolved plugin.
-- **`options` flow descriptor → `createPlugin`.** Anything the user passes when registering the plugin (`analyticsPlugin({ enabled: false })`) is preserved on the descriptor and forwarded to `createPlugin`. Sandboxed plugins don't have this surface — they read settings from KV instead.
-- **`id`, `version`, and `capabilities` appear twice.** Once on the descriptor, once on `definePlugin()`. They should match. The descriptor's copy is what `astro.config.mjs` sees at build time; the `definePlugin()` copy is what runs at request time.
-- **Native route handlers take a single argument** — `(ctx: RouteContext)` where `ctx.input`, `ctx.request`, `ctx.requestMeta`, and `ctx.user` (the authenticated caller on private routes) are merged with the regular `PluginContext` properties. This is the opposite of standard format's two-argument shape. See [API routes](/plugins/creating-plugins/api-routes/) for the full surface (everything else is identical).
-
-## Plugin id rules
-
-The `id` field must match `/^[a-z][a-z0-9_-]*$/` — start with a lowercase letter, then letters, digits, hyphens, or underscores. The id is used as a single path segment in plugin route URLs and as part of generated SQL identifiers for plugin storage indexes, so anything outside that pattern fails at runtime. The following values show which ids are accepted:
-
-```typescript
-// Valid
-"seo";
-"audit-log";
-"audit_log";
-"plugin-forms";
-
-// Invalid
-"@my-org/plugin-forms";  // scoped form not allowed at runtime
-"MyPlugin";              // no uppercase
-"42-plugin";             // can't start with a digit
-"my.plugin";             // no dots
-```
-
-Pair an unscoped `id` with a scoped npm package name in `entrypoint` — the package name and the plugin id are separate concerns.
-
-## Version format
-
-Use semantic versioning. The following values show which version strings are accepted:
-
-```typescript
-version: "1.0.0";       // valid
-version: "1.2.3-beta";  // valid (prerelease)
-version: "1.0";         // invalid (missing patch)
-```
-
-## Register the plugin
-
-In your site's `astro.config.mjs`, import the descriptor factory and pass it into the `plugins: []` array — native plugins always run in-process, never in `sandboxed: []`:
-
-```typescript title="astro.config.mjs"
-import { defineConfig } from "astro/config";
-import emdash from "emdash/astro";
-import { analyticsPlugin } from "@my-org/plugin-analytics";
-
-export default defineConfig({
-	integrations: [
-		emdash({
-			plugins: [
-				analyticsPlugin({ enabled: true, maxEvents: 500 }),
-			],
+routes: {
+	status: {
+		permission: "plugins:read",
+		handler: async (ctx) => ({
+			pluginId: ctx.plugin.id,
+			callerId: ctx.user?.id ?? null,
 		}),
-	],
-});
-```
-
-## Settings UI
-
-Native plugins can use `admin.settingsSchema` for an auto-generated settings form, which is the simplest path:
-
-```typescript
-admin: {
-	settingsSchema: {
-		apiKey: { type: "secret", label: "API Key" },
-		enabled: { type: "boolean", label: "Enabled", default: true },
-		maxItems: { type: "number", label: "Max items", min: 1, max: 1000, default: 100 },
 	},
 },
 ```
 
-Field types: `string`, `number`, `boolean`, `select`, `secret`, `url`, `email`. Each accepts `label`, `description`, `default`, plus type-specific extras like `min`/`max`/`options`. Settings are persisted to the same per-plugin KV store sandboxed plugins use — read them with `ctx.kv.get<T>("settings:<key>")` from anywhere.
+The equivalent sandboxed handler receives `(routeCtx, ctx)` as two arguments. Authentication, permissions, input schemas, and route URLs otherwise follow the shared [API routes](/plugins/creating-plugins/api-routes/) contract.
 
-The generated form appears behind the gear icon on the plugin's card in **Plugins** (admins only — editing plugin settings requires the `plugins:manage` permission). Secret fields are write-only: the admin never sees the stored value, only whether one is set.
+<Aside type="caution">
+	Capabilities gate the APIs exposed through `ctx`, but a native plugin has no isolation boundary. It can import host packages, access environment variables, call `fetch()` directly, and affect the host process. Install native packages only from publishers you trust.
+</Aside>
 
-For richer settings UI than `settingsSchema` provides, ship custom React pages — see [React admin pages and widgets](/plugins/creating-native-plugins/react-admin/).
+## Add another surface
 
-## Complete example — audit log plugin
-
-The following plugin records every content create, update, and delete to indexed storage and exposes a recent-activity route:
-
-```typescript title="src/index.ts"
-import { definePlugin } from "emdash";
-import type { PluginDescriptor } from "emdash";
-
-interface AuditEntry {
-	timestamp: string;
-	action: "create" | "update" | "delete";
-	collection: string;
-	resourceId: string;
-	userId?: string;
-}
-
-export function auditLogPlugin(): PluginDescriptor {
-	return {
-		id: "audit-log",
-		version: "0.1.0",
-		format: "native",
-		entrypoint: "@emdash-cms/plugin-audit-log",
-	};
-}
-
-export function createPlugin() {
-	return definePlugin({
-		id: "audit-log",
-		version: "0.1.0",
-
-		storage: {
-			entries: {
-				indexes: [
-					"timestamp",
-					"action",
-					"collection",
-					["collection", "timestamp"],
-					["action", "timestamp"],
-				],
-			},
-		},
-
-		admin: {
-			settingsSchema: {
-				retentionDays: {
-					type: "number",
-					label: "Retention (days)",
-					description: "Days to keep entries. 0 = forever.",
-					default: 90,
-					min: 0,
-					max: 365,
-				},
-			},
-			pages: [{ path: "/history", label: "Audit History", icon: "history" }],
-			widgets: [{ id: "recent-activity", title: "Recent Activity", size: "half" }],
-		},
-
-		hooks: {
-			"content:afterSave": {
-				priority: 200,
-				handler: async (event, ctx) => {
-					const entry: AuditEntry = {
-						timestamp: new Date().toISOString(),
-						action: event.isNew ? "create" : "update",
-						collection: event.collection,
-						resourceId: event.content.id as string,
-					};
-					await ctx.storage.entries.put(`${Date.now()}-${event.content.id}`, entry);
-				},
-			},
-
-			"content:afterDelete": {
-				priority: 200,
-				handler: async (event, ctx) => {
-					await ctx.storage.entries.put(`${Date.now()}-${event.id}`, {
-						timestamp: new Date().toISOString(),
-						action: "delete",
-						collection: event.collection,
-						resourceId: event.id,
-					});
-				},
-			},
-		},
-
-		routes: {
-			recent: {
-				handler: async (ctx) => {
-					const result = await ctx.storage.entries.query({
-						orderBy: { timestamp: "desc" },
-						limit: 10,
-					});
-					return {
-						entries: result.items.map((item) => ({
-							id: item.id,
-							...(item.data as AuditEntry),
-						})),
-					};
-				},
-			},
-		},
-	});
-}
-
-export default createPlugin;
-```
-
-## Testing
-
-Test a native plugin by creating a minimal Astro site with the plugin registered:
-
-<Steps>
-1. Create a test site with EmDash installed.
-2. Register your plugin in `astro.config.mjs`, importing it directly from your local source path.
-3. Run the dev server and trigger hooks by creating, updating, or deleting content.
-4. Check the console for `ctx.log` output and verify storage via API routes.
-</Steps>
-
-For unit tests, mock the `PluginContext` interface and call hook handlers directly.
-
-## What's next
-
-- [React admin pages and widgets](/plugins/creating-native-plugins/react-admin/) — ship custom React UI for the admin panel.
-- [Portable Text rendering components](/plugins/creating-native-plugins/portable-text-components/) — provide Astro components that render plugin-defined block types.
-- [Page fragments](/plugins/creating-native-plugins/page-fragments/) — inject scripts, stylesheets, or HTML into public pages.
-- [Distributing native plugins](/plugins/creating-native-plugins/distributing/) — npm packaging and versioning.
+- [React admin pages and widgets](/plugins/creating-native-plugins/react-admin/) covers settings, custom pages, dashboard widgets, editor panels, and list columns.
+- [Portable Text rendering components](/plugins/creating-native-plugins/portable-text-components/) registers Astro components for plugin blocks.
+- [Page fragments](/plugins/creating-native-plugins/page-fragments/) adds trusted scripts or HTML to public pages.
+- [Distributing native plugins](/plugins/creating-native-plugins/distributing/) packages the build and source entrypoints for npm.


### PR DESCRIPTION
## What does this PR do?

Rewrites the native-plugin authoring path as one coherent set of guides:

- shortens the first-plugin tutorial around the generated native scaffold and a working content hook
- explains the build-time descriptor and runtime `createPlugin()` boundary
- documents generated settings, trusted React pages and widgets, editor panels, and list columns with current APIs
- separates sandbox-compatible Portable Text editor definitions from native Astro renderers
- documents trusted page-fragment types, safety, page context, and layout insertion points
- provides a complete npm package, tarball test, publication, and installation path

The examples follow current public types, runtime behavior, CLI output, package exports, and first-party plugin patterns. No published package changes.

No linked issue.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

`pnpm typecheck` and the package test suite were not run because this changes only MDX documentation. The documentation build, current CLI scaffold, and copyable JSON examples were checked directly. The five MDX files were formatted with Prettier; root `pnpm format` was not run because it would touch unrelated files. Tests, admin-string extraction, changeset, Discussion, and UI screenshots are not applicable.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI Codex (GPT-5)

## Screenshots / test output

Not applicable; this PR does not change the interface.

Verified:

- `pnpm lint`
- `pnpm lint:quick`
- `pnpm lint:json | jq '.diagnostics | length'` → `0`
- `pnpm --dir docs build`
- `git diff --check`
- native scaffold command and generated package/ID output
- all JSON code examples parse
