### PR TITLE
fix(admin): hide dashboard quick actions for hidden collections

### DIFF
--- a/.changeset/hidden-collections-dashboard-quick-action.md
+++ b/.changeset/hidden-collections-dashboard-quick-action.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the dashboard showing a "+ New …" quick action for collections marked `hidden`, matching the sidebar link the flag already removes.

--- a/docs/src/content/docs/themes/seed-files.mdx
+++ b/docs/src/content/docs/themes/seed-files.mdx
@@ -137,7 +137,7 @@ A collection requires `slug`, `label`, and `fields`:
 | `supports` | `string[]` | Any of `drafts`, `revisions`, `preview`, `scheduling`, `search`, and `seo` |
 | `urlPattern` | `string` | Public pattern such as `/posts/{slug}` |
 | `routable` | `boolean` | Whether published entries require a slug; defaults to `true` |
-| `hidden` | `boolean` | Hides only the generated sidebar link |
+| `hidden` | `boolean` | Hides the generated sidebar link and dashboard quick action; the collection stays reachable by URL and API |
 | `sortOrder` | `number` | Explicit admin-sidebar position; ordered collections come first, ascending |
 | `commentsEnabled` | `boolean` | Enables comments for the collection |
 | `editLocking` | `boolean` | Enables edit locks; defaults to `true` |

--- a/packages/admin/src/components/Dashboard.tsx
+++ b/packages/admin/src/components/Dashboard.tsx
@@ -18,6 +18,7 @@ import {
 } from "./ContentStatusBadge.js";
 import { RouterLinkButton } from "./RouterLinkButton";
 import { SandboxedPluginWidget } from "./SandboxedPluginWidget";
+import { visibleCollectionEntries } from "./Sidebar.js";
 
 const DASHBOARD_STATUS_STATES: Record<string, ContentStatusState> = {
 	published: "published",
@@ -143,7 +144,7 @@ function DashboardCardInset({ className, ...props }: React.ComponentPropsWithout
 
 function QuickActions({ manifest }: { manifest: AdminManifest }) {
 	const { t } = useLingui();
-	const collections = Object.entries(manifest.collections);
+	const collections = visibleCollectionEntries(manifest.collections);
 
 	return (
 		<div className="flex flex-wrap items-center gap-2">

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -62,13 +62,13 @@ export function filterNavItemsByRole<T extends { minRole?: number }>(
 }
 
 /**
- * Manifest collections that get an auto-generated sidebar entry, in manifest
- * order. Pure function — exported so tests can pin the `hidden` contract
- * without rendering the sidebar.
+ * Manifest collections that get an auto-generated sidebar entry and dashboard
+ * quick action, in manifest order. Pure function — exported so tests can pin
+ * the `hidden` contract without rendering the sidebar.
  *
  * A hidden collection is still shipped in the manifest and stays fully
- * routable at `/content/:collection`; it only loses its nav link, so a plugin
- * that owns the collection end to end can steer editors to its own admin UI.
+ * routable at `/content/:collection`, so a plugin that owns the collection end
+ * to end can steer editors to its own admin UI.
  */
 export function visibleCollectionEntries<T extends { hidden?: boolean }>(
 	collections: Record<string, T>,

--- a/packages/admin/src/lib/api/schema.ts
+++ b/packages/admin/src/lib/api/schema.ts
@@ -39,7 +39,7 @@ export interface SchemaCollection {
 	/** Published entries require a slug unless this is false. */
 	routable?: boolean;
 	hasSeo: boolean;
-	/** Sidebar entry omitted in the admin; the collection stays reachable by URL */
+	/** Sidebar entry and dashboard quick action omitted in the admin; the collection stays reachable by URL */
 	hidden: boolean;
 	/** Explicit sidebar position; absent means the alphabetical fallback */
 	sortOrder?: number;

--- a/packages/admin/tests/components/Dashboard.test.tsx
+++ b/packages/admin/tests/components/Dashboard.test.tsx
@@ -213,6 +213,22 @@ describe("Dashboard", () => {
 			.toHaveAttribute("href", "/content/pages/new");
 	});
 
+	it("omits quick actions for hidden collections", async () => {
+		mockFetchDashboardStats.mockResolvedValue(makeStats([]));
+		const withHidden: AdminManifest = {
+			...manifest,
+			collections: {
+				...manifest.collections,
+				sync_runs: { ...manifest.collections.pages!, labelSingular: "Sync run", hidden: true },
+			},
+		};
+
+		const screen = await render(<Dashboard manifest={withHidden} />);
+
+		await expect.element(screen.getByRole("link", { name: "Page" })).toBeInTheDocument();
+		await expect.element(screen.getByRole("link", { name: "Sync run" })).not.toBeInTheDocument();
+	});
+
 	it("uses the same heading level for every dashboard card title", async () => {
 		mockFetchDashboardStats.mockResolvedValue(makeStats([]));
 

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -37,9 +37,9 @@ export interface ManifestCollection {
 	titleField?: string;
 	dateField?: string;
 	/**
-	 * Omit the auto-generated sidebar entry in the admin. The collection is
-	 * still listed in the manifest so its routes, editor, and API keep working
-	 * — only the navigation link is dropped.
+	 * Omit the auto-generated sidebar entry and dashboard quick action in the
+	 * admin. The collection is still listed in the manifest so its routes,
+	 * editor, and API keep working.
 	 */
 	hidden?: boolean;
 	/** Valid custom field slugs to render in the admin content list. */

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -433,7 +433,7 @@ export interface CollectionTable {
 	date_field: string | null; // field slug (datetime) for the admin list Date column (NULL = default)
 	url_pattern: string | null; // URL pattern with {slug} placeholder (e.g. "/blog/{slug}")
 	routable: Generated<number>; // 0 or 1 — published entries require a slug when enabled
-	hidden: Generated<number>; // 0 or 1 — omit the auto-generated admin sidebar entry
+	hidden: Generated<number>; // 0 or 1 — omit the auto-generated sidebar entry and dashboard quick action
 	sort_order: number | null; // explicit admin sidebar position; NULL = alphabetical fallback
 	comments_enabled: Generated<number>; // 0 or 1
 	comments_moderation: Generated<string>; // 'all' | 'first_time' | 'none'

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -205,10 +205,10 @@ export interface Collection {
 	/** Whether published entries require a public slug. Defaults to true. */
 	routable?: boolean;
 	/**
-	 * Omit this collection's auto-generated entry from the admin sidebar.
-	 * The collection stays fully functional everywhere else (API, MCP, hooks,
-	 * direct `/content/:collection` URLs) — this only hides the nav link, so a
-	 * plugin that owns the collection can point editors at its own admin UI.
+	 * Omit this collection's auto-generated sidebar entry and dashboard quick
+	 * action. The collection stays fully functional everywhere else (API, MCP,
+	 * hooks, direct `/content/:collection` URLs), so a plugin that owns the
+	 * collection can point editors at its own admin UI.
 	 */
 	hidden: boolean;
 	/**
@@ -271,7 +271,7 @@ export interface CreateCollectionInput {
 	urlPattern?: string;
 	routable?: boolean;
 	hasSeo?: boolean;
-	/** Omit the auto-generated admin sidebar entry (defaults to false) */
+	/** Omit the auto-generated sidebar entry and dashboard quick action (defaults to false) */
 	hidden?: boolean;
 	/** Explicit admin sidebar position (omit for the alphabetical fallback) */
 	sortOrder?: number | null;
@@ -293,7 +293,7 @@ export interface UpdateCollectionInput {
 	urlPattern?: string | null;
 	routable?: boolean;
 	hasSeo?: boolean;
-	/** Omit the auto-generated admin sidebar entry */
+	/** Omit the auto-generated sidebar entry and dashboard quick action */
 	hidden?: boolean;
 	/** Explicit admin sidebar position; `null` clears it back to alphabetical */
 	sortOrder?: number | null;

--- a/packages/core/src/seed/types.ts
+++ b/packages/core/src/seed/types.ts
@@ -78,8 +78,9 @@ export interface SeedCollection {
 	/** Require a slug before an entry can be published. Defaults to true. */
 	routable?: boolean;
 	/**
-	 * Omit this collection from the admin sidebar. It stays reachable through
-	 * the API, MCP, plugin hooks, and direct `/content/:collection` URLs.
+	 * Omit this collection from the admin sidebar and the dashboard quick
+	 * actions. It stays reachable through the API, MCP, plugin hooks, and
+	 * direct `/content/:collection` URLs.
 	 */
 	hidden?: boolean;
 	/**


### PR DESCRIPTION
## What does this PR do?

The `hidden` flag on a collection removes its auto-generated sidebar entry so that a plugin which manages the collection end to end can keep editors out of it. The dashboard's quick actions are built from the same manifest and still rendered a "+ New …" button for every hidden collection, inviting editors to create entries by hand in a machine-managed collection.

The dashboard now filters through the same `visibleCollectionEntries` helper the sidebar uses. A regression test covers it, and the `hidden` docs and type comments name both surfaces.

Left as is on purpose: the command palette still lists hidden collections under "Go to …", since it is a search that admins use to navigate directly; the dashboard's Content card and Recent Activity are server-side stats and unchanged.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
- [x] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude Fable 5.1

## Screenshots / test output

Production site with `calendar_sync_runs` set to `hidden: true` (German admin locale).

![Dashboard quick actions before: fifteen "+" buttons including "+ Sync-Lauf" for the hidden collection](https://raw.githubusercontent.com/swissky/emdash/assets/dashboard-hidden-quick-actions/hidden-quick-action-before.jpg)

![Dashboard quick actions after: the same row without "+ Sync-Lauf"](https://raw.githubusercontent.com/swissky/emdash/assets/dashboard-hidden-quick-actions/hidden-quick-action-after.png)
