### PR TITLE
fix(core): don't save the inline Portable Text editor when nothing changed

### DIFF
--- a/.changeset/inline-editor-unchanged-saves.md
+++ b/.changeset/inline-editor-unchanged-saves.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes visual editing saving a new draft when nothing changed. With edit mode on, the inline Portable Text editor saved the body every time focus left it and every time the page was left, even if no one had typed, because each save check compared freshly generated block keys against the stored ones. Entries picked up drafts that differed only in `_key` and showed "Pending changes" in the admin. The editor now compares its document with the one last saved, so an unedited body is never saved and a real edit is saved once.

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -2096,6 +2096,12 @@ export function InlinePortableTextEditor({
 	tablePlaceholder = TableBlockNode.options.placeholder,
 }: InlinePortableTextEditorProps) {
 	const initialRef = React.useRef(value);
+	// The editor document as last known to be stored: the one the loaded
+	// content produced, then whatever each successful save sent. Saves compare
+	// against it structurally. Comparing serialized Portable Text against the
+	// raw `value` never matched, because serialization mints new `_key`s on
+	// every call, so every blur and every page leave saved a new draft.
+	const savedDocRef = React.useRef<Editor["state"]["doc"] | null>(null);
 	const savingRef = React.useRef(false);
 	const editorRef = React.useRef<ReturnType<typeof useEditor>>(null);
 
@@ -2159,9 +2165,9 @@ export function InlinePortableTextEditor({
 			// one that can still land.
 			if (savingRef.current && !options?.keepalive) return;
 
-			const current = JSON.stringify(getBlocks());
-			const initial = JSON.stringify(initialRef.current);
-			if (current === initial) return;
+			const doc = editorRef.current?.state.doc;
+			if (!doc || !savedDocRef.current || doc.eq(savedDocRef.current)) return;
+			const blocks = getBlocks();
 
 			savingRef.current = true;
 			try {
@@ -2171,13 +2177,14 @@ export function InlinePortableTextEditor({
 						method: "PUT",
 						credentials: "same-origin",
 						headers: { "Content-Type": "application/json", "X-EmDash-Request": "1" },
-						body: JSON.stringify({ data: { [field]: getBlocks() } }),
+						body: JSON.stringify({ data: { [field]: blocks } }),
 						keepalive: options?.keepalive ?? false,
 					},
 				);
 
 				if (res.ok) {
-					initialRef.current = getBlocks();
+					initialRef.current = blocks;
+					savedDocRef.current = doc;
 					document.dispatchEvent(new CustomEvent("emdash:save", { detail: { state: "saved" } }));
 					document.dispatchEvent(
 						new CustomEvent("emdash:content-changed", {
@@ -2289,9 +2296,10 @@ export function InlinePortableTextEditor({
 		},
 	});
 
-	// Store editor ref for getBlocks
+	// Store editor ref for getBlocks, and record the loaded document as saved.
 	React.useEffect(() => {
 		editorRef.current = editor;
+		if (editor && !savedDocRef.current) savedDocRef.current = editor.state.doc;
 	}, [editor]);
 
 	// Slash menu command handler

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -2096,11 +2096,9 @@ export function InlinePortableTextEditor({
 	tablePlaceholder = TableBlockNode.options.placeholder,
 }: InlinePortableTextEditorProps) {
 	const initialRef = React.useRef(value);
-	// The editor document as last known to be stored: the one the loaded
-	// content produced, then whatever each successful save sent. Saves compare
-	// against it structurally. Comparing serialized Portable Text against the
-	// raw `value` never matched, because serialization mints new `_key`s on
-	// every call, so every blur and every page leave saved a new draft.
+	// The editor document last known to be stored: the one the loaded content
+	// produced, then the one each successful save sent. `save()` does nothing
+	// while the current document is structurally equal to it (`Node.eq`).
 	const savedDocRef = React.useRef<Editor["state"]["doc"] | null>(null);
 	const savingRef = React.useRef(false);
 	const editorRef = React.useRef<ReturnType<typeof useEditor>>(null);

--- a/packages/core/tests/unit/components/inline-portable-text-unchanged-save.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-unchanged-save.test.ts
@@ -108,6 +108,11 @@ describe("inline Portable Text editor saves", () => {
 	type TestEditor = {
 		commands: { insertContentAt: (pos: number, text: string) => boolean; undo: () => boolean };
 	};
+	// The component does not expose its editor, and @tiptap/react has no
+	// public way to reach it from the DOM, so this uses the instance Tiptap's
+	// core attaches to its view's root element (`view.dom.editor`). The
+	// alternative, synthesizing input events for ProseMirror in jsdom, is less
+	// reliable than the internal it would avoid.
 	function editorOf(editable: HTMLElement): TestEditor {
 		const editor = (editable as HTMLElement & { editor?: TestEditor }).editor;
 		expect(editor).toBeDefined();

--- a/packages/core/tests/unit/components/inline-portable-text-unchanged-save.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-unchanged-save.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { InlinePortableTextEditor } from "../../../src/components/InlinePortableTextEditor.js";
+
+const actGlobal = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+// A stored body whose keys came from somewhere else (an import, the admin
+// editor), including a link, whose mark refers to its markDef by key.
+const storedBody = [
+	{
+		_type: "block" as const,
+		_key: "stored-a",
+		style: "normal" as const,
+		markDefs: [],
+		children: [{ _type: "span" as const, _key: "stored-a-1", text: "First paragraph.", marks: [] }],
+	},
+	{
+		_type: "block" as const,
+		_key: "stored-b",
+		style: "normal" as const,
+		markDefs: [{ _type: "link", _key: "stored-link", href: "https://example.com/" }],
+		children: [
+			{ _type: "span" as const, _key: "stored-b-1", text: "Read ", marks: [] },
+			{ _type: "span" as const, _key: "stored-b-2", text: "the guide", marks: ["stored-link"] },
+			{ _type: "span" as const, _key: "stored-b-3", text: " first.", marks: [] },
+		],
+	},
+];
+
+describe("inline Portable Text editor saves", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let puts: Array<{ url: string; body: unknown }>;
+
+	beforeEach(() => {
+		actGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement("div");
+		document.body.append(container);
+		root = createRoot(container);
+		puts = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+				const url =
+					typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+				if (init?.method === "PUT") {
+					puts.push({ url, body: typeof init.body === "string" ? JSON.parse(init.body) : init.body });
+				}
+				return Response.json({ data: {} });
+			}),
+		);
+	});
+
+	afterEach(async () => {
+		await act(async () => root.unmount());
+		container.remove();
+		delete actGlobal.IS_REACT_ACT_ENVIRONMENT;
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	async function mount() {
+		await act(async () => {
+			root.render(
+				React.createElement(InlinePortableTextEditor, {
+					value: structuredClone(storedBody),
+					collection: "posts",
+					entryId: "entry-1",
+					field: "body",
+				}),
+			);
+		});
+		const editable = container.querySelector<HTMLElement>(".ProseMirror");
+		expect(editable).not.toBeNull();
+		return editable!;
+	}
+
+	async function blur(editable: HTMLElement) {
+		const outside = document.createElement("button");
+		document.body.append(outside);
+		await act(async () => {
+			editable.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: outside }));
+		});
+		outside.remove();
+	}
+
+	it("does not save when focus leaves an unedited body", async () => {
+		const editable = await mount();
+		await blur(editable);
+		await blur(editable);
+		await blur(editable);
+		expect(puts).toHaveLength(0);
+	});
+
+	it("does not save on page leave when the body was never touched", async () => {
+		await mount();
+		await act(async () => {
+			window.dispatchEvent(new Event("pagehide"));
+		});
+		expect(puts).toHaveLength(0);
+	});
+
+	type TestEditor = {
+		commands: { insertContentAt: (pos: number, text: string) => boolean; undo: () => boolean };
+	};
+	function editorOf(editable: HTMLElement): TestEditor {
+		const editor = (editable as HTMLElement & { editor?: TestEditor }).editor;
+		expect(editor).toBeDefined();
+		return editor!;
+	}
+
+	it("saves a real edit once, and not again on the next blur", async () => {
+		const editable = await mount();
+		await act(async () => {
+			editorOf(editable).commands.insertContentAt(1, "Edited. ");
+		});
+
+		await blur(editable);
+		expect(puts).toHaveLength(1);
+		expect(puts[0]!.url).toBe("/_emdash/api/content/posts/entry-1");
+
+		await blur(editable);
+		expect(puts).toHaveLength(1);
+	});
+
+	it("does not save an edit that was undone before focus left", async () => {
+		const editable = await mount();
+		await act(async () => {
+			editorOf(editable).commands.insertContentAt(1, "Edited. ");
+		});
+		await act(async () => {
+			editorOf(editable).commands.undo();
+		});
+
+		await blur(editable);
+		expect(puts).toHaveLength(0);
+	});
+});

--- a/packages/core/tests/unit/components/inline-portable-text-unchanged-save.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-unchanged-save.test.ts
@@ -49,7 +49,10 @@ describe("inline Portable Text editor saves", () => {
 				const url =
 					typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
 				if (init?.method === "PUT") {
-					puts.push({ url, body: typeof init.body === "string" ? JSON.parse(init.body) : init.body });
+					puts.push({
+						url,
+						body: typeof init.body === "string" ? JSON.parse(init.body) : init.body,
+					});
 				}
 				return Response.json({ data: {} });
 			}),


### PR DESCRIPTION
## What does this PR do?

With visual editing on, the inline Portable Text editor saves the body every time focus leaves it and every time the page is left, even when nobody typed. Each save creates a draft that differs from the live version only in `_key` values, so entries show "Pending changes" that no one made.

Closes #2877

### Cause

- `pmToPortableText()` mints a new `_key` for every block, span and link markDef on every call (`k()` is `Math.random()`), and spans refer to link markDefs by those keys.
- `save()` compared `JSON.stringify(getBlocks())` against `initialRef`, which starts as the raw stored value and, after a save, becomes another fresh serialization. The two never match.
- `handleBlur` and the `pagehide` keepalive flush both call `save()`, so an untouched body is saved on every blur and on every page leave.

### Fix

One file, `InlinePortableTextEditor.tsx`. Change detection moves from serialized Portable Text to the editor's own document:

- The document the loaded content produces is recorded as the saved document once the editor exists.
- `save()` returns early when `editor.state.doc.eq(savedDoc)`, ProseMirror's structural equality over node types, attributes, marks and text. ProseMirror nodes have no `_key`, so the random keys never enter the comparison.
- After a successful save, the saved document becomes the document whose blocks were sent. The blocks are serialized once and that same array is sent, rather than calling `getBlocks()` again.

Two side effects, both improvements:

- An edit undone before focus leaves is no longer saved.
- An edit typed while a save is in flight is no longer absorbed into the baseline. Previously `initialRef = getBlocks()` after the response picked it up, so that edit could never be saved.

The stored shape does not change: the PUT still sends the editor's blocks with their keys. Making keys deterministic, so they stop churning on real saves, is a separate change and is not in this PR.

### Can this hide a real edit?

No. `Node.eq` compares the whole document tree: node types and order, attributes (heading level, alignment, list fields, image and link attributes), marks and text. Reordering, splitting or merging blocks, typing, or changing a link all produce a document that is not `eq`. The only thing it cannot see is `_key`, which lives only in the serialized Portable Text, and ignoring `_key` is the point.

I first tried a canonical-JSON comparison that dropped `_key` and remapped link-mark references to their markDef position. It worked, but it needed about 40 lines of normalization, plus care for every place Portable Text carries a key reference. Comparing the editor document avoids that class of mistake.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes: no errors in the changed files. `tsgo --noEmit` in `packages/core` reports errors only in untouched files (`src/api/handlers/registry.ts`, `src/registry/*`, `src/plugins/types.ts`, `src/utils/slugify.ts`) in my environment.
- [x] `pnpm lint` passes: `oxlint --type-aware` clean on the changed files
- [x] `pnpm test` passes (or targeted tests for my change): all 15 files in `tests/unit/components` pass (89 tests)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (`emdash`: patch)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude (Claude Code)

## Screenshots / test output

Not applicable (no UI change). New file `tests/unit/components/inline-portable-text-unchanged-save.test.ts`; the stored body includes a link paragraph. Against current `main` without the fix:

```
× does not save when focus leaves an unedited body
    expected [ …3 PUTs ] to have a length of +0 but got 3
× does not save on page leave when the body was never touched
    expected [ …1 PUT ] to have a length of +0 but got 1
× saves a real edit once, and not again on the next blur
    expected [ …2 PUTs ] to have a length of 1 but got 2
× does not save an edit that was undone before focus left
    expected [ …1 PUT ] to have a length of +0 but got 1
```

With the fix, all four pass.
