### PR TITLE
fix(media): add image/bmp to the default media upload allowlist

### DIFF
--- a/.changeset/add-bmp-to-allowlist.md
+++ b/.changeset/add-bmp-to-allowlist.md
@@ -1,0 +1,8 @@
+---
+"emdash": patch
+"@emdash-cms/admin": patch
+---
+
+Fixes BMP uploads failing with `File type not allowed`. `image/bmp` was missing from the default media upload allowlist, so a `.bmp` file was rejected before it ever reached storage — the same shape of bug as the earlier AVIF regression (#2683). BMP is a plain raster format with no active-content risk, so it carries the same safety profile as PNG/GIF/WebP/AVIF and needed no security tradeoff to add.
+
+`image/bmp` is now accepted by the upload routes (`POST /_emdash/api/media`, `POST /_emdash/api/media/upload-url`) and the MCP `media_upload` tool, which all read the same allowlist. `.bmp` also works as extension shorthand in a field's own `allowedMimeTypes`, matches the "Images" preset in the allowed-types editor, and appears in the admin upload dialog's file picker and thumbnail preview. Uploaded BMP files render inline (`Content-Disposition: inline`) like other safe raster types instead of being forced to download.

--- a/docs/src/content/docs/guides/media-library.mdx
+++ b/docs/src/content/docs/guides/media-library.mdx
@@ -54,7 +54,7 @@ finishes.
 
 The local Media Library accepts these file groups by default:
 
-- PNG, JPEG, GIF, WebP, and AVIF images;
+- PNG, JPEG, GIF, WebP, AVIF, and BMP images;
 - common video formats such as MP4, WebM, and QuickTime video;
 - common audio formats such as MP3, WAV, and Ogg audio; and
 - PDF documents.

--- a/packages/admin/src/components/AllowedTypesEditor.tsx
+++ b/packages/admin/src/components/AllowedTypesEditor.tsx
@@ -14,7 +14,7 @@ interface Preset {
 const PRESETS: ReadonlyArray<Preset> = [
 	{
 		key: "images",
-		mimeTypes: ["image/png", "image/jpeg", "image/gif", "image/webp", "image/avif"],
+		mimeTypes: ["image/png", "image/jpeg", "image/gif", "image/webp", "image/avif", "image/bmp"],
 	},
 	{ key: "pdf", mimeTypes: ["application/pdf"] },
 	{

--- a/packages/admin/src/components/MediaUploadDialog.tsx
+++ b/packages/admin/src/components/MediaUploadDialog.tsx
@@ -24,7 +24,7 @@ import {
 } from "./media/useMediaUploadQueue.js";
 
 export const LOCAL_MEDIA_UPLOAD_ACCEPT =
-	"image/png,image/jpeg,image/gif,image/webp,image/avif,video/*,audio/*,application/pdf";
+	"image/png,image/jpeg,image/gif,image/webp,image/avif,image/bmp,video/*,audio/*,application/pdf";
 
 const MAX_PREVIEW_BYTES = 8 * 1024 * 1024;
 const PREVIEW_MIME_TYPES = new Set([
@@ -33,6 +33,7 @@ const PREVIEW_MIME_TYPES = new Set([
 	"image/gif",
 	"image/webp",
 	"image/avif",
+	"image/bmp",
 ]);
 
 export interface MediaUploadDialogProps {

--- a/packages/admin/src/lib/mime-utils.ts
+++ b/packages/admin/src/lib/mime-utils.ts
@@ -6,6 +6,7 @@ export const EXTENSION_TO_MIME: Readonly<Record<string, string>> = {
 	".gif": "image/gif",
 	".webp": "image/webp",
 	".avif": "image/avif",
+	".bmp": "image/bmp",
 	".svg": "image/svg+xml",
 	".mp3": "audio/mpeg",
 	".wav": "audio/wav",

--- a/packages/core/src/api/handlers/media-allowlist.ts
+++ b/packages/core/src/api/handlers/media-allowlist.ts
@@ -22,6 +22,7 @@ export const GLOBAL_UPLOAD_ALLOWLIST: readonly string[] = [
 	"image/gif",
 	"image/webp",
 	"image/avif",
+	"image/bmp",
 	"video/",
 	"audio/",
 	"application/pdf",

--- a/packages/core/src/astro/routes/api/media/file/[...key].ts
+++ b/packages/core/src/astro/routes/api/media/file/[...key].ts
@@ -21,6 +21,7 @@ const SAFE_INLINE_TYPES = new Set([
 	"image/gif",
 	"image/webp",
 	"image/avif",
+	"image/bmp",
 	"image/x-icon",
 	"video/mp4",
 	"video/webm",

--- a/packages/core/src/media/image-endpoint.ts
+++ b/packages/core/src/media/image-endpoint.ts
@@ -67,6 +67,7 @@ const SAFE_INLINE_IMAGE_TYPES = new Set([
 	"image/gif",
 	"image/webp",
 	"image/avif",
+	"image/bmp",
 	"image/x-icon",
 ]);
 

--- a/packages/core/src/media/mime.ts
+++ b/packages/core/src/media/mime.ts
@@ -24,6 +24,7 @@ export const EXTENSION_TO_MIME: Readonly<Record<string, string>> = {
 	".gif": "image/gif",
 	".webp": "image/webp",
 	".avif": "image/avif",
+	".bmp": "image/bmp",
 	".svg": "image/svg+xml",
 	".mp3": "audio/mpeg",
 	".wav": "audio/wav",

--- a/packages/core/tests/unit/astro/routes.test.ts
+++ b/packages/core/tests/unit/astro/routes.test.ts
@@ -211,4 +211,20 @@ describe("media file catch-all route", () => {
 
 		expect(response.headers.get("Cache-Control")).toBe("public, max-age=31536000, immutable");
 	});
+
+	it("serves image/bmp inline, same as the other safe raster types", async () => {
+		const { context } = mockMediaContext("photo.bmp", "image/bmp");
+
+		const response = await getMediaFile(context);
+
+		expect(response.headers.get("Content-Disposition")).toBe("inline");
+	});
+
+	it("forces attachment for a type outside SAFE_INLINE_TYPES", async () => {
+		const { context } = mockMediaContext("icon.svg", "image/svg+xml");
+
+		const response = await getMediaFile(context);
+
+		expect(response.headers.get("Content-Disposition")).toBe("attachment");
+	});
 });

--- a/packages/core/tests/unit/media/image-endpoint.test.ts
+++ b/packages/core/tests/unit/media/image-endpoint.test.ts
@@ -156,6 +156,10 @@ describe("originalMediaHeaders", () => {
 		expect(h["Content-Security-Policy"]).toContain("sandbox");
 	});
 
+	it("renders image/bmp inline, same as the other safe raster types", () => {
+		expect(originalMediaHeaders("image/bmp")["Content-Disposition"]).toBe("inline");
+	});
+
 	it("forces attachment + sandbox for SVG and other active types", () => {
 		expect(originalMediaHeaders("image/svg+xml")["Content-Disposition"]).toBe("attachment");
 		expect(originalMediaHeaders("application/pdf")["Content-Disposition"]).toBe("attachment");

--- a/packages/core/tests/unit/media/media-allowlist.test.ts
+++ b/packages/core/tests/unit/media/media-allowlist.test.ts
@@ -19,6 +19,10 @@ describe("GLOBAL_UPLOAD_ALLOWLIST", () => {
 		expect(matchesMimeAllowlist("image/avif", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);
 	});
 
+	it("allows image/bmp, a raster format with no active-content risk", () => {
+		expect(matchesMimeAllowlist("image/bmp", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);
+	});
+
 	it("still allows video, audio, and pdf", () => {
 		expect(matchesMimeAllowlist("video/mp4", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);
 		expect(matchesMimeAllowlist("audio/mpeg", GLOBAL_UPLOAD_ALLOWLIST)).toBe(true);

--- a/packages/core/tests/unit/media/mime.test.ts
+++ b/packages/core/tests/unit/media/mime.test.ts
@@ -77,6 +77,7 @@ describe("expandExtensionShorthand", () => {
 		expect(expandExtensionShorthand(".pdf")).toBe("application/pdf");
 		expect(expandExtensionShorthand(".PDF")).toBe("application/pdf");
 		expect(expandExtensionShorthand(".avif")).toBe("image/avif");
+		expect(expandExtensionShorthand(".bmp")).toBe("image/bmp");
 		expect(expandExtensionShorthand(".docx")).toBe(
 			"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 		);


### PR DESCRIPTION
## What does this PR do?

BMP uploads fail with "File type not allowed" because image/bmp is missing from GLOBAL_UPLOAD_ALLOWLIST — the same shape of regression as the earlier missing-AVIF bug (#2683). BMP is a plain raster format with no active-content risk, so it needs no security tradeoff to allow, unlike SVG.

Also adds image/bmp to the two "safe to render inline" sets (SAFE_INLINE_TYPES in the media file route, SAFE_INLINE_IMAGE_TYPES in media/image-endpoint.ts) so an uploaded BMP renders in an <img> instead of being forced to download — without this a BMP would upload but still be unusable as an image. Extends .bmp extension shorthand support and the admin upload dialog/allowed-types preset to match.

Closes #3063

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] ~~User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.~~ Not applicable.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] ~~New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...~~ Not applicable.
- [ ] ~~I have included screenshots below if this PR changes the UI~~ Not applicable.

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Claude Sonnet 5 in Claude Code

## Screenshots / test output

<!-- Screenshots are required for every UI change. Show the rendered result and include before-and-after images when the result alone is not enough. Use descriptive alt text. For non-UI changes, write "Not applicable"; test output remains optional. -->

Not applicable