### PR TITLE
docs: reconcile sandboxed plugin authoring guides

### DIFF
--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -454,19 +454,14 @@ the provider under **Settings → Email**.
 
 ## Environment Variables
 
-### Recommended: encryption key
+### Encryption key validation
 
-`EMDASH_ENCRYPTION_KEY` is the key for encrypting plugin secrets at
-rest (webhook tokens, Turnstile keys, etc.). The key is validated on
-startup; plugin secret encryption uses it once enabled. Set it on
-every deployment so secrets are protected without a later config
-change.
+`EMDASH_ENCRYPTION_KEY` currently affects startup validation only. EmDash does not use it to encrypt
+or decrypt data. Plugin secret values remain unencrypted in the database even when this variable is
+set.
 
-The key is provided by you and never stored in the database; only
-encrypted ciphertext is. Losing it means losing every secret encrypted
-with it.
-
-Generate a key and store it as a Worker secret with the following commands:
+If you set the variable, generate a valid value and store it as a Worker secret with the following
+commands:
 
 ```bash
 npx emdash secrets generate
@@ -474,9 +469,8 @@ wrangler secret put EMDASH_ENCRYPTION_KEY
 ```
 
 <Aside type="caution">
-Never commit the encryption key to your repository, and back it up
-somewhere durable (a password manager, KMS, or your team's secret
-store). The plain text value lives only in your environment.
+	Treat the database and its backups as sensitive because they contain plaintext plugin secrets.
+	Never commit secret values to your repository.
 </Aside>
 
 ### Optional: stable-value overrides
@@ -493,7 +487,9 @@ needs to share the secret with your main site.
 | `EMDASH_IP_SALT` | Override for the auto-generated commenter-IP hash salt. |
 | `EMDASH_AUTH_SECRET` | Optional. If set, it is used as the IP-salt source (unless `EMDASH_IP_SALT` is also set, which takes precedence), keeping commenter-IP hashes stable for installs that already rely on it. Leave it unset for a new deployment. |
 
-Access environment variables in your configuration using `import.meta.env` or the Cloudflare `env` binding.
+EmDash reads secret environment variables at runtime through `process.env`. For Worker bindings,
+import `env` from `cloudflare:workers`. Do not read secrets through `import.meta.env`; Vite can inline
+build-time values into the server bundle.
 
 For the complete inventory of every secret EmDash uses — including storage locations, rotation steps, and what breaks when a key is lost — see [Secrets & Key Management](/deployment/secrets/).
 

--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -456,9 +456,8 @@ the provider under **Settings → Email**.
 
 ### Encryption key validation
 
-`EMDASH_ENCRYPTION_KEY` currently affects startup validation only. EmDash does not use it to encrypt
-or decrypt data. Plugin secret values remain unencrypted in the database even when this variable is
-set.
+`EMDASH_ENCRYPTION_KEY` does not currently encrypt plugin secrets. If the variable is set, EmDash
+checks its format during startup, but plugin secret values remain unencrypted in the database.
 
 If you set the variable, generate a valid value and store it as a Worker secret with the following
 commands:
@@ -487,9 +486,9 @@ needs to share the secret with your main site.
 | `EMDASH_IP_SALT` | Override for the auto-generated commenter-IP hash salt. |
 | `EMDASH_AUTH_SECRET` | Optional. If set, it is used as the IP-salt source (unless `EMDASH_IP_SALT` is also set, which takes precedence), keeping commenter-IP hashes stable for installs that already rely on it. Leave it unset for a new deployment. |
 
-EmDash reads secret environment variables at runtime through `process.env`. For Worker bindings,
-import `env` from `cloudflare:workers`. Do not read secrets through `import.meta.env`; Vite can inline
-build-time values into the server bundle.
+Read EmDash secrets from `process.env` at runtime. Read Worker bindings from `env`, imported from
+`cloudflare:workers`. Never read secrets through `import.meta.env`: Vite replaces those values at
+build time and can write them into the server bundle.
 
 For the complete inventory of every secret EmDash uses — including storage locations, rotation steps, and what breaks when a key is lost — see [Secrets & Key Management](/deployment/secrets/).
 

--- a/docs/src/content/docs/deployment/nodejs.mdx
+++ b/docs/src/content/docs/deployment/nodejs.mdx
@@ -170,23 +170,21 @@ docker compose up -d
 
 ## Environment Variables
 
-### Recommended: encryption key
+### Encryption key validation
 
-`EMDASH_ENCRYPTION_KEY` is the key for encrypting plugin secrets at
-rest. The key is validated on startup; plugin secret encryption uses
-it once enabled. Set it on every deployment so secrets are protected
-without a later config change.
+`EMDASH_ENCRYPTION_KEY` currently affects startup validation only. EmDash does not use it to encrypt
+or decrypt data. Plugin secret values remain unencrypted in the database even when this variable is
+set.
 
-Generate a key and add the result to your environment:
+If you set the variable, generate a valid value and add the result to your environment:
 
 ```bash
 npx emdash secrets generate  # add the result to your environment
 ```
 
-The key is provided by you and never stored in the database; only
-encrypted ciphertext is. Back it up somewhere durable (a password
-manager, KMS, or your team's secret store) — losing it means losing
-every secret encrypted with it.
+The value is operator-provided and is not stored in the database. Losing it has no current
+data-recovery impact because no stored data depends on it. Treat the database and its backups as
+sensitive because they contain plaintext plugin secrets.
 
 ### Optional: stable-value overrides
 

--- a/docs/src/content/docs/deployment/nodejs.mdx
+++ b/docs/src/content/docs/deployment/nodejs.mdx
@@ -172,9 +172,8 @@ docker compose up -d
 
 ### Encryption key validation
 
-`EMDASH_ENCRYPTION_KEY` currently affects startup validation only. EmDash does not use it to encrypt
-or decrypt data. Plugin secret values remain unencrypted in the database even when this variable is
-set.
+`EMDASH_ENCRYPTION_KEY` does not currently encrypt plugin secrets. If the variable is set, EmDash
+checks its format during startup, but plugin secret values remain unencrypted in the database.
 
 If you set the variable, generate a valid value and add the result to your environment:
 

--- a/docs/src/content/docs/deployment/secrets.mdx
+++ b/docs/src/content/docs/deployment/secrets.mdx
@@ -11,7 +11,7 @@ EmDash uses a small set of secrets across previews, comments, authentication, st
 
 | Secret                                             | Source                            | Stored in                                | Lost key impact                                 |
 | -------------------------------------------------- | --------------------------------- | ---------------------------------------- | ----------------------------------------------- |
-| [`EMDASH_ENCRYPTION_KEY`](#the-encryption-key)     | Operator (`emdash secrets generate`) | Environment / Worker secret only         | Encrypted plugin secrets become unrecoverable (once encryption at rest ships) |
+| [`EMDASH_ENCRYPTION_KEY`](#the-encryption-key)     | Operator (`emdash secrets generate`) | Environment / Worker secret only         | No current impact; the value is only validated |
 | [Preview secret](#preview-secret)                  | Auto-generated (env override)     | `options` table (`emdash:preview_secret`) | Outstanding preview links stop working; new ones are fine |
 | [IP salt](#ip-salt)                                | Auto-generated (env override)     | `options` table (`emdash:ip_salt`)        | Past comment rate-limit continuity resets       |
 | [Session & API tokens](#session-and-api-tokens)    | Generated per session/token       | Session store / database (hashes only)   | Nothing — plaintext is never stored             |
@@ -24,9 +24,12 @@ EmDash uses a small set of secrets across previews, comments, authentication, st
 
 ## The encryption key
 
-`EMDASH_ENCRYPTION_KEY` is the site's key for encrypting plugin secrets at rest. It is **operator-provided and never stored in the database** — the database only ever holds ciphertext, so a leaked database backup does not expose the key.
+`EMDASH_ENCRYPTION_KEY` currently affects startup validation only. EmDash does not use it to encrypt
+or decrypt data. If the variable is set, EmDash validates its format at startup. A malformed value
+produces an operator-facing log message without stopping request paths.
 
-Generate one and set it as an environment variable (or Worker secret):
+To set the variable, generate a valid value and add it to the runtime environment (or Worker
+secret):
 
 ```bash
 npx emdash secrets generate
@@ -36,23 +39,11 @@ npx emdash secrets generate
 wrangler secret put EMDASH_ENCRYPTION_KEY
 ```
 
-The format is `emdash_enc_v1_` followed by 32 random bytes as unpadded base64url. The key is validated at runtime startup; a malformed value logs an operator-facing error without taking down request paths.
+The format is `emdash_enc_v1_` followed by 32 random bytes as unpadded base64url. The value is operator-provided and is not stored in the database. Losing it has no current data-recovery impact because no stored data depends on it.
 
 <Aside type="caution">
-	Back the key up somewhere durable (password manager, KMS, your team's secret store). Losing it
-	means losing every secret encrypted with it — the ciphertext in the database cannot be recovered.
-</Aside>
-
-### Rotation
-
-The variable accepts a comma-separated list of keys. The **first** entry is the primary and is used for new writes; all entries are tried for decryption. Every encrypted value is tagged with an 8-character key fingerprint (the _kid_, printable via `emdash secrets fingerprint <key>`), so the runtime picks the right key automatically.
-
-To rotate: generate a new key, prepend it to the list (`EMDASH_ENCRYPTION_KEY="new,old"`), redeploy, and drop the old key once existing values have been re-encrypted.
-
-<Aside type="note">
-	The encryption layer that consumes this key is not active yet — today the key is validated but
-	inert, and [plugin secrets](#plugin-secrets) are stored unencrypted. Set the key now so your
-	deployment is ready the moment plugin-secret encryption ships, without a config scramble.
+	Plugin secret values are stored as plaintext in the database. Setting
+	`EMDASH_ENCRYPTION_KEY` does not protect them. Restrict access to the database and its backups.
 </Aside>
 
 ## Generated site secrets
@@ -106,8 +97,7 @@ Settings a plugin declares with `type: "secret"` (API keys for email providers, 
 <Aside type="caution">
 	Plugin secrets are currently stored **unencrypted** in the database. Anyone with database access
 	(including backups) can read them. Prefer scoped, revocable API keys, and treat database backups
-	as sensitive. Encryption at rest using [`EMDASH_ENCRYPTION_KEY`](#the-encryption-key) is planned;
-	setting the key today requires no migration later.
+	as sensitive.
 </Aside>
 
 - **Rotation:** rotate the key at the provider and paste the new value into the plugin's settings page. Takes effect immediately.
@@ -134,7 +124,6 @@ The separate `emdash-plugin` CLI (package `@emdash-cms/plugin-cli`) targets the 
 
 | I want to…                              | Do this                                                                        |
 | --------------------------------------- | ------------------------------------------------------------------------------ |
-| Rotate the encryption key               | Prepend a new key: `EMDASH_ENCRYPTION_KEY="new,old"`, redeploy, drop old later |
 | Invalidate all preview links            | Delete the `emdash:preview_secret` option row (or change the env override)    |
 | Reset comment rate-limit hashing        | Change `EMDASH_IP_SALT` (or delete the `emdash:ip_salt` option row)           |
 | Revoke a leaked API token               | Admin → Users → API tokens → revoke, then create a replacement                |

--- a/docs/src/content/docs/deployment/secrets.mdx
+++ b/docs/src/content/docs/deployment/secrets.mdx
@@ -11,7 +11,7 @@ EmDash uses a small set of secrets across previews, comments, authentication, st
 
 | Secret                                             | Source                            | Stored in                                | Lost key impact                                 |
 | -------------------------------------------------- | --------------------------------- | ---------------------------------------- | ----------------------------------------------- |
-| [`EMDASH_ENCRYPTION_KEY`](#the-encryption-key)     | Operator (`emdash secrets generate`) | Environment / Worker secret only         | No current impact; the value is only validated |
+| [`EMDASH_ENCRYPTION_KEY`](#the-encryption-key)     | Operator (`emdash secrets generate`) | Environment / Worker secret only         | No current data impact; EmDash only checks its format |
 | [Preview secret](#preview-secret)                  | Auto-generated (env override)     | `options` table (`emdash:preview_secret`) | Outstanding preview links stop working; new ones are fine |
 | [IP salt](#ip-salt)                                | Auto-generated (env override)     | `options` table (`emdash:ip_salt`)        | Past comment rate-limit continuity resets       |
 | [Session & API tokens](#session-and-api-tokens)    | Generated per session/token       | Session store / database (hashes only)   | Nothing — plaintext is never stored             |
@@ -24,12 +24,12 @@ EmDash uses a small set of secrets across previews, comments, authentication, st
 
 ## The encryption key
 
-`EMDASH_ENCRYPTION_KEY` currently affects startup validation only. EmDash does not use it to encrypt
-or decrypt data. If the variable is set, EmDash validates its format at startup. A malformed value
-produces an operator-facing log message without stopping request paths.
+`EMDASH_ENCRYPTION_KEY` does not currently encrypt plugin secrets or any other stored data. If the
+variable is set, EmDash checks its format during startup. A malformed value produces an
+operator-facing log message, but the site continues to handle requests.
 
-To set the variable, generate a valid value and add it to the runtime environment (or Worker
-secret):
+The following command generates a correctly formatted value. Store it in the runtime environment
+or as a Worker secret if your deployment uses this variable.
 
 ```bash
 npx emdash secrets generate

--- a/docs/src/content/docs/guides/backups.mdx
+++ b/docs/src/content/docs/guides/backups.mdx
@@ -20,7 +20,7 @@ A JSON backup includes:
 - Site settings such as the title, tagline, URL, locale, logo, display preferences, social profiles,
   and SEO defaults. These come from the `site:`, `emdash:site_`, and `emdash:locale` setting groups.
 
-The JSON backup excludes every other database table. This includes:
+It omits all other database tables, including:
 
 - User accounts, sessions, passkeys, OAuth data, API tokens, and other authentication data
 - Plugin storage and plugin settings, including plugin secrets
@@ -40,9 +40,8 @@ Backups are JSON files in the same snapshot format used by EmDash's preview syst
 
 Under **Settings → Backups** in the admin, the **Download backup** button generates a fresh backup and downloads it as a JSON file. Requires the admin role.
 
-The download provides an offline copy for inspection or custom migration tooling. EmDash cannot
-restore it. Use one of the raw database recovery options below before bulk imports, schema changes,
-or major upgrades.
+The download is for inspection or custom migration tooling. Before bulk imports, schema changes, or
+major upgrades, create a restorable database backup using one of the options below.
 
 ## Automatic backups to storage
 
@@ -90,11 +89,6 @@ Time Travel keeps 30 days of history on the paid plan (7 days on free) with minu
 
 See the [D1 Time Travel documentation](https://developers.cloudflare.com/d1/reference/time-travel/) for details.
 
-<Aside type="tip">
-	D1 Time Travel and raw database dumps can restore a database. EmDash JSON backups are exports of
-	selected content data and cannot be restored by EmDash.
-</Aside>
-
 ## Offsite database dumps
 
 For a complete SQL dump of the raw database (including users and auth tables), use Wrangler:
@@ -113,6 +107,5 @@ On Node deployments, the database is a single SQLite file — copy it while the 
 
 ## JSON restore
 
-EmDash has no admin action, API endpoint, or CLI command that restores a JSON backup. The JSON file
-is export-only. To recover a site, use D1 Time Travel, import a raw D1 SQL dump, or restore the
-SQLite database file as described above.
+EmDash has no admin action, API endpoint, or CLI command for JSON restore. Use D1 Time Travel, a raw
+D1 SQL dump, or a copy of the SQLite database as described above.

--- a/docs/src/content/docs/guides/backups.mdx
+++ b/docs/src/content/docs/guides/backups.mdx
@@ -5,30 +5,29 @@ description: Download site backups, schedule automatic backups to storage, and r
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-EmDash can export selected site data as JSON. Raw database backups provide the recovery options for restoring a site.
+Use a JSON backup when you need an offline copy of selected content data. Use a raw database backup
+or point-in-time recovery when you need to restore the site.
 
 ## What's in a backup
 
 A JSON backup includes:
 
 - All content entries, including drafts, scheduled posts, and trashed items
-- Collection and field definitions
-- Taxonomy definitions, terms, and content assignments
-- Menus and menu items, sections, widget areas and widgets, SEO records, migration records, revisions, and media metadata
-- Options whose names start with `site:`, `emdash:site_`, or `emdash:locale`
-
-The export contains the schema and rows for every `ec_*` content table and the following system
-tables: `_emdash_collections`, `_emdash_fields`, `_emdash_taxonomy_defs`, `_emdash_menus`,
-`_emdash_menu_items`, `_emdash_sections`, `_emdash_widget_areas`, `_emdash_widgets`, `_emdash_seo`,
-`_emdash_migrations`, `taxonomies`, `content_taxonomies`, `media`, `options`, and `revisions`.
+- Collection and field definitions that make up the content model
+- Taxonomy definitions, terms, and the terms assigned to each entry
+- Menus and menu items, sections, widget areas and widgets, SEO records, revision history, media
+  metadata, and database migration history
+- Site settings such as the title, tagline, URL, locale, logo, display preferences, social profiles,
+  and SEO defaults. These come from the `site:`, `emdash:site_`, and `emdash:locale` setting groups.
 
 The JSON backup excludes every other database table. This includes:
 
 - User accounts, sessions, passkeys, OAuth data, API tokens, and other authentication data
 - Plugin storage and plugin settings, including plugin secrets
 - Comments and reactions, redirects and 404 logs, bylines, content relations and references, audit logs, rate limits, and scheduled-task state
-- Media folders, usage indexes, upload state, and media binaries
-- Options outside the three allowed prefixes, including the preview signing secret and backup settings
+- Media folders, records of where media is used, incomplete or in-progress uploads, and the media
+  files themselves
+- Other site options, including the preview signing secret and backup schedule
 
 Backups are JSON files in the same snapshot format used by EmDash's preview system, versioned with the EmDash release that created them.
 
@@ -41,8 +40,9 @@ Backups are JSON files in the same snapshot format used by EmDash's preview syst
 
 Under **Settings → Backups** in the admin, the **Download backup** button generates a fresh backup and downloads it as a JSON file. Requires the admin role.
 
-Use this download to retain or inspect the included content data outside EmDash. Use one of the raw
-database recovery options below before bulk imports, schema changes, or major upgrades.
+The download provides an offline copy for inspection or custom migration tooling. EmDash cannot
+restore it. Use one of the raw database recovery options below before bulk imports, schema changes,
+or major upgrades.
 
 ## Automatic backups to storage
 

--- a/docs/src/content/docs/guides/backups.mdx
+++ b/docs/src/content/docs/guides/backups.mdx
@@ -5,32 +5,44 @@ description: Download site backups, schedule automatic backups to storage, and r
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-EmDash gives you three layers of protection for your content, from zero-config point-in-time recovery on Cloudflare to downloadable archives you keep yourself.
+EmDash can export selected site data as JSON. Raw database backups provide the recovery options for restoring a site.
 
 ## What's in a backup
 
-A backup contains everything needed to reconstruct your site's content:
+A JSON backup includes:
 
 - All content entries, including drafts, scheduled posts, and trashed items
-- Collection and field definitions (your content model)
-- Taxonomies and term assignments
-- Menus, widgets, sections, and SEO settings
-- Revisions and media metadata
-- Site settings (title, tagline, display preferences)
+- Collection and field definitions
+- Taxonomy definitions, terms, and content assignments
+- Menus and menu items, sections, widget areas and widgets, SEO records, migration records, revisions, and media metadata
+- Options whose names start with `site:`, `emdash:site_`, or `emdash:locale`
 
-Backups deliberately **exclude**:
+The export contains the schema and rows for every `ec_*` content table and the following system
+tables: `_emdash_collections`, `_emdash_fields`, `_emdash_taxonomy_defs`, `_emdash_menus`,
+`_emdash_menu_items`, `_emdash_sections`, `_emdash_widget_areas`, `_emdash_widgets`, `_emdash_seo`,
+`_emdash_migrations`, `taxonomies`, `content_taxonomies`, `media`, `options`, and `revisions`.
 
-- User accounts, sessions, passkeys, and API tokens — auth data is neither portable nor safe in a downloadable file
-- Secrets (preview signing secret, plugin configuration)
-- Media binaries — the actual files live in your storage bucket (R2, S3, or local); a backup carries their metadata so references stay intact
+The JSON backup excludes every other database table. This includes:
+
+- User accounts, sessions, passkeys, OAuth data, API tokens, and other authentication data
+- Plugin storage and plugin settings, including plugin secrets
+- Comments and reactions, redirects and 404 logs, bylines, content relations and references, audit logs, rate limits, and scheduled-task state
+- Media folders, usage indexes, upload state, and media binaries
+- Options outside the three allowed prefixes, including the preview signing secret and backup settings
 
 Backups are JSON files in the same snapshot format used by EmDash's preview system, versioned with the EmDash release that created them.
+
+<Aside type="caution">
+	EmDash does not implement restoring this JSON format. Do not rely on a JSON export as a recovery
+	point before a destructive operation. Use a raw database backup or point-in-time recovery instead.
+</Aside>
 
 ## One-click download
 
 Under **Settings → Backups** in the admin, the **Download backup** button generates a fresh backup and downloads it as a JSON file. Requires the admin role.
 
-This is the right tool before risky operations: bulk imports, schema changes, or major upgrades.
+Use this download to retain or inspect the included content data outside EmDash. Use one of the raw
+database recovery options below before bulk imports, schema changes, or major upgrades.
 
 ## Automatic backups to storage
 
@@ -79,9 +91,8 @@ Time Travel keeps 30 days of history on the paid plan (7 days on free) with minu
 See the [D1 Time Travel documentation](https://developers.cloudflare.com/d1/reference/time-travel/) for details.
 
 <Aside type="tip">
-	Time Travel and EmDash backups complement each other: Time Travel is your disaster-recovery net
-	for the last 30 days; downloaded backups are user-holdable archives with no expiry that survive
-	account or database deletion.
+	D1 Time Travel and raw database dumps can restore a database. EmDash JSON backups are exports of
+	selected content data and cannot be restored by EmDash.
 </Aside>
 
 ## Offsite database dumps
@@ -92,12 +103,16 @@ For a complete SQL dump of the raw database (including users and auth tables), u
 npx wrangler d1 export my-database --remote --output=backup.sql
 ```
 
+Restore that raw SQL dump with the following command:
+
+```bash
+npx wrangler d1 execute my-database --remote --file=backup.sql
+```
+
 On Node deployments, the database is a single SQLite file — copy it while the server is stopped, or use `sqlite3 emdash.db ".backup backup.db"` for a consistent online copy.
 
-## Restoring a backup
+## JSON restore
 
-Restoring from a backup JSON is intentionally not exposed as a one-click admin action yet — overwriting a live database deserves more friction than a button. Current options:
-
-- **Cloudflare:** use D1 Time Travel (above) for point-in-time restore.
-- **Full dumps:** import a `wrangler d1 export` dump with `npx wrangler d1 execute my-database --remote --file=backup.sql`.
-- **Backup JSON:** the format matches EmDash's snapshot format; a guided CLI restore is planned. Track [Discussion #142](https://github.com/emdash-cms/emdash/discussions/142).
+EmDash has no admin action, API endpoint, or CLI command that restores a JSON backup. The JSON file
+is export-only. To recover a site, use D1 Time Travel, import a raw D1 SQL dump, or restore the
+SQLite database file as described above.

--- a/docs/src/content/docs/guides/working-with-content.mdx
+++ b/docs/src/content/docs/guides/working-with-content.mdx
@@ -211,7 +211,7 @@ Perform actions on multiple entries at once:
 3. Select an action:
    - **Publish** - Set all selected to published
    - **Archive** - Set all selected to archived
-   - **Delete** - Permanently remove selected
+   - **Delete** - Move selected entries to Trash
 
 4. Confirm the action
 
@@ -254,7 +254,7 @@ When the publication date arrives, the content automatically becomes published.
 
 ## Deleting Content
 
-Delete content from the edit screen or content list:
+Delete content from the edit screen or content list to move it to Trash:
 
 ### From the Editor
 
@@ -273,8 +273,8 @@ Delete content from the edit screen or content list:
 3. Confirm the deletion
 
 <Aside type="caution">
-	Deleted content is permanently removed and cannot be recovered. Consider archiving instead if you
-	might need the content later.
+	Content in Trash can be restored. An administrator can permanently delete an entry from Trash in
+	a separate operation; permanent deletion cannot be undone.
 </Aside>
 
 ## Content API
@@ -291,16 +291,20 @@ Content-Type: application/json
 Authorization: Bearer YOUR_API_TOKEN
 
 {
-  "title": "My New Post",
+  "data": {
+    "title": "My New Post",
+    "content": []
+  },
   "slug": "my-new-post",
-  "content": "<p>Post content here</p>",
   "status": "draft"
 }
 ```
 
 ### Update Content
 
-The following request updates an existing post and publishes it:
+The following request updates an existing post. Put collection fields inside `data`. Pass the
+opaque `_rev` from the latest GET response to reject the write if the entry changed in the
+meantime:
 
 ```bash
 PUT /_emdash/api/content/posts/my-new-post
@@ -308,19 +312,37 @@ Content-Type: application/json
 Authorization: Bearer YOUR_API_TOKEN
 
 {
-  "title": "Updated Title",
-  "status": "published"
+  "data": {
+    "title": "Updated Title"
+  },
+  "_rev": "REVISION_TOKEN"
+}
+```
+
+Updating content saves a draft revision. Publish that revision with the publish endpoint, using the
+new `_rev` returned by the update response:
+
+```bash
+POST /_emdash/api/content/posts/my-new-post/publish
+Content-Type: application/json
+Authorization: Bearer YOUR_API_TOKEN
+
+{
+  "_rev": "UPDATED_REVISION_TOKEN"
 }
 ```
 
 ### Delete Content
 
-The following request permanently deletes a post:
+The following request moves a post to Trash:
 
 ```bash
 DELETE /_emdash/api/content/posts/my-new-post
 Authorization: Bearer YOUR_API_TOKEN
 ```
+
+Restore it with `POST /_emdash/api/content/posts/my-new-post/restore`. Administrators can
+permanently delete it with `DELETE /_emdash/api/content/posts/my-new-post/permanent`.
 
 ## Translating Content
 

--- a/docs/src/content/docs/guides/working-with-content.mdx
+++ b/docs/src/content/docs/guides/working-with-content.mdx
@@ -272,9 +272,19 @@ Delete content from the edit screen or content list to move it to Trash:
 
 3. Confirm the deletion
 
+### Restore from Trash
+
+1. Open the collection that contained the entry.
+
+2. Select the **Trash** tab above the content list.
+
+3. Find the entry and select its **Restore** action.
+
+The entry returns to the collection with its previous content and status.
+
 <Aside type="caution">
-	Content in Trash can be restored. An administrator can permanently delete an entry from Trash in
-	a separate operation; permanent deletion cannot be undone.
+	Administrators also see a separate **Permanently delete** action in Trash. Permanent deletion
+	cannot be undone.
 </Aside>
 
 ## Content API
@@ -293,7 +303,13 @@ Authorization: Bearer YOUR_API_TOKEN
 {
   "data": {
     "title": "My New Post",
-    "content": []
+    "content": [
+      {
+        "_type": "block",
+        "style": "normal",
+        "children": [{ "_type": "span", "text": "Post content goes here." }]
+      }
+    ]
   },
   "slug": "my-new-post",
   "status": "draft"

--- a/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
@@ -3,19 +3,31 @@ title: API Routes
 description: Expose REST endpoints from your sandboxed plugin for the admin UI and external integrations.
 ---
 
-import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside } from "@astrojs/starlight/components";
 
 Plugins can expose API routes for their admin UI and external integrations. Routes are mounted under `/_emdash/api/plugins/<slug>/<route-name>` (the `<slug>` is the plugin's `slug` field from `emdash-plugin.jsonc` — exposed at runtime as `ctx.plugin.id`) and run inside the sandbox runtime with the same `PluginContext` that hooks receive.
 
-This page covers sandboxed plugins. The API surface for native plugins is the same; the only difference is the handler signature — see the note in [Native plugins](/plugins/creating-native-plugins/your-first-native-plugin/) for details.
+This page covers sandboxed plugins. Native plugins use the same route options, authentication, and URL layout, but their handlers receive one combined context object. See [Your first native plugin](/plugins/creating-native-plugins/your-first-native-plugin/) for that signature.
 
 ## Defining routes
 
-Declare routes in the default export of `src/plugin.ts`:
+Declare routes in the default export of `src/plugin.ts`. Add `zod` as a runtime dependency when a route validates input or is exposed as an MCP tool:
+
+```sh
+pnpm add zod
+```
+
+The following example validates a submissions request and queries plugin storage:
 
 ```typescript title="src/plugin.ts"
 import type { SandboxedPlugin } from "emdash/plugin";
-import { z } from "astro/zod";
+import { z } from "zod";
+
+const submissionsInput = z.object({
+	formId: z.string().optional(),
+	limit: z.coerce.number().int().min(1).max(100).default(50),
+	cursor: z.string().optional(),
+});
 
 export default {
 	routes: {
@@ -26,13 +38,12 @@ export default {
 		},
 
 		submissions: {
-			input: z.object({
-				formId: z.string().optional(),
-				limit: z.number().default(50),
-				cursor: z.string().optional(),
-			}),
 			handler: async (routeCtx, ctx) => {
-				const { formId, limit, cursor } = routeCtx.input;
+				const parsed = submissionsInput.safeParse(routeCtx.input);
+				if (!parsed.success) {
+					return { ok: false, error: { code: "VALIDATION_ERROR" } };
+				}
+				const { formId, limit, cursor } = parsed.data;
 
 				const result = await ctx.storage.submissions.query({
 					where: formId ? { formId } : undefined,
@@ -41,16 +52,16 @@ export default {
 					cursor,
 				});
 
-				return result;
+				return { ok: true, ...result };
 			},
 		},
 	},
 } satisfies SandboxedPlugin;
 ```
 
-`satisfies SandboxedPlugin` infers `routeCtx` and `ctx` — no parameter annotations needed. Sandboxed route handlers take **two arguments**: `(routeCtx, ctx)`.
+`satisfies SandboxedPlugin` infers the route and plugin context types, so the parameters need no annotations. Sandboxed route handlers take **two arguments**: `(routeCtx, ctx)`.
 
-- `routeCtx` carries request-shaped data: `{ input, request, requestMeta }`.
+- `routeCtx` carries request-shaped data: `{ input, request, requestMeta }`. Its `input` remains `unknown`, so validate it before use.
 - `ctx` is the same `PluginContext` you get inside hooks — `ctx.storage`, `ctx.kv`, `ctx.content`, `ctx.http`, `ctx.log`, etc.
 
 ### Filtering indexed content fields
@@ -104,15 +115,14 @@ Routes mount at `/_emdash/api/plugins/<slug>/<route-name>`. Route names can incl
 routes: {
 	create: {
 		permission: "content:create",
-		input: z.object({ title: z.string() }),
 		handler: async (routeCtx, ctx) => {
-			// ...
+			// Validate routeCtx.input, then create content through ctx.
 		},
 	},
 },
 ```
 
-Private routes require the `X-EmDash-Request: 1` CSRF header for cookie-authenticated requests. The admin UI sends it automatically; token-authenticated requests are exempt.
+Private routes require their declared permission for every HTTP method. They also require the `X-EmDash-Request: 1` CSRF header for cookie-authenticated requests, including `GET` and `HEAD`, because a plugin route can run the same handler for any method. The admin UI sends the header automatically. Token-authenticated requests are exempt from the header but still need the `admin` token scope and the route permission.
 
 To opt a route out of authentication, mark it `public: true`:
 
@@ -120,9 +130,10 @@ To opt a route out of authentication, mark it `public: true`:
 routes: {
 	track: {
 		public: true,
-		input: z.object({ event: z.string() }),
 		handler: async (routeCtx, ctx) => {
-			ctx.log.info("Tracked", { event: routeCtx.input.event });
+			const parsed = z.object({ event: z.string() }).safeParse(routeCtx.input);
+			if (!parsed.success) return { ok: false, error: "INVALID_EVENT" };
+			ctx.log.info("Tracked", { event: parsed.data.event });
 			return { ok: true };
 		},
 	},
@@ -160,22 +171,6 @@ routes: {
 
 Note that caller identity is separate from the `users:read` capability: `routeCtx.user` tells you **who is calling** and is always available on private routes, while `ctx.users` is a user-directory **lookup** that requires the capability.
 
-### Caching public responses
-
-API responses default to `Cache-Control: private, no-store`. For public routes that serve the same data to everyone — a product catalog, a public search index — that means every page view pays a full round-trip to the origin. Public routes can opt in to CDN/browser caching with `cacheControl`:
-
-```typescript
-routes: {
-	catalog: {
-		public: true,
-		cacheControl: "public, max-age=60, stale-while-revalidate=300",
-		handler: async (ctx) => listProducts(ctx),
-	},
-},
-```
-
-The header is applied only to **successful GET responses of public routes**. Errors are never cached, other methods keep the default, and setting `cacheControl` on a private route has no effect — authenticated responses always stay `private, no-store`.
-
 ## Exposing a route as an MCP tool
 
 Plugins may explicitly expose selected private routes through EmDash's MCP server. MCP exposure is never inferred from the route list:
@@ -190,9 +185,11 @@ export default {
 	routes: {
 		"events/create": {
 			permission: "content:create",
-			input: createEventInput,
 			handler: async (routeCtx, ctx) => {
-				return { id: await createEvent(routeCtx.input, ctx) };
+				const parsed = createEventInput.safeParse(routeCtx.input);
+				if (!parsed.success) return { ok: false, error: "INVALID_EVENT" };
+				const input = parsed.data;
+				return { id: await createEvent(input, ctx) };
 			},
 		},
 	},
@@ -216,19 +213,26 @@ An administrator must separately enable a plugin's MCP tools after reviewing the
 
 ## Input validation
 
-`input` accepts a Zod schema. The dispatcher parses the request body (POST/PUT/PATCH) or the URL query string (GET/HEAD/DELETE), validates it, and passes the typed result to your handler as `routeCtx.input`. Invalid input returns a 400 before your handler runs.
+EmDash parses JSON request bodies for `POST`, `PUT`, and `PATCH`. It parses query parameters for `GET`, `HEAD`, and `DELETE`. The parsed value reaches a sandboxed handler as `routeCtx.input: unknown`, so validate it inside the handler before reading fields or performing side effects.
+
+Use `safeParse` when invalid input is an expected caller error. This lets the route return a stable JSON result instead of turning invalid input into an internal exception:
 
 ```typescript
+const createInput = z.object({
+	title: z.string().min(1).max(200),
+	email: z.string().email(),
+	priority: z.enum(["low", "medium", "high"]).default("medium"),
+	tags: z.array(z.string()).optional(),
+});
+
 routes: {
 	create: {
-		input: z.object({
-			title: z.string().min(1).max(200),
-			email: z.string().email(),
-			priority: z.enum(["low", "medium", "high"]).default("medium"),
-			tags: z.array(z.string()).optional(),
-		}),
 		handler: async (routeCtx, ctx) => {
-			const { title, email, priority, tags } = routeCtx.input;
+			const parsed = createInput.safeParse(routeCtx.input);
+			if (!parsed.success) {
+				return { ok: false, error: { code: "VALIDATION_ERROR" } };
+			}
+			const { title, email, priority, tags } = parsed.data;
 
 			await ctx.storage.items.put(`item_${Date.now()}`, {
 				title,
@@ -238,7 +242,7 @@ routes: {
 				createdAt: new Date().toISOString(),
 			});
 
-			return { success: true };
+			return { ok: true };
 		},
 	},
 },
@@ -246,27 +250,22 @@ routes: {
 
 ### Query-string input (GET/HEAD/DELETE)
 
-Bodyless methods have no request body, so their input comes from the URL query
-string. The dispatcher turns the query into an object before validation:
-
-- A repeated key becomes an array — `?tag=a&tag=b` parses to `{ tag: ["a", "b"] }`,
-  so an `z.array(z.string())` field works.
-- A single key stays a scalar — `?tag=a` parses to `{ tag: "a" }`.
-
-Every query value is a **string**, so schemas for these routes should either accept
-strings or coerce. Use `z.coerce` for non-string fields:
+Bodyless methods have no request body, so their input comes from the URL query string. Every value is a string. Repeated keys become arrays, so `?tag=a&tag=b` becomes `{ tag: ["a", "b"] }`; a single `?tag=a` remains `{ tag: "a" }`. Use `z.coerce` for numbers and other non-string values:
 
 ```typescript
+const listInput = z.object({
+	status: z.enum(["open", "closed"]).optional(),
+	limit: z.coerce.number().int().min(1).max(100).default(20),
+	tag: z.union([z.string(), z.array(z.string())]).optional(),
+});
+
 routes: {
 	list: {
 		// GET /_emdash/api/plugins/<slug>/list?status=open&limit=20&tag=a&tag=b
-		input: z.object({
-			status: z.enum(["open", "closed"]).optional(),
-			limit: z.coerce.number().int().max(100).default(20),
-			tag: z.array(z.string()).optional(),
-		}),
 		handler: async (routeCtx, ctx) => {
-			const { status, limit, tag } = routeCtx.input;
+			const parsed = listInput.safeParse(routeCtx.input);
+			if (!parsed.success) return { ok: false, error: "INVALID_QUERY" };
+			const { status, limit, tag } = parsed.data;
 			// ...
 		},
 	},
@@ -284,43 +283,34 @@ return [1, 2, 3];                 // wrapped to { success: true, data: [1, 2, 3]
 
 ## Errors
 
-Throw to return an error response. Anything that isn't a known plugin error returns a generic message — internal exceptions are masked rather than leaking stack traces or database errors:
+Throw when a sandboxed route cannot complete. EmDash logs the exception and returns a `ROUTE_ERROR`. The thrown message may be included in that response, so never put credentials, personal data, internal paths, or stack traces in an exception message:
 
 ```typescript
-handler: async (routeCtx, ctx) => {
-	const item = await ctx.storage.items.get(routeCtx.input.id);
-	if (!item) {
-		throw new Error("Item not found");
+handler: async (_routeCtx, ctx) => {
+	try {
+		return await refreshRemoteIndex(ctx);
+	} catch {
+		ctx.log.error("Remote index refresh failed");
+		throw new Error("Remote index refresh failed");
 	}
-	return item;
 },
 ```
 
-For a specific status code, throw a `Response`:
+Sandboxed plugin code cannot select an arbitrary HTTP status by throwing a `Response`; a `Response` does not cross every sandbox runner's boundary as a structured error. EmDash assigns statuses to authentication, authorization, CSRF, and missing-route failures before the handler runs. Return a JSON result for expected validation and domain outcomes, and reserve exceptions for unexpected failures.
 
-```typescript
-handler: async (routeCtx, ctx) => {
-	const item = await ctx.storage.items.get(routeCtx.input.id);
-	if (!item) {
-		throw new Response(JSON.stringify({ error: "Not found" }), {
-			status: 404,
-			headers: { "Content-Type": "application/json" },
-		});
-	}
-	return item;
-},
-```
+An expected error returned as JSON still uses the route's successful HTTP response and appears inside EmDash's outer `{ success: true, data: ... }` envelope. Include a stable application-level code so clients can distinguish that outcome.
 
 ## HTTP methods
 
-Routes respond to all methods. Branch on `routeCtx.request.method` if you need per-method behaviour:
+The route name, not the HTTP method, selects a handler. If a route changes state, accept only the intended method before performing the mutation:
 
 ```typescript
 routes: {
 	item: {
-		input: z.object({ id: z.string() }),
 		handler: async (routeCtx, ctx) => {
-			const { id } = routeCtx.input;
+			const parsed = z.object({ id: z.string() }).safeParse(routeCtx.input);
+			if (!parsed.success) return { ok: false, error: "INVALID_ID" };
+			const { id } = parsed.data;
 
 			switch (routeCtx.request.method) {
 				case "GET":
@@ -329,7 +319,7 @@ routes: {
 					await ctx.storage.items.delete(id);
 					return { deleted: true };
 				default:
-					throw new Response("Method not allowed", { status: 405 });
+					return { error: "METHOD_NOT_ALLOWED", allowed: ["GET", "DELETE"] };
 			}
 		},
 	},
@@ -350,80 +340,17 @@ handler: async (routeCtx, ctx) => {
 
 	ctx.log.info("Request", { meta: requestMeta });
 
-	if (request.method !== "POST") {
-		throw new Response("POST required", { status: 405 });
-	}
+	if (request.method !== "POST") return { error: "POST_REQUIRED" };
 },
 ```
 
 ## Common patterns
 
-### Settings via KV
+### Settings and paginated data
 
-Sandboxed plugins read and write settings through the KV store, conventionally under a `settings:` prefix. The auto-generated `settingsSchema` form is native-only — for sandboxed plugins, expose the read/write through routes and render the form in [Block Kit](/plugins/creating-plugins/block-kit/).
+Plugin settings use private routes, Block Kit forms, and `ctx.kv`. [Settings](/plugins/creating-plugins/settings/) provides the complete loading, validation, form, and secret-handling pattern.
 
-```typescript
-routes: {
-	settings: {
-		handler: async (_routeCtx, ctx) => {
-			const settings = await ctx.kv.list("settings:");
-			const result: Record<string, unknown> = {};
-			for (const entry of settings) {
-				result[entry.key.replace("settings:", "")] = entry.value;
-			}
-			return result;
-		},
-	},
-
-	"settings/save": {
-		input: z.object({
-			enabled: z.boolean().optional(),
-			apiKey: z.string().optional(),
-			maxItems: z.number().optional(),
-		}),
-		handler: async (routeCtx, ctx) => {
-			for (const [key, value] of Object.entries(routeCtx.input)) {
-				if (value !== undefined) {
-					await ctx.kv.set(`settings:${key}`, value);
-				}
-			}
-			return { success: true };
-		},
-	},
-},
-```
-
-### Paginated list
-
-Return cursor-based pagination from a storage query — the response shape matches what the rest of EmDash uses:
-
-```typescript
-routes: {
-	list: {
-		input: z.object({
-			limit: z.number().min(1).max(100).default(50),
-			cursor: z.string().optional(),
-			status: z.string().optional(),
-		}),
-		handler: async (routeCtx, ctx) => {
-			const { limit, cursor, status } = routeCtx.input;
-
-			const result = await ctx.storage.items.query({
-				where: status ? { status } : undefined,
-				orderBy: { createdAt: "desc" },
-				limit,
-				cursor,
-			});
-
-			return {
-				items: result.items.map((item) => ({ id: item.id, ...item.data })),
-				cursor: result.cursor,
-				hasMore: result.hasMore,
-			};
-		},
-	},
-},
-```
+Routes that list plugin data should return the cursor from `ctx.storage.<collection>.query()`. [Storage pagination](/plugins/creating-plugins/storage/#pagination) shows how to pass a cursor and drain multiple pages without exceeding the 100-item page maximum.
 
 ### External API proxy
 
@@ -432,15 +359,16 @@ Proxy a request to an external service through `ctx.http` (requires `network:req
 ```typescript
 routes: {
 	forecast: {
-		input: z.object({ city: z.string() }),
 		handler: async (routeCtx, ctx) => {
+			const parsed = z.object({ city: z.string().min(1) }).safeParse(routeCtx.input);
+			if (!parsed.success) return { ok: false, error: "INVALID_CITY" };
 			if (!ctx.http) throw new Error("Network capability not granted");
 
 			const apiKey = await ctx.kv.get<string>("settings:apiKey");
 			if (!apiKey) throw new Error("API key not configured");
 
 			const response = await ctx.http.fetch(
-				`https://api.weather.example.com/forecast?city=${routeCtx.input.city}`,
+				`https://api.weather.example.com/forecast?city=${encodeURIComponent(parsed.data.city)}`,
 				{ headers: { "X-API-Key": apiKey } },
 			);
 
@@ -453,25 +381,9 @@ routes: {
 },
 ```
 
-## Calling routes from the admin UI
+## Calling routes from Block Kit
 
-Use `usePluginAPI()` from the admin package — it adds the `X-EmDash-Request` CSRF header and the plugin id prefix automatically:
-
-```typescript
-import { usePluginAPI } from "@emdash-cms/admin";
-
-function SettingsPage() {
-	const api = usePluginAPI();
-
-	const handleSave = async (settings) => {
-		await api.post("settings/save", settings);
-	};
-
-	const loadSettings = async () => {
-		return api.get("settings");
-	};
-}
-```
+Sandboxed plugins do not ship React code to the admin. Declare an `admin` route and return Block Kit responses. EmDash sends `page_load`, `block_action`, and `form_submit` interactions to that private route with the correct URL and CSRF header. [Block Kit](/plugins/creating-plugins/block-kit/) shows the interaction contract and a complete route.
 
 ## Calling routes from queue and scheduled handlers
 
@@ -521,7 +433,7 @@ curl -X POST https://your-site.com/_emdash/api/plugins/forms/track \
   -d '{"event": "pageview"}'
 ```
 
-Private routes need session credentials or an API token with the `admin` scope:
+Private routes need session credentials plus `X-EmDash-Request: 1`, or an API token with the `admin` scope. The following server-to-server request uses a token:
 
 ```bash
 curl -X POST https://your-site.com/_emdash/api/plugins/forms/create \
@@ -531,6 +443,8 @@ curl -X POST https://your-site.com/_emdash/api/plugins/forms/create \
 ```
 
 ## Route context reference
+
+The following interfaces summarize the portable values available to a sandboxed route handler:
 
 ```typescript
 // What sandboxed route handlers receive as their two arguments
@@ -542,7 +456,7 @@ interface SandboxedRequest {
 }
 
 interface SandboxedRouteContext {
-	input: unknown; // narrow with the `input` Zod schema at the route level
+	input: unknown; // validate inside the handler before use
 	request: SandboxedRequest;
 	requestMeta?: unknown;
 	user?: UserInfo; // authenticated caller on private routes; undefined on public routes

--- a/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
@@ -130,12 +130,11 @@ routes: {
 ```
 
 <Aside type="caution">
-	A public route skips authentication and token scope checks, but it does not bypass EmDash's
-	protection against cross-origin browser requests. For requests that can change data, EmDash accepts
-	a matching site `Origin` or the `X-EmDash-Request: 1` header and rejects a different or malformed
-	`Origin` with a 403 response. Webhooks and other non-browser clients usually omit the `Origin`
-	header and remain allowed. Anyone on the internet can therefore call a public route. Validate all
-	input, and verify the service's signature or token when it provides one.
+	A public route skips authentication and token scope checks, but not protection against cross-origin
+	browser requests. For requests that can change data, EmDash accepts a matching site `Origin` or the
+	`X-EmDash-Request: 1` header; a different or malformed `Origin` returns 403. Webhooks and other
+	non-browser clients usually omit `Origin` and remain allowed, so anyone can call a public route.
+	Validate all input and verify the service's signature or token when available.
 </Aside>
 
 ### The authenticated caller

--- a/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
@@ -130,13 +130,12 @@ routes: {
 ```
 
 <Aside type="caution">
-	Public routes skip authentication and token scope checks. Requests using methods other than GET,
-	HEAD, or OPTIONS still pass EmDash's browser-origin check. EmDash accepts these requests when they
-	include `X-EmDash-Request: 1`, have an `Origin` that matches the site's internal or configured
-	public origin, or have no `Origin` header. A cross-origin or malformed `Origin` is rejected with a
-	403 response. Non-browser clients such as webhook senders usually omit `Origin`, so anyone on the
-	internet can still call a public route. Validate all input and authenticate the payload when the
-	external service supports signatures or tokens.
+	A public route skips authentication and token scope checks, but it does not bypass EmDash's
+	protection against cross-origin browser requests. For requests that can change data, EmDash accepts
+	a matching site `Origin` or the `X-EmDash-Request: 1` header and rejects a different or malformed
+	`Origin` with a 403 response. Webhooks and other non-browser clients usually omit the `Origin`
+	header and remain allowed. Anyone on the internet can therefore call a public route. Validate all
+	input, and verify the service's signature or token when it provides one.
 </Aside>
 
 ### The authenticated caller

--- a/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/api-routes.mdx
@@ -114,7 +114,7 @@ routes: {
 
 Private routes require the `X-EmDash-Request: 1` CSRF header for cookie-authenticated requests. The admin UI sends it automatically; token-authenticated requests are exempt.
 
-To opt a route out of auth and CSRF, mark it `public: true`:
+To opt a route out of authentication, mark it `public: true`:
 
 ```typescript
 routes: {
@@ -130,7 +130,13 @@ routes: {
 ```
 
 <Aside type="caution">
-	Public routes skip authentication, scope, and CSRF entirely. Anyone on the internet can call them. Use `public: true` only for endpoints that need to accept external traffic — webhooks, public-facing search endpoints — and validate the input carefully.
+	Public routes skip authentication and token scope checks. Requests using methods other than GET,
+	HEAD, or OPTIONS still pass EmDash's browser-origin check. EmDash accepts these requests when they
+	include `X-EmDash-Request: 1`, have an `Origin` that matches the site's internal or configured
+	public origin, or have no `Origin` header. A cross-origin or malformed `Origin` is rejected with a
+	403 response. Non-browser clients such as webhook senders usually omit `Origin`, so anyone on the
+	internet can still call a public route. Validate all input and authenticate the payload when the
+	external service supports signatures or tokens.
 </Aside>
 
 ### The authenticated caller

--- a/docs/src/content/docs/plugins/creating-plugins/block-kit.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/block-kit.mdx
@@ -12,7 +12,10 @@ EmDash's Block Kit lets sandboxed plugins describe their admin UI as JSON. The h
 </Aside>
 
 <Aside type="tip">
-	Block Kit elements are also used for [Portable Text block editing fields](/plugins/creating-native-plugins/portable-text-components/). When a plugin declares `fields` on a block type, the editor renders a Block Kit form for editing block data (URL, title, parameters, etc.).
+	Native plugins also use Block Kit elements to describe [Portable Text block editing
+	fields](/plugins/creating-native-plugins/portable-text-components/). Sandboxed plugins cannot
+	register custom Portable Text block types because their rendering components would need to load
+	into the host site at build time.
 </Aside>
 
 ## How it works
@@ -24,43 +27,77 @@ EmDash's Block Kit lets sandboxed plugins describe their admin UI as JSON. The h
 5. When the user interacts (clicks a button, submits a form), the admin sends the interaction back to the plugin.
 6. The plugin returns new blocks, and the cycle repeats.
 
-```typescript
-import type { SandboxedPlugin } from "emdash/plugin";
+Add `@emdash-cms/blocks` and `zod` to the plugin when it defines a Block Kit page:
 
-interface BlockInteraction {
-	type: "page_load" | "block_action" | "form_submit";
-	page?: string;
-	action_id?: string;
-	values?: Record<string, unknown>;
+```sh
+pnpm add @emdash-cms/blocks zod
+```
+
+Declare the page in the plugin manifest so the admin has a navigation entry to load:
+
+```jsonc title="emdash-plugin.jsonc"
+"admin": {
+	"pages": [{ "path": "/settings", "label": "Settings", "icon": "settings" }],
+}
+```
+
+The following `admin` route validates the interaction, renders a form on page load, and stores its values on submit:
+
+```typescript title="src/plugin.ts"
+import type { SandboxedPlugin } from "emdash/plugin";
+import type { BlockResponse } from "@emdash-cms/blocks";
+import { z } from "zod";
+
+const interactionSchema = z.discriminatedUnion("type", [
+	z.object({ type: z.literal("page_load"), page: z.string() }),
+	z.object({
+		type: z.literal("block_action"),
+		action_id: z.string(),
+		block_id: z.string().optional(),
+		value: z.unknown().optional(),
+	}),
+	z.object({
+		type: z.literal("form_submit"),
+		action_id: z.string(),
+		block_id: z.string().optional(),
+		values: z.object({ api_url: z.url(), enabled: z.boolean() }),
+	}),
+]);
+
+function renderSettings(): BlockResponse {
+	return {
+		blocks: [
+			{ type: "header", text: "Save Log settings" },
+			{
+				type: "form",
+				block_id: "settings",
+				fields: [
+					{ type: "text_input", action_id: "api_url", label: "API URL" },
+					{ type: "toggle", action_id: "enabled", label: "Enabled", initial_value: true },
+				],
+				submit: { label: "Save", action_id: "save" },
+			},
+		],
+	};
 }
 
 export default {
 	routes: {
 		admin: {
 			handler: async (routeCtx, ctx) => {
-				const interaction = routeCtx.input as BlockInteraction;
+				const parsed = interactionSchema.safeParse(routeCtx.input);
+				if (!parsed.success) return { blocks: [] };
+				const interaction = parsed.data;
 
 				if (interaction.type === "page_load") {
-					return {
-						blocks: [
-							{ type: "header", text: "My Plugin Settings" },
-							{
-								type: "form",
-								block_id: "settings",
-								fields: [
-									{ type: "text_input", action_id: "api_url", label: "API URL" },
-									{ type: "toggle", action_id: "enabled", label: "Enabled", initial_value: true },
-								],
-								submit: { label: "Save", action_id: "save" },
-							},
-						],
-					};
+					return renderSettings();
 				}
 
 				if (interaction.type === "form_submit" && interaction.action_id === "save") {
-					await ctx.kv.set("settings", interaction.values);
+					await ctx.kv.set("settings:apiUrl", interaction.values.api_url);
+					await ctx.kv.set("settings:enabled", interaction.values.enabled);
 					return {
-						blocks: [/* ... updated blocks ... */],
+						...renderSettings(),
 						toast: { message: "Settings saved", type: "success" },
 					};
 				}
@@ -72,7 +109,7 @@ export default {
 } satisfies SandboxedPlugin;
 ```
 
-The route handler takes two arguments: `routeCtx` (with `input`, `request`, `requestMeta`) and `ctx` (the `PluginContext`). `satisfies SandboxedPlugin` infers both.
+The `admin` route is private by default. EmDash sends the correct CSRF header when the admin calls it. The handler still validates `routeCtx.input` because its TypeScript type is `unknown` and a caller can invoke a private plugin route outside the Block Kit page.
 
 ## Block types
 
@@ -86,11 +123,16 @@ The route handler takes two arguments: `routeCtx` (with `input`, `request`, `req
 | `actions`   | Horizontal row of buttons and controls                                                  |
 | `stats`     | Dashboard metric cards with trend indicators                                            |
 | `form`      | Input fields with conditional visibility and submit                                     |
-| `image`     | Block-level image with caption                                                          |
+| `image`     | Block-level image with alt text and an optional title                                  |
 | `context`   | Small muted help text                                                                   |
 | `columns`   | 2–3 column layout with nested blocks                                                    |
-| `empty`     | Empty-state placeholder with icon, title, description, optional command line, and action buttons |
+| `empty`     | Empty-state title with an optional description, command, and action buttons            |
 | `accordion` | Collapsible section wrapping nested blocks                                              |
+| `chart`     | Line or bar time series, or a chart with custom options                                |
+| `banner`    | Status or alert message with a title or description                                     |
+| `meter`     | Numeric value displayed against a minimum and maximum                                   |
+| `code`      | Read-only TypeScript, TSX, JSONC, Bash, or CSS code                                     |
+| `tab`       | Labeled panels containing nested blocks                                                  |
 
 ## Element types
 
@@ -102,16 +144,22 @@ The route handler takes two arguments: `routeCtx` (with `input`, `request`, `req
 | `select`        | Dropdown select                              |
 | `toggle`        | On/off switch                                |
 | `secret_input`  | Masked input for API keys and tokens         |
+| `checkbox`      | Select several values from a fixed list      |
+| `combobox`      | Searchable single-value selection            |
+| `date_input`    | Date value                                   |
+| `radio`         | Single choice from a visible option list     |
+
+The Portable Text field editor also supports `repeater` and `media_picker`. They are not form fields for a sandboxed plugin admin page.
 
 ## Builder helpers
 
-The `@emdash-cms/blocks` package exports builder helpers for cleaner code:
+The `@emdash-cms/blocks` package exports the same shapes through `blocks` and `elements` builder objects. Builders reduce property-name mistakes while returning ordinary JSON-compatible objects:
 
 ```typescript
 import { blocks, elements } from "@emdash-cms/blocks";
 
-const { header, form, section, stats } = blocks;
-const { textInput, toggle, select, button } = elements;
+const { header, form } = blocks;
+const { textInput, toggle, select } = elements;
 
 return {
 	blocks: [
@@ -154,6 +202,8 @@ Form fields can be conditionally shown based on other field values:
 ```
 
 The `api_key` field only appears when `auth_enabled` is toggled on. Conditions are evaluated client-side with no round-trip.
+
+`secret_input` uses `has_value: true` to show that a value already exists; it does not accept or return the stored value on page load. The field masks typing in the browser, but it does not encrypt a value written to `ctx.kv`. Follow [Secret settings](/plugins/creating-plugins/settings/#secret-values) before storing credentials.
 
 ## Try it
 

--- a/docs/src/content/docs/plugins/creating-plugins/capabilities.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/capabilities.mdx
@@ -23,7 +23,7 @@ Capabilities live in `emdash-plugin.jsonc`, alongside `slug` and the rest of the
 }
 ```
 
-Declare only what the plugin actually needs. Capability declarations are also what the marketplace shows site operators on the consent dialog — extra capabilities are friction at install time and a security flag in audits.
+Declare only what the plugin actually needs. The marketplace shows these capabilities to site operators before installation, so every extra declaration asks them to approve access the plugin does not use.
 
 ## Capability reference
 
@@ -42,7 +42,7 @@ Declare only what the plugin actually needs. Capability declarations are also wh
 | `hooks.email-events:register`       | Allows registering `email:beforeSend` / `email:afterSend` hooks                   |
 | `hooks.page-fragments:register`     | Allows registering the `page:fragments` hook (native plugins only)                |
 
-A few things worth knowing:
+The following rules affect which capabilities a plugin needs:
 
 - **Implications.** `content:write` automatically implies `content:read`; `media:write` implies `media:read`; `network:request:unrestricted` implies `network:request`. You don't need to list both.
 - **Taxonomies are a separate, read-only surface.** `taxonomies:read` grants access to taxonomy definitions, their terms, and the terms assigned to an entry via `ctx.taxonomies`. It is independent of `content:read` — declare both if the plugin reads content *and* its classification. There is no taxonomy *write* access from plugins.
@@ -65,19 +65,19 @@ Locale matching is case-insensitive and stores the casing from the site's locale
 
 ## Network host allowlists
 
-Plugins with `network:request` can only fetch hosts listed in `allowedHosts`. Wildcards are supported for subdomains:
+Plugins with `network:request` can only fetch hosts listed in `allowedHosts`. A leading `*.` matches both the named domain and its subdomains:
 
 ```jsonc title="emdash-plugin.jsonc"
 "capabilities": ["network:request"],
 "allowedHosts": [
 	"api.example.com",     // exact host
-	"*.cdn.example.com"    // any subdomain of cdn.example.com
+	"*.cdn.example.com"    // cdn.example.com and any subdomain
 ]
 ```
 
 The bridge checks the request URL's host against the allowlist before forwarding the request. A request to a host that wasn't declared throws inside the plugin without ever leaving the sandbox.
 
-`network:request:unrestricted` skips the allowlist check entirely. It's intended for plugins where the operator configures the destination URL at runtime (webhook senders, generic HTTP forwarders). Avoid it for plugins where the destination is part of the plugin's design — declare `network:request` with explicit hosts instead, so the consent dialog tells operators exactly where the plugin is going to call.
+`network:request:unrestricted` skips the manifest host allowlist. The sandbox bridge still accepts only HTTP and HTTPS, blocks known internal hosts and private literal addresses, rechecks every redirect, and removes credential headers when a redirect crosses origins. Use unrestricted access only when an operator supplies the destination at runtime. For fixed destinations, declare `network:request` with explicit hosts so the consent dialog names them.
 
 ## What the sandbox enforces
 
@@ -87,13 +87,13 @@ When a sandbox runner is active, the runtime enforces:
 
 1. **Capability gating.** The PluginContext factory only populates `ctx.content`, `ctx.taxonomies`, `ctx.media`, `ctx.http`, `ctx.users`, `ctx.email` when the corresponding capability is declared. Calling a method on an undeclared capability isn't possible — there's no object there.
 
-2. **Storage and KV scoping.** Every storage and KV operation is scoped to the plugin's slug. A plugin can't read another plugin's KV or its storage collections, and it can only access storage collections it declared in the manifest.
+2. **Storage and KV scoping.** Every storage and KV operation is scoped to the runtime plugin ID. A plugin can't read another plugin's KV or storage collections, and it can access only collections declared in its manifest.
 
 3. **Network isolation.** Direct `fetch()` and other network primitives are blocked by the runner. The only way to reach the network is `ctx.http.fetch()`, which goes through the bridge's host validation.
 
 4. **No host bindings.** Sandboxed plugins don't see environment variables, the filesystem, or any platform bindings — even if your host worker has them. The plugin runtime is a clean isolate with only the bridge and the declared capabilities.
 
-5. **Resource limits.** The runner can enforce CPU, subrequest, wall-clock, and memory limits per invocation. The exact limits depend on which runner you're using; the Cloudflare runner uses the platform's Worker Loader limits (50ms CPU per invocation, 10 subrequests, 30 second wall-clock, ~128MB memory). The Node.js workerd runner (`@emdash-cms/sandbox-workerd`) enforces wall-clock time via `Promise.race`; CPU and memory limits are Cloudflare platform features and are not enforced by standalone workerd. Hooks that exceed the runner's limits are aborted; the EmDash hook timeout (`timeout` in the hook config) enforces a stricter ceiling on top of that.
+5. **Resource limits.** The Cloudflare runner defaults to 50 ms of CPU, 10 subrequests, and 30 seconds of wall time per invocation. Worker Loader enforces CPU and subrequests; the runner enforces wall time. Worker Loader has a platform memory ceiling, but its per-plugin `memoryMb` option is not currently enforceable. The Node.js workerd runner enforces only the 30-second wall-time default; it warns when a site configures CPU, memory, or subrequest limits that standalone workerd cannot enforce. A per-hook `timeout` applies only when the sandboxed-format plugin runs in process.
 
 </Steps>
 
@@ -101,8 +101,8 @@ When a sandbox runner is active, the runtime enforces:
 
 A few things the capability system doesn't and can't cover:
 
-- **Behaviour within a granted capability.** A plugin with `content:write` can edit any content, not only its own. Capabilities are coarse — they say "this plugin can write content," not "this plugin can write only the content it created." Audit-time review is the only check on what a plugin actually does within its grant.
-- **Entry edit locks.** `ctx.content.update()` writes through an entry's [edit lock](/reference/rest-api/#entry-edit-lock), so an editor who has that entry open in the admin does not stop a plugin write. `ctx.content.delete()` behaves the same way, and releases the lock along with the entry it trashes.
+- **Behaviour within a granted capability.** A plugin with `content:write` can edit any content, not only its own. Capabilities are coarse — they say "this plugin can write content," not "this plugin can write only the content it created." An operator must evaluate the plugin's code and publisher before granting that access.
+- **Entry edit locks.** `ctx.content.update()` and `ctx.content.delete()` are programmatic writes. An editor holding the entry's advisory edit lock does not block them. Coordinate plugin writes with editors when both may update the same entry.
 - **Operator trust on Node.js.** When the configured sandbox runner reports unavailable (no Cloudflare Worker Loader, no Node-side runner installed, etc.), `sandboxed: []` plugins are skipped at startup. You can move them into `plugins: []` to run them in-process — but then there's no V8 isolate, no resource limits, and the plugin can call `fetch()` directly or read environment variables. Treat that as native-level trust.
 - **Side channels.** Timing, log output, and stored data are all visible to anyone with appropriate access to the host environment. Don't use the sandbox as a confidentiality boundary against the operator running it.
 
@@ -110,14 +110,14 @@ A few things the capability system doesn't and can't cover:
 
 When an operator installs a sandboxed plugin from the marketplace, EmDash shows a consent dialog listing the declared capabilities. Updates that add capabilities — for example, a plugin that previously only read content now wants to make network requests — surface as a capability diff and require fresh approval before the new version takes effect.
 
-This is why declaring extra capabilities matters even if you "might use them later". They show up as friction at every install and update, and security audits flag plugins that ask for more than they obviously need. List exactly what the plugin uses, and add new capabilities in a real version when the plugin actually starts using them.
+Declaring capabilities for possible future use makes every installation or update ask for unnecessary access. List what the current version uses, then add a capability in the version that starts using it.
 
 ## Bundle-time validation
 
 `emdash-plugin bundle` and `emdash-plugin publish` perform additional checks:
 
 - Every declared capability must be in the recognised set (typos fail the build).
-- `network:request` requires a non-empty `allowedHosts`; `network:request:unrestricted` requires it to be empty. See [the manifest reference](/plugins/creating-plugins/manifest/#capabilities).
+- `network:request` requires a non-empty `allowedHosts`; `network:request:unrestricted` requires it to be empty. See [Capabilities and hosts](/plugins/creating-plugins/manifest/#capabilities-and-hosts).
 - The bundled `backend.js` can't import Node.js built-ins (`fs`, `path`, `child_process`, etc.) — sandbox runtimes don't provide them.
 
-See [Bundling and publishing](/plugins/creating-plugins/publishing/) for the full list of checks.
+See [the manifest reference](/plugins/creating-plugins/manifest/#trust-contract) for the authoring fields and [Bundling and publishing](/plugins/creating-plugins/publishing/#validation) for bundle checks.

--- a/docs/src/content/docs/plugins/creating-plugins/choosing-a-format.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/choosing-a-format.mdx
@@ -5,11 +5,9 @@ description: Pick between sandboxed and native plugins before you start writing 
 
 import { Aside, CardGrid, LinkCard } from "@astrojs/starlight/components";
 
-EmDash plugins ship in one of two formats: **sandboxed** or **native**. The choice affects how the plugin is installed, what enforcement it gets at runtime, and which features are available.
+EmDash plugins use one of two formats: **sandboxed** or **native**. Choose the format before writing the plugin because the authoring shape, installation path, and trust boundary differ.
 
-**Default to sandboxed.** Sandboxed plugins can be published to the marketplace and installed from the admin UI with one click. Native plugins require a code change, an `npm install`, and a redeploy on every site that wants them. Sandboxed is what end users want.
-
-Choose native only when you need a feature the sandbox can't provide.
+Choose a sandboxed plugin unless the plugin needs a native-only integration. Sandboxed plugins can be published to the registry and installed from the admin UI. A native plugin is an npm package that a site operator installs in the project and adds to `astro.config.mjs` before redeploying.
 
 ## At a glance
 
@@ -18,9 +16,9 @@ Choose native only when you need a feature the sandbox can't provide.
 | Authoring shape                     | `emdash-plugin.jsonc` + `src/plugin.ts`            | `definePlugin()` descriptor           |
 | Install method                      | One-click from the admin marketplace               | `npm install` + edit `astro.config`   |
 | Runs in                             | An isolated runtime provided by a sandbox runner   | Same process as your Astro site       |
-| Capabilities                        | Enforced by the sandbox bridge                     | Enforced in-process by the same bridge |
-| Resource limits                     | Enforced by the runner — typically CPU, subrequests, wall-time, memory | None                  |
-| Network access                      | `ctx.http` only, restricted to `allowedHosts`      | `ctx.http` only, restricted to `allowedHosts` |
+| Capability-gated `ctx` APIs         | Enforced by the sandbox bridge                     | Gated by `PluginContext`, but not a security boundary |
+| Resource limits                     | Runner limits for CPU, subrequests, and wall time; platform memory ceiling | No per-plugin limits |
+| Network access                      | `ctx.http`, restricted to declared access          | `ctx.http` follows declarations; native code can also call `fetch()` |
 | Direct `fetch()` / `process.env`    | Blocked by the runner                              | Possible (plugin code shares the runtime) |
 | Distribution                        | `.tar.gz` bundle on the marketplace                | npm package                           |
 | Admin UI                            | Block Kit (JSON-described) routes                  | React components, or Block Kit        |
@@ -30,22 +28,22 @@ Choose native only when you need a feature the sandbox can't provide.
 | Page fragment injection             | Not available — meta/JSON-LD only via `page:metadata` | `page:fragments` hook — inline scripts, external scripts, raw HTML |
 | Constructor options                 | None — read settings from KV at runtime            | `options` on the descriptor           |
 
-## What you give up by going native
+## Costs of a native plugin
 
-Native plugins look like a more powerful version of the same thing, and they are — but the cost is steep:
+Native plugins have a different installation and trust model:
 
-- **No marketplace.** Every site has to install your npm package, edit `astro.config.mjs`, and redeploy.
+- **Project-level installation.** Every site has to install your npm package, edit `astro.config.mjs`, and redeploy.
 - **No isolation.** A bug in your plugin can crash the host process or burn its CPU budget. An unhandled rejection in a hook can take the surrounding request down with it.
-- **Trust burden on the user.** Native plugins have the same access as the host site. End users can't audit them through capability declarations alone.
+- **Trust burden on the user.** Native plugins have the same access as the host site. Capability declarations alone cannot show everything their code can do.
 
 If your plugin can do its job in the sandbox, it should.
 
 ## When to go native
 
-There are three reasons to choose native, and they're all about features that need build-time integration with the host site:
+Choose native for features that need build-time integration with the host site:
 
 1. **Custom React admin pages or widgets.** Sandboxed plugins describe their admin UI with Block Kit — a JSON schema that the admin renders on the plugin's behalf. If you need full React (custom hooks, third-party components, complex state), you need native.
-2. **Astro components for rendering Portable Text blocks on the public site.** A sandboxed plugin can declare a custom block type, but the Astro components that render it on the public site have to be loaded at build time from npm. Only native plugins can provide a `componentsEntry`.
+2. **Custom Portable Text block types.** Their editing configuration and Astro rendering components are loaded from the installed npm package. Only native plugins can provide that build-time surface.
 3. **Injecting raw HTML, scripts, or stylesheets into public pages.** The `page:fragments` hook ships first-party code to visitors' browsers — outside any sandbox boundary. It's restricted to native plugins. Sandboxed plugins can still contribute to public pages through the `page:metadata` hook, which covers a lot of real use cases:
 
    - `meta` tags (`name` + `content`) — SEO descriptions, robots directives, Twitter cards
@@ -55,12 +53,12 @@ There are three reasons to choose native, and they're all about features that ne
 
    If your "page injection" need is structured data or SEO metadata, stay sandboxed and use `page:metadata`. If you actually need to ship JavaScript or HTML into the visitor's browser, that's the case for going native.
 
-If you're not sure, go sandboxed. You can always migrate to native later — but the reverse is harder, because native-only features have no sandbox equivalent.
+If none of these features apply, use the sandboxed format.
 
-<Aside type="note" title="Same hooks, same context">
-	Sandboxed and native plugins use the same hook names, the same `PluginContext` API, and the same
-	storage and KV helpers. The format choice changes how the plugin is packaged and what extra
-	features are available — not the day-to-day code you write inside hooks and routes.
+<Aside type="note" title="Shared runtime APIs">
+	Both formats use `PluginContext`, storage, KV, and most hook names. Sandboxed hook handlers take
+	`(event, ctx)`, while sandboxed route handlers take `(routeCtx, ctx)`. Native route handlers receive
+	a single context object. The `page:fragments` hook is native-only.
 </Aside>
 
 ## Sandbox runners and platform support
@@ -79,7 +77,7 @@ If you want a sandboxed plugin to run on a platform without a sandbox runner, mo
 	<LinkCard
 		title="Your first sandboxed plugin"
 		href="/plugins/creating-plugins/your-first-plugin/"
-		description="Build, register, and run a hello-world sandboxed plugin."
+		description="Build, register, and run a sandboxed content-save plugin."
 	/>
 	<LinkCard
 		title="When to go native"

--- a/docs/src/content/docs/plugins/creating-plugins/cli.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/cli.mdx
@@ -1,11 +1,11 @@
 ---
-title: The emdash-plugin CLI
-description: init, build, dev, bundle, validate, profile setup, and publishing.
+title: The `emdash-plugin` CLI
+description: Scaffold, build, validate, publish, and maintain a sandboxed plugin.
 ---
 
 import { Steps } from "@astrojs/starlight/components";
 
-`@emdash-cms/plugin-cli` is the authoring toolchain: scaffold, build, watch, validate, bundle, publish, plus identity and discovery. The binary is `emdash-plugin`.
+`@emdash-cms/plugin-cli` scaffolds, builds, validates, and publishes sandboxed plugins. It also manages publisher sign-in, package profiles, registry discovery, and automated releases. The installed binary is `emdash-plugin`.
 
 The CLI uses an [Atmosphere account](/plugins/creating-plugins/publishing/#your-atmosphere-account) as the publisher identity for package profiles and releases.
 
@@ -20,6 +20,7 @@ emdash-plugin dev                            Watch sources and rebuild on change
 emdash-plugin bundle                         Pack dist/ + assets into a registry tarball
 emdash-plugin validate [path]                Validate emdash-plugin.jsonc against the schema
 emdash-plugin publish                        Build, upload, and publish a release
+emdash-plugin update-package [--yes]         Preview or apply package-profile changes
 emdash-plugin profile setup                  Prepare the signed package profile for delegated releases
 emdash-plugin release setup                  Create the delegated-release GitHub Actions workflow
 emdash-plugin login <handle-or-did>          Sign in with your Atmosphere account
@@ -30,7 +31,7 @@ emdash-plugin search <query>                 Free-text registry search
 emdash-plugin info <handle-or-did> <slug>    Show package details
 ```
 
-The non-interactive output commands (`whoami`, `validate`, `search`, `info`, `login`, `publish`) accept `--json` for machine-readable output. Discovery commands (`search`, `info`) accept `--registry-url <url>` (or `EMDASH_REGISTRY_URL`).
+Run `emdash-plugin <command> --help` for the current arguments and flags. Commands intended for scripts, including `validate`, `publish`, `update-package`, `search`, `info`, `login`, and `whoami`, provide JSON output where their help lists `--json`. Discovery commands accept `--registry-url <url>` or the `EMDASH_REGISTRY_URL` environment variable.
 
 The following example shows the two scripts most plugins add to `package.json`:
 
@@ -51,7 +52,9 @@ Create a new plugin with `init`:
 npx @emdash-cms/plugin-cli init my-plugin
 ```
 
-This scaffolds a self-contained plugin: `emdash-plugin.jsonc`, `src/plugin.ts` (one example route in the `satisfies SandboxedPlugin` shape), `package.json`, `tsconfig.json`, a test, a README, and `.gitignore`. A slug is the only required input. A scaffold created from just a slug is a valid starting point: the manifest carries `TODO:` comments for the few fields to fill in — publisher, author, and security contact — before the plugin will load or publish.
+This scaffolds `emdash-plugin.jsonc`, `src/plugin.ts`, `package.json`, `tsconfig.json`, a test, a README, and `.gitignore`. The source starts with one route and a bare default export annotated with `satisfies SandboxedPlugin`.
+
+A slug is the only required command-line input. Interactive setup asks for the publisher, author, and security contact. If any required answer is missing, the manifest contains a `TODO` value and is not ready to validate or build. Replace those values before using the plugin.
 
 ## `build`
 
@@ -63,15 +66,17 @@ This scaffolds a self-contained plugin: `emdash-plugin.jsonc`, `src/plugin.ts` (
 | `dist/manifest.json`                      | The plugin's manifest, including the hooks and routes read from `src/plugin.ts`. `bundle` includes this file as-is; npm consumers read it without parsing the JSONC source. |
 | `dist/index.mjs` (+ `dist/index.d.mts`)   | The descriptor module a site imports in `astro.config.mjs`. Emitted only when a sibling `package.json` exists; registry-only plugins skip it, since nothing imports it. |
 
-`dist/` is build output. Do not commit it. The scaffold's `.gitignore` excludes it, and installs rebuild it.
+`dist/` is build output. Do not commit it. The scaffold's `.gitignore` excludes it. Run `emdash-plugin build` before packing or publishing the npm package so its `files` list has the generated artifacts to include.
 
 ## `dev`
 
 Watches `src/**`, `emdash-plugin.jsonc`, and `package.json`, debouncing rebuilds at 150 ms. Rebuilds are serialised. On a **failed** rebuild it leaves the last good `dist/` in place, so a site importing the plugin via a workspace/file link keeps working until the next successful build. Ctrl-C drains cleanly.
 
-Develop against a real site by running `pnpm dev` here and `pnpm add file:../path/to/this` in the site, then importing the plugin's default export into `emdash({ sandboxed: [...] })`.
+Develop against a real site by running `pnpm dev` in the plugin directory and installing it into the site with `pnpm add file:../path/to/plugin`. Import the plugin's default export into `emdash({ sandboxed: [...] })`. The [first-plugin tutorial](/plugins/creating-plugins/your-first-plugin/#register-the-plugin) shows the complete setup.
 
 ## `validate`
+
+Validate the manifest in the current directory, or pass a different plugin directory:
 
 ```sh
 emdash-plugin validate          # ./emdash-plugin.jsonc
@@ -104,11 +109,27 @@ emdash-plugin login alice.example.com
 emdash-plugin publish
 ```
 
-`publish` reads the manifest for profile fields and enforces [publisher pinning](/plugins/creating-plugins/manifest/#publisher-pinning). On first publish, pass `--license` and a security contact, or keep them in the manifest. Explicit flags override manifest values; `--no-manifest` opts out entirely.
+`publish` reads the manifest for profile fields and enforces [publisher pinning](/plugins/creating-plugins/manifest/#publisher-pinning). Keep the license, author, security contact, and other package information in the manifest. The older profile flags and `--no-manifest` remain available for legacy scripted publishing; check `publish --help` before maintaining one of those flows.
 
 Pass `--url <https-url>` to use an externally hosted package bundle. The CLI downloads and validates the URL before publishing. Add `--local <path>` to verify that a local tarball matches the downloaded bytes.
 
-Full walkthrough: [Bundling and publishing](/plugins/creating-plugins/publishing/).
+Follow [Bundling and publishing](/plugins/creating-plugins/publishing/) for the complete local release flow.
+
+## `update-package`
+
+Use `update-package` to change an existing package profile without creating a release. It reads the profile fields in `emdash-plugin.jsonc`, fetches the current signed profile, and prints the proposed changes:
+
+```sh
+emdash-plugin update-package
+```
+
+The command is a dry run unless you pass `--yes`:
+
+```sh
+emdash-plugin update-package --yes
+```
+
+The write uses the current record CID as a precondition. If another process changes the profile after the command reads it, the update fails with `STALE_RECORD` instead of overwriting the newer record. Removing an optional property from the manifest leaves its published value unchanged; set the intended replacement explicitly.
 
 ## `profile setup`
 
@@ -145,9 +166,11 @@ It accepts the `profile setup` flags plus the following workflow options:
 | `--action-ref <ref>` | `main` | EmDash repository ref containing the release Action. |
 | `--force` | `false` | Replace an existing generated workflow. Without it, setup leaves the existing file unchanged. |
 
-The command never pushes the generated workflow. Follow [Automated plugin releases](/plugins/creating-plugins/delegated-releases/) to authorise the release service, connect the workflow, and publish the first release.
+The command never pushes the generated workflow. Follow [Automated plugin releases](/plugins/creating-plugins/delegated-releases/) to review it, authorise the release service, connect the workflow, and publish the first release.
 
 ## Programmatic API
+
+Build or bundle a plugin from Node.js by importing the CLI's programmatic functions:
 
 ```ts
 import { buildPlugin, bundlePlugin } from "@emdash-cms/plugin-cli";

--- a/docs/src/content/docs/plugins/creating-plugins/delegated-releases.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/delegated-releases.mdx
@@ -5,7 +5,7 @@ description: Publish sandboxed plugins from GitHub Actions through the EmDash re
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-Automated releases build and publish a sandboxed plugin when you push a version tag or start a GitHub Actions workflow manually. Your [Atmosphere account](/plugins/creating-plugins/publishing/#your-atmosphere-account) owns the package profile and release records. GitHub identifies the approved workflow, and the release service verifies and publishes the result without storing an account credential in the repository.
+Automated releases build and publish a sandboxed plugin when you push a version tag or start a GitHub Actions workflow manually. Your [Atmosphere account](/plugins/creating-plugins/publishing/#your-atmosphere-account) continues to own the package profile and release records. GitHub identifies the approved workflow, and the release service verifies the build and writes the release through a narrow delegation. The repository does not store an Atmosphere account credential.
 
 Use [`emdash-plugin publish`](/plugins/creating-plugins/publishing/#publish) for a release started from your computer. Use this guide when GitHub Actions should build and publish releases.
 
@@ -80,7 +80,7 @@ pnpm exec emdash-plugin validate
 
 5. Create a workflow invitation.
 
-   Enter the plugin ID from `emdash-plugin.jsonc`, then select **Create invitation**. Add the one-time value to the GitHub repository as an Actions secret named `EMDASH_CONNECTION_INVITATION`.
+   Enter the plugin's `slug` from `emdash-plugin.jsonc`, then select **Create invitation**. Add the one-time value to the GitHub repository as an Actions secret named `EMDASH_CONNECTION_INVITATION`.
 
    The invitation is valid for 30 minutes and can connect only the named plugin. Create a new invitation if it expires before the workflow consumes it.
 
@@ -143,7 +143,7 @@ The service stores publisher and approver state separately. Signing in to view y
 
 The generated workflow uses the Action from `apps/release-action`. The Action accepts either a built bundle plus raw Sigstore provenance, or a compatibility `release-file` containing checksum-bound HTTPS artifact sources. Do not combine `release-file` with bundle or provenance inputs.
 
-The standard generated workflow supplies these inputs:
+The standard generated workflow supplies these inputs. They are shown here so you can review the generated file without having to infer what each value authorizes:
 
 | Input | Value |
 | --- | --- |

--- a/docs/src/content/docs/plugins/creating-plugins/hooks.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/hooks.mdx
@@ -7,7 +7,7 @@ import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Hooks let plugins run code in response to events. All hooks receive an event object and the plugin context, and they're declared at plugin definition time — there's no dynamic registration at runtime.
 
-This page covers sandboxed plugins. Hooks work identically in native plugins; native plugins can additionally register `page:fragments`.
+This page covers sandboxed plugins. Native plugins use the same hook names and event types, but they use the in-process hook pipeline and can additionally register `page:fragments`. Sandboxed save rejection and isolated-runner failure behavior are described below.
 
 ## Hook signature
 
@@ -24,7 +24,7 @@ async (event, ctx) => ReturnType;
 
 ## Hook configuration
 
-A hook can be declared as a bare handler or wrapped in a config object:
+A hook can be declared as a bare handler or wrapped in a config object. Prefer the bare form unless the plugin also supports deliberate in-process execution and needs the metadata described below.
 
 <Tabs>
 <TabItem label="Simple">
@@ -42,8 +42,6 @@ hooks: {
 	"content:afterSave": {
 		priority: 100,
 		timeout: 5000,
-		dependencies: ["audit-log"],
-		errorPolicy: "continue",
 		handler: async (event, ctx) => {
 			ctx.log.info("Content saved");
 		},
@@ -59,14 +57,32 @@ hooks: {
 | -------------- | ----------------------- | --------- | -------------------------------------------------------------------------------------------- |
 | `priority`     | `number`                | `100`     | Execution order. Lower numbers run first.                                                    |
 | `timeout`      | `number`                | `5000`    | Maximum execution time in milliseconds.                                                      |
-| `dependencies` | `string[]`              | `[]`      | Plugin ids that must run before this hook.                                                   |
-| `errorPolicy`  | `"abort" \| "continue"` | `"abort"` | Whether to stop the pipeline on error.                                                       |
 | `exclusive`    | `boolean`               | `false`   | Only one plugin can be the active provider. Used for `email:deliver` and `comment:moderate`. |
 | `handler`      | `function`              | —         | The hook handler function. Required.                                                         |
 
-<Aside type="tip">
-	Use `errorPolicy: "continue"` for non-critical hooks like notifications. Use `"abort"` (the default) when the hook's result is essential to the operation succeeding.
+<Aside type="caution" title="Isolated runners use their own ordering and timeout">
+	The authoring type also accepts `dependencies` and `errorPolicy`, and the in-process adapter uses all
+	of these configuration fields. An isolated sandbox runner currently invokes sandboxed plugins in load
+	order and applies its per-invocation wall-time limit. Do not use hook metadata to coordinate two
+	sandboxed plugins or to recover from an isolated hook failure.
 </Aside>
+
+## Required capabilities
+
+Several hooks expose protected data or can change an operation. EmDash registers them only when the manifest declares the matching capability:
+
+| Hooks | Capability | Reason |
+| --- | --- | --- |
+| `content:beforeSave` | `content:write` | The hook can replace submitted content. |
+| Other `content:*` hooks | `content:read` | Their events expose content or identify an entry. |
+| `media:beforeUpload` | `media:write` | The hook can replace upload metadata or stop the upload. |
+| `media:afterUpload` | `media:read` | Its event exposes the stored media item. |
+| `email:beforeSend`, `email:afterSend` | `hooks.email-events:register` | The hooks inspect email lifecycle events. |
+| `email:deliver` | `hooks.email-transport:register` | The hook becomes an email transport provider. |
+| All `comment:*` hooks | `users:read` | Comment events can contain author contact information and request metadata. |
+| `page:fragments` | `hooks.page-fragments:register` | The hook injects first-party page content and is native-only. |
+
+Lifecycle hooks, `cron`, and `page:metadata` have no registration capability. Declare the listed capability even when a hook only reads its event and does not call the matching `ctx` API. The declaration gives the operator an accurate consent prompt, gates the `ctx` API, and is required when the plugin runs in process. [Capabilities and security](/plugins/creating-plugins/capabilities/) explains the runtime effect.
 
 ## Lifecycle hooks
 
@@ -75,6 +91,8 @@ Run during plugin installation, activation, deactivation, and removal.
 ### `plugin:install`
 
 Runs once when the plugin is first added to a site.
+
+This example assumes the manifest declares an `items` storage collection:
 
 ```typescript
 "plugin:install": async (_event, ctx) => {
@@ -118,8 +136,11 @@ Runs when the plugin is removed from a site.
 "plugin:uninstall": async (event, ctx) => {
 	ctx.log.info("Uninstalling plugin...");
 	if (event.deleteData) {
-		const result = await ctx.storage.items.query({ limit: 1000 });
-		await ctx.storage.items.deleteMany(result.items.map((i) => i.id));
+		while (true) {
+			const result = await ctx.storage.items.query({ limit: 100 });
+			if (result.items.length === 0) break;
+			await ctx.storage.items.deleteMany(result.items.map((item) => item.id));
+		}
 	}
 },
 ```
@@ -174,12 +195,13 @@ Runs after content is successfully saved. Use for side effects like notification
 
 ```typescript
 "content:afterSave": async (event, ctx) => {
-	ctx.log.info(`${event.isNew ? "Created" : "Updated"} ${event.collection}/${event.content.id}`);
+	const contentId = String(event.content.id);
+	ctx.log.info(`${event.isNew ? "Created" : "Updated"} ${event.collection}/${contentId}`);
 
 	if (ctx.http) {
 		await ctx.http.fetch("https://api.example.com/webhook", {
 			method: "POST",
-			body: JSON.stringify({ event: "content:save", id: event.content.id }),
+			body: JSON.stringify({ event: "content:save", id: contentId }),
 		});
 	}
 },
@@ -201,7 +223,9 @@ Runs before content is deleted. Return `false` to cancel; `true` or `void` allow
 },
 ```
 
-**Event:** `{ id, collection }` — **Returns:** `boolean | void`
+**Event:** `{ id, collection, permanent: false }` — **Returns:** `boolean | void`
+
+This hook runs before an entry is moved to trash. Removing an entry permanently from trash does not run `content:beforeDelete` again.
 
 ### `content:afterDelete`
 
@@ -213,7 +237,7 @@ Runs after content is successfully deleted.
 },
 ```
 
-**Event:** `{ id, collection }` — **Returns:** `Promise<void>`
+**Event:** `{ id, collection, permanent }` — **Returns:** `Promise<void>`. `permanent` is `false` when the entry was moved to trash and `true` when the entry was removed permanently.
 
 ### `content:afterPublish`
 
@@ -312,6 +336,20 @@ Contributes typed metadata to `<head>` — meta tags, OpenGraph properties, allo
 		canonical: string | null;
 		image: string | null;
 		content?: { collection: string; id: string; slug: string | null };
+		seo?: {
+			ogTitle?: string | null;
+			ogDescription?: string | null;
+			ogImage?: string | null;
+			robots?: string | null;
+		};
+		articleMeta?: {
+			publishedTime?: string | null;
+			modifiedTime?: string | null;
+			author?: string | null;
+		};
+		siteName?: string;
+		breadcrumbs?: Array<{ name: string; url: string }>;
+		siteUrl?: string;
 	}
 }
 ```
@@ -324,7 +362,7 @@ Contributes typed metadata to `<head>` — meta tags, OpenGraph properties, allo
 | ---------- | -------------------------------------------------- | ----------------------------------------------------- |
 | `meta`     | `<meta name="..." content="...">`                  | `key` or `name`                                       |
 | `property` | `<meta property="..." content="...">`              | `key` or `property`                                   |
-| `link`     | `<link rel="canonical\|alternate" href="...">`     | canonical: singleton; alternate: `key` or `hreflang`  |
+| `link`     | `<link rel="<allowed value>" href="...">`           | canonical: singleton; alternate: `key` or `hreflang`  |
 | `jsonld`   | `<script type="application/ld+json">`              | `id` (if present)                                     |
 
 First contribution wins for any dedupe key. `<EmDashHead>` composes contributions in the order plugins → site settings → template-provided base metadata, so plugin contributions override everything below them. On content pages, the entry's SEO panel values are folded into the page context before the base metadata is generated — they replace the template-provided fields (and are what your hook sees on the page context), while plugin contributions still win via first-wins dedup. Link `rel` is restricted to a security-locked allowlist (`canonical`, `alternate`, `author`, `license`, `nlweb`, `site.standard.document`); `href` must be HTTP or HTTPS.
@@ -337,7 +375,7 @@ Sandboxed plugins can't use this hook because its output runs as first-party cod
 
 ## Hook execution order
 
-Hooks run in this order:
+When a sandboxed-format plugin runs in process, hooks use the shared hook pipeline:
 
 1. Hooks with lower `priority` values run first.
 2. For equal priorities, hooks run in plugin registration order.
@@ -358,30 +396,22 @@ Hooks run in this order:
 }
 ```
 
+An isolated sandbox runner invokes active sandboxed plugins in load order. Keep hooks independent: do not require one sandboxed plugin to run before another.
+
 ## Error handling
 
-When a hook throws or times out:
+Sandboxed hook failures depend on when the hook runs:
 
-- **`errorPolicy: "abort"`** — the entire pipeline stops and the originating operation may fail.
-- **`errorPolicy: "continue"`** — the error is logged and remaining hooks still run.
+- A thrown `content:beforeSave` error fails the save with `CONTENT_HOOK_ERROR`. Return the documented `SAVE_REJECTED` envelope when the editor should see a specific validation reason.
+- Returning `false` from `content:beforeDelete` stops the move to trash. If that hook throws, EmDash logs the error and continues the deletion.
+- Content after-hooks run after the operation succeeds. Their errors are logged and cannot roll the operation back.
+- Lifecycle, media, email, and comment hooks follow the contract of their originating operation. Use the [Hook reference](/reference/hooks/) to check a specific return value before relying on failure behavior.
 
-```typescript
-"content:afterSave": {
-	timeout: 5000,
-	errorPolicy: "continue",
-	handler: async (event, ctx) => {
-		await ctx.http!.fetch("https://unreliable-api.com/notify");
-	},
-},
-```
-
-<Aside type="tip">
-	`errorPolicy: "continue"` is right for analytics, notifications, and external syncs — the originating save still succeeds even if your hook fails.
-</Aside>
+An in-process plugin can use `errorPolicy: "abort"` or `"continue"` in the full config form. That setting is not a portable recovery control for an isolated sandboxed plugin.
 
 ## Timeouts
 
-Hooks default to 5000ms. Bump the timeout for slower work:
+The in-process hook pipeline defaults to 5,000 ms and accepts a longer `timeout` in the full config form:
 
 ```typescript
 "content:afterSave": {
@@ -393,7 +423,10 @@ Hooks default to 5000ms. Bump the timeout for slower work:
 ```
 
 <Aside type="caution">
-	The configured `timeout` is enforced at the EmDash runner level. The sandbox runner may also enforce its own resource limits (CPU, subrequests, wall-clock) that can terminate a hook before its `timeout` fires. See [Capabilities and security](/plugins/creating-plugins/capabilities/).
+	Isolated runners use their own invocation limit instead of this hook value. The supplied Cloudflare
+	and Node.js runners default to 30 seconds of wall time, and the Cloudflare runner can stop work sooner
+	when it reaches its CPU or subrequest limit. See [Capabilities and
+	security](/plugins/creating-plugins/capabilities/).
 </Aside>
 
 ## Hook reference
@@ -406,8 +439,8 @@ Hooks default to 5000ms. Bump the timeout for slower work:
 | `plugin:uninstall`       | Plugin removed                | `void`                               | No        |
 | `content:beforeSave`     | Before content save           | Modified content, rejection envelope, or `void` | No        |
 | `content:afterSave`      | After content save            | `void`                               | No        |
-| `content:beforeDelete`   | Before content delete         | `false` to cancel, else allow        | No        |
-| `content:afterDelete`    | After content delete          | `void`                               | No        |
+| `content:beforeDelete`   | Before content moves to trash | `false` to cancel, else allow        | No        |
+| `content:afterDelete`    | After trash or permanent delete | `void`                             | No        |
 | `content:afterPublish`   | After content publish         | `void`                               | No        |
 | `content:afterUnpublish`  | After content unpublish       | `void`                               | No        |
 | `content:afterRestore`    | After content restore         | `void`                               | No        |

--- a/docs/src/content/docs/plugins/creating-plugins/manifest.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/manifest.mdx
@@ -1,15 +1,15 @@
 ---
 title: The plugin manifest
-description: Reference for emdash-plugin.jsonc — identity, trust contract, profile fields, and publisher pinning.
+description: Reference for emdash-plugin.jsonc identity, access, storage, admin UI, and registry fields.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-Every sandboxed plugin has an `emdash-plugin.jsonc` next to its `package.json`. It is hand-edited and holds the plugin's identity, its trust contract (capabilities, hosts, storage), and the profile fields the registry shows. `emdash-plugin init` scaffolds one; the CLI reads `./emdash-plugin.jsonc` automatically for `build`, `dev`, `validate`, `bundle`, and `publish`.
+Every sandboxed plugin has an `emdash-plugin.jsonc` file in its root directory. It sits next to `package.json` when the plugin is also an npm package. The manifest identifies the plugin, declares the access and storage it needs, and supplies information for its registry listing and releases. The plugin CLI reads it when validating, building, bundling, publishing, and preparing automated releases.
 
-The file is **JSONC**: comments and trailing commas are allowed.
+The file uses JSON with Comments (JSONC), so comments and trailing commas are valid. Keep the `$schema` property created by `emdash-plugin init`; editors use the generated schema for completion, while `emdash-plugin validate` performs the complete check.
 
-The following example shows a complete manifest for an image-gallery plugin:
+The following example includes each group of fields:
 
 ```jsonc title="emdash-plugin.jsonc"
 {
@@ -21,173 +21,191 @@ The following example shows a complete manifest for an image-gallery plugin:
 	"license": "MIT",
 	"author": { "name": "Jane Doe", "url": "https://example.com" },
 	"security": { "email": "security@example.com" },
-
-	// Optional profile
 	"name": "Gallery",
-	"description": "Image gallery block for EmDash.",
+	"description": "Image galleries for EmDash content.",
 	"keywords": ["gallery", "images"],
-	"repo": "https://github.com/example/plugin-gallery",
+	"sections": {
+		"installation": { "file": "./docs/installation.md" },
+		"faq": { "file": "./docs/faq.md" },
+	},
 
-	// Trust contract
 	"capabilities": ["content:read"],
 	"allowedHosts": [],
-	"storage": {}
+	"storage": {
+		"galleries": { "indexes": ["contentId"] },
+	},
+
+	"admin": {
+		"pages": [{ "path": "/gallery", "label": "Gallery", "icon": "image" }],
+	},
+
+	"repo": "https://github.com/example/plugin-gallery",
+	"release": {
+		"requires": { "env:emdash": ">=0.37.0" },
+		"artifacts": {
+			"icon": { "file": "./images/icon.png" },
+			"screenshots": [{ "file": "./images/editor.png", "lang": "en" }],
+		},
+	},
 }
 ```
 
-<Aside type="tip" title="$schema gives you IDE completion">
-	The bundled JSON Schema drives hover hints and validation in editors that
-	honour `$schema` (VS Code, JetBrains). Keep the `$schema` line; the CLI
-	strips it before validating. The editor check is looser than
-	`emdash-plugin validate`, which is the authoritative check.
-</Aside>
+## Identity and version
 
-## Identity
+| Field | Required | Rules |
+| --- | --- | --- |
+| `slug` | Yes | Starts with a lowercase letter, then uses lowercase letters, digits, `-`, or `_`; maximum 64 characters. |
+| `publisher` | Yes | Atmosphere account DID or handle. A DID is recommended because handles can change owners. |
+| `version` | Sometimes | Semver 2.0 without build metadata. Omit it when `package.json` supplies the version. |
 
-| Field       | Required | Notes                                                                                          |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `slug`      | Yes      | URL-safe id within the publisher's namespace. `/^[a-z][a-z0-9_-]*$/`, max 64 chars. |
-| `publisher` | Yes      | Your [Atmosphere account](/plugins/creating-plugins/publishing/#your-atmosphere-account)'s DID or handle. See [Publisher pinning](#publisher-pinning). |
-| `version`   | No       | Semver 2.0 without build-metadata. Usually omit it — see below.                                |
+The publisher and slug identify the package in the registry. The slug is also used in plugin route URLs, so it is not the npm package name: use `gallery` for a package such as `@example/plugin-gallery`.
 
-`slug` and `publisher` together are the package's identity. EmDash derives the package's full identifier from them automatically.
+### Keep one version value
 
-### `version` lives in `package.json`
+The build reconciles `version` with `package.json#version`:
 
-The build reconciles the manifest's `version` against `package.json#version`:
+- If both files set the version, the values must match.
+- If one file sets the version, the build uses it.
+- If neither file sets the version, the build fails.
 
-- Both set and equal → fine.
-- Both set and different → hard error.
-- One set → that value wins.
-- Neither set → hard error.
+For an npm package, keep the version in `package.json` and omit it from the manifest. A registry-only plugin without `package.json` must set `version` in the manifest.
 
-The recommended pattern for an npm-distributed plugin is to **omit `version` from the manifest** and let `package.json` be the single source of truth (your release tooling already bumps it there). Registry-only plugins with no `package.json` must set `version` in the manifest — there is nowhere else for it to live.
+## Package profile
 
-## Profile
+The package profile supplies the stable information shown across releases.
 
-These feed the registry listing. `license`, an author (`author` or `authors`), and a security contact (`security` or `securityContacts`) are required; the rest are optional.
+| Field | Required | Rules |
+| --- | --- | --- |
+| `license` | Yes | Non-empty SPDX expression, up to 256 characters. |
+| `author` or `authors` | Yes | Use one form. `author` has `name` and optional `url` or `email`; `authors` accepts 1–32 entries. |
+| `security` or `securityContacts` | Yes | Use one form. Each contact must contain an `email`, a `url`, or both; the list accepts 1–8 entries. |
+| `name` | No | Display name, up to 1,024 characters. The slug is used when this is absent. |
+| `description` | No | Short description, up to 1,024 characters. Keep it near the 140-grapheme registry convention so lists do not need to truncate it. |
+| `keywords` | No | Up to five non-empty strings, each no longer than 128 characters. |
+| `sections` | No | Long-form CommonMark sections for `description`, `installation`, `faq`, `changelog`, and `security`. |
 
-| Field                      | Required | Notes                                                              |
-| -------------------------- | -------- | ------------------------------------------------------------------ |
-| `license`                  | Yes      | SPDX expression (`"MIT"`, `"Apache-2.0"`, `"MIT OR Apache-2.0"`). Used on first publish; the existing profile wins on later publishes. |
-| `author` / `authors`       | Yes      | One of the two. `author: { name, url?, email? }` for a single author; `authors: [...]` (≤ 32) for several. Setting both is an error. |
-| `security` / `securityContacts` | Yes | One of the two. Each contact needs at least one of `email` or `url`. `securityContacts: [...]` (≤ 8) for several. Setting both is an error. |
-| `name`                     | No       | Display name. Defaults to the slug.                                |
-| `description`              | No       | Keep it short (around 140 characters). Long values may be truncated in lists. |
-| `keywords`                 | No       | ≤ 5 entries.                                                       |
-| `repo`                     | No       | `https://` URL of the source repository. [Automated releases](/plugins/creating-plugins/delegated-releases/) require a canonical public GitHub URL; setup asks for it when omitted. |
+Each section can be an inline string or a file reference relative to the manifest:
 
-Use the singular `author` / `security` form unless you genuinely have multiple — it is the common case and the scaffold emits it.
+```jsonc title="emdash-plugin.jsonc"
+"sections": {
+	"description": "A longer description written in CommonMark.",
+	"installation": { "file": "./docs/installation.md" },
+	"security": { "file": "./SECURITY.md" },
+}
+```
+
+Each resolved section is limited to 20,000 bytes and 2,000 graphemes. A file reference must remain inside the manifest directory; absolute paths and `..` paths that escape it are rejected.
+
+`publish` creates the package profile on the first release. Later releases do not replace its profile fields. Edit a published profile with `emdash-plugin update-package`: the command previews the changes by default and writes them only with `--yes`.
 
 ## Trust contract
 
-The trust contract is `capabilities`, `allowedHosts`, and `storage`. All three default to empty, so a plugin that needs no extra privileges can omit them entirely.
+The trust contract consists of `capabilities`, `allowedHosts`, and `storage`. These fields tell an operator what the plugin can access and which plugin-owned collections it creates.
 
-```jsonc
-{
-	"capabilities": ["network:request", "content:read"],
-	"allowedHosts": ["api.example.com", "*.cdn.example.com"],
-	"storage": {
-		"events": { "indexes": ["timestamp"] },
-		"submissions": { "indexes": ["email"], "uniqueIndexes": ["token"] }
-	}
+The following declaration permits content reads, permits requests to one API and its subdomains, and creates one storage collection:
+
+```jsonc title="emdash-plugin.jsonc"
+"capabilities": ["content:read", "network:request"],
+"allowedHosts": ["api.example.com", "*.cdn.example.com"],
+"storage": {
+	"events": {
+		"indexes": ["savedAt", ["collection", "savedAt"]],
+		"uniqueIndexes": ["eventId"],
+	},
 }
 ```
 
-<Aside type="caution" title="Changing the trust contract requires a version bump">
-	Installed sites consented to the capabilities, hosts, and storage of the
-	version they have. Changing any of these without bumping `version` would
-	let new behaviour slip past that consent. Bump **major** for a broadened
-	trust contract.
-</Aside>
+### Capabilities and hosts
 
-### Capabilities
+All three fields default to empty. The scaffold writes the empty values explicitly so a reviewer can see that the plugin asks for no additional access or collections.
 
-The recognised names:
-
-| Capability                          | Grants                                              |
-| ----------------------------------- | --------------------------------------------------- |
-| `content:read` / `content:write`    | Read / mutate site content via `ctx`.               |
-| `taxonomies:read`                   | Read taxonomy definitions and terms (read-only).    |
-| `media:read` / `media:write`        | Read / write media.                                 |
-| `users:read`                        | Read user records.                                  |
-| `email:send`                        | Send email via `ctx`.                               |
-| `network:request`                   | Outbound HTTP via `ctx.http`, restricted to `allowedHosts`. |
-| `network:request:unrestricted`      | Outbound HTTP to any host. Used instead of `network:request`. |
-| `hooks.email-transport:register`    | Register an email transport hook.                   |
-| `hooks.email-events:register`       | Register email lifecycle hooks.                     |
-| `hooks.page-fragments:register`     | Register a `page:fragments` hook (native only).     |
-
-Two cross-field rules the CLI enforces (the editor's JSON-Schema check does not — run `emdash-plugin validate`):
-
-- `network:request` **requires** a non-empty `allowedHosts`. If the plugin really must reach any host, use `network:request:unrestricted` instead.
-- `network:request:unrestricted` **requires** `allowedHosts` to be empty — the unrestricted capability already grants every host, so a list would contradict it.
-
-Host patterns are bare hostnames (no scheme, path, or whitespace). A leading `*.` allows subdomains: `*.cdn.example.com`.
+`network:request` requires at least one bare hostname in `allowedHosts`. `network:request:unrestricted` requires an empty list because it deliberately permits any public host. [Capabilities and security](/plugins/creating-plugins/capabilities/) is the canonical reference for every capability, its implications, host patterns, and runtime enforcement.
 
 ### Storage
 
-A map of collection name → index config. Collection names follow the same `/^[a-z][a-z0-9_]*$/` rule (the runtime uses the name as a SQL table suffix). Indexes are field names or composite arrays; `uniqueIndexes` are queryable too — don't also list them in `indexes`.
+Each key in `storage` names one plugin-owned collection. Its `indexes` and `uniqueIndexes` determine which fields the plugin can filter or order by. [Storage](/plugins/creating-plugins/storage/) explains collection names, index design, queries, and pagination.
 
-```jsonc
-"storage": {
-	"events": { "indexes": ["timestamp", ["collection", "timestamp"]] }
-}
-```
+Changing any part of the trust contract requires a new plugin version because installed sites consented to the earlier declaration. Use a major version for a broadened contract.
 
-## Admin surface
+## Admin pages and widgets
 
-Optional. Sandboxed plugins render admin pages and dashboard widgets through [Block Kit](/plugins/creating-plugins/block-kit/); the manifest only declares where they appear. Omit the `admin` key entirely if the plugin has no admin UI.
+Sandboxed plugins render admin pages and dashboard widgets with [Block Kit](/plugins/creating-plugins/block-kit/). The manifest declares where they appear:
 
-```jsonc
+```jsonc title="emdash-plugin.jsonc"
 "admin": {
-	"pages": [{ "path": "/gallery", "label": "Gallery", "icon": "image" }],
-	"widgets": [{ "id": "recent-uploads", "title": "Recent uploads", "size": "half" }]
+	"pages": [{ "path": "/settings", "label": "Settings", "icon": "settings" }],
+	"widgets": [{ "id": "recent-events", "title": "Recent events", "size": "half" }],
 }
 ```
 
-A plugin that declares `admin.pages` or `admin.widgets` must also serve an `admin` route in `src/plugin.ts` that renders the Block Kit content — the schema can't enforce that (route names are probed from source, not the manifest), but the runtime checks it.
+Page paths begin with `/` and contain letters, digits, `/`, `_`, or `-`. Widget IDs use the same lowercase identifier characters as plugin slugs. Widget sizes are `full`, `half`, or `third`.
+
+A plugin that declares a page or widget must define a route named `admin` in `src/plugin.ts`. The bundle check fails if that route is missing because EmDash would have nothing to call for the Block Kit response.
+
+## Release fields
+
+`release` describes a particular version. The top-level `repo` URL is written into release records and is also used by automated-release setup to bind the package profile to its GitHub repository.
+
+| Field | Purpose |
+| --- | --- |
+| `repo` | HTTPS URL of the source repository. Automated release setup requires a canonical public GitHub repository URL. |
+| `release.requires` | Host requirements keyed by `env:<name>` or a package DID, with semver ranges as values. |
+| `release.artifacts.icon` | Image shown as the release icon. |
+| `release.artifacts.banner` | Banner image for the release listing. |
+| `release.artifacts.screenshots` | Ordered screenshot gallery with up to eight entries. |
+
+Use `env:emdash` and `env:astro` to set the EmDash and Astro version ranges that can install the release:
+
+```jsonc title="emdash-plugin.jsonc"
+"release": {
+	"requires": {
+		"env:emdash": ">=0.37.0",
+		"env:astro": ">=5.0.0 <7.0.0",
+	},
+}
+```
+
+EmDash checks these requirements before installation. An invalid range fails manifest validation; an incompatible release is not installed.
+
+Artifact file paths are relative to the manifest and must remain inside its directory. PNG, JPEG, and WebP are supported. Each file is limited to 1 MiB and 8,192 pixels in either dimension. An optional `lang` property identifies a localized image with a BCP 47 language tag. Publishing uploads these files separately from the plugin bundle and records their measured type, dimensions, checksum, and personal data server (PDS) blob reference.
 
 ## Publisher pinning
 
-`publisher` pins the publishing identity so you can't accidentally publish a plugin under the wrong account.
-
-On your **first successful publish**, if the manifest's `publisher` matches the active session, it stays as written. If you scaffolded with `emdash-plugin init` and left it blank, the CLI writes the active session's DID back into the manifest.
-
-The following example shows the line the CLI writes, with the resolved handle added as a comment for readability:
+`publisher` prevents an accidental publish from the wrong Atmosphere account. Prefer the account's DID:
 
 ```jsonc title="emdash-plugin.jsonc"
 "publisher": "did:plc:abc123def456", // jane.example.com
 ```
 
-On **every subsequent publish**, the CLI resolves the active session and the pinned `publisher` to DIDs and compares them. A mismatch fails immediately with `MANIFEST_PUBLISHER_MISMATCH` — there is no override flag. Resolve it deliberately:
+Before publishing or preparing automated releases, the CLI compares the manifest publisher with the active session. A handle is resolved to its current DID for the comparison. A mismatch fails with `MANIFEST_PUBLISHER_MISMATCH`; there is no override flag.
 
-- Wrong session: `emdash-plugin switch <did>`, then publish again.
-- Genuinely transferring the plugin to a new publisher: edit `publisher` in the manifest.
-
-<Aside type="note" title="Prefer a DID over a handle">
-	You can pin a handle (`"publisher": "example.com"`) instead of a DID. The
-	CLI resolves it to a DID before comparing, so it works as a friendlier
-	alias. Handles can change owners, though: if the handle later points
-	somewhere else, publishing refuses. Pin a `did:plc:...` for long-lived
-	plugins.
-</Aside>
-
-## Validate without publishing
+If the wrong session is active, run `emdash-plugin whoami`, then switch to the pinned account:
 
 ```sh
-emdash-plugin validate          # ./emdash-plugin.jsonc
-emdash-plugin validate path/    # a specific directory
+emdash-plugin switch did:plc:abc123def456
 ```
 
-Offline schema check with `tsc`-style `file:line:column` diagnostics, including the cross-field rules. Suitable for a pre-commit hook or CI step. Duplicate keys and unknown keys are errors (strict mode catches `"licens"` typos).
+Change the manifest publisher only when transferring the package to another account.
 
-## CLI flags still win
+<Aside type="caution" title="A handle is a mutable pin">
+	A handle can move to another DID. If that happens, the CLI resolves the new owner and refuses to
+	publish from the original account. A DID remains stable when the account changes its handle.
+</Aside>
 
-Explicit flags (`--license`, `--author-name`, …) override manifest values when both are set — useful for CI overrides. `--no-manifest` skips the manifest entirely (and warns if one exists at the default path, so the publisher-pin safety story stays visible).
+## Validate the manifest
 
-## Next
+Validate the manifest before building or publishing:
 
-- [The `emdash-plugin` CLI](/plugins/creating-plugins/cli/)
-- [Bundling and publishing](/plugins/creating-plugins/publishing/)
-- [Capabilities and security](/plugins/creating-plugins/capabilities/)
+```sh
+emdash-plugin validate
+```
+
+Pass a file or directory to validate a different manifest:
+
+```sh
+emdash-plugin validate ./packages/plugin-gallery
+```
+
+Validation is offline. It reports duplicate properties, unknown fields, invalid values, mutually exclusive forms, and cross-field errors such as `network:request` without a non-empty `allowedHosts` list.
+
+Continue with [the plugin CLI](/plugins/creating-plugins/cli/) for build commands or [Bundling and publishing](/plugins/creating-plugins/publishing/) for the release flow.

--- a/docs/src/content/docs/plugins/creating-plugins/migrating-to-the-cli.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/migrating-to-the-cli.mdx
@@ -33,6 +33,29 @@ pnpm add -D @emdash-cms/plugin-cli
 
 Replace `emdash-registry` with `emdash-plugin` everywhere you call it. Every subcommand keeps its name (`bundle`, `publish`, `login`, `whoami`, `switch`, `validate`), and `init`, `build`, and `dev` are added. See [The plugin CLI](/plugins/creating-plugins/cli/).
 
+### Renamed: capability names use resource-first spelling
+
+Earlier manifests used capability names such as `read:content` and `network:fetch`. The authoring manifest accepts only the current names, although the runtime still normalizes legacy names in already-published bundles during the compatibility window.
+
+#### What should I do?
+
+Replace every legacy name in the manifest:
+
+| Earlier name | Current name |
+| --- | --- |
+| `network:fetch` | `network:request` |
+| `network:fetch:any` | `network:request:unrestricted` |
+| `read:content` | `content:read` |
+| `write:content` | `content:write` |
+| `read:media` | `media:read` |
+| `write:media` | `media:write` |
+| `read:users` | `users:read` |
+| `email:provide` | `hooks.email-transport:register` |
+| `email:intercept` | `hooks.email-events:register` |
+| `page:inject` | `hooks.page-fragments:register` |
+
+Use `network:request` with a non-empty `allowedHosts` list. Use `network:request:unrestricted` with an empty list only when an operator chooses the destination at runtime. [Capabilities and security](/plugins/creating-plugins/capabilities/) explains the current permissions and network rules.
+
 ### Changed: sandboxed plugins are defined with `satisfies SandboxedPlugin`
 
 Earlier releases wrapped the plugin's hooks and routes in `definePlugin()` imported from `emdash`, with each handler's parameters annotated by hand.
@@ -166,11 +189,11 @@ These are removed. They were helper aliases for the previous `definePlugin` shap
 
 Use `SandboxedPlugin` from `emdash/plugin` for the same purpose. A sandboxed plugin's default export is already typed by its `satisfies SandboxedPlugin` annotation, so there is no replacement for `isStandardPluginDefinition`; identify a plugin by its structure (`{ hooks?, routes? }`) if you need to.
 
-### Renamed: the runtime `SandboxedPlugin` type is now `SandboxedPluginInstance`
+### Renamed: sandbox-runner handles use `SandboxedPluginInstance`
 
 This affects only authors of a custom `SandboxRunner`, such as `@emdash-cms/cloudflare`. Most plugin authors can skip it.
 
-`SandboxedPlugin` from `emdash` now refers to the author-facing source shape. The runtime handle returned by `SandboxRunner.load` is `SandboxedPluginInstance`.
+The author-facing `SandboxedPlugin` type is available only from the type-only `emdash/plugin` entry point. The runtime handle returned by `SandboxRunner.load` is exported from `emdash` as `SandboxedPluginInstance`.
 
 #### What should I do?
 
@@ -199,7 +222,20 @@ export default defineConfig({
 });
 ```
 
-If your plugin accepted configuration through its factory, that configuration moves to the admin UI's plugin settings. Read it at runtime through `ctx.kv` or settings instead. See [Settings](/plugins/creating-plugins/settings/).
+If your plugin accepted configuration through its factory, move that configuration to an admin settings page and read it from `ctx.kv`. Sandboxed plugin descriptors are plain objects and cannot receive constructor options. See [Settings](/plugins/creating-plugins/settings/).
+
+## Verify the migrated plugin
+
+Run the plugin's tests, validate the authoring manifest, and execute the complete build and bundle checks:
+
+```sh
+pnpm test
+pnpm exec emdash-plugin validate
+pnpm exec emdash-plugin build
+pnpm exec emdash-plugin bundle --validate-only
+```
+
+Then install the local package into a development site and exercise each migrated hook and route. The build can confirm their names and shapes, but it cannot confirm that a route returns the intended data or that a hook preserves content correctly.
 
 ## Next
 

--- a/docs/src/content/docs/plugins/creating-plugins/publishing.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/publishing.mdx
@@ -24,7 +24,7 @@ Publish directly from the CLI, or use the [automated release service](/plugins/c
 
 ## Choose a publishing method
 
-Both methods create the same signed package and release records. Choose where the release build should run.
+Both methods create publisher-owned package and release records. Choose where the release build should run and which credential should authorize it.
 
 | Method | Use it when | Account access |
 | --- | --- | --- |
@@ -66,9 +66,7 @@ emdash-plugin login alice.example.com
 emdash-plugin publish
 ```
 
-`publish` runs the same build and validation checks as `bundle`, creates the gzip archive, uploads it to your Personal Data Server (PDS), uploads any declared listing images, and writes the release record.
-
-Sites need a version of EmDash that supports PDS-hosted registry artifacts before they can install a blob-only release. Use the [external package URL](#use-an-external-package-url) path when the release must remain installable on older sites.
+`publish` runs the same build and validation checks as `bundle`, creates the gzip archive, uploads it to your personal data server (PDS), uploads any declared listing images, and writes the release record.
 
 ## Bundle
 
@@ -93,8 +91,8 @@ emdash-plugin bundle [--dir <path>] [--out-dir|-o <path>] [--validate-only]
 | `manifest.json` | Yes      | Generated manifest: id, version, capabilities, hosts, and the hooks and routes read from your source. You do not maintain this by hand. |
 | `backend.js`    | Yes      | The built, self-contained runtime file (`dist/plugin.mjs`). |
 | `README.md`     | No       | Plugin documentation.                                        |
-| `icon.png`      | No       | 256×256 PNG.                                                 |
-| `screenshots/`  | No       | Up to 5, max 1920×1080.                                       |
+| `icon.png`      | No       | Conventional bundle icon. Must be a readable PNG; 256×256 is recommended. |
+| `screenshots/`  | No       | Up to eight `.png`, `.jpg`, or `.jpeg` files; 1920×1080 or smaller is recommended. |
 
 ### Validation
 
@@ -103,8 +101,8 @@ emdash-plugin bundle [--dir <path>] [--out-dir|-o <path>] [--validate-only]
 - **Size caps (RFC 0001, decompressed):** total ≤ 256 KB, per-file ≤ 128 KB, ≤ 20 files. The gzipped tarball is a fraction of that.
 - **No Node built-ins in `backend.js`** — sandbox code can't import `fs`, `path`, `child_process`, etc. Use Web APIs, or move that logic to a native plugin.
 - **Capability sanity** — names must be in the recognised set.
-- **Trust-contract coherence** — the `network:request` / `allowedHosts` cross-rules from [the manifest](/plugins/creating-plugins/manifest/#capabilities).
-- **Asset limits** — icon 256×256, ≤ 5 screenshots at ≤ 1920×1080.
+- **Trust-contract coherence** — the `network:request` / `allowedHosts` cross-rules from [Capabilities and hosts](/plugins/creating-plugins/manifest/#capabilities-and-hosts).
+- **Conventional bundle assets** — an unreadable `icon.png` or screenshot is skipped. The CLI warns when the icon is not 256×256 or a screenshot exceeds 1920×1080, but dimensions alone do not fail the bundle. Every included file still counts toward the file and decompressed-size caps.
 
 To inspect the tarball before publishing, list its contents:
 
@@ -138,6 +136,8 @@ The following manifest block adds listing images. Paths are relative to `emdash-
 }
 ```
 
+Manifest-declared listing images are separate from the conventional `icon.png` and `screenshots/` files included in the tarball. Publishing uploads each declared image to the publisher's PDS and writes its blob reference into the release record. Each image is limited to 1 MiB and 8,192 pixels in either dimension; a release can declare up to eight screenshots. See [Release fields](/plugins/creating-plugins/manifest/#release-fields) for the complete shape.
+
 What `publish` does:
 
 <Steps>
@@ -170,9 +170,16 @@ emdash-plugin publish \\
   --local dist/gallery-1.0.0.tar.gz
 ```
 
-### Versions are immutable
+### Versions are immutable by default
 
-A published version cannot be overwritten or republished. Bump `version` before publishing again. The build reads `version` from `package.json` (see [the manifest reference](/plugins/creating-plugins/manifest/#version-lives-in-packagejson)). Bump **major** for a broadened [trust contract](/plugins/creating-plugins/manifest/#trust-contract), **minor** for new hooks or routes, and **patch** for fixes.
+`emdash-plugin publish` refuses to replace an existing release at the same slug and version. Bump `version` before publishing again. The build reads `version` from `package.json` (see [Keep one version value](/plugins/creating-plugins/manifest/#keep-one-version-value)). Bump **major** for a broadened [trust contract](/plugins/creating-plugins/manifest/#trust-contract), **minor** for new hooks or routes, and **patch** for fixes.
+
+<Aside type="caution" title="Overwriting can trigger a takedown">
+	The direct CLI exposes `--allow-overwrite` as a recovery option, but changing a release record at
+	an existing version breaks the registry's immutable-release expectation. Aggregators and labelers
+	may treat it as a takedown or replacement event. Automated releases are create-only. Prefer a new
+	version unless you are deliberately repairing a record and have checked the downstream effect.
+</Aside>
 
 ### Publisher mismatch
 

--- a/docs/src/content/docs/plugins/creating-plugins/settings.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/settings.mdx
@@ -1,17 +1,15 @@
 ---
 title: Settings
-description: Per-plugin configuration through the KV store, exposed in the admin UI as a Block Kit page.
+description: Store sandboxed-plugin configuration in KV and edit it through a Block Kit page.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-Sandboxed plugins store their settings in the per-plugin **KV store** and render the editing UI as a [Block Kit](/plugins/creating-plugins/block-kit/) page: you describe the form in JSON and serve it from a route.
+Sandboxed plugins store site-specific settings in their private key-value (KV) store. A Block Kit admin page loads the current values, accepts changes, validates them, and writes them through `ctx.kv`.
 
-Everything happens through the same machinery the plugin already uses for hooks and routes — there's nothing extra to learn.
+## Read and write KV values
 
-## The KV store
-
-Every plugin gets a private key-value store accessible as `ctx.kv` in any hook or route. It's the canonical place for settings and any other small persistent state:
+Every hook and route receives this KV interface on `ctx`:
 
 ```typescript
 interface KVAccess {
@@ -22,73 +20,86 @@ interface KVAccess {
 }
 ```
 
-KV is per-plugin — keys you write are stored under your plugin id and aren't visible to other plugins.
+KV is namespaced by plugin. Two plugins can use the same key without reading or overwriting each other's values.
 
-### Reading and writing
+Use prefixes to separate user settings from internal state and cached values:
+
+| Prefix | Purpose | Example |
+| --- | --- | --- |
+| `settings:` | User-configurable values | `settings:apiKey` |
+| `state:` | Persistent internal state | `state:lastSync` |
+| `cache:` | Reusable computed or remote data | `cache:feed` |
+
+The following calls cover the KV operations:
 
 ```typescript
-// Read
 const enabled = await ctx.kv.get<boolean>("settings:enabled");
-const config = await ctx.kv.get<{ url: string; timeout: number }>("state:config");
-
-// Write
-await ctx.kv.set("settings:lastSync", new Date().toISOString());
-await ctx.kv.set("state:cache", { data: items, expiry: Date.now() + 3600000 });
-
-// Delete
-const deleted = await ctx.kv.delete("state:tempData");
-
-// List by prefix
+await ctx.kv.set("state:lastSync", new Date().toISOString());
+const deleted = await ctx.kv.delete("cache:feed");
 const allSettings = await ctx.kv.list("settings:");
-// → [{ key: "settings:enabled", value: true }, ...]
 ```
 
-### Key naming conventions
+`get` returns `null` when the key does not exist. `list` returns keys without EmDash's internal plugin namespace prefix.
 
-Use prefixes to keep different kinds of values separate. The convention across EmDash plugins:
+## Add a settings page
 
-| Prefix      | Purpose                       | Example           |
-| ----------- | ----------------------------- | ----------------- |
-| `settings:` | User-configurable preferences | `settings:apiKey` |
-| `state:`    | Internal plugin state         | `state:lastSync`  |
-| `cache:`    | Cached data                   | `cache:results`   |
+Declare the page in `emdash-plugin.jsonc` so it appears in the plugin's admin navigation:
 
-```typescript
-// Clear prefixes
-await ctx.kv.set("settings:webhookUrl", url);
-await ctx.kv.set("state:lastRun", timestamp);
-await ctx.kv.set("cache:feed", feedData);
-
-// Avoid bare keys
-await ctx.kv.set("url", url);
+```jsonc title="emdash-plugin.jsonc"
+"admin": {
+	"pages": [{ "path": "/settings", "label": "Settings", "icon": "settings" }],
+}
 ```
 
-## Settings UI in Block Kit
+The plugin must also provide a private route named `admin`. EmDash sends `page_load` when the page opens and `form_submit` when the user submits the form.
 
-Sandboxed plugins describe their settings page as Block Kit. The admin sends a `page_load` interaction to a route on your plugin (conventionally `routes.admin`), and the plugin returns a JSON description of the form. When the user clicks Save, the admin sends a `block_action` or `form_submit` interaction back; the plugin writes to KV and returns updated blocks.
+Add `@emdash-cms/blocks` and `zod` to use the response type and validate interactions:
+
+```sh
+pnpm add @emdash-cms/blocks zod
+```
+
+The following route loads three values and writes only validated form fields:
 
 ```typescript title="src/plugin.ts"
+import type { BlockResponse } from "@emdash-cms/blocks";
 import type { PluginContext, SandboxedPlugin } from "emdash/plugin";
+import { z } from "zod";
 
-interface BlockInteraction {
-	type: "page_load" | "block_action" | "form_submit";
-	page?: string;
-	action_id?: string;
-	values?: Record<string, unknown>;
-}
+const interactionSchema = z.discriminatedUnion("type", [
+	z.object({ type: z.literal("page_load"), page: z.string() }),
+	z.object({
+		type: z.literal("form_submit"),
+		action_id: z.string(),
+		block_id: z.string().optional(),
+		values: z.object({
+			apiKey: z.string().optional(),
+			enabled: z.boolean(),
+			maxItems: z.number().int().min(1).max(1000),
+		}),
+	}),
+	z.object({
+		type: z.literal("block_action"),
+		action_id: z.string(),
+		block_id: z.string().optional(),
+		value: z.unknown().optional(),
+	}),
+]);
 
 export default {
 	routes: {
 		admin: {
 			handler: async (routeCtx, ctx) => {
-				const interaction = routeCtx.input as BlockInteraction;
+				const parsed = interactionSchema.safeParse(routeCtx.input);
+				if (!parsed.success) return { blocks: [] };
+				const interaction = parsed.data;
 
 				if (interaction.type === "page_load" && interaction.page === "/settings") {
 					return renderSettings(ctx);
 				}
 
 				if (interaction.type === "form_submit" && interaction.action_id === "save") {
-					await saveSettings(ctx, interaction.values ?? {});
+					await saveSettings(ctx, interaction.values);
 					return {
 						...(await renderSettings(ctx)),
 						toast: { message: "Settings saved", type: "success" },
@@ -101,8 +112,8 @@ export default {
 	},
 } satisfies SandboxedPlugin;
 
-async function renderSettings(ctx: PluginContext) {
-	const apiKey = (await ctx.kv.get<string>("settings:apiKey")) ?? "";
+async function renderSettings(ctx: PluginContext): Promise<BlockResponse> {
+	const apiKeyConfigured = (await ctx.kv.get<string>("settings:apiKey")) !== null;
 	const enabled = (await ctx.kv.get<boolean>("settings:enabled")) ?? true;
 	const maxItems = (await ctx.kv.get<number>("settings:maxItems")) ?? 100;
 
@@ -117,7 +128,7 @@ async function renderSettings(ctx: PluginContext) {
 						type: "secret_input",
 						action_id: "apiKey",
 						label: "API key",
-						initial_value: apiKey,
+						has_value: apiKeyConfigured,
 					},
 					{
 						type: "toggle",
@@ -140,63 +151,43 @@ async function renderSettings(ctx: PluginContext) {
 	};
 }
 
-async function saveSettings(ctx: PluginContext, values: Record<string, unknown>) {
-	for (const [key, value] of Object.entries(values)) {
-		if (value !== undefined) {
-			await ctx.kv.set(`settings:${key}`, value);
-		}
-	}
+async function saveSettings(
+	ctx: PluginContext,
+	values: { apiKey?: string; enabled: boolean; maxItems: number },
+) {
+	if (values.apiKey) await ctx.kv.set("settings:apiKey", values.apiKey);
+	await ctx.kv.set("settings:enabled", values.enabled);
+	await ctx.kv.set("settings:maxItems", values.maxItems);
 }
 ```
 
-To wire the settings page into the admin sidebar, declare it in the manifest:
+The submitted values omit the secret until the user edits it, and may contain an empty string if the user focuses and clears the field. `saveSettings` writes a new API key only when the submitted string is non-empty. The page uses `has_value` to show that a saved value exists without returning the value to the browser.
 
-```jsonc title="emdash-plugin.jsonc"
-"admin": {
-	"pages": [{ "path": "/settings", "label": "Settings", "icon": "settings" }]
-}
-```
-
-EmDash routes `page_load` interactions for that path to your `admin` route automatically.
-
-See [Block Kit](/plugins/creating-plugins/block-kit/) for the full set of block types, form fields, conditional fields, and the `@emdash-cms/blocks` builder helpers.
+[Block Kit](/plugins/creating-plugins/block-kit/) is the canonical reference for interactions, blocks, form elements, builders, and conditional fields.
 
 ## Secret values
 
-Block Kit's `secret_input` field renders as a masked input. Treat any value the user enters there with care:
+<Aside type="caution" title="KV does not encrypt secrets">
+	`secret_input` masks the field in the browser. EmDash still serializes a value written with
+	`ctx.kv.set()` as ordinary JSON in the site's database; it does not apply field-level encryption.
+	Database administrators and anyone with a readable backup can recover the value. Do not log it,
+	return it from a route, or put it back into a Block Kit response.
+</Aside>
 
-```typescript
-{
-	type: "secret_input",
-	action_id: "apiKey",
-	label: "API key",
-	// Don't seed initial_value with the real secret — pass an empty string or a sentinel,
-	// and only overwrite when the user enters a non-empty value.
-	initial_value: "",
-}
-```
+Use KV only when that storage model is acceptable for the credential. If a secret must come from a deployment secret store and must not be written to the EmDash database, use a native plugin or an external credential service. Sandboxed plugins cannot read the host process's environment or platform bindings.
 
-When saving, skip empty strings to avoid clearing the existing secret on every save:
+Provide a separate, deliberate action if users need to clear a secret. Treating an empty masked field as deletion can erase a working credential when a user saves an unrelated setting.
 
-```typescript
-async function saveSettings(ctx: PluginContext, values: Record<string, unknown>) {
-	if (typeof values.apiKey === "string" && values.apiKey.length > 0) {
-		await ctx.kv.set("settings:apiKey", values.apiKey);
-	}
-	// ... other fields
-}
-```
+## Default values and upgrades
 
-## Default values
-
-KV reads return `null` for keys that haven't been written. Pass defaults at the read site:
+Apply defaults when reading a key so existing installations receive a new setting without a migration:
 
 ```typescript
 const enabled = (await ctx.kv.get<boolean>("settings:enabled")) ?? true;
 const maxItems = (await ctx.kv.get<number>("settings:maxItems")) ?? 100;
 ```
 
-Or persist defaults during installation:
+You can persist initial values during installation:
 
 ```typescript
 hooks: {
@@ -207,24 +198,17 @@ hooks: {
 },
 ```
 
-The trade-off is that `plugin:install` runs once per install. If you ship a new setting in a later version, only fresh installs see the default — existing installs need either a migration in `plugin:activate` (idempotent: only write if missing) or to keep using the read-time fallback.
+`plugin:install` runs only for a new installation. When a later release adds a setting, existing sites do not run it again. Keep the read-time fallback, or initialize the missing key idempotently during `plugin:activate`.
 
-## Settings vs storage vs KV
+## Choose KV or storage
 
-| Use case                       | Mechanism                                          |
-| ------------------------------ | -------------------------------------------------- |
-| Admin-editable preferences     | `ctx.kv` with `settings:` prefix + Block Kit page  |
-| Internal plugin state          | `ctx.kv` with `state:` prefix                      |
-| Document collections (queries) | `ctx.storage`                                      |
+| Data | Use |
+| --- | --- |
+| Small user-configurable values | `ctx.kv` with a `settings:` prefix |
+| Small internal state or cursors | `ctx.kv` with a `state:` prefix |
+| Queryable records such as submissions or logs | A declared `ctx.storage` collection |
+| Content edited through the regular EmDash editor | A site content collection |
 
-**KV** is for small values keyed by a string — settings, sync cursors, cached computations. No queries, no indexes.
+KV supports direct key access and prefix listing, but it has no field queries or indexes. [Storage](/plugins/creating-plugins/storage/) provides document collections with indexed filtering, ordering, counting, and pagination.
 
-**Storage** is for document collections with indexed queries — form submissions, audit logs, anything where you want to filter, paginate, or count.
-
-## Storage layout
-
-KV values live in the `_options` table with plugin-namespaced keys. Your code uses `settings:apiKey`; EmDash stores it as `plugin:<your-plugin-id>:settings:apiKey`. The prefix is added automatically and prevents one plugin from reading or overwriting another's KV data.
-
-## Native plugins: `settingsSchema`
-
-If you're writing a native plugin (because you need React admin pages or PT components), you can declare a settings schema directly inside `definePlugin()` and let EmDash auto-generate the form. See [Native plugins](/plugins/creating-native-plugins/your-first-native-plugin/) for that path.
+Native plugins can instead declare `admin.settingsSchema` inside `definePlugin()` and let EmDash generate the form. See [Your first native plugin](/plugins/creating-native-plugins/your-first-native-plugin/) for that format.

--- a/docs/src/content/docs/plugins/creating-plugins/storage.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/storage.mdx
@@ -5,7 +5,7 @@ description: Persist plugin data in document collections with indexed queries.
 
 import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
-Sandboxed plugins can store their own data in document collections. You declare collections and indexes in the [manifest](/plugins/creating-plugins/manifest/), and EmDash creates the schema automatically — no migrations to write.
+Sandboxed plugins can store their own records in document collections. Declare each collection and its indexes in the [manifest](/plugins/creating-plugins/manifest/#trust-contract). EmDash creates and updates the matching indexes when the plugin loads.
 
 This page covers sandboxed plugins. The collection API is identical for native plugins; the only difference is that native plugins declare `storage` inside `definePlugin()` rather than in the manifest.
 
@@ -17,6 +17,7 @@ For sandboxed plugins, `storage` lives in `emdash-plugin.jsonc`. The declaration
 {
 	"slug": "forms",
 	// ...identity + profile...
+	"capabilities": ["content:read"],
 
 	"storage": {
 		"submissions": {
@@ -37,8 +38,12 @@ For sandboxed plugins, `storage` lives in `emdash-plugin.jsonc`. The declaration
 
 Each key in `storage` is a collection name. The `indexes` array lists fields that can be queried efficiently — single-field indexes as strings, composite indexes as arrays of strings. See [the manifest reference](/plugins/creating-plugins/manifest/#storage) for the full rules.
 
+Collection names start with a lowercase letter and contain lowercase letters, digits, or underscores. Index field names start with a letter and contain letters, digits, or underscores. Put a unique field or field combination in `uniqueIndexes`; a unique index is already queryable, so do not repeat it in `indexes`.
+
 <Aside type="note">
-	Storage is scoped to the plugin slug. A `submissions` collection in the `forms` plugin is completely separate from `submissions` in another plugin — the plugin can only see its own data.
+	Storage is scoped to the runtime plugin ID. A `submissions` collection in the `forms` plugin is
+	separate from a collection with the same name in another plugin, and each plugin can access only
+	its declared collections.
 </Aside>
 
 ## Using storage at runtime
@@ -72,6 +77,8 @@ export default {
 Accessing a collection that wasn't declared in the manifest throws — the bridge enforces this at the runtime level.
 
 ## Collection API
+
+Each declared collection provides the following read, write, batch, query, and count methods:
 
 ```typescript
 interface StorageCollection<T = unknown> {
@@ -113,11 +120,13 @@ const result = await ctx.storage.submissions.query({
 
 ### Query options
 
+Pass these options to `query()` to filter, order, and page the result:
+
 ```typescript
 interface QueryOptions {
 	where?: WhereClause;
 	orderBy?: Record<string, "asc" | "desc">;
-	limit?: number;     // default 50, max 1000
+	limit?: number;     // default 50, max 100
 	cursor?: string;    // for pagination
 }
 ```
@@ -163,6 +172,8 @@ where: {
 
 ### Ordering
 
+Set one or more indexed fields to ascending or descending order:
+
 ```typescript
 orderBy: { createdAt: "desc" }   // newest first
 orderBy: { score: "asc" }        // lowest first
@@ -197,6 +208,8 @@ async function getAllSubmissions(ctx: PluginContext) {
 
 ## Counting
 
+Count every record in a collection, or only records matching indexed fields:
+
 ```typescript
 const total = await ctx.storage.submissions.count();
 
@@ -206,6 +219,8 @@ const pending = await ctx.storage.submissions.count({
 ```
 
 ## Batch operations
+
+Use the batch methods when one operation reads, writes, or deletes several known record IDs:
 
 ```typescript
 const items = await ctx.storage.submissions.getMany(["sub_1", "sub_2", "sub_3"]);
@@ -228,7 +243,7 @@ Choose indexes based on actual query patterns:
 | Filter by `formId`                       | `"formId"`                           |
 | Filter by `formId`, order by `createdAt` | `["formId", "createdAt"]`            |
 | Order by `createdAt` only                | `"createdAt"`                        |
-| Filter by `status` and `formId`          | `"status"` and `"formId"` (separate) |
+| Filter by `status` and `formId` together | `["status", "formId"]`              |
 
 Composite indexes support queries that filter on the first field and optionally order by the second:
 
@@ -238,6 +253,8 @@ query({ where: { formId: "contact" }, orderBy: { createdAt: "desc" } });  // use
 query({ where: { formId: "contact" } });                                  // uses index (filter only)
 query({ where: { createdAt: { gte: "2024-01-01" } } });                   // does NOT use this composite — filter starts at the wrong field
 ```
+
+Every field named anywhere in `indexes` or `uniqueIndexes` passes the query API's indexed-field check. The order of a composite index still determines which query shapes the database can execute efficiently. Add a separate `"createdAt"` index when the plugin frequently filters or orders by that field without `formId`.
 
 ## Type safety
 
@@ -289,32 +306,16 @@ Pick the right mechanism for each kind of data:
 
 If site editors need to view or edit the data in the admin UI through the regular content editor, create a site collection instead.
 
-## Implementation details
+## How collections are isolated
 
-Plugin storage uses a single namespaced table:
+EmDash stores plugin documents with the plugin ID, collection name, record ID, JSON data, and timestamps. Those namespacing columns are part of every key and index. A plugin receives accessors only for the collections in its manifest, and the sandbox bridge rejects access to any other collection.
 
-```sql
-CREATE TABLE _plugin_storage (
-	plugin_id TEXT NOT NULL,
-	collection TEXT NOT NULL,
-	id TEXT NOT NULL,
-	data JSON NOT NULL,
-	created_at TEXT,
-	updated_at TEXT,
-	PRIMARY KEY (plugin_id, collection, id)
-);
-```
-
-EmDash creates expression indexes for declared fields:
-
-```sql
-CREATE INDEX idx_forms_submissions_formId
-	ON _plugin_storage(json_extract(data, '$.formId'))
-	WHERE plugin_id = 'forms' AND collection = 'submissions';
-```
-
-This design gives you no migrations, portability across SQLite/libSQL/D1, plugin-level isolation, and parameterised queries on every path.
+Declared fields become expression indexes alongside the plugin and collection namespace. EmDash generates the dialect-specific SQL for SQLite, D1, and PostgreSQL; plugin code uses the same collection API on each database.
 
 ## Adding indexes
 
-When you add an index in a plugin update, EmDash creates it automatically on next startup. Adding an index is safe and requires no data migration. When you remove an index, EmDash drops it — and queries on that field start failing with a validation error, which is the intended signal.
+When a plugin update adds an index, EmDash creates it the next time the plugin loads. A unique index cannot be created while existing records contain duplicate values, so check and resolve duplicates before releasing that change.
+
+When an update removes an index, EmDash drops it. Any query or ordering that still uses the field then fails validation. Update the code and manifest together.
+
+Indexes are part of the manifest's storage trust contract. Bump the plugin version whenever you add, remove, or change one, and use a major version when the change breaks an existing query or uniqueness assumption.

--- a/docs/src/content/docs/plugins/creating-plugins/your-first-plugin.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/your-first-plugin.mdx
@@ -1,133 +1,89 @@
 ---
 title: Your first sandboxed plugin
-description: Build, register, and run a hello-world sandboxed plugin.
+description: Scaffold, register, and run a sandboxed plugin that responds to content saves.
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-This guide builds a minimal sandboxed plugin from scratch. The plugin logs every content save and exposes a single API route. It runs in an isolated runtime provided by the configured sandbox runner. The same code also runs in-process when a site operator moves it from `sandboxed: []` into `plugins: []`, for example on a platform without a sandbox runner.
+This tutorial creates a sandboxed plugin that records content-save events and exposes a small health route. You will scaffold the package with the plugin CLI, add one hook and one route, register the plugin with an EmDash site, and confirm that both handlers run.
 
-If you haven't decided between sandboxed and native, read [Choosing a plugin format](/plugins/creating-plugins/choosing-a-format/) first.
+If you have not chosen a plugin format, read [Choosing a plugin format](/plugins/creating-plugins/choosing-a-format/) first.
 
-<Aside type="tip" title="The fast path">
-	`npx @emdash-cms/plugin-cli init my-plugin` scaffolds everything below —
-	manifest, `src/plugin.ts`, `package.json`, `tsconfig.json`, a test. This
-	guide explains what it generates so you can write or edit it by hand.
-</Aside>
+## Prerequisites
 
-## Two pieces
+You need:
 
-A sandboxed plugin is:
+- Node.js and pnpm;
+- an EmDash site with a [sandbox runner](/deployment/plugin-sandbox/) configured; and
+- an [Atmosphere account](/plugins/creating-plugins/publishing/#your-atmosphere-account) handle or DID for the manifest's publisher field.
 
-1. **`emdash-plugin.jsonc`** — a hand-edited [manifest](/plugins/creating-plugins/manifest/): identity, the trust contract (capabilities, hosts, storage), and profile fields. No code.
-2. **`src/plugin.ts`** — the runtime: hooks and routes. Type-only imports from `emdash/plugin`; no runtime `emdash` import.
-
-`emdash-plugin build` reads both and emits the `dist/` artifacts a site consumes.
-
-The following example shows the file layout of a complete plugin:
-
-```
-my-plugin/
-├── emdash-plugin.jsonc   # Identity + trust contract + profile
-├── src/
-│   └── plugin.ts         # Hooks, routes — runs in the sandbox runtime
-├── package.json
-└── tsconfig.json
-```
-
-## Set up the package
+## Scaffold the plugin
 
 <Steps>
 
-1. Create the directory and a `package.json`. The build is `emdash-plugin build`; there is no `tsdown` invocation to write.
+1. Run the plugin scaffolder from the directory that will contain the new project.
 
-   ```json title="package.json"
-   {
-   	"name": "@my-org/plugin-hello",
-   	"version": "0.1.0",
-   	"type": "module",
-   	"main": "dist/index.mjs",
-   	"exports": {
-   		".": {
-   			"import": "./dist/index.mjs",
-   			"types": "./dist/index.d.mts"
-   		},
-   		"./sandbox": "./dist/plugin.mjs"
-   	},
-   	"files": ["dist", "emdash-plugin.jsonc"],
-   	"scripts": {
-   		"build": "emdash-plugin build",
-   		"dev": "emdash-plugin dev"
-   	},
-   	"peerDependencies": {
-   		"emdash": ">=0.13.0"
-   	},
-   	"devDependencies": {
-   		"@emdash-cms/plugin-cli": "0.2.0",
-   		"emdash": ">=0.13.0",
-   		"typescript": "^5.9.0"
-   	}
-   }
+   ```sh
+   pnpm dlx @emdash-cms/plugin-cli init save-log
    ```
 
-   `"."` is the generated descriptor a site imports; `"./sandbox"` is the built runtime file. `emdash-plugin build` generates both.
+   The command asks for the publisher, author, and security contact, then creates this structure:
 
-2. Add a `tsconfig.json`:
+   ```text
+   save-log/
+   ├── emdash-plugin.jsonc
+   ├── package.json
+   ├── src/
+   │   └── plugin.ts
+   ├── tests/
+   │   └── plugin.test.ts
+   ├── tsconfig.json
+   ├── README.md
+   └── .gitignore
+   ```
 
-   ```json title="tsconfig.json"
-   {
-   	"compilerOptions": {
-   		"target": "ES2022",
-   		"module": "preserve",
-   		"moduleResolution": "bundler",
-   		"strict": true,
-   		"esModuleInterop": true,
-   		"verbatimModuleSyntax": true,
-   		"skipLibCheck": true,
-   		"types": []
-   	},
-   	"include": ["src/**/*"],
-   	"exclude": ["node_modules"]
-   }
+   If you skip an answer, the generated manifest contains a `TODO` value. Replace every `TODO` before validating or building the plugin.
+
+2. Install the generated package's dependencies.
+
+   ```sh
+   cd save-log
+   pnpm install
    ```
 
 </Steps>
 
-## Write the manifest
+## Define the plugin's access and storage
 
-`emdash-plugin.jsonc` carries the plugin's identity (`slug`), its trust contract (`capabilities`, `allowedHosts`, `storage`), profile fields, and the [publisher pin](/plugins/creating-plugins/manifest/#publisher-pinning). Set `publisher` to the DID for your [Atmosphere account](/plugins/creating-plugins/publishing/#your-atmosphere-account).
+`emdash-plugin.jsonc` contains the plugin's identity, registry information, and trust contract. Add the `content:read` capability because `content:afterSave` exposes saved content to the plugin. Declare an `events` storage collection so the hook can keep a queryable record of each save.
 
-The following example shows a complete manifest for the hello plugin:
+The following manifest contains the fields used in this tutorial. Keep the publisher, author, and security values produced by the scaffolder.
 
 ```jsonc title="emdash-plugin.jsonc"
 {
 	"$schema": "./node_modules/@emdash-cms/plugin-cli/schemas/emdash-plugin.schema.json",
 
-	"slug": "plugin-hello",
-	"publisher": "did:plc:abc123def456", // your Atmosphere account DID
+	"slug": "save-log",
+	"publisher": "did:plc:abc123def456",
 
 	"license": "MIT",
 	"author": { "name": "Jane Doe", "url": "https://example.com" },
 	"security": { "email": "security@example.com" },
+	"description": "Records content-save events.",
 
-	"capabilities": [],
+	"capabilities": ["content:read"],
 	"allowedHosts": [],
-	"storage": { "events": { "indexes": ["timestamp"] } }
+	"storage": {
+		"events": { "indexes": ["savedAt"] },
+	},
 }
 ```
 
-Notes on this manifest:
+The `content:read` declaration tells the site operator that the hook receives saved content and is required when this plugin format runs in process. Accessing `ctx.storage.events` would throw if the collection were absent. [The manifest reference](/plugins/creating-plugins/manifest/) explains the remaining fields and validation rules.
 
-- **`slug` is a URL-safe id, not the npm package name.** `/^[a-z][a-z0-9_-]*$/`, max 64 chars. It's a single path segment in plugin route URLs (`/_emdash/api/plugins/<slug>/...`) and part of generated SQL identifiers for storage indexes, so `@`, `/`, leading digits, and uppercase all fail. Pair an unscoped `slug` (`plugin-hello`) with a scoped npm package name.
-- **`storage` declares collections up front.** `ctx.storage.events` works at runtime only because `events` is declared here. Accessing an undeclared collection throws.
-- **`version` is omitted.** The build reads it from `package.json` so there's one source of truth. See [the manifest reference](/plugins/creating-plugins/manifest/#version-lives-in-packagejson).
-- **The trust contract is consent.** Changing `capabilities`, `allowedHosts`, or `storage` later requires a version bump — installed sites consented to the old contract.
+## Add the hook and route
 
-## Write the runtime
-
-`src/plugin.ts` default-exports a bare object annotated with `satisfies SandboxedPlugin`. `emdash/plugin` provides only types, so a sandboxed plugin has no runtime dependency on `emdash`.
-
-The following example logs every content save to plugin storage and exposes a `recent` route that returns the last ten saves:
+Replace the generated `src/plugin.ts` with the following runtime definition:
 
 ```typescript title="src/plugin.ts"
 import type { SandboxedPlugin } from "emdash/plugin";
@@ -136,95 +92,145 @@ export default {
 	hooks: {
 		"content:afterSave": {
 			handler: async (event, ctx) => {
-				ctx.log.info("Content saved", {
+				const savedAt = new Date().toISOString();
+				const contentId = String(event.content.id);
+				await ctx.storage.events.put(`${savedAt}:${contentId}`, {
+					savedAt,
 					collection: event.collection,
-					id: event.content.id,
+					contentId,
 				});
 
-				await ctx.storage.events.put(`save-${Date.now()}`, {
-					timestamp: new Date().toISOString(),
+				ctx.log.info("Content save recorded", {
 					collection: event.collection,
-					contentId: event.content.id,
+					contentId,
 				});
 			},
 		},
 	},
 
 	routes: {
-		recent: {
+		health: {
+			public: true,
 			handler: async (_routeCtx, ctx) => {
-				const result = await ctx.storage.events.query({ limit: 10 });
-				return { events: result.items };
+				return { ok: true, plugin: ctx.plugin.id };
 			},
 		},
 	},
 } satisfies SandboxedPlugin;
 ```
 
-Notes on the runtime file:
+`src/plugin.ts` default-exports a plain object. The type-only `SandboxedPlugin` import gives the hook and route their parameter types without adding the EmDash runtime to the bundle.
 
-- **`satisfies SandboxedPlugin` types everything.** It infers `event` from the hook name (with the full canonical event type) and `ctx` as `PluginContext`, so handlers need no parameter annotations. A typo'd hook key like `"content:afterSav"` is a compile error.
-- **Hook handlers take `(event, ctx)`.** The event shape depends on the hook name; see the [Hooks guide](/plugins/creating-plugins/hooks/).
-- **Route handlers take `(routeCtx, ctx)`** — two arguments. `routeCtx` is `{ input, request, requestMeta? }`; `ctx` is the same `PluginContext`. Routes are reachable at `/_emdash/api/plugins/<slug>/<route-name>`.
-- **`ctx.storage.events` works because `events` is declared in the manifest.**
-- **`ctx.kv` is always available** — a per-plugin key-value store with `get`, `set`, `delete`, `list(prefix)`.
+Hook handlers receive `(event, ctx)`. Route handlers receive `(routeCtx, ctx)`. The `health` route is public and read-only, so it can be checked without an admin session. Public routes are internet-facing; [API routes](/plugins/creating-plugins/api-routes/#authentication-and-csrf) explains the authentication and browser-origin rules before you expose real data or mutations.
+
+## Update the generated test
+
+The scaffolded test expects the original `hello` route. Replace it with a test for the `health` route:
+
+```typescript title="tests/plugin.test.ts"
+import { describe, expect, it } from "vitest";
+
+import plugin from "../src/plugin.js";
+
+describe("health route", () => {
+	it("identifies the running plugin", async () => {
+		const route = plugin.routes?.health;
+		if (!route || typeof route !== "object" || !("handler" in route)) {
+			throw new Error("health route handler not found");
+		}
+
+		const result = await route.handler({} as never, makeTestContext());
+		expect(result).toEqual({ ok: true, plugin: "test-plugin" });
+	});
+});
+
+function makeTestContext() {
+	return {
+		plugin: { id: "test-plugin", version: "0.1.0" },
+	} as unknown as import("emdash").PluginContext;
+}
+```
+
+## Validate and build
+
+Run the generated test, validate the manifest, and build the npm artifacts.
+
+```sh
+pnpm test
+pnpm exec emdash-plugin validate
+pnpm exec emdash-plugin build
+```
+
+The build creates:
+
+- `dist/plugin.mjs`, containing the hook and route code;
+- `dist/manifest.json`, containing the runtime manifest and the discovered hook and route names; and
+- `dist/index.mjs`, the default-exported descriptor that a site imports.
+
+`dist/` is generated output. The scaffold excludes it from Git because the plugin build recreates it.
 
 ## Register the plugin
 
-In the site's `astro.config.mjs`, import the plugin's default export and pass it in. Sandboxed plugins go in `sandboxed: []`; in-process plugins go in `plugins: []`. A sandboxed plugin works in both. The example below uses `sandboxed:`:
+Install the local package in your EmDash site. Run this command from the site's directory and adjust the relative path if the projects are not siblings.
 
-```typescript title="astro.config.mjs"
+```sh
+pnpm add file:../save-log
+```
+
+Import the generated default export in `astro.config.mjs` and add it to `sandboxed`:
+
+```javascript title="astro.config.mjs"
 import { defineConfig } from "astro/config";
 import emdash from "emdash/astro";
-import { sandbox } from "@emdash-cms/cloudflare";
-import hello from "@my-org/plugin-hello";
+import saveLog from "save-log";
 
 export default defineConfig({
 	integrations: [
 		emdash({
-			sandboxed: [hello],
-			sandboxRunner: sandbox(),
+			sandboxed: [saveLog],
+			sandboxRunner: "@emdash-cms/sandbox-workerd/sandbox",
 		}),
 	],
 });
 ```
 
-`sandboxRunner` is the pluggable piece. The example uses `sandbox()` from `@emdash-cms/cloudflare`, the runner most sites use today. If no runner is configured (or the configured runner is unavailable on the current platform), `sandboxed: []` plugins are skipped at startup — move the plugin into `plugins: []` to run it in-process.
+This example uses the Node.js workerd runner. Keep the runner already configured by your site if it uses Cloudflare Workers or another supported setup.
 
-<Aside type="caution" title="Cloudflare runner needs Worker Loader">
-	The `@emdash-cms/cloudflare` sandbox runner uses Cloudflare Workers' Dynamic
-	Worker Loader, so `wrangler.jsonc` needs a `worker_loaders` binding:
-
-	```jsonc title="wrangler.jsonc"
-	{
-		"worker_loaders": [{ "binding": "LOADER" }]
-	}
-	```
-
-	Without it the runner reports as unavailable at startup and sandboxed
-	plugins are skipped. Other runners have their own platform requirements. See
-	[Sandboxed vs Native](/plugins/creating-plugins/choosing-a-format/) for the
-	platform matrix.
+<Aside type="caution" title="A runner is required">
+	EmDash skips plugins in `sandboxed` when the configured runner is unavailable. Follow [Plugin
+	Sandbox](/deployment/plugin-sandbox/) to configure the Node.js or Cloudflare runner before testing
+	the plugin.
 </Aside>
 
-## Build and run
+## Run the plugin
 
-From the plugin directory:
+Start both development processes:
 
-```sh
-emdash-plugin validate   # schema-check the manifest first
-emdash-plugin build      # emit dist/
+1. Run `pnpm dev` in the plugin directory. The CLI rebuilds the plugin when its source or manifest changes.
+2. Run the site's development command in the site directory.
+
+Open the following route on the site:
+
+```text
+http://localhost:4321/_emdash/api/plugins/save-log/health
 ```
 
-For an edit loop, run `emdash-plugin dev` (rebuilds on save, keeps the last good `dist/` on a failed build). In the site, install or link the plugin (`pnpm add file:../plugin-hello` or a workspace link) and start the dev server. Save a piece of content in the admin and you should see `Content saved …` in the logs; `GET /_emdash/api/plugins/plugin-hello/recent` returns the last ten save events.
+The response contains the standard API envelope and the value returned by the plugin:
 
-## What to read next
+```json
+{
+	"success": true,
+	"data": { "ok": true, "plugin": "save-log" },
+}
+```
 
-- [The manifest](/plugins/creating-plugins/manifest/) — every field, the trust contract, publisher pinning
-- [The `emdash-plugin` CLI](/plugins/creating-plugins/cli/) — `build`, `dev`, `bundle`
-- [Hooks](/plugins/creating-plugins/hooks/) — the full set of events
-- [API routes](/plugins/creating-plugins/api-routes/) — input validation, public routes, errors
-- [Storage and KV](/plugins/creating-plugins/storage/) — query options, indexes, batch operations
-- [Capabilities and security](/plugins/creating-plugins/capabilities/) — content access, network, host allowlists
-- [Bundling and publishing](/plugins/creating-plugins/publishing/) — publish a plugin to the registry
-- [Automated plugin releases](/plugins/creating-plugins/delegated-releases/) — publish from GitHub Actions
+Save an entry in the EmDash admin. The site log contains `Content save recorded`, and the hook writes one item to the plugin's `events` collection.
+
+## Continue building
+
+- [Hooks](/plugins/creating-plugins/hooks/) explains hook events, capabilities, ordering, and errors.
+- [API routes](/plugins/creating-plugins/api-routes/) covers validation, permissions, public routes, and MCP exposure.
+- [Block Kit](/plugins/creating-plugins/block-kit/) adds an admin page without shipping browser JavaScript.
+- [Settings](/plugins/creating-plugins/settings/) stores site-specific plugin configuration.
+- [Storage](/plugins/creating-plugins/storage/) covers indexed queries and pagination.
+- [Bundling and publishing](/plugins/creating-plugins/publishing/) publishes the plugin to the registry.


### PR DESCRIPTION
## What does this PR do?

Reconciles the complete sandboxed-plugin authoring journey across format selection, scaffolding, manifests, CLI commands, capabilities, hooks, routes, Block Kit, settings, storage, publishing, automated releases, and migration.

- Aligns examples and limits with the current authoring types, generated manifest schema, CLI behavior, sandbox runners, and first-party plugins.
- Preserves the public-route authentication and browser-origin safety guidance while correcting portable input and error handling.
- Makes each repeated contract canonical on one page and links to it from the surrounding journey.
- Documents that Block Kit masks secret inputs while plugin KV stores their values as ordinary JSON in the site database.

This PR is temporarily based on #3029 so its shared safety guidance stays intact and this review diff contains only the sandboxed-plugin pages. It can be retargeted to `main` after #3029 merges.

Closes: not applicable.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

Formatting was run on every changed MDX file with the repository's Prettier version. The root `pnpm format` command was not run because it formats the entire repository rather than this documentation scope.

Tests were not added because this changes documentation only. The code examples were checked against existing executable coverage, and the first-plugin source and replacement test were type-checked and run together.

Admin localization, a changeset, an approved feature Discussion, and UI screenshots are not applicable. This PR changes no package behavior or admin UI and includes no `messages.po` files.

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Screenshots are not applicable because this PR changes documentation content, not product UI.

Validated with:

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:quick`
- `pnpm --dir docs build`
- 182 focused plugin CLI tests
- 329 focused core plugin route, hook, capability, and storage tests
- 96 focused Block Kit tests
- generated manifest and Block Kit example validation
- first-plugin example type-check and test
- `git diff --check`
