### PR TITLE
fix(core): retain plugin bundles across updates

### DIFF
--- a/.changeset/calm-bundles-stay.md
+++ b/.changeset/calm-bundles-stay.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes overlapping marketplace or registry plugin updates and downgrades deleting the active plugin bundle. Updates retain previous version bundles so delayed work cannot remove a version that becomes active again.

--- a/packages/core/src/api/handlers/marketplace.ts
+++ b/packages/core/src/api/handlers/marketplace.ts
@@ -728,9 +728,6 @@ export async function handleMarketplaceUpdate(
 
 		await syncDeclaredStorageIndexes(db, [bundle.manifest]);
 
-		// Clean up old bundle from R2 (best-effort)
-		deleteBundleFromR2(storage, pluginId, oldVersion).catch(() => {});
-
 		return {
 			success: true,
 			data: {

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -1574,11 +1574,6 @@ export async function handleRegistryUpdate(
 
 		await syncDeclaredStorageIndexes(db, [bundle.manifest]);
 
-		// Best-effort cleanup of the old bundle. Failures here don't roll
-		// back the upgrade (the new bundle is already stored and committed
-		// in the state row); the orphan is just storage we'll pay for.
-		deleteBundleFromR2(storage, pluginId, oldVersion, "registry").catch(() => {});
-
 		return {
 			success: true,
 			data: {

--- a/packages/core/tests/unit/api/marketplace-handlers.test.ts
+++ b/packages/core/tests/unit/api/marketplace-handlers.test.ts
@@ -95,6 +95,24 @@ function createMockStorage(): Storage {
 	};
 }
 
+function deferStorageDeletes(storage: Storage): { releaseDeletes: () => void } {
+	const deleteImmediately = storage.delete.bind(storage);
+	let released = false;
+	const pending: Array<() => void> = [];
+	storage.delete = async (key: string): Promise<void> => {
+		if (!released) {
+			await new Promise<void>((resolve) => pending.push(resolve));
+		}
+		await deleteImmediately(key);
+	};
+	return {
+		releaseDeletes() {
+			released = true;
+			for (const resolve of pending.splice(0)) resolve();
+		},
+	};
+}
+
 function createMockSandboxRunner(): SandboxRunner & {
 	loadedPlugins: Array<{ manifest: PluginManifest; code: string }>;
 } {
@@ -734,6 +752,23 @@ describe("Marketplace handlers", () => {
 			expect(result.data?.oldVersion).toBe("1.0.0");
 			expect(result.data?.newVersion).toBe("2.0.0");
 			expect(result.data?.capabilityChanges.added).toContain("network:request");
+			expect(await storage.exists("marketplace/test-seo/1.0.0/manifest.json")).toBe(true);
+			expect(await storage.exists("marketplace/test-seo/2.0.0/manifest.json")).toBe(true);
+
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(detail), { status: 200 }));
+			const retried = await handleMarketplaceUpdate(
+				db,
+				storage,
+				sandboxRunner,
+				MARKETPLACE_URL,
+				"test-seo",
+				{ confirmCapabilityChanges: true },
+			);
+			expect(retried).toMatchObject({
+				success: false,
+				error: { code: "ALREADY_UP_TO_DATE" },
+			});
+			expect(await storage.exists("marketplace/test-seo/2.0.0/manifest.json")).toBe(true);
 		});
 
 		it("treats deprecated → current capability rename as no change", async () => {
@@ -787,6 +822,70 @@ describe("Marketplace handlers", () => {
 			expect(result.success).toBe(true);
 			expect(result.data?.capabilityChanges.added).toEqual([]);
 			expect(result.data?.capabilityChanges.removed).toEqual([]);
+		});
+
+		it("keeps a downgraded bundle active when an earlier update finishes later", async () => {
+			const repo = new PluginStateRepository(db);
+			await repo.upsert("test-seo", "1.0.0", "active", {
+				source: "marketplace",
+				marketplaceVersion: "1.0.0",
+			});
+
+			const encoder = new TextEncoder();
+			const initialManifest = mockManifest("test-seo", "1.0.0");
+			await storage.upload({
+				key: "marketplace/test-seo/1.0.0/manifest.json",
+				body: encoder.encode(JSON.stringify(initialManifest)),
+				contentType: "application/json",
+			});
+			await storage.upload({
+				key: "marketplace/test-seo/1.0.0/backend.js",
+				body: encoder.encode("export default {};"),
+				contentType: "application/javascript",
+			});
+			const deferredDeletes = deferStorageDeletes(storage);
+
+			const nextManifest = mockManifest("test-seo", "2.0.0");
+			const nextDetail = mockPluginDetail("test-seo", "2.0.0");
+			nextDetail.latestVersion!.checksum = "";
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(nextDetail), { status: 200 }));
+			fetchSpy.mockResolvedValueOnce(
+				new Response(await createMockBundle(nextManifest), { status: 200 }),
+			);
+			const updated = await handleMarketplaceUpdate(
+				db,
+				storage,
+				sandboxRunner,
+				MARKETPLACE_URL,
+				"test-seo",
+			);
+			expect(updated.success).toBe(true);
+
+			const initialDetail = mockPluginDetail("test-seo", "1.0.0");
+			initialDetail.latestVersion!.checksum = "";
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(initialDetail), { status: 200 }));
+			fetchSpy.mockResolvedValueOnce(
+				new Response(await createMockBundle(initialManifest), { status: 200 }),
+			);
+			const downgraded = await handleMarketplaceUpdate(
+				db,
+				storage,
+				sandboxRunner,
+				MARKETPLACE_URL,
+				"test-seo",
+			);
+			expect(downgraded).toMatchObject({
+				success: true,
+				data: { oldVersion: "2.0.0", newVersion: "1.0.0" },
+			});
+
+			deferredDeletes.releaseDeletes();
+			await new Promise((resolve) => setImmediate(resolve));
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(await repo.get("test-seo")).toMatchObject({ version: "1.0.0" });
+			expect(await storage.exists("marketplace/test-seo/1.0.0/manifest.json")).toBe(true);
+			expect(await storage.exists("marketplace/test-seo/1.0.0/backend.js")).toBe(true);
 		});
 	});
 

--- a/packages/core/tests/unit/api/registry-install-conformance.test.ts
+++ b/packages/core/tests/unit/api/registry-install-conformance.test.ts
@@ -53,8 +53,13 @@ interface ConformanceContext {
 	options: AuthoritativeRecordReadOptions;
 }
 
-function createMemoryStorage(): Storage & { keys(): string[] } {
+function createMemoryStorage(options?: { deferDeletes?: boolean }): Storage & {
+	keys(): string[];
+	releaseDeletes(): void;
+} {
 	const values = new Map<string, { body: Uint8Array; contentType: string }>();
+	let deletesReleased = options?.deferDeletes !== true;
+	const pendingDeletes: Array<() => void> = [];
 	return {
 		async upload(input): Promise<UploadResult> {
 			let body: Uint8Array;
@@ -78,6 +83,9 @@ function createMemoryStorage(): Storage & { keys(): string[] } {
 			};
 		},
 		async delete(key): Promise<void> {
+			if (!deletesReleased) {
+				await new Promise<void>((resolve) => pendingDeletes.push(resolve));
+			}
 			values.delete(key);
 		},
 		async exists(key): Promise<boolean> {
@@ -94,6 +102,10 @@ function createMemoryStorage(): Storage & { keys(): string[] } {
 			throw new Error("Not implemented");
 		},
 		keys: () => [...values.keys()].toSorted(),
+		releaseDeletes() {
+			deletesReleased = true;
+			for (const resolve of pendingDeletes.splice(0)) resolve();
+		},
 	};
 }
 
@@ -322,7 +334,8 @@ describe("registry delegated-release conformance", () => {
 		},
 	);
 
-	it("updates with the same verification and CID-bound re-consent", async () => {
+	it("updates with CID-bound re-consent and keeps a concurrent downgrade bundle active", async () => {
+		storage = createMemoryStorage({ deferDeletes: true });
 		const initial = await createDelegatedReleaseConformanceFixture();
 		const context = await createContext(initial);
 		await mockAggregator(initial, context);
@@ -424,6 +437,57 @@ describe("registry delegated-release conformance", () => {
 		expect(await new PluginStateRepository(db).get(installed.data.pluginId)).toMatchObject({
 			version: next.version,
 		});
+		expect(storage.keys()).toEqual(
+			expect.arrayContaining([
+				`registry/${installed.data.pluginId}/${initial.version}/manifest.json`,
+				`registry/${installed.data.pluginId}/${next.version}/manifest.json`,
+			]),
+		);
+
+		const retried = await handleRegistryUpdate(
+			db,
+			storage,
+			sandbox,
+			registryConfig,
+			installed.data.pluginId,
+			{ authoritativeRecords: nextOptions },
+		);
+		expect(retried).toMatchObject({
+			success: false,
+			error: { code: "ALREADY_UP_TO_DATE" },
+		});
+		expect(storage.keys()).toContain(
+			`registry/${installed.data.pluginId}/${next.version}/manifest.json`,
+		);
+
+		await mockAggregator(initial, context);
+		artifactFetch(initial.artifactBytes);
+		const downgraded = await handleRegistryUpdate(
+			db,
+			storage,
+			sandbox,
+			registryConfig,
+			installed.data.pluginId,
+			{ authoritativeRecords: context.options },
+		);
+		expect(downgraded).toMatchObject({
+			success: true,
+			data: { oldVersion: next.version, newVersion: initial.version },
+		});
+
+		storage.releaseDeletes();
+		await new Promise((resolve) => setImmediate(resolve));
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(await new PluginStateRepository(db).get(installed.data.pluginId)).toMatchObject({
+			version: initial.version,
+		});
+		expect(storage.keys()).toEqual(
+			expect.arrayContaining([
+				`registry/${installed.data.pluginId}/${initial.version}/backend.js`,
+				`registry/${installed.data.pluginId}/${initial.version}/manifest.json`,
+			]),
+		);
 	});
 
 	it.each([


### PR DESCRIPTION
## What does this PR do?

Plugin updates retain previous marketplace and registry bundles instead of deleting them after the active state changes. This prevents a delayed cleanup from deleting a version that became active again during an overlapping update or downgrade.

Install-failure cleanup and explicit uninstall cleanup are unchanged. Generation-fenced garbage collection can be added separately without putting the active bundle at risk.

Part of #1350.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: n/a — bug fix
- [ ] I have included screenshots below if this PR changes the UI — n/a, no UI changes

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.6

## Screenshots / test output

Not applicable; no UI changes.

- Focused update/concurrency tests: 45 passed
- Broader handler, registry, and storage tests: 168 passed
- Root build and typecheck passed
- Type-aware lint: 0 diagnostics
- Formatting, changeset validation, and diff checks passed
