### PR TITLE
docs: refresh core reference pages

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
+    "prebuild": "node scripts/check-reference-inventories.mjs",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",

--- a/docs/scripts/check-reference-inventories.mjs
+++ b/docs/scripts/check-reference-inventories.mjs
@@ -1,0 +1,426 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const docsDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = resolve(docsDirectory, "..");
+const SECTION_PATTERN = /^### `([^`]+)`$/gm;
+const HOOK_TABLE_PATTERN = /^\| `([^`]+)`\s+\|/gm;
+const API_CONTRACT_PATTERN = /^\| `([^`]+)` \|/gm;
+const TEMPLATE_PATH_PATTERN = /\/src\/(pages|layouts|components)\//;
+const EMDASH_IMPORT_PATTERN = /^import\s*\{([^;]+?)\}\s*from\s*["']emdash["'];/gm;
+const TYPE_PREFIX_PATTERN = /^type\s+/;
+const IMPORT_ALIAS_PATTERN = /\s+as\s+/;
+const ADAPTER_ARGUMENT_PATTERN = /\(.*$/;
+const EMDASH_COMMAND_PREFIX_PATTERN = /^emdash\s+/;
+const COMMAND_ARGUMENT_PATTERN = /\s+<[^>]+>/g;
+const CLI_HEADING_PATTERN = /^(#{3,4}) `([^`]+)`[^\n]*$/gm;
+const CLI_OPTION_PATTERN = /--([A-Za-z][\w-]*)/g;
+const CLI_NEGATED_OPTION_LINE_PATTERN = /^.*There is no .*$/gm;
+const CLI_OPTION_TABLE_PATTERN = /^\| `--([A-Za-z][\w-]*)[^`]*`/gm;
+const TEMPLATE_EXTENSIONS = new Set([".astro", ".ts", ".tsx", ".js", ".mjs"]);
+
+function readRepositoryFile(path) {
+	return readFileSync(resolve(repositoryRoot, path), "utf8");
+}
+
+function parseSource(path) {
+	return ts.createSourceFile(
+		path,
+		readRepositoryFile(path),
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TS,
+	);
+}
+
+function propertyName(node) {
+	if (!node) return undefined;
+	if (ts.isIdentifier(node) || ts.isStringLiteral(node) || ts.isNumericLiteral(node)) {
+		return node.text;
+	}
+	return undefined;
+}
+
+function findInterface(source, name) {
+	const declaration = source.statements.find(
+		(statement) => ts.isInterfaceDeclaration(statement) && statement.name.text === name,
+	);
+	if (!declaration) throw new Error(`Could not find interface ${name} in ${source.fileName}`);
+	return declaration;
+}
+
+function findTypeAlias(source, name) {
+	const declaration = source.statements.find(
+		(statement) => ts.isTypeAliasDeclaration(statement) && statement.name.text === name,
+	);
+	if (!declaration) throw new Error(`Could not find type ${name} in ${source.fileName}`);
+	return declaration;
+}
+
+function stringLiteralUnionMembers(type) {
+	const members = ts.isUnionTypeNode(type) ? type.types : [type];
+	return members.map((member) => {
+		if (!ts.isLiteralTypeNode(member) || !ts.isStringLiteral(member.literal)) {
+			throw new Error("Expected a string-literal union");
+		}
+		return member.literal.text;
+	});
+}
+
+function compareInventory(label, sourceValues, documentedValues) {
+	const source = new Set(sourceValues);
+	const documented = new Set(documentedValues);
+	const missing = [...source]
+		.filter((value) => !documented.has(value))
+		.toSorted((a, b) => a.localeCompare(b));
+	const extra = [...documented]
+		.filter((value) => !source.has(value))
+		.toSorted((a, b) => a.localeCompare(b));
+	if (missing.length === 0 && extra.length === 0) return;
+
+	const details = [];
+	if (missing.length > 0) details.push(`missing: ${missing.join(", ")}`);
+	if (extra.length > 0) details.push(`not in source: ${extra.join(", ")}`);
+	throw new Error(`${label} is out of date (${details.join("; ")})`);
+}
+
+function walk(directory) {
+	return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+		const path = join(directory, entry.name);
+		return entry.isDirectory() ? walk(path) : [path];
+	});
+}
+
+function markdownSection(markdown, heading) {
+	const start = markdown.indexOf(`${heading}\n`);
+	if (start === -1) throw new Error(`Could not find ${heading}`);
+	const next = markdown.indexOf("\n## ", start + heading.length);
+	return markdown.slice(start, next === -1 ? undefined : next);
+}
+
+function checkFieldTypes() {
+	const source = parseSource("packages/core/src/schema/types.ts");
+	const fieldTypes = stringLiteralUnionMembers(findTypeAlias(source, "FieldType").type);
+	const reference = readRepositoryFile("docs/src/content/docs/reference/field-types.mdx");
+	const sections = Array.from(reference.matchAll(SECTION_PATTERN), (match) => match[1]);
+	compareInventory("Field type sections", fieldTypes, sections);
+}
+
+function checkHooks() {
+	const source = parseSource("packages/core/src/plugins/types.ts");
+	const hooks = findInterface(source, "PluginHooks").members.map((member) =>
+		propertyName(member.name),
+	);
+	if (hooks.some((hook) => hook === undefined))
+		throw new Error("PluginHooks has an unnamed member");
+
+	const reference = readRepositoryFile("docs/src/content/docs/reference/hooks.mdx");
+	const sections = Array.from(reference.matchAll(SECTION_PATTERN), (match) => match[1]).filter(
+		(name) => name === "cron" || name.includes(":"),
+	);
+	const overview = markdownSection(reference, "## Hook overview");
+	const table = Array.from(overview.matchAll(HOOK_TABLE_PATTERN), (match) => match[1]);
+	compareInventory("Hook sections", hooks, sections);
+	compareInventory("Hook overview", hooks, table);
+}
+
+function exportedAdapterNames(path) {
+	const source = parseSource(path);
+	const names = [];
+	for (const statement of source.statements) {
+		if (
+			ts.isFunctionDeclaration(statement) &&
+			statement.name &&
+			statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
+		) {
+			names.push(statement.name.text);
+		}
+		if (
+			ts.isExportDeclaration(statement) &&
+			!statement.isTypeOnly &&
+			statement.moduleSpecifier &&
+			statement.exportClause &&
+			ts.isNamedExports(statement.exportClause)
+		) {
+			for (const element of statement.exportClause.elements) {
+				if (!element.isTypeOnly) names.push(element.name.text);
+			}
+		}
+	}
+	return names;
+}
+
+function checkConfiguration() {
+	const source = parseSource("packages/core/src/astro/integration/runtime.ts");
+	const config = findInterface(source, "EmDashConfig");
+	const authoredOptions = config.members
+		.filter((member) => !member.getFullText(source).includes("not authored by the user"))
+		.map((member) => propertyName(member.name));
+	if (authoredOptions.some((option) => option === undefined)) {
+		throw new Error("EmDashConfig has an unnamed member");
+	}
+
+	const reference = readRepositoryFile("docs/src/content/docs/reference/configuration.mdx");
+	const integrationOptions = markdownSection(reference, "## Integration options");
+	const optionHeadings = Array.from(
+		integrationOptions.matchAll(SECTION_PATTERN),
+		(match) => match[1],
+	);
+	const documentedOptions = optionHeadings.map((heading) => heading.split(".")[0]);
+	compareInventory("EmDashConfig options", authoredOptions, documentedOptions);
+
+	const adapterSources = [
+		"packages/core/src/db/adapters.ts",
+		"packages/core/src/astro/storage/adapters.ts",
+		"packages/core/src/astro/object-cache/adapters.ts",
+		"packages/cloudflare/src/index.ts",
+	];
+	const adapters = adapterSources.flatMap(exportedAdapterNames);
+	const documentedAdapters = Array.from(reference.matchAll(SECTION_PATTERN), (match) => match[1])
+		.filter((heading) => heading.includes("("))
+		.map((heading) => heading.replace(ADAPTER_ARGUMENT_PATTERN, ""));
+	compareInventory("Configuration adapter sections", adapters, documentedAdapters);
+}
+
+function siteTemplateImports() {
+	const templatesRoot = resolve(repositoryRoot, "templates");
+	const imports = new Set();
+	for (const path of walk(templatesRoot)) {
+		const repositoryPath = relative(repositoryRoot, path);
+		if (!TEMPLATE_PATH_PATTERN.test(repositoryPath)) continue;
+		if (!TEMPLATE_EXTENSIONS.has(extname(path))) continue;
+		const contents = readFileSync(path, "utf8");
+		for (const match of contents.matchAll(EMDASH_IMPORT_PATTERN)) {
+			for (const specifier of match[1].split(",")) {
+				const trimmed = specifier.trim();
+				if (TYPE_PREFIX_PATTERN.test(trimmed)) continue;
+				const name = trimmed.split(IMPORT_ALIAS_PATTERN)[0];
+				if (name) imports.add(name);
+			}
+		}
+	}
+	return [...imports];
+}
+
+function checkSiteTemplateApi() {
+	const reference = readRepositoryFile("docs/src/content/docs/reference/api.mdx");
+	const contract = markdownSection(reference, "## Site-template API contract");
+	const documented = Array.from(contract.matchAll(API_CONTRACT_PATTERN), (match) => match[1]);
+	compareInventory("Site-template API contract", siteTemplateImports(), documented);
+}
+
+function cliProgram() {
+	const cliRoot = resolve(repositoryRoot, "packages/core/src/cli");
+	const files = walk(cliRoot).filter((path) => extname(path) === ".ts");
+	return ts.createProgram(files, {
+		allowJs: false,
+		module: ts.ModuleKind.NodeNext,
+		moduleResolution: ts.ModuleResolutionKind.NodeNext,
+		skipLibCheck: true,
+		target: ts.ScriptTarget.ESNext,
+	});
+}
+
+function unwrapExpression(expression) {
+	let current = expression;
+	while (
+		ts.isAsExpression(current) ||
+		ts.isSatisfiesExpression(current) ||
+		ts.isParenthesizedExpression(current)
+	) {
+		current = current.expression;
+	}
+	return current;
+}
+
+function resolveDeclarationExpression(expression, checker) {
+	const unwrapped = unwrapExpression(expression);
+	if (!ts.isIdentifier(unwrapped)) return unwrapped;
+	let symbol = checker.getSymbolAtLocation(unwrapped);
+	if (symbol?.flags & ts.SymbolFlags.Alias) symbol = checker.getAliasedSymbol(symbol);
+	const declaration = symbol?.declarations?.find(ts.isVariableDeclaration);
+	return declaration?.initializer
+		? resolveDeclarationExpression(declaration.initializer, checker)
+		: unwrapped;
+}
+
+function resolveObject(expression, checker) {
+	const resolved = resolveDeclarationExpression(expression, checker);
+	if (ts.isObjectLiteralExpression(resolved)) return resolved;
+	if (ts.isCallExpression(resolved) && resolved.arguments[0]) {
+		const argument = unwrapExpression(resolved.arguments[0]);
+		if (ts.isObjectLiteralExpression(argument)) return argument;
+	}
+	return undefined;
+}
+
+function objectProperty(object, name) {
+	return object.properties.find(
+		(property) => ts.isPropertyAssignment(property) && propertyName(property.name) === name,
+	);
+}
+
+function collectArgumentDefinitions(object, checker, definitions = new Map()) {
+	for (const property of object.properties) {
+		if (ts.isSpreadAssignment(property)) {
+			const spread = resolveObject(property.expression, checker);
+			if (spread) collectArgumentDefinitions(spread, checker, definitions);
+			continue;
+		}
+		if (!ts.isPropertyAssignment(property) && !ts.isShorthandPropertyAssignment(property)) continue;
+		const name = propertyName(property.name);
+		if (!name) continue;
+		const expression = ts.isPropertyAssignment(property) ? property.initializer : property.name;
+		definitions.set(name, expression);
+	}
+	return definitions;
+}
+
+function literalPropertyValue(expression, checker, name) {
+	const object = resolveObject(expression, checker);
+	const property = object && objectProperty(object, name);
+	if (!property || !ts.isPropertyAssignment(property)) return undefined;
+	const value = unwrapExpression(property.initializer);
+	if (ts.isStringLiteral(value) || value.kind === ts.SyntaxKind.TrueKeyword) {
+		return ts.isStringLiteral(value) ? value.text : true;
+	}
+	return undefined;
+}
+
+function collectCliContract() {
+	const program = cliProgram();
+	const checker = program.getTypeChecker();
+	const entry = program.getSourceFile(resolve(repositoryRoot, "packages/core/src/cli/index.ts"));
+	const main = entry?.statements
+		.filter(ts.isVariableStatement)
+		.flatMap((statement) => statement.declarationList.declarations)
+		.find((declaration) => ts.isIdentifier(declaration.name) && declaration.name.text === "main");
+	if (!main?.initializer) throw new Error("Could not find the EmDash CLI command tree");
+	const root = resolveObject(main.initializer, checker);
+	if (!root) throw new Error("Could not resolve the EmDash CLI root command");
+
+	const commands = new Set();
+	const options = new Map();
+	function visit(command, path) {
+		const subCommandsProperty = objectProperty(command, "subCommands");
+		const subCommands =
+			subCommandsProperty && ts.isPropertyAssignment(subCommandsProperty)
+				? resolveObject(subCommandsProperty.initializer, checker)
+				: undefined;
+		if (subCommands) {
+			for (const property of subCommands.properties) {
+				if (!ts.isPropertyAssignment(property) && !ts.isShorthandPropertyAssignment(property))
+					continue;
+				const name = propertyName(property.name);
+				if (!name) continue;
+				const childPath = [...path, name];
+				commands.add(childPath.join(" "));
+				const expression = ts.isPropertyAssignment(property) ? property.initializer : property.name;
+				const child = resolveObject(expression, checker);
+				if (!child) throw new Error(`Could not resolve CLI command ${childPath.join(" ")}`);
+				visit(child, childPath);
+			}
+			return;
+		}
+
+		const argsProperty = objectProperty(command, "args");
+		const args =
+			argsProperty && ts.isPropertyAssignment(argsProperty)
+				? resolveObject(argsProperty.initializer, checker)
+				: undefined;
+		const commandOptions = [];
+		if (args) {
+			for (const [name, definition] of collectArgumentDefinitions(args, checker)) {
+				if (literalPropertyValue(definition, checker, "type") !== "positional") {
+					commandOptions.push(name);
+				}
+			}
+		}
+		options.set(path.join(" "), commandOptions);
+	}
+
+	visit(root, []);
+
+	const clientFactory = program.getSourceFile(
+		resolve(repositoryRoot, "packages/core/src/cli/client-factory.ts"),
+	);
+	const connectionArgs = clientFactory?.statements
+		.filter(ts.isVariableStatement)
+		.flatMap((statement) => statement.declarationList.declarations)
+		.find(
+			(declaration) =>
+				ts.isIdentifier(declaration.name) && declaration.name.text === "connectionArgs",
+		);
+	if (!connectionArgs?.initializer) throw new Error("Could not find shared CLI connection options");
+	const connectionObject = resolveObject(connectionArgs.initializer, checker);
+	if (!connectionObject) throw new Error("Could not resolve shared CLI connection options");
+	const commonOptions = [...collectArgumentDefinitions(connectionObject, checker).keys()];
+
+	return { commands: [...commands], options, commonOptions };
+}
+
+function normalizeCommandHeading(heading) {
+	return heading
+		.replace(EMDASH_COMMAND_PREFIX_PATTERN, "")
+		.replace(COMMAND_ARGUMENT_PATTERN, "")
+		.trim();
+}
+
+function cliHeadings(reference) {
+	return Array.from(reference.matchAll(CLI_HEADING_PATTERN), (match) => ({
+		level: match[1].length,
+		command: normalizeCommandHeading(match[2]),
+		start: match.index,
+	}));
+}
+
+function checkCli() {
+	const reference = readRepositoryFile("docs/src/content/docs/reference/cli.mdx");
+	const { commands, options, commonOptions } = collectCliContract();
+	const commonFlagsSection = markdownSection(reference, "## Common flags");
+	const documentedCommonOptions = Array.from(
+		commonFlagsSection.matchAll(CLI_OPTION_TABLE_PATTERN),
+		(match) => match[1],
+	);
+	compareInventory("CLI common options", commonOptions, documentedCommonOptions);
+
+	const commandsSection = markdownSection(reference, "## Commands");
+	const headings = cliHeadings(commandsSection);
+	const documentedCommands = headings.map(({ command }) => command);
+	compareInventory("CLI command sections", commands, documentedCommands);
+
+	const commonOptionSet = new Set(commonOptions);
+	for (const [command, commandOptions] of options) {
+		const headingIndex = headings.findIndex((heading) => heading.command === command);
+		if (headingIndex === -1) continue;
+		const heading = headings[headingIndex];
+		const end = headings
+			.slice(headingIndex + 1)
+			.find((candidate) => candidate.level <= heading.level)?.start;
+		const section = commandsSection.slice(heading.start, end);
+		const positiveOptionText = section.replace(CLI_NEGATED_OPTION_LINE_PATTERN, "");
+		const sectionOptions = new Set(
+			Array.from(positiveOptionText.matchAll(CLI_OPTION_PATTERN), (match) => match[1]),
+		);
+		const expected = new Set(commandOptions);
+		const documented = Array.from(sectionOptions, (option) =>
+			option.startsWith("no-") && expected.has(option.slice(3)) ? option.slice(3) : option,
+		);
+		const expectedSpecific = commandOptions.filter((option) => !commonOptionSet.has(option));
+		const documentedSpecific = documented.filter(
+			(option) => !(commonOptionSet.has(option) && expected.has(option)),
+		);
+		compareInventory(`CLI options for ${command}`, expectedSpecific, documentedSpecific);
+	}
+}
+
+checkFieldTypes();
+checkHooks();
+checkConfiguration();
+checkSiteTemplateApi();
+checkCli();
+
+console.log("Reference inventories match their source contracts.");

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -1,11 +1,30 @@
 ---
 title: JavaScript API Reference
-description: Programmatic API for querying and managing EmDash content.
+description: Site-template API for reading and presenting EmDash content.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-EmDash exports functions for querying content and working with preview, settings, menus, taxonomies, widget areas, sections, and search.
+This page covers the public API used by Astro pages, layouts, and components to read and present an EmDash site. It does not inventory every export from the `emdash` package root: database repositories, API handlers, migration utilities, plugin-authoring APIs, and other server internals have separate references or are intended for framework integration code.
+
+The **site-template API contract** in this reference lists every function imported from `emdash` by EmDash's maintained site templates. Type-only imports such as `MediaValue` belong to the relevant data-model documentation. Related functions are documented in the same sections when they help a site author, but the page does not cover unrelated root exports.
+
+## Site-template API contract
+
+The maintained templates call these runtime helpers:
+
+| Function | Used for |
+| -------- | -------- |
+| `decodeSlug` | Decoding a dynamic route parameter before lookup |
+| `getEmDashCollection` | Reading and filtering entries in a collection |
+| `getEmDashEntry` | Reading one entry by ID or slug |
+| `getMenu` | Rendering a navigation menu and its resolved links |
+| `getSeoMeta` | Resolving an entry's SEO panel values and template fallbacks |
+| `getSiteSettings` | Reading public site identity and other global settings |
+| `getTaxonomyTerms` | Rendering taxonomy navigation, filters, and term indexes |
+| `getTerm` | Reading one taxonomy term for an archive page |
+| `getTermsForEntries` | Batch-loading one taxonomy for a list of entries |
+| `search` | Searching published content across collections |
 
 ## Content queries
 
@@ -37,14 +56,25 @@ if (error) {
 The `options` parameter accepts the following filter:
 
 ```ts
+interface WhereRange {
+	gt?: string;
+	gte?: string;
+	lt?: string;
+	lte?: string;
+}
+
 interface CollectionFilter {
 	status?: "draft" | "published" | "archived";
 	limit?: number;
 	cursor?: string; // Keyset pagination — pass a previous `nextCursor`
 	offset?: number; // Offset pagination — skip N entries (use with `limit`)
-	where?: Record<string, string | string[]>; // Filter by field or taxonomy
+	where?: Record<string, string | string[] | WhereRange>;
+	orderBy?: Record<string, "asc" | "desc">;
+	locale?: string;
 }
 ```
+
+`cursor` and `offset` are mutually exclusive. The `where` keys can name content fields, taxonomies, or `byline`; range objects are available for ordered comparisons.
 
 #### Returns
 
@@ -54,6 +84,7 @@ The function resolves to a `CollectionResult`:
 interface CollectionResult<T> {
 	entries: ContentEntry<T>[]; // Empty array if error or none found
 	error?: Error; // Set if query failed
+	cacheHint: CacheHint; // Tags and last-modified time for Astro route caching
 	nextCursor?: string; // Cursor for the next keyset page, if any
 	hasMore?: boolean; // Whether more entries exist beyond this page (when `limit` is set)
 }
@@ -120,7 +151,7 @@ if (!post) {
 | `slugOrId`   | `string` | Entry slug or ID |
 | `options`    | `{ locale?: string }` | Optional. Locale for slug resolution |
 
-Preview mode is handled automatically — the middleware detects `_preview` tokens and serves draft content via `AsyncLocalStorage`. The optional `options` parameter only accepts a `locale` for slug resolution; preview state requires no parameter.
+Preview mode is handled automatically: when the request has a valid `_preview` token, the query serves draft content. The optional `options` parameter only accepts a `locale` for slug resolution; preview state requires no parameter.
 
 #### Returns
 
@@ -131,6 +162,8 @@ interface EntryResult<T> {
 	entry: ContentEntry<T> | null; // null if not found
 	error?: Error; // Set only for actual errors, not "not found"
 	isPreview: boolean; // true if draft content is being served
+	fallbackLocale?: string; // Set when locale fallback returned another locale
+	cacheHint: CacheHint; // Tags and last-modified time for Astro route caching
 }
 ```
 
@@ -157,6 +190,46 @@ if (!entry) {
 }
 ```
 
+### `getTranslations()`
+
+Fetch the available translations of one entry by collection slug and database ID:
+
+```ts
+import { getTranslations } from "emdash";
+
+const { translations, error } = await getTranslations("posts", post.data.id);
+```
+
+The result contains the shared `translationGroup`, a `translations` array, and an optional `error`. Each translation summary includes `id`, `locale`, `slug`, and `status`.
+
+### `resolveEmDashPath()`
+
+Resolve a public pathname against the URL patterns configured for routable collections:
+
+```ts
+import { resolveEmDashPath } from "emdash";
+
+const result = await resolveEmDashPath("/blog/hello-world");
+
+if (result) {
+	console.log(result.collection, result.entry.data.title);
+}
+```
+
+The result contains the matched `collection`, `entry`, and route `params`. The function returns `null` when no configured URL pattern matches.
+
+### `getEditMeta()`
+
+Read the non-enumerable visual-editing metadata attached to a Portable Text value:
+
+```ts
+import { getEditMeta } from "emdash";
+
+const meta = getEditMeta(post.data.content);
+```
+
+It returns `{ collection, id, field }` for an annotated value, or `undefined` when the value has no annotation.
+
 ## Content types
 
 ### `ContentEntry`
@@ -171,17 +244,46 @@ interface ContentEntry<T = Record<string, unknown>> {
 }
 ```
 
-The `edit` proxy provides visual editing annotations. Spread it onto elements to enable inline editing: `{...entry.edit.title}`. In production, this produces no output.
+The `edit` proxy provides visual editing annotations. Spread it onto elements to enable inline editing: `{...entry.edit.title}`. Outside edit mode, it produces no output.
 
 The `data` object contains all content fields plus system fields:
 
 - `id` - Unique identifier
 - `slug` - URL-friendly identifier
 - `status` - "draft" | "published" | "archived"
-- `createdAt` - ISO timestamp
-- `updatedAt` - ISO timestamp
-- `publishedAt` - Publication timestamp or null; retained when content is unpublished
+- `createdAt` - Creation time as a `Date`
+- `updatedAt` - Last update time as a `Date`
+- `publishedAt` - Publication time as a `Date`, or `null`; retained when content is unpublished
 - Plus all custom fields defined in your collection schema
+
+## URL helpers
+
+### `decodeSlug()` and `slugify()`
+
+Use `decodeSlug()` on a dynamic route parameter before passing it to a content query. It returns `undefined` for a missing parameter and otherwise applies `decodeURIComponent()`, which throws for malformed percent encoding:
+
+```ts
+function decodeSlug(raw: string | undefined): string | undefined;
+```
+
+```ts
+import { decodeSlug, getEmDashEntry } from "emdash";
+
+const slug = decodeSlug(Astro.params.slug);
+const { entry } = slug ? await getEmDashEntry("posts", slug) : { entry: null };
+```
+
+`slugify(value)` converts text to a lowercase, hyphen-separated slug. Use it when a template needs to construct a slug from a label; stored entry slugs already come from EmDash.
+
+### `sanitizeHref()` and `isSafeHref()`
+
+These helpers reject unsafe link schemes such as `javascript:`. `isSafeHref(value)` returns a boolean. `sanitizeHref(value)` returns the original safe URL or `"#"` when the value is empty or unsafe.
+
+```ts
+import { sanitizeHref } from "emdash";
+
+const href = sanitizeHref(menuItem.url);
+```
 
 ## Preview system
 
@@ -194,10 +296,12 @@ import { generatePreviewToken } from "emdash";
 
 const token = await generatePreviewToken({
 	contentId: "posts:01HXK5MZSN...",
-	secret: process.env.EMDASH_ADMIN_SECRET,
+	secret: process.env.EMDASH_PREVIEW_SECRET!,
 	expiresIn: 3600, // 1 hour
 });
 ```
+
+`contentId` must use the `collection:id` format. `expiresIn` accepts seconds or a duration ending in `s`, `m`, `h`, `d`, or `w` and defaults to `"1h"`. Keep the signing secret on the server.
 
 ### `verifyPreviewToken()`
 
@@ -208,7 +312,7 @@ import { verifyPreviewToken } from "emdash";
 
 const result = await verifyPreviewToken({
 	token,
-	secret: process.env.EMDASH_ADMIN_SECRET,
+	secret: process.env.EMDASH_PREVIEW_SECRET!,
 });
 
 if (result.valid) {
@@ -216,6 +320,37 @@ if (result.valid) {
 	// cid is "collection:id" format, e.g. "posts:my-draft-post"
 }
 ```
+
+Pass either `token` or `url` with the signing `secret`. An invalid token returns `{ valid: false, error }`, where `error` is `"none"`, `"malformed"`, `"invalid"`, or `"expired"`.
+
+### `parseContentId()`
+
+Split a preview payload's `collection:id` value into its two parts:
+
+```ts
+import { parseContentId } from "emdash";
+
+const parsed = parseContentId(result.payload.cid);
+```
+
+It returns `{ collection, id }` and throws when the value has no colon separator.
+
+### `getPreviewUrl()` and `buildPreviewUrl()`
+
+`getPreviewUrl()` creates and signs a preview URL. It accepts `collection`, `id`, and `secret`, plus optional `expiresIn`, `baseUrl`, `pathPattern`, and `locale` values:
+
+```ts
+import { getPreviewUrl } from "emdash";
+
+const previewUrl = await getPreviewUrl({
+	collection: "posts",
+	id: post.id,
+	secret: process.env.EMDASH_PREVIEW_SECRET!,
+	pathPattern: "/blog/{id}",
+});
+```
+
+Without `baseUrl`, it returns a site-relative URL. Use `buildPreviewUrl({ path, token, baseUrl? })` when a token already exists.
 
 ### `isPreviewRequest()`
 
@@ -229,6 +364,8 @@ if (isPreviewRequest(Astro.url)) {
 	// Verify and show preview content
 }
 ```
+
+`getPreviewToken()` returns the `_preview` query parameter or `null` when it is absent. The EmDash middleware verifies normal preview requests and supplies preview state to `getEmDashEntry()` automatically; these helpers are for custom preview routes and tooling.
 
 ## Content converters
 
@@ -249,6 +386,11 @@ const prosemirrorDoc = portableTextToProsemirror(portableText);
 Read site-wide settings with `getSiteSettings` and `getSiteSetting`:
 
 ```ts
+function getSiteSettings(): Promise<Partial<SiteSettings>>;
+function getSiteSetting<K extends SiteSettingKey>(key: K): Promise<SiteSettings[K] | undefined>;
+```
+
+```ts
 import { getSiteSettings, getSiteSetting } from "emdash";
 
 // Get all settings
@@ -260,9 +402,80 @@ const title = await getSiteSetting("title");
 
 Settings are read-only from the runtime API. Use the admin API to update them.
 
+`getSiteSettings()` returns a partial object because unset keys are omitted. Media settings such as the site logo and favicon are resolved to media-reference objects before the function returns.
+
+`getSiteSettingsWithCacheHint()` returns `{ data, cacheHint }`. Pass the hint to `Astro.cache.set()` when an Astro route cache should be invalidated after site settings change.
+
+## SEO
+
+Resolve the SEO panel values and content fallbacks for a page with `getSeoMeta()`:
+
+```ts
+function getSeoMeta<T>(content: SeoContentInput<T>, options?: SeoMetaOptions): SeoMeta;
+
+interface SeoMetaOptions {
+	siteTitle?: string;
+	siteUrl?: string;
+	titleSeparator?: string; // Default: " | "
+	path?: string;
+	defaultOgImage?: string;
+	defaultTitle?: string;
+	defaultDescription?: string;
+}
+
+interface SeoMeta {
+	title: string;
+	description: string | null;
+	ogTitle: string;
+	ogDescription: string | null;
+	ogImage: string | null;
+	canonical: string | null;
+	robots: string | null;
+}
+```
+
+```ts
+import { getSeoMeta } from "emdash";
+
+const meta = getSeoMeta(post, {
+	siteTitle: "Example Blog",
+	siteUrl: "https://example.com",
+	path: `/blog/${post.data.slug}`,
+});
+```
+
+It returns the resolved title, description, Open Graph values, canonical URL, and robots value. `getContentSeo(content)` returns the raw SEO object without applying template fallbacks.
+
+For translated content, `getHreflangAlternates(collection, entryId, { siteUrl? })` returns published, routable locale variants as `{ hreflang, href }` objects and adds an `x-default` entry. It returns an empty array when internationalization is disabled, the current entry is marked `noindex`, or no absolute site URL is available.
+
+## Comments
+
+Fetch approved comments and their count for an entry:
+
+```ts
+import { getCommentCount, getComments } from "emdash";
+
+const { items: comments, total } = await getComments({
+	collection: "posts",
+	contentId: post.data.id,
+	threaded: true,
+	reactions: true,
+	sort: "best",
+});
+
+const count = await getCommentCount("posts", post.data.id);
+```
+
+`threaded` nests replies below their parent. The default `sort` is `"oldest"`; `"best"` ranks top-level comments by reactions and enables reaction counts automatically. Server-rendered comment queries return at most 500 approved comments; use the REST API when a client needs pagination.
+
 ## Menus
 
 Fetch navigation menus and iterate their items, including nested children:
+
+```ts
+function getMenu(name: string, options?: { locale?: string }): Promise<Menu | null>;
+function getMenus(options?: { locale?: string }): Promise<MenuSummary[]>;
+```
 
 ```ts
 import { getMenu, getMenus } from "emdash";
@@ -282,9 +495,46 @@ if (primaryMenu) {
 }
 ```
 
+`getMenu(name, { locale? })` follows the configured locale fallback chain. `getMenus({ locale? })` lists menu summaries for the resolved request or configured locale; without internationalization it lists every locale. `getMenuWithCacheHint()` returns `{ data, cacheHint }` for routes using Astro's cache.
+
+## Bylines
+
+Fetch an author profile by ID or slug, or list entries credited to a byline:
+
+```ts
+import { getByline, getBylineBySlug, getEntriesByByline } from "emdash";
+
+const profile = await getBylineBySlug("jane-doe", { locale: "en" });
+const posts = profile
+	? await getEntriesByByline("posts", profile.translationGroup ?? profile.id)
+	: [];
+```
+
+`getByline(id)` returns one profile or `null`. The slug lookup accepts an optional locale and follows the locale fallback chain. Content queries already hydrate an entry's ordered credits into `entry.data.bylines`; use these standalone helpers for author pages and byline archives.
+
 ## Taxonomies
 
 Fetch taxonomy terms, a single term, an entry's terms, or entries by term:
+
+```ts
+function getTaxonomyTerms(
+	taxonomyName: string,
+	options?: { locale?: string; includeCounts?: boolean },
+): Promise<TaxonomyTerm[]>;
+
+function getTerm(
+	taxonomyName: string,
+	slug: string,
+	options?: { locale?: string; includeCounts?: boolean },
+): Promise<TaxonomyTerm | null>;
+
+function getTermsForEntries(
+	collection: string,
+	entryIds: string[],
+	taxonomyName: string,
+	options?: { locale?: string },
+): Promise<Map<string, TaxonomyTerm[]>>;
+```
 
 ```ts
 import { getTaxonomyTerms, getTerm, getEntryTerms, getEntriesByTerm } from "emdash";
@@ -301,6 +551,29 @@ const postCategories = await getEntryTerms("posts", "post-123", "category");
 // Get entries with a specific term
 const newsPosts = await getEntriesByTerm("posts", "category", "news");
 ```
+
+`getTaxonomyDefs({ locale? })` lists taxonomy definitions, while `getTaxonomyDef(name, { locale? })` returns one definition or `null`. Locale-aware definition and term lookups follow the configured fallback chain.
+
+`getTaxonomyTerms(name, { locale?, includeCounts? })` returns a tree for hierarchical taxonomies and includes visible-entry counts by default. Pass `includeCounts: false` when the template does not render counts. Content queries also hydrate assigned terms into each entry's `data.terms`; use `getEntryTerms()` when you only have a collection name and entry ID.
+
+For archive pages that render terms beside many entries, batch the lookup instead of calling `getEntryTerms()` in a loop:
+
+```ts
+import { getAllTermsForEntries, getTermsForEntries } from "emdash";
+
+const termsByPost = await getTermsForEntries(
+	"posts",
+	posts.map(post => post.data.id),
+	"category",
+);
+
+const allTermsByPost = await getAllTermsForEntries(
+	"posts",
+	posts.map(post => post.data.id),
+);
+```
+
+`getTermsForEntries()` returns a map from entry ID to the requested taxonomy's terms. `getAllTermsForEntries()` returns a map from entry ID to terms grouped by taxonomy name. `getTaxonomyTermsWithCacheHint()` returns `{ data, cacheHint }` for an Astro-cached route.
 
 ## Widget areas
 
@@ -321,6 +594,8 @@ if (sidebar) {
 	});
 }
 ```
+
+`getWidgetAreaWithCacheHint(name)` returns `{ data, cacheHint }` for routes using Astro's cache. Widget areas and their widgets are ordered by their configured sort order.
 
 ## Sections
 
@@ -345,6 +620,23 @@ const cta = await getSection("newsletter-cta");
 ## Search
 
 Run a global search across collections. Results include highlighted snippets:
+
+```ts
+function search(query: string, options?: SearchOptions): Promise<SearchResponse>;
+
+interface SearchOptions {
+	collections?: string[]; // Default: every searchable collection
+	status?: string; // Default: "published"
+	locale?: string; // Default: all locales
+	limit?: number; // Default: 20
+	cursor?: string;
+}
+
+interface SearchResponse {
+	items: SearchResult[];
+	nextCursor?: string;
+}
+```
 
 ```ts
 import { search } from "emdash";
@@ -375,24 +667,18 @@ if (results.nextCursor) {
 
 ## Error handling
 
-EmDash exports error classes for handling specific failures. The following example catches validation and schema errors:
+Content queries return operational errors in their result instead of throwing. A missing entry is not an operational error: `entry` is `null` and `error` remains undefined.
 
 ```ts
-import {
-  EmDashDatabaseError,
-  EmDashValidationError,
-  EmDashStorageError,
-  SchemaError,
-} from "emdash";
+const { entry, error } = await getEmDashEntry("posts", slug);
 
-try {
-  await repo.create({ ... });
-} catch (error) {
-  if (error instanceof EmDashValidationError) {
-    console.error("Validation failed:", error.message);
-  }
-  if (error instanceof SchemaError) {
-    console.error("Schema error:", error.code, error.details);
-  }
+if (error) {
+	return new Response("Content could not be loaded", { status: 500 });
+}
+
+if (!entry) {
+	return Astro.redirect("/404");
 }
 ```
+
+Helpers without a result envelope can throw when their input is invalid or a database operation fails. Handle those errors at the route boundary when the page can provide a useful fallback. The repository and handler error classes used by lower-level server integrations are outside this site-template API.

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -5,7 +5,7 @@ description: Command-line interface for EmDash CMS.
 
 import { Aside } from "@astrojs/starlight/components";
 
-The EmDash CLI provides commands for managing an EmDash CMS instance — database setup, type generation, content CRUD, schema management, media, and more.
+The EmDash CLI provides commands for database setup, type generation, creating and editing content, schema management, media, and plugin development.
 
 ## Installation
 
@@ -21,31 +21,83 @@ Start your site with its package script, such as `pnpm dev`. The package script 
 
 ## Authentication
 
-Commands using the shared remote client resolve authentication in this order:
+Commands that connect to a running EmDash instance resolve authentication in this order:
 
 1. **`--token` flag** — explicit token on the command line
 2. **`EMDASH_TOKEN` env var**
 3. **Stored credentials** from `~/.config/emdash/auth.json` (saved by `emdash login`)
 4. **Dev bypass** — if the URL is localhost and no token is available, automatically authenticates via the dev bypass endpoint
 
-These commands accept `--url` (from `EMDASH_URL`, falling back to `http://localhost:4321`) and `--token` flags. Authentication commands have their own connection options. When targeting a local dev server, no token is needed.
+The `types`, `whoami`, `content`, `schema`, `media`, `search`, `taxonomy`, and `menu` commands connect to a running instance. Authentication commands have their own connection options. When targeting a local development server, no token is needed.
 
-## Common Flags
+## Common flags
 
-These flags are available on commands using the shared remote client:
+Connection flags vary by command. The grouped commands below mean every subcommand in that group.
 
-| Flag                    | Alias | Description                            | Default                          |
-| ----------------------- | ----- | -------------------------------------- | -------------------------------- |
-| `--url`                 | `-u`  | EmDash instance URL                    | `EMDASH_URL` or `http://localhost:4321` |
-| `--token`               | `-t`  | Auth token                             | From env/stored creds            |
-| `--header "Name: Value"` | `-H`  | Custom request header; may be repeated | From `EMDASH_HEADERS`/stored creds |
-| `--json`                |       | Output as JSON (for piping)            | Auto-detected from TTY           |
+| Flag                      | Alias | Available on | Description and default |
+| ------------------------- | ----- | ------------ | ----------------------- |
+| `--url`                   | `-u`  | `types`, `login`, `logout`, `whoami`, `content`, `schema`, `media`, `search`, `taxonomy`, `menu` | Instance URL; defaults to `EMDASH_URL` or `http://localhost:4321` |
+| `--token`                 | `-t`  | `types`, `whoami`, `content`, `schema`, `media`, `search`, `taxonomy`, `menu` | Token from the flag, `EMDASH_TOKEN`, or stored credentials |
+| `--header "Name: Value"` | `-H`  | `types`, `login`, `content`, `schema`, `media`, `search`, `taxonomy`, `menu` | Repeatable header merged with `EMDASH_HEADERS` and stored headers |
+| `--json`                  |       | `whoami`, `content`, `schema`, `media`, `search`, `taxonomy`, `menu` | Write raw JSON instead of terminal-formatted output |
 
 ## Output
 
-For commands using the shared remote client, stdout is pretty-printed with consola when it is a TTY and becomes raw JSON when piped or when `--json` is set. `emdash migrate` emits JSON only with its explicit `--json` option.
+When a command writes results to an interactive terminal, it formats them for reading. The commands listed with `--json` above write raw JSON when the flag is set or their output is piped. `emdash migrate` emits JSON only with its explicit `--json` option.
 
 ## Commands
+
+### `emdash init`
+
+Initialize a local SQLite database from the template metadata in `package.json`. The command runs core migrations, then applies the optional SQL file named by `emdash.schema`. Run `emdash seed` separately for JSON seed data.
+
+```bash
+npx emdash init [options]
+```
+
+| Option       | Alias | Description                         | Default       |
+| ------------ | ----- | ----------------------------------- | ------------- |
+| `--database` | `-d`  | SQLite database path                | `./data.db`   |
+| `--cwd`      |       | Project working directory           | Current directory |
+| `--force`    | `-f`  | Reapply the template schema when collections already exist | `false` |
+
+Without `--force`, an initialized database is left unchanged. This command opens a local SQLite file directly; use `emdash migrate` for deployment-managed D1, PostgreSQL, libSQL, or Hyperdrive migrations.
+
+### `emdash doctor`
+
+Check a local SQLite database for connection, migration, collection, table, and user problems. If the project has a Wrangler configuration, the command also checks that a Cron Trigger and EmDash `scheduled()` handler are configured together.
+
+```bash
+npx emdash doctor [options]
+```
+
+| Option       | Alias | Description               | Default       |
+| ------------ | ----- | ------------------------- | ------------- |
+| `--database` | `-d`  | SQLite database path      | `./data.db`   |
+| `--cwd`      |       | Project working directory | Current directory |
+| `--json`     |       | Emit structured results   | `false`       |
+
+The command reports each check as pass, warning, or failure and exits non-zero when a check fails.
+
+### `emdash seed`
+
+Validate or apply a JSON seed to a local SQLite database. The command uses the positional path when provided, then `.emdash/seed.json`, then the `emdash.seed` path from `package.json`.
+
+```bash
+npx emdash seed [path] [options]
+```
+
+| Option             | Alias | Description                                            | Default                          |
+| ------------------ | ----- | ------------------------------------------------------ | -------------------------------- |
+| `--database`       | `-d`  | SQLite database path                                   | `./data.db`                      |
+| `--cwd`            |       | Project working directory                              | Current directory                |
+| `--validate`       |       | Validate the seed without changing the database        | `false`                          |
+| `--no-content`     |       | Skip entries, bylines, and taxonomy terms               | `false`                          |
+| `--on-conflict`    |       | Handle existing records with `skip`, `update`, or `error` | `skip`                         |
+| `--uploads-dir`    |       | Local directory used for seed media                    | `./uploads`                      |
+| `--media-base-url` |       | Base URL stored for local seed media                   | `/_emdash/api/media/file`        |
+
+Applying a seed runs core migrations first. Use `--validate` in continuous integration when you need to check the file without opening or creating the database.
 
 ### `emdash migrate`
 
@@ -100,6 +152,13 @@ See [Manage Core Database Migrations](/deployment/core-migrations/) for deployme
 
 The legacy command initializes and migrates a local SQLite database before starting Astro. That behavior does not use the database adapter configured by the site and is incompatible with Cloudflare D1 development. Existing invocations now print a deprecation warning before doing any database work.
 
+| Option       | Alias | Description                                      | Default       |
+| ------------ | ----- | ------------------------------------------------ | ------------- |
+| `--database` | `-d`  | Local SQLite database path                       | `./data.db`   |
+| `--types`    | `-t`  | Fetch remote types before starting Astro         | `false`       |
+| `--port`     | `-p`  | Astro development-server port                    | `4321`        |
+| `--cwd`      |       | Project working directory                        | Current directory |
+
 ### `emdash types`
 
 Generate TypeScript types from a running EmDash instance's schema.
@@ -110,12 +169,14 @@ npx emdash types [options]
 
 #### Options
 
-| Option     | Alias | Description              | Default              |
-| ---------- | ----- | ------------------------ | -------------------- |
-| `--url`    | `-u`  | EmDash instance URL    | `http://localhost:4321` |
-| `--token`  | `-t`  | Auth token               | From env/stored creds |
-| `--output` | `-o`  | Output path for types    | `.emdash/types.ts` |
-| `--cwd`    |       | Working directory        | Current directory    |
+| Option     | Alias | Description                        | Default                    |
+| ---------- | ----- | ---------------------------------- | -------------------------- |
+| `--url`    | `-u`  | EmDash instance URL                | `http://localhost:4321`     |
+| `--token`  | `-t`  | Auth token                         | From env or stored credentials |
+| `--header` | `-H`  | Custom request header; repeatable  | From env or stored credentials |
+| `--json`   |       | Accepted but does not change this command's files or progress output | — |
+| `--output` | `-o`  | Output path for types              | `.emdash/types.ts`          |
+| `--cwd`    |       | Working directory                  | Current directory          |
 
 #### Examples
 
@@ -147,9 +208,10 @@ npx emdash login [options]
 
 #### Options
 
-| Option  | Alias | Description           | Default                |
-| ------- | ----- | --------------------- | ---------------------- |
-| `--url` | `-u`  | EmDash instance URL | `http://localhost:4321` |
+| Option     | Alias | Description                       | Default                    |
+| ---------- | ----- | --------------------------------- | -------------------------- |
+| `--url`    | `-u`  | EmDash instance URL               | `http://localhost:4321`     |
+| `--header` | `-H`  | Custom request header; repeatable | From `EMDASH_HEADERS`       |
 
 #### Behavior
 
@@ -206,6 +268,7 @@ npx emdash content list posts --status published --limit 10
 | Option     | Description          |
 | ---------- | -------------------- |
 | `--status` | Filter by status     |
+| `--locale` | Filter by locale     |
 | `--limit`  | Maximum items        |
 | `--cursor` | Pagination cursor    |
 
@@ -216,9 +279,11 @@ npx emdash content get posts 01ABC123
 npx emdash content get posts 01ABC123 --raw
 ```
 
-| Option  | Description                                      |
-| ------- | ------------------------------------------------ |
-| `--raw` | Return raw Portable Text (skip markdown conversion) |
+| Option        | Description                                           |
+| ------------- | ----------------------------------------------------- |
+| `--locale`    | Locale to use when the ID argument is a slug          |
+| `--raw`       | Return raw Portable Text instead of Markdown          |
+| `--published` | Ignore a pending draft and return published data only |
 
 The response includes a `_rev` token. Pass it to `content update` to confirm you have seen the current state before overwriting it.
 
@@ -261,6 +326,8 @@ npx emdash content update posts 01ABC123 \
 | `--rev`           | Revision token from `get` (required)                     |
 | `--data`          | JSON string with content data                            |
 | `--file`          | Read data from a JSON file                               |
+| `--locale`        | Locale to use when the ID argument is a slug              |
+| `--draft`         | Keep the update as a draft instead of auto-publishing     |
 | `--override-lock` | Write even though another editor has the entry open      |
 
 If the item has changed since your `get`, the server returns 409 Conflict — re-read and try again.
@@ -278,17 +345,23 @@ npx emdash content delete posts 01ABC123
 
 Soft-deletes the content item (moves to trash).
 
+Pass `--override-lock` to delete an entry that another editor has open.
+
 #### `content publish <collection> <id>`
 
 ```bash
 npx emdash content publish posts 01ABC123
 ```
 
+Pass `--override-lock` to publish an entry that another editor has open.
+
 #### `content unpublish <collection> <id>`
 
 ```bash
 npx emdash content unpublish posts 01ABC123
 ```
+
+Pass `--override-lock` to unpublish an entry that another editor has open.
 
 #### `content schedule <collection> <id>`
 
@@ -300,6 +373,8 @@ npx emdash content schedule posts 01ABC123 --at 2026-03-01T09:00:00Z
 | ------ | ------------------------------- |
 | `--at` | ISO 8601 datetime (required)    |
 
+Pass `--override-lock` to schedule an entry that another editor has open.
+
 #### `content restore <collection> <id>`
 
 ```bash
@@ -307,6 +382,16 @@ npx emdash content restore posts 01ABC123
 ```
 
 Restores a trashed content item.
+
+#### `content translations <collection> <id>`
+
+List every translation in the entry's translation group:
+
+```bash
+npx emdash content translations posts 01ABC123
+```
+
+The result includes each translation's ID, locale, slug, status, and whether it is the requested entry.
 
 ### `emdash schema`
 
@@ -363,7 +448,7 @@ npx emdash schema add-field posts featured --type boolean --required
 
 | Option       | Description                                                                                      |
 | ------------ | ------------------------------------------------------------------------------------------------ |
-| `--type`     | Field type: string, text, number, integer, boolean, datetime, image, reference, portableText, json (required) |
+| `--type`     | Field type: string, text, url, number, integer, boolean, datetime, select, multiSelect, portableText, image, file, reference, json, slug, or repeater (required) |
 | `--label`    | Field label (defaults to field slug)                                                             |
 | `--required` | Whether the field is required                                                                    |
 
@@ -447,6 +532,7 @@ npx emdash search "hello" --collection posts --limit 5
 | Option         | Alias | Description          |
 | -------------- | ----- | -------------------- |
 | `--collection` | `-c`  | Filter by collection |
+| `--locale`     |       | Filter by locale     |
 | `--limit`      | `-l`  | Maximum results      |
 
 ### `emdash taxonomy`
@@ -502,6 +588,83 @@ npx emdash menu get primary
 
 Returns the menu with all its items.
 
+### `emdash plugin`
+
+Create, validate, bundle, and publish EmDash plugins. Marketplace login is separate from login to a CMS instance.
+
+#### `plugin init`
+
+Scaffold a sandboxed or native plugin:
+
+```bash
+npx emdash plugin init --dir ./my-plugin --name my-plugin --format sandboxed
+```
+
+| Option     | Description                                                        | Default           |
+| ---------- | ------------------------------------------------------------------ | ----------------- |
+| `--dir`    | Directory to create                                                 | Current directory |
+| `--name`   | Plugin package name or ID                                           | Interactive prompt |
+| `--format` | `sandboxed` or `native`                                             | Interactive prompt |
+| `--native` | Shortcut for `--format native`                                     | `false`           |
+
+#### `plugin bundle`
+
+Validate a plugin and create its marketplace tarball:
+
+```bash
+npx emdash plugin bundle --dir ./my-plugin --outDir ./artifacts
+```
+
+| Option           | Alias | Description                                  | Default           |
+| ---------------- | ----- | -------------------------------------------- | ----------------- |
+| `--dir`          |       | Plugin directory                             | Current directory |
+| `--outDir`       | `-o`  | Tarball output directory                     | `./dist`          |
+| `--validateOnly` |       | Run validation without creating a tarball    | `false`           |
+
+#### `plugin validate`
+
+Run the same validation as `plugin bundle` without creating a tarball:
+
+```bash
+npx emdash plugin validate --dir ./my-plugin
+```
+
+The optional `--dir` selects the plugin directory and defaults to the current directory.
+
+#### `plugin publish`
+
+Upload a bundle to the marketplace and, by default, wait for its processing result:
+
+```bash
+npx emdash plugin publish --tarball ./dist/my-plugin-1.0.0.tar.gz
+```
+
+| Option       | Description                                                    | Default                              |
+| ------------ | -------------------------------------------------------------- | ------------------------------------ |
+| `--tarball`  | Existing plugin tarball                                        | —                                    |
+| `--dir`      | Plugin directory used with `--build`                           | Current directory                    |
+| `--build`    | Build the plugin before upload                                 | `false`                              |
+| `--registry` | Marketplace base URL                                           | `https://marketplace.emdashcms.com`  |
+| `--no-wait`  | Exit after upload without waiting for the processing result    | `false`                              |
+
+Provide `--tarball`, or pass `--build` to build from `--dir` first.
+
+#### `plugin login`
+
+Authenticate to the marketplace through GitHub device flow. `--registry` selects a different marketplace and defaults to `https://marketplace.emdashcms.com`.
+
+```bash
+npx emdash plugin login
+```
+
+#### `plugin logout`
+
+Remove the saved marketplace credential. The optional `--registry` must identify the same marketplace used for login.
+
+```bash
+npx emdash plugin logout
+```
+
 ### `emdash export-seed`
 
 Export database schema and content as a seed file. Works directly on a local SQLite file.
@@ -517,9 +680,9 @@ npx emdash export-seed [options] > seed.json
 | `--database`     | `-d`  | Database file path                                   | `./data.db`       |
 | `--cwd`          |       | Working directory                                    | Current directory |
 | `--with-content` |       | Include content (all or comma-separated collections) |                   |
-| `--no-pretty`    |       | Disable JSON formatting                              | `false`           |
+| `--pretty` / `--no-pretty` |       | Enable or disable indented JSON output              | Pretty output enabled |
 
-#### Output Format
+#### Output format
 
 The exported seed file includes:
 
@@ -530,7 +693,11 @@ The exported seed file includes:
 - **Widget Areas**: Widget areas and widgets
 - **Content** (if requested): Entries with `$media` references and `$ref:` syntax for portability
 
-### `emdash secrets generate`
+### `emdash secrets`
+
+Generate and inspect the key used to encrypt plugin secrets.
+
+#### `secrets generate`
 
 Generate an `EMDASH_ENCRYPTION_KEY` for your deployment. The key is used to
 encrypt plugin secrets at rest.
@@ -552,7 +719,7 @@ npx emdash secrets generate --write .env
 Replacing a key in a deployment with existing encrypted data will leave
 those secrets unreadable, so the protection is intentional.
 
-### `emdash secrets fingerprint <key>`
+#### `secrets fingerprint <key>`
 
 Print the 8-character fingerprint (kid) of a key without exposing its
 value. This is useful in CI for verifying the right key was deployed. The following command prints a key's fingerprint:
@@ -561,11 +728,35 @@ value. This is useful in CI for verifying the right key was deployed. The follow
 npx emdash secrets fingerprint emdash_enc_v1_...
 ```
 
-## Generated Files
+### `emdash auth` (deprecated)
+
+<Aside type="caution" title="Deprecated command">
+	`emdash auth` is retained for scripts that still generate the legacy
+	`EMDASH_AUTH_SECRET`. New installations use `emdash secrets generate` to create the separate
+	`EMDASH_ENCRYPTION_KEY`.
+</Aside>
+
+#### `auth secret`
+
+Generate a legacy `EMDASH_AUTH_SECRET` value:
+
+```bash
+npx emdash auth secret
+```
+
+Existing installations can keep this variable to preserve stable commenter-IP hashes. It does not encrypt plugin secrets.
+
+## Generated files
+
+### `emdash-env.d.ts`
+
+The Astro integration generates `emdash-env.d.ts` in the project root when the local development server starts. It refreshes the file after schema changes made through the running development site. The declarations augment `EmDashCollections`, so calls such as `getEmDashCollection("posts")` infer the fields defined in the local database.
+
+This file is automatic and belongs to the local Astro development workflow. You do not need to run `emdash types` to create it.
 
 ### `.emdash/types.ts`
 
-The `emdash types` command generates TypeScript interfaces for each collection:
+The `emdash types` command fetches a running instance's schema and writes standalone TypeScript interfaces. Use it when the schema lives on a remote EmDash instance, when tooling needs a file at a custom path, or when the local Astro development server is not running:
 
 ```ts title=".emdash/types.ts"
 // Generated by EmDash CLI
@@ -575,15 +766,29 @@ import type { PortableTextBlock } from "emdash";
 
 export interface Post {
 	id: string;
+	slug: string | null;
+	status: string;
 	title: string;
-	content: PortableTextBlock[];
+	content?: PortableTextBlock[];
+	createdAt: Date;
+	updatedAt: Date;
 	publishedAt: Date | null;
+	bylines?: ContentBylineCredit[];
+	terms?: Record<string, TaxonomyTerm[]>;
 }
 ```
 
+The remote output contains standalone collection interfaces and does not augment `EmDashCollections`. It changes only when you run `emdash types`; `emdash-env.d.ts` uses module augmentation and refreshes as part of local development.
+
+<Aside type="caution">
+	The current remote output always includes `bylines` and `terms`, but does not import their
+	`ContentBylineCredit` and `TaxonomyTerm` types. Add both names to the generated `import type`
+	line before type-checking the file. Running `emdash types` again overwrites that manual fix.
+</Aside>
+
 ### `.emdash/schema.json`
 
-The command also writes a raw schema export for tooling:
+The command also writes a raw schema export named `schema.json` beside the selected TypeScript output. With the default output path, the file is `.emdash/schema.json`:
 
 ```json title=".emdash/schema.json"
 {
@@ -598,7 +803,7 @@ The command also writes a raw schema export for tooling:
 }
 ```
 
-## Environment Variables
+## Environment variables
 
 | Variable                  | Description                              |
 | ------------------------- | ---------------------------------------- |
@@ -626,7 +831,9 @@ Add common commands as `package.json` scripts for convenience:
 }
 ```
 
-## Exit Codes
+## General exit codes
+
+Most commands use `0` for success and `1` for an error. `emdash migrate` also uses codes `2`, `3`, `4`, and `130` for the specific outcomes listed in its [exit-code table](#exit-codes).
 
 | Code | Description                              |
 | ---- | ---------------------------------------- |

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -5,7 +5,7 @@ description: Complete reference for EmDash configuration options.
 
 import { Aside } from "@astrojs/starlight/components";
 
-EmDash is configured through two files: `astro.config.mjs` for the integration and `src/live.config.ts` for content collections.
+The main EmDash configuration lives in `astro.config.mjs`, while `src/live.config.ts` registers the content loader. Deployment-specific values can also come from environment variables. A small `package.json` metadata block supports template labels and legacy local CLI flows.
 
 ## Astro integration
 
@@ -70,7 +70,7 @@ migrations: {
 
 ### `storage`
 
-**Required.** Media storage adapter configuration. Choose one adapter:
+**Optional.** Media storage adapter configuration. EmDash stores files in `./.emdash/uploads` and serves them through `/_emdash/api/media/file` when this option is omitted. Choose an adapter when the default local directory is not suitable:
 
 ```js
 // Local filesystem (development)
@@ -100,6 +100,34 @@ storage: s3({
 ```
 
 See [Storage Options](/deployment/storage/) for details.
+
+### `images`
+
+**Optional.** Controls whether EmDash integrates stored media with Astro's image optimization. The default is `true`.
+
+When enabled, EmDash wraps Astro's image endpoint so `<Image>` and `getImage()` can read source bytes directly from the configured storage adapter. This also works when the original media URL is behind Cloudflare Access. Set `images: false` when another image service handles the media or when every image should render without EmDash's endpoint wrapper.
+
+```js
+emdash({
+	images: false,
+});
+```
+
+### `mediaProviders`
+
+**Optional.** Adds media services to the media library. The storage-backed local provider remains available automatically; each descriptor in this array adds another place editors can browse or upload media.
+
+The following example adds Cloudflare Images and Cloudflare Stream:
+
+```js title="astro.config.mjs"
+import { cloudflareImages, cloudflareStream } from "@emdash-cms/cloudflare";
+
+emdash({
+	mediaProviders: [cloudflareImages({}), cloudflareStream({})],
+});
+```
+
+Provider credentials are resolved at runtime. The empty configurations above use the default Cloudflare environment variables described in the [`cloudflareImages(config)`](#cloudflareimagesconfig) and [`cloudflareStream(config)`](#cloudflarestreamconfig) adapter sections. See [Media Library: Media providers](/guides/media-library/#media-providers) for binding and rendering setup.
 
 ### `objectCache`
 
@@ -167,15 +195,94 @@ export const onRequest = defineMiddleware(async ({ request }, next) => {
 
 On Node, use the same middleware shape with a Node-compatible cache such as Redis. Cache keys and bypass rules must include every request property that changes the rendered response.
 
+### `playground`
+
+**Optional.** Enables the middleware used by disposable, browser-based EmDash playgrounds. It creates a writable Durable Object database for each session, applies the configured seed, and signs the visitor in as an anonymous administrator before the normal EmDash middleware runs.
+
+```js title="astro.config.mjs"
+import { playgroundDatabase } from "@emdash-cms/cloudflare";
+
+emdash({
+	database: playgroundDatabase({ binding: "PLAYGROUND_DB" }),
+	playground: {
+		middlewareEntrypoint: "@emdash-cms/cloudflare/db/playground-middleware",
+	},
+});
+```
+
+This mode requires `@emdash-cms/cloudflare` and a Durable Object binding. It bypasses the normal setup and authentication middleware, so use it only for ephemeral demo sites rather than a production CMS.
+
 ### `plugins`
 
-**Optional.** Array of EmDash plugins. The following example registers one plugin:
+**Optional.** Array of plugins that run in the same process as the Astro site. Native plugins belong here. A sandbox-compatible plugin can also run here when you trust it with full process access and do not need isolation.
+
+The following example registers a native plugin:
 
 ```js
 import seoPlugin from "@emdash-cms/plugin-seo";
 
 plugins: [seoPlugin()];
 ```
+
+Native plugins can use server and framework APIs directly, so they cannot be moved to `sandboxed` unless the package also provides a sandbox-compatible plugin entry point. See [Choose a plugin format](/plugins/creating-plugins/choosing-a-format/) for the authoring and deployment differences.
+
+### `sandboxed`
+
+**Optional.** Array of sandbox-compatible plugins that use EmDash's declared plugin APIs and run in isolated runtimes. Do not place a native plugin here: native code can depend on process and framework access that the sandbox does not provide.
+
+```js title="astro.config.mjs"
+import thirdPartyPlugin from "third-party-emdash-plugin";
+import { sandbox } from "@emdash-cms/cloudflare";
+
+emdash({
+	sandboxed: [thirdPartyPlugin()],
+	sandboxRunner: sandbox(),
+});
+```
+
+Sandboxed plugins are skipped when no usable sandbox runner is configured. See [Plugin Sandbox](/deployment/plugin-sandbox/) for the Cloudflare and Node.js runner setup.
+
+### `sandboxRunner`
+
+**Optional.** Module specifier for the factory that starts isolated plugin runtimes. It is required for plugins in `sandboxed` and for marketplace or registry plugins.
+
+On Cloudflare Workers, use the `sandbox()` adapter:
+
+```js
+import { sandbox } from "@emdash-cms/cloudflare";
+
+emdash({
+	sandboxRunner: sandbox(),
+});
+```
+
+Node.js deployments use the workerd runner module documented in [Plugin Sandbox: Node.js](/deployment/plugin-sandbox/#nodejs).
+
+### `sandbox`
+
+**Optional.** Controls whether a configured sandbox runner isolates plugins. Sandboxing is enabled when `sandboxRunner` is configured. Set `sandbox: false` only to diagnose whether a problem comes from a plugin or its sandbox runtime:
+
+```js
+emdash({
+	sandboxRunner: sandbox(),
+	sandbox: false,
+});
+```
+
+With `false`, plugins declared in `sandboxed` and installed from the marketplace run in the main server process without isolation or resource limits. Restore sandboxing after the diagnosis.
+
+### `marketplace`
+
+**Optional.** Base URL for the plugin marketplace shown in the admin. Marketplace plugins require `sandboxRunner` because they always run sandboxed.
+
+```js
+emdash({
+	marketplace: "https://marketplace.emdashcms.com",
+	sandboxRunner: sandbox(),
+});
+```
+
+Production URLs must use HTTPS; HTTP is accepted only for `localhost` and `127.0.0.1` during development. When `experimental.registry` is also configured, the registry supplies new installs and updates while plugins already installed from the marketplace continue to run.
 
 ### `fonts`
 
@@ -264,6 +371,20 @@ Built-in providers:
 
 Third-party packages can register their own providers using the same `AuthProviderDescriptor` shape — see [Login Providers](/guides/authentication/#login-providers).
 
+### `mcp`
+
+**Optional.** Enables the Model Context Protocol (MCP) endpoint at `/_emdash/api/mcp`. The endpoint is enabled by default and requires a bearer token, so enabling it does not grant anonymous access.
+
+Set the option to `false` when the site must not expose an MCP endpoint:
+
+```js
+emdash({
+	mcp: false,
+});
+```
+
+See [MCP Server Reference](/reference/mcp-server/) for token creation and client configuration.
+
 ### `siteUrl`
 
 **Optional.** The public browser-facing origin for the site (scheme + host + optional port, **no path**).
@@ -304,7 +425,9 @@ On **Cloudflare Workers**, the env-var fallback reads `process.env`, which is em
 	canonical/OG URLs you build yourself.
 </Aside>
 
-#### Multi-origin passkey verification
+### `allowedOrigins`
+
+**Optional.** Additional browser origins accepted by passkey verification for a deployment available on more than one hostname.
 
 `siteUrl` defines a single canonical origin. When the same EmDash deployment is reachable under several hostnames that share a registrable parent domain (e.g. `https://example.com` and `https://preview.example.com`), passkey verification rejects assertions whose origin doesn't match `siteUrl` exactly -- even though WebAuthn allows passkeys to be valid across subdomains under the same `rpId`.
 
@@ -442,6 +565,26 @@ emdash({
 
 Uploads that exceed the configured limit are rejected with a `413 Payload Too Large` response on the direct upload path, or a `400 Validation Error` on the signed-URL path.
 
+### `admin`
+
+**Optional.** Replaces EmDash branding in the admin interface. These values do not change the public site's title, logo, or favicon.
+
+```js
+emdash({
+	admin: {
+		logo: "/images/agency-logo.webp",
+		siteName: "Agency CMS",
+		favicon: "/favicon.ico",
+	},
+});
+```
+
+| Option     | Type     | Description                                      |
+| ---------- | -------- | ------------------------------------------------ |
+| `logo`     | `string` | Logo URL or path for the login page and sidebar  |
+| `siteName` | `string` | Name shown in the sidebar and browser title      |
+| `favicon`  | `string` | Favicon URL or path for admin pages               |
+
 ### `toolbar`
 
 **Optional.** Controls how the editor toolbar (the floating pill on public pages) is delivered. Defaults to `"server"`.
@@ -479,9 +622,9 @@ In every mode, the toolbar can be dismissed in the browser via its × button (pe
 
 #### `experimental.registry`
 
-**Optional.** Point the admin dashboard's plugin browse and install flows at a federated [plugin registry](/plugins/registry/) instead of the central marketplace. Requires a [`sandboxRunner`](/deployment/plugin-sandbox/), because registry plugins run sandboxed.
+**Optional.** Use the experimental [plugin registry](/plugins/registry/) as the admin dashboard's source for browsing and installing plugins instead of the marketplace. Registry plugins run sandboxed, so this option requires a [`sandboxRunner`](/deployment/plugin-sandbox/).
 
-Pass a bare aggregator URL string, or an object when you need a labeller or a release-age policy. The following example uses the object form:
+Pass the registry service URL as a string, or use an object when the site needs moderation sources or a release-age policy. The following example uses the object form:
 
 ```js title="astro.config.mjs"
 import { sandbox } from "@emdash-cms/cloudflare";
@@ -503,10 +646,10 @@ emdash({
 
 | Option                            | Type                   | Description                                                                                   |
 | --------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------- |
-| `aggregatorUrl`                   | `string`               | Aggregator origin where the registry's XRPC endpoints are mounted. HTTPS in production.        |
-| `acceptLabelers`                  | `string`               | Optional comma-separated bare labeller DIDs used as a validated request and cache declaration. It cannot override aggregator policy. |
+| `aggregatorUrl`                   | `string`               | Base URL of the registry service. Use HTTPS in production.                                    |
+| `acceptLabelers`                  | `string`               | Optional comma-separated decentralized identifiers (DIDs) for moderation services accepted by the request. A DID is a stable Atmosphere account identifier. This setting cannot override the registry service's policy. |
 | `policy.minimumReleaseAge`        | `string \| number`     | Hold back releases newer than this age. Duration string (`"48h"`, `"7d"`) or seconds.          |
-| `policy.minimumReleaseAgeExclude` | `string[]`             | DIDs (or `<did>/<slug>` pairs) exempt from the holdback.                                        |
+| `policy.minimumReleaseAgeExclude` | `string[]`             | Publisher DIDs, or `<did>/<plugin-slug>` pairs, exempt from the holdback.                     |
 
 See [The plugin registry](/plugins/registry/) for the full workflow, trust model, and how to query the registry from your own site.
 
@@ -581,6 +724,7 @@ Cloudflare D1 database. Import from `@emdash-cms/cloudflare`.
 | `binding`        | `string` | —                    | D1 binding name from `wrangler.jsonc`               |
 | `session`        | `string` | `"disabled"`         | Read replication mode: `"disabled"`, `"auto"`, or `"primary-first"` |
 | `bookmarkCookie` | `string` | `"__em_d1_bookmark"` | Cookie name for session bookmarks                   |
+| `coalesce`       | `boolean` | `false`               | Batch concurrent reads in the same event-loop turn; requires a session mode other than `"disabled"` |
 
 The following example shows a basic binding and one with read replicas enabled:
 
@@ -599,6 +743,67 @@ When `session` is `"auto"` or `"primary-first"`, EmDash uses the D1 Sessions API
 	Provision the D1 database separately; see [Manage Core Database
 	Migrations](/deployment/core-migrations/).
 </Aside>
+
+### `hyperdrive(config?)`
+
+PostgreSQL through a Cloudflare Hyperdrive binding. Import this adapter from `@emdash-cms/cloudflare`.
+
+| Option                         | Type      | Default          | Description                                                                 |
+| ------------------------------ | --------- | ---------------- | --------------------------------------------------------------------------- |
+| `binding`                      | `string`  | `"HYPERDRIVE"`   | Primary Hyperdrive binding with query caching disabled                      |
+| `cachedBinding`                | `string`  | —                | Optional second, caching-enabled binding for anonymous public reads         |
+| `preferUncachedAfterWriteMs`   | `number`  | `60_000`         | How long public reads use the primary after a content write when `cachedBinding` is set |
+| `migrationConnectionStringEnv` | `string`  | Derived from the primary binding | Environment variable containing the direct PostgreSQL URL used by `emdash migrate` |
+| `max`                          | `number`  | `5`              | Maximum connections from one Worker isolate to Hyperdrive                   |
+
+The following example routes authenticated requests and writes through the uncached binding, while anonymous public reads can use the cached binding:
+
+```js
+hyperdrive({
+	binding: "HYPERDRIVE",
+	cachedBinding: "HYPERDRIVE_CACHED",
+	preferUncachedAfterWriteMs: 60_000,
+});
+```
+
+Both bindings must point to the same database. Install `pg` version 8.16.3 or later, enable the `nodejs_compat` compatibility flag, and configure a direct database URL for deployment migrations. See [Database Options: Hyperdrive](/deployment/database/#hyperdrive) for the complete Worker and migration setup.
+
+### `durableObjects(config)`
+
+Stores the CMS in one SQLite-backed Durable Object. Import this adapter from `@emdash-cms/cloudflare`.
+
+| Option           | Type     | Default             | Description                                                        |
+| ---------------- | -------- | ------------------- | ------------------------------------------------------------------ |
+| `binding`        | `string` | required            | Durable Object namespace binding for the `EmDashDB` class          |
+| `name`           | `string` | `"emdash"`          | Singleton object name; change it only to isolate multiple databases behind one binding |
+| `session`        | `string` | `"disabled"`        | `"auto"` routes anonymous reads to replicas and writes to the primary |
+| `bookmarkCookie` | `string` | `"__em_do_bookmark"` | Cookie used for read-your-writes consistency in `"auto"` mode      |
+
+```js
+durableObjects({ binding: "DB_DO", session: "auto" });
+```
+
+Replica routing requires the `experimental` and `replica_routing` compatibility flags plus the Durable Object class and migration entries in `wrangler.jsonc`.
+
+### `previewDatabase(config)`
+
+Creates one isolated snapshot database per preview session in a Durable Object. The only option is the required `binding` name:
+
+```js
+previewDatabase({ binding: "PREVIEW_DB" });
+```
+
+This adapter is for preview infrastructure, not a production site's primary database.
+
+### `playgroundDatabase(config)`
+
+Creates one writable seeded database per playground session in a Durable Object. Pair it with the [`playground`](#playground) integration option:
+
+```js
+playgroundDatabase({ binding: "PLAYGROUND_DB" });
+```
+
+The required `binding` identifies the playground Durable Object namespace. Use this adapter only for disposable demo sites.
 
 ## Storage adapters
 
@@ -646,6 +851,8 @@ r2({
 S3-compatible storage. All config fields are optional: any field omitted from
 `s3({...})` is resolved from the matching `S3_*` environment variable when the
 Node process starts. Explicit values always take precedence.
+
+After config and environment values are merged, `endpoint` and `bucket` are required. If either credential is set, both `accessKeyId` and `secretAccessKey` are required. Missing values fail startup with the `MISSING_S3_CONFIG` error code.
 
 **Prerequisite:** install `@aws-sdk/client-s3` and `@aws-sdk/s3-request-presigner`
 in your project. EmDash core does not bundle the AWS SDK. See
@@ -720,6 +927,111 @@ memoryCache({
 
 See [Object Cache](/deployment/object-cache/) for setup and behavior.
 
+## Authentication and sandbox adapters
+
+These adapters return values for the `auth` and `sandboxRunner` integration options.
+
+### `access(config)`
+
+Replaces the built-in passkey login with Cloudflare Access authentication. Import it from `@emdash-cms/cloudflare` and pass the result to [`auth`](#auth):
+
+```js
+import { access } from "@emdash-cms/cloudflare";
+
+emdash({
+	auth: access({
+		teamDomain: "myteam.cloudflareaccess.com",
+		audienceEnvVar: "CF_ACCESS_AUDIENCE",
+	}),
+});
+```
+
+`teamDomain` is required. The adapter can read the application audience from `audience` or from the variable named by `audienceEnvVar`; it also accepts `autoProvision`, `defaultRole`, `syncRoles`, and `roleMapping`. The [`auth`](#auth) option documents their defaults and role behavior.
+
+### `sandbox()`
+
+Selects Cloudflare Worker Loader as the plugin sandbox runner. Import it from `@emdash-cms/cloudflare` and pass its return value to [`sandboxRunner`](#sandboxrunner):
+
+```js
+import { sandbox } from "@emdash-cms/cloudflare";
+
+emdash({
+	sandboxRunner: sandbox(),
+});
+```
+
+The site also needs a Worker Loader binding and the plugin bridge entry point. See [Plugin Sandbox: Cloudflare Workers](/deployment/plugin-sandbox/#cloudflare-workers) for those deployment settings.
+
+## Media provider adapters
+
+Pass media provider descriptors to [`mediaProviders`](#mediaproviders). Both built-in Cloudflare providers are imported from `@emdash-cms/cloudflare`.
+
+### `cloudflareImages(config)`
+
+Adds Cloudflare Images for browsing, uploading, deleting, and delivering image assets.
+
+| Option           | Type      | Default                  | Description                                      |
+| ---------------- | --------- | ------------------------ | ------------------------------------------------ |
+| `accountId`      | `string`  | From `CF_ACCOUNT_ID`     | Cloudflare account ID                            |
+| `accountIdEnvVar` | `string` | `"CF_ACCOUNT_ID"`        | Variable used when `accountId` is omitted        |
+| `accountHash`    | `string`  | From `CF_IMAGES_ACCOUNT_HASH` | Account hash used in delivery URLs           |
+| `accountHashEnvVar` | `string` | `"CF_IMAGES_ACCOUNT_HASH"` | Variable used when `accountHash` is omitted |
+| `apiToken`       | `string`  | From `CF_IMAGES_TOKEN`   | Token with Cloudflare Images read and edit permissions |
+| `apiTokenEnvVar` | `string`  | `"CF_IMAGES_TOKEN"`      | Variable used when `apiToken` is omitted         |
+| `deliveryDomain` | `string`  | `imagedelivery.net`      | Custom image delivery hostname                   |
+| `defaultVariant` | `string`  | `"public"`               | Image variant used for display                   |
+
+```js
+mediaProviders: [cloudflareImages({ defaultVariant: "public" })];
+```
+
+### `cloudflareStream(config)`
+
+Adds Cloudflare Stream for browsing, searching, uploading, deleting, and playing video assets.
+
+| Option              | Type      | Default                | Description                                      |
+| ------------------- | --------- | ---------------------- | ------------------------------------------------ |
+| `accountId`         | `string`  | From `CF_ACCOUNT_ID`   | Cloudflare account ID                            |
+| `accountIdEnvVar`   | `string`  | `"CF_ACCOUNT_ID"`      | Variable used when `accountId` is omitted        |
+| `apiToken`          | `string`  | From `CF_STREAM_TOKEN` | Token with Cloudflare Stream read and edit permissions |
+| `apiTokenEnvVar`    | `string`  | `"CF_STREAM_TOKEN"`    | Variable used when `apiToken` is omitted         |
+| `customerSubdomain` | `string`  | Cloudflare default     | Custom Stream delivery hostname                  |
+| `controls`          | `boolean` | `true`                 | Show player controls                             |
+| `autoplay`          | `boolean` | `false`                | Start playback automatically                     |
+| `loop`              | `boolean` | `false`                | Repeat playback                                  |
+| `muted`             | `boolean` | `false`, or `true` with autoplay | Mute playback                         |
+
+```js
+mediaProviders: [cloudflareStream({ controls: true })];
+```
+
+See [Media Library: Media providers](/guides/media-library/#media-providers) for the required bindings and rendering components.
+
+## Astro cache adapter
+
+### `cloudflareCache(config?)`
+
+<Aside type="caution" title="Deprecated adapter">
+	`cloudflareCache()` is retained for existing sites. New Cloudflare sites should enable native
+	Workers Caching in `wrangler.jsonc` and use `cacheCloudflare()` from
+	`@astrojs/cloudflare/cache`. The native provider invalidates through `cache.purge()` and does
+	not need zone credentials.
+</Aside>
+
+The legacy adapter returns an Astro `cache.provider` that stores responses in the Workers Cache API and purges cache tags through the Cloudflare REST API:
+
+```js title="astro.config.mjs"
+import { cloudflareCache } from "@emdash-cms/cloudflare";
+
+export default defineConfig({
+	cache: {
+		provider: cloudflareCache(),
+	},
+});
+```
+
+It accepts `cacheName` (default `"emdash"`) and `bookmarkCookie` (default `"__em_d1_bookmark"`), plus `zoneId` or `zoneIdEnvVar` and `apiToken` or `apiTokenEnvVar` for purge-by-tag requests. The default variable names are `CF_ZONE_ID` and `CF_CACHE_PURGE_TOKEN`.
+
 ## Live collections
 
 Configure the EmDash loader in `src/live.config.ts`:
@@ -773,6 +1085,7 @@ Templates and sites can declare optional metadata under an `emdash` key in `pack
 {
 	"emdash": {
 		"label": "My Blog Template",
+		"schema": ".emdash/schema.sql",
 		"seed": ".emdash/seed.json",
 		"url": "https://my-site.pages.dev"
 	}
@@ -782,12 +1095,15 @@ Templates and sites can declare optional metadata under an `emdash` key in `pack
 | Option        | Description                        |
 | ------------- | ---------------------------------- |
 | `label`       | Template name for display          |
+| `schema`      | Optional SQL schema read by `emdash init` |
 | `seed`        | Path to seed JSON file             |
-| `url`         | Remote URL for schema sync         |
+| `url`         | Remote URL used by the deprecated `emdash dev --types` flow |
 
 ## TypeScript configuration
 
-EmDash generates types in `.emdash/types.ts`. Add a path alias to your `tsconfig.json`:
+During local development, the Astro integration generates `emdash-env.d.ts` in the project root and refreshes it after schema changes. The file augments the `emdash` module, so the standard `getEmDashCollection()` and `getEmDashEntry()` imports infer local collection fields without a path alias.
+
+The separate `emdash types` command fetches schema from a running local or remote instance and writes `.emdash/types.ts` by default. Add an alias only when application code imports that standalone output directly:
 
 ```json title="tsconfig.json"
 {
@@ -799,7 +1115,7 @@ EmDash generates types in `.emdash/types.ts`. Add a path alias to your `tsconfig
 }
 ```
 
-Generate types with the following command:
+Generate the standalone remote-schema types with the following command:
 
 ```bash
 npx emdash types

--- a/docs/src/content/docs/reference/field-types.mdx
+++ b/docs/src/content/docs/reference/field-types.mdx
@@ -30,7 +30,7 @@ The following table lists every field type and its SQLite column:
 | `slug`         | TEXT          | URL-safe identifier        |
 | `repeater`     | JSON          | Repeating group of fields  |
 
-## Text Types
+## Text types
 
 ### `string`
 
@@ -53,7 +53,7 @@ Short, single-line text. Use for titles, names, and short values.
 
 - `minLength` — Minimum character count
 - `maxLength` — Maximum character count
-- `pattern` — Regex pattern to match
+- `pattern` — Regular expression the value must match
 
 **Widget options:**
 
@@ -78,28 +78,44 @@ Multi-line plain text. Use for descriptions, excerpts, and longer plain text.
 
 - `minLength` — Minimum character count
 - `maxLength` — Maximum character count
+- `pattern` — Regular expression the value must match
 
 **Widget options:**
 
 - `rows` — Number of rows in textarea (default: 3)
 
-### `slug`
+### `url`
 
-URL-safe identifier. Automatically generated from another field or manually entered.
+A web address. The content API rejects values that are not valid URLs.
 
 ```ts
 {
-  slug: "slug",
-  label: "URL Slug",
+  slug: "website",
+  label: "Website",
+  type: "url",
+  required: true,
+}
+```
+
+URL fields are stored as text. Use a `string` field instead when a value may be a relative path such as `/about`, because relative paths are not valid values for a `url` field.
+
+### `slug`
+
+Text intended to hold a slug-like value. This custom field type does not generate or sanitize its value.
+
+```ts
+{
+  slug: "legacy_slug",
+  label: "Legacy Slug",
   type: "slug",
   required: true,
   unique: true,
 }
 ```
 
-Slugs are automatically sanitized: lowercased, spaces replaced with hyphens, special characters removed.
+Every content entry already has a reserved system `slug`, which EmDash manages separately for public URLs. Use a custom `slug` field only when the content model needs another stored slug-like value.
 
-## Number Types
+## Number types
 
 ### `number`
 
@@ -164,7 +180,7 @@ True or false. Use for toggles and flags.
 
 Stored as SQLite INTEGER (0 or 1).
 
-## Date and Time
+## Date and time
 
 ### `datetime`
 
@@ -178,14 +194,9 @@ Date and time value. Stored in ISO 8601 format.
 }
 ```
 
-**Validation options:**
-
-- `min` — Minimum date (ISO string)
-- `max` — Maximum date (ISO string)
-
 **Storage format:** `2025-01-24T12:00:00.000Z`
 
-## Selection Types
+## Selection types
 
 ### `select`
 
@@ -206,7 +217,7 @@ Single selection from predefined options.
 
 **Validation options:**
 
-- `options` — Array of allowed values (required)
+- `options` — Optional array of allowed values. Provide it to present predefined choices and reject other strings; without it, validation accepts any string.
 
 Stored as TEXT containing the selected value.
 
@@ -227,11 +238,11 @@ Multiple selections from predefined options.
 
 **Validation options:**
 
-- `options` — Array of allowed values (required)
+- `options` — Optional array of allowed values. Provide it to present predefined choices and reject other strings; without it, validation accepts any string array.
 
 Stored as JSON array: `["news", "tutorial"]`
 
-## Rich Content
+## Rich content
 
 ### `portableText`
 
@@ -258,14 +269,14 @@ The value is stored as a JSON array of Portable Text blocks, for example:
 ]
 ```
 
-Plugins can add custom block types (embeds, widgets, etc.) to the editor. These appear in the slash command menu and are automatically rendered on the site. See [Portable Text rendering components](/plugins/creating-native-plugins/portable-text-components/).
+Plugins can add custom block types (embeds, widgets, etc.) to the editor. These appear in the slash command menu. Rendering the saved block on the public site requires an Astro component from a native plugin or companion package. See [Portable Text rendering components](/plugins/creating-native-plugins/portable-text-components/).
 
 <Aside>
 	Portable Text is a specification for structured rich text. See
 	[portabletext.org](https://portabletext.org) for details.
 </Aside>
 
-## Media Types
+## Media types
 
 ### `image`
 
@@ -276,26 +287,36 @@ Reference to an uploaded image. Includes metadata like dimensions and alt text.
   slug: "featuredImage",
   label: "Featured Image",
   type: "image",
+  validation: {
+    allowedMimeTypes: ["image/jpeg", "image/png"],
+  },
   options: {
-    showPreview: true,
+    darkVariant: true,
   },
 }
 ```
 
 **Widget options:**
 
-- `showPreview` — Show image preview in admin (default: true)
 - `darkVariant` — Offer editors a second slot for an image shown in dark color schemes (default: false). See [Dark Mode](/guides/dark-mode/).
+
+**Validation options:**
+
+- `allowedMimeTypes` — Non-empty list of exact MIME types accepted for the selected media
 
 The value is stored as an object with the media reference and its metadata:
 
 ```json
 {
 	"id": "01HXK5MZSN...",
-	"url": "https://cdn.example.com/image.jpg",
+	"src": "/_emdash/api/media/file/01HXK5MZSN...",
 	"alt": "Description",
 	"width": 1920,
-	"height": 1080
+	"height": 1080,
+	"provider": "local",
+	"meta": {
+		"storageKey": "01HXK5MZSN....jpg"
+	}
 }
 ```
 
@@ -324,8 +345,15 @@ Reference to an uploaded file such as a document or PDF.
   slug: "document",
   label: "Document",
   type: "file",
+  validation: {
+    allowedMimeTypes: ["application/pdf"],
+  },
 }
 ```
+
+**Validation options:**
+
+- `allowedMimeTypes` — Non-empty list of exact MIME types accepted for the selected media
 
 The value is stored as a provider reference with cached metadata:
 
@@ -346,7 +374,7 @@ persisted value as-is and do not hydrate it from the media library. See
 [File values and current metadata](/guides/media-library/#file-values-and-current-metadata) for the
 canonical lookup APIs when you need fresh metadata or a provider-specific URL.
 
-## Relational Types
+## Relational types
 
 ### `reference`
 
@@ -367,21 +395,14 @@ Reference to another content entry.
 **Widget options:**
 
 - `collection` — Target collection slug (required)
-- `allowMultiple` — Allow multiple references (default: false)
 
-A single reference is stored as the target entry ID:
+A reference is stored as the target entry ID:
 
 ```json
 "01HXK5MZSN..."
 ```
 
-Multiple references are stored as an array of entry IDs:
-
-```json
-["01HXK5MZSN...", "01HXK6NATS..."]
-```
-
-## Flexible Types
+## Flexible types
 
 ### `json`
 
@@ -399,6 +420,49 @@ Stored as-is in SQLite JSON column.
 
 <Aside type="caution">JSON fields have no validation. Use sparingly for truly dynamic data.</Aside>
 
+### `repeater`
+
+A repeating list of structured rows. Define at least one sub-field in `validation.subFields`; editors can then add, remove, reorder, and edit rows without entering raw JSON.
+
+The following field stores a list of product specifications:
+
+```ts
+{
+  slug: "specifications",
+  label: "Specifications",
+  type: "repeater",
+  validation: {
+    minItems: 1,
+    maxItems: 12,
+    subFields: [
+      { slug: "label", label: "Label", type: "string", required: true },
+      { slug: "value", label: "Value", type: "text", required: true },
+      { slug: "source", label: "Source", type: "url" },
+    ],
+  },
+}
+```
+
+Repeater values are stored as an array of objects:
+
+```json
+[
+	{
+		"label": "Weight",
+		"value": "1.2 kg",
+		"source": "https://example.com/specifications"
+	}
+]
+```
+
+The allowed sub-field types are `string`, `text`, `url`, `number`, `integer`, `boolean`, `datetime`, `select`, and `image`. Repeaters cannot contain another repeater or a complex field such as `portableText`, `reference`, or `file`.
+
+Repeater validation accepts these properties:
+
+- `subFields` — One or more sub-field definitions. Each definition requires `slug`, `label`, and `type`; it can also set `required`. A `select` sub-field supplies its choices through `options`.
+- `minItems` — Minimum number of rows. Must be zero or greater.
+- `maxItems` — Maximum number of rows. Must be one or greater and cannot be less than `minItems`.
+
 ## Field properties
 
 All fields support these common properties:
@@ -410,7 +474,9 @@ All fields support these common properties:
 | `type`         | `FieldType` | Field type (required)               |
 | `required`     | `boolean`   | Require a value (default: false)    |
 | `unique`       | `boolean`   | Enforce uniqueness (default: false) |
+| `searchable`   | `boolean`   | Include the field in full-text search (default: false) |
 | `indexed`      | `boolean`   | Enable indexed field sorting/filtering |
+| `translatable` | `boolean`   | Store a value per locale (default: true) |
 | `defaultValue` | `unknown`   | Default value for new entries       |
 | `validation`   | `object`    | Type-specific validation rules      |
 | `widget`       | `string`    | Custom widget override              |
@@ -421,6 +487,8 @@ All fields support these common properties:
 `datetime`, `select`, `reference`, and `slug`. An indexed field can be passed as the `orderBy`
 field or used in `fieldFilters` in content list queries. Avoid indexing fields that are not used
 for sorting or filtering because every index adds storage and write overhead.
+
+`searchable` adds the field's text to the collection's full-text search index. Set `translatable: false` for identifiers, prices, flags, and other values that must stay the same across every translation of an entry; when one locale changes a non-translatable field, EmDash synchronizes the value to its translated entries.
 
 ## Reserved field slugs
 

--- a/docs/src/content/docs/reference/hooks.mdx
+++ b/docs/src/content/docs/reference/hooks.mdx
@@ -39,9 +39,11 @@ The following table lists every hook, what triggers it, what it can modify, and 
 | `plugin:deactivate`     | When plugin is disabled               | Nothing           | No        |
 | `plugin:uninstall`      | When plugin is removed                | Nothing           | No        |
 
-## Content Hooks
+## Content hooks
 
 ### `content:beforeSave`
+
+**Capability:** `content:write`
 
 Runs before content is saved to the database. Use it to validate, transform, or enrich content. A sandboxed hook rejects a save by returning a version 1 hook result with a `SAVE_REJECTED` error and a plain-text `reason` of 1–500 characters. The API responds with `SAVE_REJECTED`, and the admin identifies the plugin and shows the reason as text. Empty, overlong, malformed, and unknown error results fail the save with a generic `CONTENT_HOOK_ERROR` response.
 
@@ -83,13 +85,30 @@ interface ContentHookEvent {
 
 On an update, `content` holds only the submitted field values. Load the stored item with `ctx.content.get(event.collection, event.id)` when the hook needs to compare against it.
 
-#### Return Value
+#### Return value
 
 - Return modified content object to apply changes
 - Return a sandbox hook error envelope to reject the save with a bounded plain-text reason
 - Return `void` to pass through unchanged
 
+A sandboxed hook returns this complete envelope to reject a save:
+
+```ts
+return {
+	__emdashSandboxHookResult: true,
+	version: 1,
+	error: {
+		code: "SAVE_REJECTED",
+		reason: "Add a summary before saving.",
+	},
+};
+```
+
+The host trims `reason` and accepts between 1 and 500 characters.
+
 ### `content:afterSave`
+
+**Capability:** `content:read`
 
 Runs after content is saved. Use for side effects like notifications, cache invalidation, or external syncing.
 
@@ -109,11 +128,17 @@ hooks: {
 }
 ```
 
-#### Return Value
+#### Event
+
+`content:afterSave` receives `content`, `collection`, and `isNew`. `content` is the complete saved entry, with its database ID in `content.id` and collection fields under `content.data`. The separate optional `id` used by `content:beforeSave` updates is absent after the save.
+
+#### Return value
 
 No return value expected.
 
 ### `content:beforeDelete`
+
+**Capability:** `content:read`
 
 Runs before content is deleted. Use to validate deletion or prevent it.
 
@@ -140,28 +165,64 @@ hooks: {
 interface ContentDeleteEvent {
 	id: string; // Entry ID
 	collection: string; // Collection slug
+	permanent?: false; // Present for native plugins; omitted in the sandbox runtime
 }
 ```
 
-#### Return Value
+`content:beforeDelete` only runs when an entry moves to trash. Native plugins receive `permanent: false`; the sandbox runtime sends only `id` and `collection`. Do not use this field to branch inside a sandboxed hook. Permanent deletion bypasses `content:beforeDelete`, so the hook cannot prevent an administrator from permanently deleting an entry that is already in the trash.
+
+#### Return value
 
 - Return `false` to cancel deletion
 - Return `true` or `void` to allow
 
 ### `content:afterDelete`
 
+**Capability:** `content:read`
+
 Runs after content is deleted. Use for cleanup tasks.
 
 ```ts
 hooks: {
   "content:afterDelete": async (event, ctx) => {
-    const { id, collection } = event;
+    const { id, collection, permanent } = event;
 
-    // Clean up related data
-    await ctx.storage.relatedItems.delete(`${collection}:${id}`);
+    if (permanent) {
+      await ctx.storage.relatedItems.delete(`${collection}:${id}`);
+    }
   },
 }
 ```
+
+The event contains `id`, `collection`, and `permanent`. `permanent` is `false` when the entry moves to trash and `true` when it is permanently deleted. Check it before removing data that a restored trashed entry would still need. This hook has no return value.
+
+### `content:afterPublish`
+
+Runs after an entry is published successfully, including an entry that EmDash publishes automatically at its scheduled time. Use it for work that depends on the published entry, such as notifying another service or refreshing an external search index.
+
+```ts
+hooks: {
+  "content:afterPublish": async (event, ctx) => {
+    ctx.log.info(`Published ${event.collection}/${event.content.id}`);
+  },
+}
+```
+
+The hook requires the `content:read` capability. EmDash runs it after the publish response, so its return value cannot change the entry or undo the publication. An error is logged; with `errorPolicy: "abort"`, later publish hooks do not run.
+
+### `content:afterUnpublish`
+
+Runs after an entry is unpublished successfully. Use it to remove or update copies of content held by external systems.
+
+```ts
+hooks: {
+  "content:afterUnpublish": async (event, ctx) => {
+    ctx.log.info(`Unpublished ${event.collection}/${event.content.id}`);
+  },
+}
+```
+
+This hook has the same `content:read` capability requirement, deferred execution, event shape, and no-return-value contract as `content:afterPublish`.
 
 ### `content:afterRestore`
 
@@ -208,13 +269,17 @@ interface ContentStateChangeEvent {
 }
 ```
 
-#### Return Value
+This event shape is shared by `content:afterPublish`, `content:afterUnpublish`, `content:afterRestore`, `content:afterSchedule`, and `content:afterUnschedule`. `content` is the complete entry after the state change, including its `id`, `slug`, and status; collection fields are under `content.data`.
+
+#### Return value
 
 No return value expected.
 
-## Media Hooks
+## Media hooks
 
 ### `media:beforeUpload`
+
+**Capability:** `media:write`
 
 Runs before a file is uploaded. Use to validate, rename, or reject files.
 
@@ -250,13 +315,15 @@ interface MediaUploadEvent {
 }
 ```
 
-#### Return Value
+#### Return value
 
 - Return modified file metadata to apply changes
 - Return `void` to pass through unchanged
 - Throw to reject the upload
 
 ### `media:afterUpload`
+
+**Capability:** `media:read`
 
 Runs after a file is uploaded. Use for processing, thumbnails, or metadata extraction.
 
@@ -290,7 +357,13 @@ interface MediaAfterUploadEvent {
 }
 ```
 
-## Lifecycle Hooks
+#### Return value
+
+No return value expected.
+
+## Lifecycle hooks
+
+Lifecycle hooks require no registration capability.
 
 ### `plugin:install`
 
@@ -332,6 +405,8 @@ hooks: {
 }
 ```
 
+`plugin:install`, `plugin:activate`, and `plugin:deactivate` receive an empty event object. They have no return value.
+
 ### `plugin:uninstall`
 
 Runs when a plugin is removed. Use for cleanup.
@@ -362,9 +437,13 @@ interface UninstallEvent {
 }
 ```
 
-## Cron Hook
+The uninstall hook has no return value.
+
+## Cron hook
 
 ### `cron`
+
+**Capability:** None required
 
 Fired when a scheduled task executes. Schedule tasks with `ctx.cron.schedule()`.
 
@@ -389,9 +468,11 @@ interface CronEvent {
 }
 ```
 
-## Email Hooks
+The cron hook has no return value.
 
-Email hooks run in order: `email:beforeSend`, then `email:deliver`, then `email:afterSend`.
+## Email hooks
+
+For messages sent by plugins, email hooks run in order: `email:beforeSend`, then `email:deliver`, then `email:afterSend`. System authentication messages go directly to `email:deliver`; they do not run through `email:beforeSend` or `email:afterSend`.
 
 ### `email:beforeSend`
 
@@ -422,11 +503,10 @@ interface EmailBeforeSendEvent {
 }
 ```
 
-#### Return Value
+#### Return value
 
 - Return modified message to transform
 - Return `false` to cancel delivery
-- Return `void` to pass through unchanged
 
 ### `email:deliver`
 
@@ -445,6 +525,17 @@ hooks: {
 }
 ```
 
+#### Event and return value
+
+```ts
+interface EmailDeliverEvent {
+	message: { to: string; subject: string; text: string; html?: string };
+	source: string;
+}
+```
+
+The hook has no return value. `source` is `"system"` for EmDash authentication messages and the plugin ID for messages sent by a plugin.
+
 ### `email:afterSend`
 
 **Capability:** `hooks.email-events:register`
@@ -462,9 +553,32 @@ hooks: {
 }
 ```
 
-## Comment Hooks
+#### Event and return value
+
+`email:afterSend` receives the same `message` and `source` fields as `email:deliver`. It has no return value.
+
+## Comment hooks
 
 Comment hooks run in order: `comment:beforeCreate`, then `comment:moderate`, then `comment:afterCreate`. The `comment:afterModerate` hook fires separately when an admin changes a comment's status.
+
+After a comment is stored, hooks receive this record shape:
+
+```ts
+interface StoredComment {
+	id: string;
+	collection: string;
+	contentId: string;
+	parentId: string | null;
+	authorName: string;
+	authorEmail: string;
+	authorUserId: string | null;
+	body: string;
+	status: string;
+	moderationMetadata: Record<string, unknown> | null;
+	createdAt: string;
+	updatedAt: string;
+}
+```
 
 ### `comment:beforeCreate`
 
@@ -502,7 +616,7 @@ interface CommentBeforeCreateEvent {
 }
 ```
 
-#### Return Value
+#### Return value
 
 - Return modified event to transform
 - Return `false` to reject
@@ -545,7 +659,7 @@ interface CommentModerateEvent {
 }
 ```
 
-#### Return Value
+#### Return value
 
 ```ts
 { status: "approved" | "pending" | "spam"; reason?: string }
@@ -555,14 +669,15 @@ interface CommentModerateEvent {
 
 **Capability:** `users:read`
 
-Fire-and-forget hook after a comment is stored. Use for notifications.
+Fire-and-forget hook after a comment is stored. Use for notifications. Sending email also requires the `email:send` capability and a configured `email:deliver` provider; without both, `ctx.email` is undefined.
 
 ```ts
 hooks: {
   "comment:afterCreate": async (event, ctx) => {
-    if (event.comment.status === "approved") {
-      await ctx.email?.send({
-        to: event.contentAuthor?.email,
+    const recipient = event.contentAuthor?.email;
+    if (event.comment.status === "approved" && recipient && ctx.email) {
+      await ctx.email.send({
+        to: recipient,
         subject: `New comment on "${event.content.title}"`,
         text: `${event.comment.authorName} commented: ${event.comment.body}`,
       });
@@ -570,6 +685,19 @@ hooks: {
   },
 }
 ```
+
+#### Event and return value
+
+```ts
+interface CommentAfterCreateEvent {
+	comment: StoredComment;
+	metadata: Record<string, unknown>;
+	content: { id: string; collection: string; slug: string; title?: string };
+	contentAuthor?: { id: string; name: string | null; email: string };
+}
+```
+
+The hook has no return value.
 
 ### `comment:afterModerate`
 
@@ -581,16 +709,53 @@ Fire-and-forget hook when an admin manually changes a comment's status.
 
 ```ts
 interface CommentAfterModerateEvent {
-	comment: { id: string; /* ... */ };
+	comment: StoredComment;
 	previousStatus: string;
 	newStatus: string;
 	moderator: { id: string; name: string | null };
 }
 ```
 
-## Page Hooks
+The hook has no return value.
+
+## Page hooks
 
 Page hooks run when rendering public pages. They allow plugins to inject metadata and scripts.
+
+Both page hooks receive the current public page context:
+
+```ts
+interface PublicPageContext {
+	url: string;
+	path: string;
+	locale: string | null;
+	kind: "content" | "custom";
+	pageType: string;
+	title: string | null;
+	pageTitle?: string | null;
+	description: string | null;
+	canonical: string | null;
+	image: string | null;
+	content?: { collection: string; id: string; slug: string | null };
+	seo?: {
+		ogTitle?: string | null;
+		ogDescription?: string | null;
+		ogImage?: string | null;
+		robots?: string | null;
+	};
+	articleMeta?: {
+		publishedTime?: string | null;
+		modifiedTime?: string | null;
+		author?: string | null;
+	};
+	siteName?: string;
+	breadcrumbs?: Array<{ name: string; url: string }>;
+	siteUrl?: string;
+}
+
+interface PageMetadataEvent { page: PublicPageContext }
+interface PageFragmentEvent { page: PublicPageContext }
+```
 
 ### `page:metadata`
 
@@ -603,14 +768,14 @@ hooks: {
   "page:metadata": async (event, ctx) => {
     return [
       { kind: "meta", name: "generator", content: "EmDash" },
-      { kind: "property", property: "og:site_name", content: event.page.siteName },
+      { kind: "property", property: "og:site_name", content: event.page.siteName ?? "My Site" },
       { kind: "jsonld", graph: { "@type": "WebSite", name: event.page.siteName } },
     ];
   },
 }
 ```
 
-#### Contribution Types
+#### Contribution types
 
 ```ts
 type PageMetadataContribution =
@@ -631,6 +796,8 @@ type PageMetadataContribution =
 ```
 
 The `key` field deduplicates contributions — only the last contribution with a given key is used.
+
+Return one contribution, an array of contributions, or `null` when the plugin has nothing to add.
 
 ### `page:fragments`
 
@@ -658,7 +825,7 @@ hooks: {
 }
 ```
 
-#### Contribution Types
+#### Contribution types
 
 ```ts
 type PageFragmentContribution =
@@ -686,7 +853,9 @@ type PageFragmentContribution =
 		};
 ```
 
-## Hook Configuration
+Return one fragment contribution, an array of contributions, or `null` when the plugin has nothing to add.
+
+## Hook configuration
 
 Hooks accept either a handler function or a configuration object:
 
@@ -706,7 +875,7 @@ hooks: {
 }
 ```
 
-### Configuration Options
+### Configuration options
 
 | Option         | Type       | Default   | Description                                          |
 | -------------- | ---------- | --------- | ---------------------------------------------------- |
@@ -716,7 +885,7 @@ hooks: {
 | `errorPolicy`  | `string`   | `"abort"` | `"continue"` to ignore errors                        |
 | `exclusive`    | `boolean`  | `false`   | Only one plugin can be the active provider (for provider-pattern hooks like `email:deliver`, `comment:moderate`) |
 
-## Plugin Context
+## Plugin context
 
 All hooks receive a context object with access to plugin APIs:
 
@@ -737,14 +906,14 @@ interface PluginContext {
 }
 ```
 
-See [Plugin Overview — Plugin Context](/plugins/overview/#plugin-context) for capability requirements and method details.
+See [Plugin capabilities](/plugins/creating-plugins/capabilities/) for the capability required by each context API.
 
 <Aside>
 	Context APIs are gated by plugin capabilities. Declare required capabilities in the plugin
 	definition.
 </Aside>
 
-## Error Handling
+## Error handling
 
 Errors in hooks are logged and handled based on `errorPolicy`:
 
@@ -766,7 +935,7 @@ hooks: {
 }
 ```
 
-## Execution Order
+## Execution order
 
 Hooks run in this order:
 


### PR DESCRIPTION
## What does this PR do?

Rebuilds the JavaScript API, CLI, configuration, field-type, and hook references from the current public contracts:

- defines the JavaScript reference as the function surface used by maintained site templates, while keeping related runtime helpers in context
- documents every CLI command and option, including the distinct local `emdash-env.d.ts` and remote `emdash types` outputs
- covers every authored `EmDashConfig` option and supported configuration adapter with defaults and constraints
- documents all 16 field types and every plugin hook, including capabilities, events, and return values
- runs a source-comparison check before the docs build so command, option, adapter, field, hook, and template-function inventories cannot drift silently

Related issue: none.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [ ] I have included screenshots below if this PR changes the UI

The scoped MDX and JSON files are excluded by the repository formatter configuration; the new JavaScript checker was formatted with oxfmt. Admin UI strings, a changeset, a feature Discussion, and screenshots are not applicable because this PR changes documentation and docs-build tooling only.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenAI GPT-5 Codex

## Screenshots / test output

Not applicable: this PR does not change the admin UI.

Verified with:

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:quick`
- `node docs/scripts/check-reference-inventories.mjs`
- `pnpm --dir docs build`
- `git diff --check`
