### PR TITLE
fix(admin): require marketplace update re-consent

### DIFF
--- a/.changeset/quiet-taxis.md
+++ b/.changeset/quiet-taxis.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": patch
+"emdash": patch
+---
+
+Fixes marketplace plugin updates so administrators review newly requested capabilities, public routes, and MCP tools before granting them. Update confirmation remains pinned to the version that was reviewed, so a newer release requires a separate review.

--- a/packages/admin/src/components/CapabilityConsentDialog.tsx
+++ b/packages/admin/src/components/CapabilityConsentDialog.tsx
@@ -22,6 +22,8 @@ export interface CapabilityConsentDialogProps {
 	mode?: "install" | "update";
 	/** Plugin display name */
 	pluginName: string;
+	/** Exact plugin version under review */
+	version?: string;
 	/** Capabilities the plugin requests */
 	capabilities: string[];
 	/** Allowed network hosts (for network:fetch capability) */
@@ -49,6 +51,7 @@ export interface CapabilityConsentDialogProps {
 export function CapabilityConsentDialog({
 	mode,
 	pluginName,
+	version,
 	capabilities,
 	allowedHosts,
 	newCapabilities = [],
@@ -95,6 +98,11 @@ export function CapabilityConsentDialog({
 								? t`${pluginName} is requesting additional permissions:`
 								: t`${pluginName} requires the following permissions:`}
 					</p>
+					{version && (
+						<p className="mt-1 text-xs text-kumo-subtle">
+							{t`Version`} <bdi dir="ltr">{version}</bdi>
+						</p>
+					)}
 				</div>
 
 				{/* Capabilities list */}

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -36,11 +36,14 @@ import {
 } from "../lib/api";
 import {
 	checkPluginUpdates,
+	MarketplaceUpdateEscalationError,
+	MarketplaceUpdateMcpConsentRequiredError,
 	PluginMcpConsentRequiredError,
 	updateMarketplacePlugin,
 	uninstallMarketplacePlugin,
 	type PluginUpdateInfo,
 	type PluginMcpConsentTool,
+	type UpdatePluginOpts,
 } from "../lib/api/marketplace.js";
 import {
 	RegistryMcpConsentRequiredError,
@@ -250,6 +253,11 @@ function PluginCard({
 	const [showUninstallConfirm, setShowUninstallConfirm] = React.useState(false);
 	const [registryEscalation, setRegistryEscalation] =
 		React.useState<RegistryUpdateEscalationError | null>(null);
+	const [marketplaceEscalation, setMarketplaceEscalation] =
+		React.useState<MarketplaceUpdateEscalationError | null>(null);
+	const [marketplaceReviewedVersion, setMarketplaceReviewedVersion] = React.useState<string | null>(
+		null,
+	);
 	const [registryVerification, setRegistryVerification] =
 		React.useState<RegistryRecordVerificationSummary | null>(null);
 	const queryClient = useQueryClient();
@@ -261,16 +269,13 @@ function PluginCard({
 	const mcpTools = plugin.mcpTools ?? [];
 
 	const updateMutation = useMutation({
-		mutationFn: (opts: RegistryUpdateOpts) =>
-			isRegistry
-				? updateRegistryPlugin(plugin.id, opts)
-				: updateMarketplacePlugin(plugin.id, {
-						confirmCapabilityChanges: true,
-						confirmMcpTools: mcpUpdateTools.length > 0,
-					}),
+		mutationFn: (opts: RegistryUpdateOpts & UpdatePluginOpts) =>
+			isRegistry ? updateRegistryPlugin(plugin.id, opts) : updateMarketplacePlugin(plugin.id, opts),
 		onSuccess: () => {
 			setShowUpdateConsent(false);
 			setRegistryEscalation(null);
+			setMarketplaceEscalation(null);
+			setMarketplaceReviewedVersion(null);
 			setRegistryVerification(null);
 			setMcpUpdateTools([]);
 			void queryClient.invalidateQueries({ queryKey: ["plugins"] });
@@ -287,9 +292,25 @@ function PluginCard({
 				setRegistryVerification(err.verification ?? null);
 				setShowUpdateConsent(true);
 			}
+			if (err instanceof MarketplaceUpdateEscalationError) {
+				setMarketplaceEscalation(err);
+				setMcpUpdateTools(err.mcpTools);
+				setShowUpdateConsent(true);
+			}
 			if (err instanceof RegistryMcpConsentRequiredError) {
 				setMcpUpdateTools(err.tools);
 				setRegistryVerification(err.verification ?? null);
+				setShowUpdateConsent(true);
+			} else if (err instanceof MarketplaceUpdateMcpConsentRequiredError) {
+				setMarketplaceEscalation(
+					new MarketplaceUpdateEscalationError(
+						"CAPABILITY_ESCALATION",
+						err.message,
+						err.capabilityChanges,
+						err.routeVisibilityChanges,
+					),
+				);
+				setMcpUpdateTools(err.tools);
 				setShowUpdateConsent(true);
 			} else if (err instanceof PluginMcpConsentRequiredError) {
 				setMcpUpdateTools(err.tools);
@@ -308,7 +329,12 @@ function PluginCard({
 			setRegistryVerification(null);
 			updateMutation.mutate({});
 		} else {
-			setShowUpdateConsent(true);
+			const targetVersion = updateInfo?.latest;
+			if (!targetVersion) return;
+			setMarketplaceEscalation(null);
+			setMarketplaceReviewedVersion(targetVersion);
+			setMcpUpdateTools([]);
+			updateMutation.mutate({ version: targetVersion });
 		}
 	};
 
@@ -325,7 +351,14 @@ function PluginCard({
 			}
 			updateMutation.mutate(opts);
 		} else {
-			updateMutation.mutate({});
+			if (!marketplaceReviewedVersion) return;
+			updateMutation.mutate({
+				version: marketplaceReviewedVersion,
+				confirmCapabilityChanges: (marketplaceEscalation?.capabilityChanges.added.length ?? 0) > 0,
+				confirmRouteVisibilityChanges:
+					(marketplaceEscalation?.routeVisibilityChanges?.newlyPublic.length ?? 0) > 0,
+				confirmMcpTools: mcpUpdateTools.length > 0,
+			});
 		}
 	};
 
@@ -657,14 +690,30 @@ function PluginCard({
 				<CapabilityConsentDialog
 					mode="update"
 					pluginName={plugin.name}
-					capabilities={plugin.capabilities}
-					newCapabilities={registryEscalation?.capabilityChanges.added ?? []}
-					newlyPublicRoutes={registryEscalation?.routeVisibilityChanges?.newlyPublic ?? []}
+					capabilities={[
+						...new Set([
+							...plugin.capabilities,
+							...(registryEscalation?.capabilityChanges.added ?? []),
+							...(marketplaceEscalation?.capabilityChanges.added ?? []),
+						]),
+					]}
+					newCapabilities={
+						registryEscalation?.capabilityChanges.added ??
+						marketplaceEscalation?.capabilityChanges.added ??
+						[]
+					}
+					newlyPublicRoutes={
+						registryEscalation?.routeVisibilityChanges?.newlyPublic ??
+						marketplaceEscalation?.routeVisibilityChanges?.newlyPublic ??
+						[]
+					}
 					mcpTools={mcpUpdateTools}
 					verification={registryVerification ?? undefined}
 					isPending={updateMutation.isPending}
 					error={
-						updateMutation.error instanceof RegistryUpdateEscalationError
+						updateMutation.error instanceof RegistryUpdateEscalationError ||
+						updateMutation.error instanceof MarketplaceUpdateEscalationError ||
+						updateMutation.error instanceof PluginMcpConsentRequiredError
 							? null
 							: getMutationError(updateMutation.error)
 					}
@@ -672,6 +721,8 @@ function PluginCard({
 					onCancel={() => {
 						setShowUpdateConsent(false);
 						setRegistryEscalation(null);
+						setMarketplaceEscalation(null);
+						setMarketplaceReviewedVersion(null);
 						setRegistryVerification(null);
 						setMcpUpdateTools([]);
 						updateMutation.reset();

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -271,7 +271,8 @@ function PluginCard({
 	const updateMutation = useMutation({
 		mutationFn: (opts: RegistryUpdateOpts & UpdatePluginOpts) =>
 			isRegistry ? updateRegistryPlugin(plugin.id, opts) : updateMarketplacePlugin(plugin.id, opts),
-		onSuccess: () => {
+		onSuccess: (_result, opts) => {
+			const installedVersion = opts.version ?? updateInfo?.latest;
 			setShowUpdateConsent(false);
 			setRegistryEscalation(null);
 			setMarketplaceEscalation(null);
@@ -283,7 +284,7 @@ function PluginCard({
 			void queryClient.invalidateQueries({ queryKey: ["manifest"] });
 			toastManager.add({
 				title: t`Plugin updated`,
-				description: t`${plugin.name} updated to v${updateInfo?.latest}`,
+				description: t`${plugin.name} updated to v${installedVersion}`,
 			});
 		},
 		onError: (err) => {
@@ -291,13 +292,11 @@ function PluginCard({
 				setRegistryEscalation(err);
 				setRegistryVerification(err.verification ?? null);
 				setShowUpdateConsent(true);
-			}
-			if (err instanceof MarketplaceUpdateEscalationError) {
+			} else if (err instanceof MarketplaceUpdateEscalationError) {
 				setMarketplaceEscalation(err);
 				setMcpUpdateTools(err.mcpTools);
 				setShowUpdateConsent(true);
-			}
-			if (err instanceof RegistryMcpConsentRequiredError) {
+			} else if (err instanceof RegistryMcpConsentRequiredError) {
 				setMcpUpdateTools(err.tools);
 				setRegistryVerification(err.verification ?? null);
 				setShowUpdateConsent(true);
@@ -315,6 +314,12 @@ function PluginCard({
 			} else if (err instanceof PluginMcpConsentRequiredError) {
 				setMcpUpdateTools(err.tools);
 				setShowUpdateConsent(true);
+			} else {
+				toastManager.add({
+					title: t`Failed to update plugin`,
+					description: err instanceof Error ? err.message : t`An error occurred`,
+					type: "error",
+				});
 			}
 		},
 	});
@@ -690,6 +695,7 @@ function PluginCard({
 				<CapabilityConsentDialog
 					mode="update"
 					pluginName={plugin.name}
+					version={isMarketplace ? (marketplaceReviewedVersion ?? undefined) : undefined}
 					capabilities={[
 						...new Set([
 							...plugin.capabilities,

--- a/packages/admin/src/lib/api/marketplace.ts
+++ b/packages/admin/src/lib/api/marketplace.ts
@@ -110,6 +110,39 @@ export class PluginMcpConsentRequiredError extends Error {
 	}
 }
 
+export class MarketplaceUpdateEscalationError extends Error {
+	readonly code: "CAPABILITY_ESCALATION" | "ROUTE_VISIBILITY_ESCALATION";
+	readonly capabilityChanges: { added: string[]; removed: string[] };
+	readonly routeVisibilityChanges?: { newlyPublic: string[] };
+	readonly mcpTools: PluginMcpConsentTool[];
+
+	constructor(
+		code: "CAPABILITY_ESCALATION" | "ROUTE_VISIBILITY_ESCALATION",
+		message: string,
+		capabilityChanges: { added: string[]; removed: string[] },
+		routeVisibilityChanges?: { newlyPublic: string[] },
+		mcpTools: PluginMcpConsentTool[] = [],
+	) {
+		super(message);
+		this.name = "MarketplaceUpdateEscalationError";
+		this.code = code;
+		this.capabilityChanges = capabilityChanges;
+		this.routeVisibilityChanges = routeVisibilityChanges;
+		this.mcpTools = mcpTools;
+	}
+}
+
+export class MarketplaceUpdateMcpConsentRequiredError extends PluginMcpConsentRequiredError {
+	constructor(
+		tools: PluginMcpConsentTool[],
+		readonly capabilityChanges: { added: string[]; removed: string[] },
+		readonly routeVisibilityChanges?: { newlyPublic: string[] },
+	) {
+		super(tools);
+		this.name = "MarketplaceUpdateMcpConsentRequiredError";
+	}
+}
+
 function isPluginMcpConsentTool(value: unknown): value is PluginMcpConsentTool {
 	if (!value || typeof value !== "object") return false;
 	return (
@@ -134,10 +167,79 @@ function getMcpConsentTools(body: unknown): PluginMcpConsentTool[] | null {
 	return valid.length > 0 ? valid : null;
 }
 
+function normaliseStringArray(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter((item): item is string => typeof item === "string")
+		: [];
+}
+
+function getMarketplaceUpdateEscalation(body: unknown): MarketplaceUpdateEscalationError | null {
+	if (!body || typeof body !== "object") return null;
+	const error = Reflect.get(body, "error");
+	if (!error || typeof error !== "object") return null;
+	const code = Reflect.get(error, "code");
+	if (code !== "CAPABILITY_ESCALATION" && code !== "ROUTE_VISIBILITY_ESCALATION") return null;
+	const details = Reflect.get(error, "details");
+	if (!details || typeof details !== "object") return null;
+	const capabilityChanges = Reflect.get(details, "capabilityChanges");
+	if (!capabilityChanges || typeof capabilityChanges !== "object") return null;
+	const added = normaliseStringArray(Reflect.get(capabilityChanges, "added"));
+	const removed = normaliseStringArray(Reflect.get(capabilityChanges, "removed"));
+	const routeVisibilityChanges = Reflect.get(details, "routeVisibilityChanges");
+	const newlyPublic =
+		routeVisibilityChanges && typeof routeVisibilityChanges === "object"
+			? normaliseStringArray(Reflect.get(routeVisibilityChanges, "newlyPublic"))
+			: [];
+	const message = Reflect.get(error, "message");
+	const mcpTools = Reflect.get(details, "mcpTools");
+	const validMcpTools = Array.isArray(mcpTools) ? mcpTools.filter(isPluginMcpConsentTool) : [];
+	return new MarketplaceUpdateEscalationError(
+		code,
+		typeof message === "string" ? message : i18n._(msg`Plugin update requires re-consent`),
+		{ added, removed },
+		newlyPublic.length > 0 ? { newlyPublic } : undefined,
+		validMcpTools,
+	);
+}
+
+function getMarketplaceUpdateMcpConsent(
+	body: unknown,
+): MarketplaceUpdateMcpConsentRequiredError | null {
+	const tools = getMcpConsentTools(body);
+	if (!tools || !body || typeof body !== "object") return null;
+	const error = Reflect.get(body, "error");
+	if (!error || typeof error !== "object") return null;
+	const details = Reflect.get(error, "details");
+	if (!details || typeof details !== "object") return null;
+	const capabilityChanges = Reflect.get(details, "capabilityChanges");
+	const added =
+		capabilityChanges && typeof capabilityChanges === "object"
+			? normaliseStringArray(Reflect.get(capabilityChanges, "added"))
+			: [];
+	const removed =
+		capabilityChanges && typeof capabilityChanges === "object"
+			? normaliseStringArray(Reflect.get(capabilityChanges, "removed"))
+			: [];
+	const routeVisibilityChanges = Reflect.get(details, "routeVisibilityChanges");
+	const newlyPublic =
+		routeVisibilityChanges && typeof routeVisibilityChanges === "object"
+			? normaliseStringArray(Reflect.get(routeVisibilityChanges, "newlyPublic"))
+			: [];
+	return new MarketplaceUpdateMcpConsentRequiredError(
+		tools,
+		{ added, removed },
+		newlyPublic.length > 0 ? { newlyPublic } : undefined,
+	);
+}
+
 /** Update request body */
 export interface UpdatePluginOpts {
+	/** Exact version reviewed by the user */
+	version?: string;
 	/** User has confirmed new capabilities */
 	confirmCapabilityChanges?: boolean;
+	/** User has confirmed newly public routes */
+	confirmRouteVisibilityChanges?: boolean;
 	confirmMcpTools?: boolean;
 }
 
@@ -227,8 +329,10 @@ export async function updateMarketplacePlugin(
 			.clone()
 			.json()
 			.catch(() => null);
-		const mcpTools = getMcpConsentTools(body);
-		if (mcpTools) throw new PluginMcpConsentRequiredError(mcpTools);
+		const escalation = getMarketplaceUpdateEscalation(body);
+		if (escalation) throw escalation;
+		const mcpConsent = getMarketplaceUpdateMcpConsent(body);
+		if (mcpConsent) throw mcpConsent;
 		await throwResponseError(response, i18n._(msg`Failed to update plugin`));
 	}
 }

--- a/packages/admin/tests/components/PluginManager.test.tsx
+++ b/packages/admin/tests/components/PluginManager.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type { PluginInfo, AdminManifest } from "../../src/lib/api";
 import type { PluginUpdateInfo } from "../../src/lib/api/marketplace";
+import { MarketplaceUpdateEscalationError } from "../../src/lib/api/marketplace";
 import { render } from "../utils/render.tsx";
 
 // Mock router
@@ -319,7 +320,7 @@ describe("PluginManager", () => {
 		await expect.element(screen.getByText("Check for updates")).toBeInTheDocument();
 	});
 
-	it("confirms marketplace capability changes with the server contract field", async () => {
+	it("preflights marketplace updates before showing the exact authority changes", async () => {
 		mockFetchPlugins.mockResolvedValue([
 			makePlugin({
 				id: "mp-plugin",
@@ -336,6 +337,23 @@ describe("PluginManager", () => {
 				hasCapabilityChanges: true,
 			},
 		]);
+		mockUpdateMarketplacePlugin.mockRejectedValueOnce(
+			new MarketplaceUpdateEscalationError(
+				"ROUTE_VISIBILITY_ESCALATION",
+				"Review the update",
+				{ added: ["network:request"], removed: [] },
+				{ newlyPublic: ["webhook"] },
+				[
+					{
+						name: "sync",
+						description: "Sync content",
+						route: "sync",
+						permission: "content:write",
+						destructive: false,
+					},
+				],
+			),
+		);
 		const screen = await render(
 			<Wrapper>
 				<PluginManager />
@@ -346,12 +364,34 @@ describe("PluginManager", () => {
 		const updateButton = screen.getByText("Update to v2.0.0");
 		await expect.element(updateButton).toBeInTheDocument();
 		await updateButton.click();
+
+		await vi.waitFor(() => {
+			expect(mockUpdateMarketplacePlugin).toHaveBeenNthCalledWith(1, "mp-plugin", {
+				version: "2.0.0",
+			});
+		});
+		await expect.element(screen.getByText("Make network requests")).toBeInTheDocument();
+		await expect.element(screen.getByText("webhook")).toBeInTheDocument();
+		await expect.element(screen.getByText("sync", { exact: true })).toBeInTheDocument();
+
+		mockCheckPluginUpdates.mockResolvedValue([
+			{
+				pluginId: "mp-plugin",
+				installed: "1.0.0",
+				latest: "3.0.0",
+				hasCapabilityChanges: true,
+			},
+		]);
+		await screen.getByText("Check for updates").click();
+		await expect.element(screen.getByText("Update to v3.0.0")).toBeInTheDocument();
 		await screen.getByText("Accept & Update").click();
 
 		await vi.waitFor(() => {
-			expect(mockUpdateMarketplacePlugin).toHaveBeenCalledWith("mp-plugin", {
+			expect(mockUpdateMarketplacePlugin).toHaveBeenNthCalledWith(2, "mp-plugin", {
+				version: "2.0.0",
 				confirmCapabilityChanges: true,
-				confirmMcpTools: false,
+				confirmRouteVisibilityChanges: true,
+				confirmMcpTools: true,
 			});
 		});
 	});

--- a/packages/admin/tests/components/PluginManager.test.tsx
+++ b/packages/admin/tests/components/PluginManager.test.tsx
@@ -5,7 +5,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type { PluginInfo, AdminManifest } from "../../src/lib/api";
 import type { PluginUpdateInfo } from "../../src/lib/api/marketplace";
-import { MarketplaceUpdateEscalationError } from "../../src/lib/api/marketplace";
+import {
+	MarketplaceUpdateEscalationError,
+	MarketplaceUpdateMcpConsentRequiredError,
+} from "../../src/lib/api/marketplace";
 import { render } from "../utils/render.tsx";
 
 // Mock router
@@ -384,6 +387,7 @@ describe("PluginManager", () => {
 		]);
 		await screen.getByText("Check for updates").click();
 		await expect.element(screen.getByText("Update to v3.0.0")).toBeInTheDocument();
+		await expect.element(screen.getByText("2.0.0", { exact: true })).toBeInTheDocument();
 		await screen.getByText("Accept & Update").click();
 
 		await vi.waitFor(() => {
@@ -394,6 +398,75 @@ describe("PluginManager", () => {
 				confirmMcpTools: true,
 			});
 		});
+		await expect.element(screen.getByText("MP Plugin updated to v2.0.0")).toBeInTheDocument();
+		await expect.element(screen.getByText("MP Plugin updated to v3.0.0")).not.toBeInTheDocument();
+	});
+
+	it("shows MCP-only update consent without an inline failure", async () => {
+		mockFetchPlugins.mockResolvedValue([
+			makePlugin({ id: "mp-plugin", name: "MP Plugin", source: "marketplace" }),
+		]);
+		mockCheckPluginUpdates.mockResolvedValue([
+			{
+				pluginId: "mp-plugin",
+				installed: "1.0.0",
+				latest: "2.0.0",
+				hasCapabilityChanges: false,
+			},
+		]);
+		mockUpdateMarketplacePlugin.mockRejectedValueOnce(
+			new MarketplaceUpdateMcpConsentRequiredError(
+				[
+					{
+						name: "sync",
+						description: "Sync content",
+						route: "sync",
+						permission: "content:write",
+						destructive: false,
+					},
+				],
+				{ added: [], removed: [] },
+			),
+		);
+
+		const screen = await render(
+			<Wrapper>
+				<PluginManager />
+			</Wrapper>,
+		);
+		await screen.getByText("Check for updates").click();
+		await screen.getByText("Update to v2.0.0").click();
+
+		await expect.element(screen.getByText("sync", { exact: true })).toBeInTheDocument();
+		await expect
+			.element(screen.getByText("Plugin MCP tools require explicit consent"))
+			.not.toBeInTheDocument();
+	});
+
+	it("reports marketplace preflight failures", async () => {
+		mockFetchPlugins.mockResolvedValue([
+			makePlugin({ id: "mp-plugin", name: "MP Plugin", source: "marketplace" }),
+		]);
+		mockCheckPluginUpdates.mockResolvedValue([
+			{
+				pluginId: "mp-plugin",
+				installed: "1.0.0",
+				latest: "2.0.0",
+				hasCapabilityChanges: false,
+			},
+		]);
+		mockUpdateMarketplacePlugin.mockRejectedValueOnce(new Error("Marketplace unavailable"));
+
+		const screen = await render(
+			<Wrapper>
+				<PluginManager />
+			</Wrapper>,
+		);
+		await screen.getByText("Check for updates").click();
+		await screen.getByText("Update to v2.0.0").click();
+
+		await expect.element(screen.getByText("Failed to update plugin")).toBeInTheDocument();
+		await expect.element(screen.getByText("Marketplace unavailable")).toBeInTheDocument();
 	});
 
 	it("hides 'Check for updates' button when no marketplace plugins", async () => {

--- a/packages/admin/tests/lib/marketplace.test.ts
+++ b/packages/admin/tests/lib/marketplace.test.ts
@@ -10,6 +10,8 @@ import {
 	describeCapability,
 	CAPABILITY_LABELS,
 	PluginMcpConsentRequiredError,
+	MarketplaceUpdateEscalationError,
+	MarketplaceUpdateMcpConsentRequiredError,
 } from "../../src/lib/api/marketplace";
 
 describe("marketplace API client", () => {
@@ -223,6 +225,82 @@ describe("marketplace API client", () => {
 				}),
 			);
 			await expect(updateMarketplacePlugin("x")).rejects.toThrow("Capability mismatch");
+		});
+
+		it("throws a structured escalation error with the server-provided diff", async () => {
+			const tool = {
+				name: "sync",
+				description: "Sync content",
+				route: "sync",
+				permission: "content:write",
+				destructive: false,
+			};
+			fetchSpy.mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						error: {
+							code: "ROUTE_VISIBILITY_ESCALATION",
+							message: "Review the update",
+							details: {
+								capabilityChanges: {
+									added: ["network:request"],
+									removed: ["content:read"],
+								},
+								routeVisibilityChanges: { newlyPublic: ["webhook"] },
+								mcpTools: [tool],
+							},
+						},
+					}),
+					{ status: 409 },
+				),
+			);
+
+			const error = await updateMarketplacePlugin("my-plugin", { version: "2.0.0" }).catch(
+				(reason: unknown) => reason,
+			);
+			expect(error).toBeInstanceOf(MarketplaceUpdateEscalationError);
+			expect(error).toMatchObject({
+				code: "ROUTE_VISIBILITY_ESCALATION",
+				capabilityChanges: {
+					added: ["network:request"],
+					removed: ["content:read"],
+				},
+				routeVisibilityChanges: { newlyPublic: ["webhook"] },
+				mcpTools: [tool],
+			});
+		});
+
+		it("preserves the complete update diff when MCP consent is required", async () => {
+			const tool = {
+				name: "sync",
+				description: "Sync content",
+				route: "sync",
+				permission: "content:write",
+				destructive: false,
+			};
+			fetchSpy.mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						error: {
+							code: "MCP_TOOL_CONSENT_REQUIRED",
+							details: {
+								mcpTools: [tool],
+								capabilityChanges: { added: ["network:request"], removed: [] },
+								routeVisibilityChanges: { newlyPublic: ["sync"] },
+							},
+						},
+					}),
+					{ status: 409 },
+				),
+			);
+
+			const error = await updateMarketplacePlugin("my-plugin").catch((reason: unknown) => reason);
+			expect(error).toBeInstanceOf(MarketplaceUpdateMcpConsentRequiredError);
+			expect(error).toMatchObject({
+				tools: [tool],
+				capabilityChanges: { added: ["network:request"], removed: [] },
+				routeVisibilityChanges: { newlyPublic: ["sync"] },
+			});
 		});
 	});
 

--- a/packages/core/src/api/handlers/marketplace.ts
+++ b/packages/core/src/api/handlers/marketplace.ts
@@ -665,6 +665,21 @@ export async function handleMarketplaceUpdate(
 		const oldCaps = oldBundle?.manifest.capabilities ?? [];
 		const capabilityChanges = diffCapabilities(oldCaps, bundle.manifest.capabilities);
 		const hasEscalation = capabilityChanges.added.length > 0;
+		const routeVisibilityChanges = diffRouteVisibility(oldBundle?.manifest, bundle.manifest);
+		const hasNewPublicRoutes = routeVisibilityChanges.newlyPublic.length > 0;
+		const oldMcpTools = [...(oldBundle?.manifest.mcp?.tools ?? [])].toSorted((a, b) =>
+			a.name.localeCompare(b.name),
+		);
+		const newMcpTools = [...(bundle.manifest.mcp?.tools ?? [])].toSorted((a, b) =>
+			a.name.localeCompare(b.name),
+		);
+		const hasMcpChanges = JSON.stringify(oldMcpTools) !== JSON.stringify(newMcpTools);
+		const mcpTools = newMcpTools.map(({ inputSchema: _, outputSchema: __, ...tool }) => tool);
+		const consentDetails = {
+			capabilityChanges,
+			routeVisibilityChanges: hasNewPublicRoutes ? routeVisibilityChanges : undefined,
+			mcpTools: hasMcpChanges ? mcpTools : undefined,
+		};
 
 		// If capabilities escalated, require explicit confirmation
 		if (hasEscalation && !opts?.confirmCapabilityChanges) {
@@ -673,42 +688,31 @@ export async function handleMarketplaceUpdate(
 				error: {
 					code: "CAPABILITY_ESCALATION",
 					message: "Plugin update requires new capabilities",
-					details: { capabilityChanges },
+					details: consentDetails,
 				},
 			};
 		}
 
 		// Diff route visibility — routes going from private to public are a
 		// security-sensitive change that exposes unauthenticated endpoints.
-		const routeVisibilityChanges = diffRouteVisibility(oldBundle?.manifest, bundle.manifest);
-		const hasNewPublicRoutes = routeVisibilityChanges.newlyPublic.length > 0;
-
 		if (hasNewPublicRoutes && !opts?.confirmRouteVisibilityChanges) {
 			return {
 				success: false,
 				error: {
 					code: "ROUTE_VISIBILITY_ESCALATION",
 					message: "Plugin update exposes new public (unauthenticated) routes",
-					details: { routeVisibilityChanges, capabilityChanges },
+					details: consentDetails,
 				},
 			};
 		}
 
-		const oldMcpTools = [...(oldBundle?.manifest.mcp?.tools ?? [])].toSorted((a, b) =>
-			a.name.localeCompare(b.name),
-		);
-		const newMcpTools = [...(bundle.manifest.mcp?.tools ?? [])].toSorted((a, b) =>
-			a.name.localeCompare(b.name),
-		);
-		if (JSON.stringify(oldMcpTools) !== JSON.stringify(newMcpTools) && !opts?.confirmMcpTools) {
+		if (hasMcpChanges && !opts?.confirmMcpTools) {
 			return {
 				success: false,
 				error: {
 					code: "MCP_TOOL_CONSENT_REQUIRED",
 					message: "Plugin update changes its MCP tools",
-					details: {
-						mcpTools: newMcpTools.map(({ inputSchema: _, outputSchema: __, ...tool }) => tool),
-					},
+					details: consentDetails,
 				},
 			};
 		}

--- a/packages/core/tests/unit/api/marketplace-handlers.test.ts
+++ b/packages/core/tests/unit/api/marketplace-handlers.test.ts
@@ -736,6 +736,70 @@ describe("Marketplace handlers", () => {
 			expect(result.data?.capabilityChanges.added).toContain("network:request");
 		});
 
+		it("includes all authority changes in the initial preflight response", async () => {
+			const repo = new PluginStateRepository(db);
+			await repo.upsert("test-seo", "1.0.0", "active", {
+				source: "marketplace",
+				marketplaceVersion: "1.0.0",
+			});
+
+			const encoder = new TextEncoder();
+			const oldManifest = mockManifest("test-seo", "1.0.0");
+			await storage.upload({
+				key: "marketplace/test-seo/1.0.0/manifest.json",
+				body: encoder.encode(JSON.stringify(oldManifest)),
+				contentType: "application/json",
+			});
+			await storage.upload({
+				key: "marketplace/test-seo/1.0.0/backend.js",
+				body: encoder.encode("export default {};"),
+				contentType: "application/javascript",
+			});
+
+			const newManifest: PluginManifest = {
+				...mockManifest("test-seo", "2.0.0"),
+				capabilities: ["content:read", "network:request"],
+				routes: [{ name: "events/create", permission: "content:create", public: true }],
+				mcp: {
+					tools: [
+						{
+							name: "createEvent",
+							description: "Create a calendar event.",
+							route: "events/create",
+							permission: "content:create",
+							destructive: false,
+							inputSchema: { type: "object" },
+						},
+					],
+				},
+			};
+			const bundleBytes = await createMockBundle(newManifest);
+			const detail = mockPluginDetail("test-seo", "2.0.0");
+			detail.latestVersion!.checksum = "";
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(detail), { status: 200 }));
+			fetchSpy.mockResolvedValueOnce(new Response(bundleBytes, { status: 200 }));
+
+			const result = await handleMarketplaceUpdate(
+				db,
+				storage,
+				sandboxRunner,
+				MARKETPLACE_URL,
+				"test-seo",
+			);
+
+			expect(result).toMatchObject({
+				success: false,
+				error: {
+					code: "CAPABILITY_ESCALATION",
+					details: {
+						capabilityChanges: { added: ["network:request"], removed: [] },
+						routeVisibilityChanges: { newlyPublic: ["events/create"] },
+						mcpTools: [expect.objectContaining({ name: "createEvent" })],
+					},
+				},
+			});
+		});
+
 		it("treats deprecated → current capability rename as no change", async () => {
 			// Installed version declared the legacy name; new version
 			// declares the canonical name. diffCapabilities normalizes


### PR DESCRIPTION
## What does this PR do?

Marketplace plugin updates now perform an unconfirmed preflight before changing the installed version. When an update adds capabilities, exposes public routes, or changes its MCP tools, the admin shows the server-provided changes and requires explicit confirmation pinned to the reviewed version.

Part of #1350.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: n/a — bug fix
- [x] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.6

## Screenshots / test output

![Marketplace update dialog showing newly requested capabilities, a public route, and an agent-callable MCP tool before confirmation](./marketplace-update-reconsent.png)

- Admin focused tests: 48 passed
- Core marketplace-handler tests: 32 passed
- Root build and typecheck passed
- Type-aware lint: 0 diagnostics
- Formatting and `git diff --check` passed

![Marketplace update dialog showing newly requested capabilities, a public route, and an agent-callable MCP tool before confirmation](https://github.com/user-attachments/assets/04364ca5-b1d4-4906-8699-2fd0429fcc43)