### PR TITLE
fix(core): surface registry configuration errors

### DIFF
--- a/.changeset/tame-registry-config-errors.md
+++ b/.changeset/tame-registry-config-errors.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/admin": patch
+---
+
+Fixes invalid plugin registry settings causing the admin manifest to fail with a generic server error. EmDash reports malformed `experimental.registry` fields while Astro loads the site configuration. If invalid registry settings reach the runtime, the admin remains available and shows which field to correct in `astro.config.mjs`.

--- a/packages/admin/src/components/RegistryConfigurationBanner.tsx
+++ b/packages/admin/src/components/RegistryConfigurationBanner.tsx
@@ -10,6 +10,9 @@ export function RegistryConfigurationBanner({ error }: { error: RegistryConfigur
 	let description: string;
 
 	switch (error.field) {
+		case "experimental.registry.aggregatorUrl":
+			description = t`Check experimental.registry.aggregatorUrl in astro.config.mjs, then restart EmDash.`;
+			break;
 		case "experimental.registry.policy.minimumReleaseAge":
 			description = t`Check experimental.registry.policy.minimumReleaseAge in astro.config.mjs, then restart EmDash.`;
 			break;
@@ -17,7 +20,7 @@ export function RegistryConfigurationBanner({ error }: { error: RegistryConfigur
 			description = t`Check experimental.registry.policy.minimumReleaseAgeExclude in astro.config.mjs, then restart EmDash.`;
 			break;
 		default:
-			description = t`Check experimental.registry.aggregatorUrl in astro.config.mjs, then restart EmDash.`;
+			description = t`Check experimental.registry in astro.config.mjs, then restart EmDash.`;
 	}
 
 	return (

--- a/packages/admin/src/components/RegistryConfigurationBanner.tsx
+++ b/packages/admin/src/components/RegistryConfigurationBanner.tsx
@@ -1,0 +1,32 @@
+import { Banner } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
+
+import type { AdminManifest } from "../lib/api/client.js";
+
+type RegistryConfigurationError = NonNullable<AdminManifest["registryConfigurationError"]>;
+
+export function RegistryConfigurationBanner({ error }: { error: RegistryConfigurationError }) {
+	const { t } = useLingui();
+	let description: string;
+
+	switch (error.field) {
+		case "experimental.registry.policy.minimumReleaseAge":
+			description = t`Check experimental.registry.policy.minimumReleaseAge in astro.config.mjs, then restart EmDash.`;
+			break;
+		case "experimental.registry.policy.minimumReleaseAgeExclude":
+			description = t`Check experimental.registry.policy.minimumReleaseAgeExclude in astro.config.mjs, then restart EmDash.`;
+			break;
+		default:
+			description = t`Check experimental.registry.aggregatorUrl in astro.config.mjs, then restart EmDash.`;
+	}
+
+	return (
+		<Banner
+			variant="error"
+			role="alert"
+			aria-label={t`Plugin registry configuration error`}
+			title={t`Plugin registry configuration error`}
+			description={description}
+		/>
+	);
+}

--- a/packages/admin/src/components/Shell.tsx
+++ b/packages/admin/src/components/Shell.tsx
@@ -1,11 +1,13 @@
 import { useMatches } from "@tanstack/react-router";
 import * as React from "react";
 
+import type { AdminManifest } from "../lib/api/client.js";
 import { useCurrentUser } from "../lib/api/current-user";
 import { getLocaleDir } from "../locales/config.js";
 import { useLocale } from "../locales/useLocale.js";
 import { AdminCommandPalette } from "./AdminCommandPalette";
 import { Header } from "./Header";
+import { RegistryConfigurationBanner } from "./RegistryConfigurationBanner.js";
 import { Sidebar, SidebarNav } from "./Sidebar";
 import { WelcomeModal } from "./WelcomeModal";
 
@@ -39,6 +41,7 @@ export interface ShellProps {
 		}>;
 		i18n?: { defaultLocale: string; locales: string[] };
 		version?: string;
+		registryConfigurationError?: AdminManifest["registryConfigurationError"];
 	};
 }
 
@@ -104,6 +107,11 @@ export function Shell({ children, manifest }: ShellProps) {
 			{/* Main content area — scrolls independently so sidebar stays full height */}
 			<div className="flex flex-1 flex-col overflow-hidden">
 				<Header />
+				{manifest.registryConfigurationError && (
+					<div className="px-6 pt-6">
+						<RegistryConfigurationBanner error={manifest.registryConfigurationError} />
+					</div>
+				)}
 				<main
 					className={
 						fullBleed

--- a/packages/admin/src/lib/api/client.ts
+++ b/packages/admin/src/lib/api/client.ts
@@ -270,6 +270,19 @@ export interface AdminManifest {
 			minimumReleaseAgeExclude?: string[];
 		};
 	};
+	/** Field-level diagnostic returned when registry configuration is invalid. */
+	registryConfigurationError?: {
+		code:
+			| "REGISTRY_AGGREGATOR_URL_REQUIRED"
+			| "REGISTRY_AGGREGATOR_URL_INVALID"
+			| "REGISTRY_AGGREGATOR_URL_FORBIDDEN"
+			| "REGISTRY_MINIMUM_RELEASE_AGE_INVALID"
+			| "REGISTRY_MINIMUM_RELEASE_AGE_EXCLUDE_INVALID";
+		field:
+			| "experimental.registry.aggregatorUrl"
+			| "experimental.registry.policy.minimumReleaseAge"
+			| "experimental.registry.policy.minimumReleaseAgeExclude";
+	};
 	/**
 	 * Admin branding overrides for white-labeling.
 	 * Set via the `admin` config in `astro.config.mjs`.

--- a/packages/admin/tests/components/RegistryConfigurationBanner.test.tsx
+++ b/packages/admin/tests/components/RegistryConfigurationBanner.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { RegistryConfigurationBanner } from "../../src/components/RegistryConfigurationBanner";
+import { render } from "../utils/render.tsx";
+
+describe("RegistryConfigurationBanner", () => {
+	it("directs administrators to the invalid aggregator URL setting", async () => {
+		const screen = await render(
+			<RegistryConfigurationBanner
+				error={{
+					code: "REGISTRY_AGGREGATOR_URL_INVALID",
+					field: "experimental.registry.aggregatorUrl",
+				}}
+			/>,
+		);
+
+		await expect
+			.element(screen.getByRole("alert", { name: "Plugin registry configuration error" }))
+			.toBeInTheDocument();
+		await expect
+			.element(
+				screen.getByText(
+					"Check experimental.registry.aggregatorUrl in astro.config.mjs, then restart EmDash.",
+				),
+			)
+			.toBeInTheDocument();
+	});
+
+	it("directs administrators to the invalid release policy setting", async () => {
+		const screen = await render(
+			<RegistryConfigurationBanner
+				error={{
+					code: "REGISTRY_MINIMUM_RELEASE_AGE_INVALID",
+					field: "experimental.registry.policy.minimumReleaseAge",
+				}}
+			/>,
+		);
+
+		await expect
+			.element(
+				screen.getByText(
+					"Check experimental.registry.policy.minimumReleaseAge in astro.config.mjs, then restart EmDash.",
+				),
+			)
+			.toBeInTheDocument();
+	});
+});

--- a/packages/admin/tests/components/RegistryConfigurationBanner.test.tsx
+++ b/packages/admin/tests/components/RegistryConfigurationBanner.test.tsx
@@ -44,4 +44,24 @@ describe("RegistryConfigurationBanner", () => {
 			)
 			.toBeInTheDocument();
 	});
+
+	it("does not name the wrong setting for a diagnostic from a newer server", async () => {
+		const screen = await render(
+			<RegistryConfigurationBanner
+				error={
+					{
+						code: "REGISTRY_FUTURE_SETTING_INVALID",
+						field: "experimental.registry.futureSetting",
+					} as never
+				}
+			/>,
+		);
+
+		await expect
+			.element(
+				screen.getByText("Check experimental.registry in astro.config.mjs, then restart EmDash."),
+			)
+			.toBeInTheDocument();
+		expect(screen.container.textContent).not.toContain("aggregatorUrl");
+	});
 });

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -27,6 +27,7 @@ import {
 import { buildMigrationManifest } from "../../migrations/manifest-builder.js";
 import { writeMigrationManifest } from "../../migrations/manifest-writer.js";
 import type { ResolvedPlugin } from "../../plugins/types.js";
+import { normalizeRegistryConfig } from "../../registry/config.js";
 import { VERSION } from "../../version.js";
 import { setDevTypegenRefresh } from "../dev-typegen.js";
 import { local } from "../storage/adapters.js";
@@ -328,6 +329,11 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 		migrations: normalizeMigrationConfig(config.migrations),
 	};
 
+	// Validate environment-independent registry settings while Astro is still
+	// evaluating its config. The command-aware check in astro:config:setup
+	// applies the stricter production localhost policy.
+	normalizeRegistryConfig(resolvedConfig.experimental?.registry, { allowLocalhost: true });
+
 	// Validate marketplace URL
 	if (resolvedConfig.marketplace) {
 		const url = resolvedConfig.marketplace;
@@ -463,6 +469,9 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 				command,
 			}) => {
 				astroCommand = command;
+				normalizeRegistryConfig(resolvedConfig.experimental?.registry, {
+					allowLocalhost: command === "dev" || command === "sync",
+				});
 				printBanner(logger);
 				// Capture the host's Astro version so the runtime can expose it
 				// to the admin and the registry install gate for `env:astro`

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -10,6 +10,7 @@ import type { Kysely } from "kysely";
 
 import type { ContentFieldFilters } from "../content-list-query.js";
 import type { RouteCallerInput, RouteMeta } from "../plugins/routes.js";
+import type { ManifestRegistryConfigurationError } from "../registry/config.js";
 
 // Re-export core types
 export type {
@@ -214,6 +215,8 @@ export interface EmDashManifest {
 			minimumReleaseAgeExclude?: string[];
 		};
 	};
+	/** Safe field-level diagnostic when the registry configuration cannot be normalized. */
+	registryConfigurationError?: ManifestRegistryConfigurationError;
 	/**
 	 * Admin branding overrides for white-labeling.
 	 * Set via the `admin` config in `astro.config.mjs`.

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -227,7 +227,7 @@ import { isContentSaveRejection } from "./plugins/save-rejection.js";
 import type { CronScheduler } from "./plugins/scheduler/types.js";
 import { PluginStateRepository } from "./plugins/state.js";
 import { syncDeclaredStorageIndexes } from "./plugins/storage-indexes.js";
-import { normalizeRegistryConfig } from "./registry/config.js";
+import { resolveManifestRegistryConfig } from "./registry/config.js";
 import { requestCached } from "./request-cache.js";
 import { getRequestContext } from "./request-context.js";
 import { publishDueContent, type PublishedRef } from "./scheduled-publish.js";
@@ -2606,11 +2606,14 @@ export class EmDashRuntime {
 					}
 				: undefined;
 
-		// Normalize the experimental registry config for browser consumption.
-		// Validation errors here surface as 500s from the manifest endpoint
-		// rather than being silently dropped -- a misconfigured registry
-		// should be loud, not invisible.
-		const registry = normalizeRegistryConfig(this.config.experimental?.registry) ?? undefined;
+		const { registry, error: registryConfigurationError } = resolveManifestRegistryConfig(
+			this.config.experimental?.registry,
+		);
+		if (registryConfigurationError) {
+			console.error(
+				`EmDash registry configuration error in ${registryConfigurationError.field} (${registryConfigurationError.code})`,
+			);
+		}
 
 		return {
 			version: VERSION,
@@ -2628,6 +2631,7 @@ export class EmDashRuntime {
 			},
 			marketplace: !!this.config.marketplace,
 			registry,
+			registryConfigurationError,
 		};
 	}
 

--- a/packages/core/src/registry/config.ts
+++ b/packages/core/src/registry/config.ts
@@ -362,6 +362,13 @@ export function normalizeRegistryConfig(
 	}
 
 	if (config.policy?.minimumReleaseAgeExclude !== undefined) {
+		if (!Array.isArray(config.policy.minimumReleaseAgeExclude)) {
+			throw new RegistryConfigurationError(
+				"REGISTRY_MINIMUM_RELEASE_AGE_EXCLUDE_INVALID",
+				"experimental.registry.policy.minimumReleaseAgeExclude",
+				"must be an array of DIDs or <did>/<slug> entries",
+			);
+		}
 		// Normalize at load time so callers (browser and server) can do
 		// plain string compares without each one re-implementing the
 		// case-folding rule.

--- a/packages/core/src/registry/config.ts
+++ b/packages/core/src/registry/config.ts
@@ -41,6 +41,39 @@ export interface ManifestRegistryConfig {
 	};
 }
 
+export type RegistryConfigurationErrorCode =
+	| "REGISTRY_AGGREGATOR_URL_REQUIRED"
+	| "REGISTRY_AGGREGATOR_URL_INVALID"
+	| "REGISTRY_AGGREGATOR_URL_FORBIDDEN"
+	| "REGISTRY_MINIMUM_RELEASE_AGE_INVALID"
+	| "REGISTRY_MINIMUM_RELEASE_AGE_EXCLUDE_INVALID";
+
+export type RegistryConfigurationField =
+	| "experimental.registry.aggregatorUrl"
+	| "experimental.registry.policy.minimumReleaseAge"
+	| "experimental.registry.policy.minimumReleaseAgeExclude";
+
+export interface ManifestRegistryConfigurationError {
+	code: RegistryConfigurationErrorCode;
+	field: RegistryConfigurationField;
+}
+
+class RegistryConfigurationError extends Error {
+	constructor(
+		public readonly code: RegistryConfigurationErrorCode,
+		public readonly field: RegistryConfigurationField,
+		message: string,
+		options?: ErrorOptions,
+	) {
+		super(`EmDash registry configuration error in ${field}: ${message}`, options);
+		this.name = "RegistryConfigurationError";
+	}
+}
+
+interface RegistryConfigurationValidationOptions {
+	allowLocalhost?: boolean;
+}
+
 /**
  * Canonicalize a capabilities list for set-style comparison.
  *
@@ -169,15 +202,27 @@ export function parseDurationSeconds(duration: string | number): number {
  * own HTTPS bundle, defeating the checksum trust chain because the
  * attacker controls the unsigned transport that supplied the checksum.
  */
-export function validateAggregatorUrl(aggregatorUrl: string): URL {
+export function validateAggregatorUrl(
+	aggregatorUrl: string,
+	options: RegistryConfigurationValidationOptions = {},
+): URL {
 	let parsed: URL;
 	try {
 		parsed = new URL(aggregatorUrl);
-	} catch {
-		throw new Error(`registry.aggregatorUrl is not a valid URL: ${aggregatorUrl}`);
+	} catch (cause) {
+		throw new RegistryConfigurationError(
+			"REGISTRY_AGGREGATOR_URL_INVALID",
+			"experimental.registry.aggregatorUrl",
+			"must be a valid URL",
+			{ cause },
+		);
 	}
 	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-		throw new Error(`registry.aggregatorUrl must use http or https: ${aggregatorUrl}`);
+		throw new RegistryConfigurationError(
+			"REGISTRY_AGGREGATOR_URL_FORBIDDEN",
+			"experimental.registry.aggregatorUrl",
+			"must use HTTP or HTTPS",
+		);
 	}
 	// Reject embedded credentials. The normalized aggregator URL ends
 	// up in the admin manifest and is shipped to every admin browser;
@@ -185,7 +230,11 @@ export function validateAggregatorUrl(aggregatorUrl: string): URL {
 	// so leaving them in would both leak the credentials and break the
 	// registry UI at runtime.
 	if (parsed.username || parsed.password) {
-		throw new Error("registry.aggregatorUrl must not contain embedded credentials (user:pass@)");
+		throw new RegistryConfigurationError(
+			"REGISTRY_AGGREGATOR_URL_FORBIDDEN",
+			"experimental.registry.aggregatorUrl",
+			"must not contain embedded credentials",
+		);
 	}
 
 	// WHATWG URL preserves the brackets on IPv6 hostnames -- strip them
@@ -205,18 +254,27 @@ export function validateAggregatorUrl(aggregatorUrl: string): URL {
 		hostname.startsWith("::ffff:127.") ||
 		hostname.startsWith("::ffff:7f00:");
 
-	if (!import.meta.env.DEV) {
+	const allowLocalhost = options.allowLocalhost ?? import.meta.env.DEV;
+	if (!allowLocalhost) {
 		if (parsed.protocol === "http:") {
-			throw new Error(`registry.aggregatorUrl must use https in production: ${aggregatorUrl}`);
+			throw new RegistryConfigurationError(
+				"REGISTRY_AGGREGATOR_URL_FORBIDDEN",
+				"experimental.registry.aggregatorUrl",
+				"must use HTTPS outside development",
+			);
 		}
 		if (isLocalhost) {
-			throw new Error(
-				`registry.aggregatorUrl points at localhost; allowed only in dev: ${aggregatorUrl}`,
+			throw new RegistryConfigurationError(
+				"REGISTRY_AGGREGATOR_URL_FORBIDDEN",
+				"experimental.registry.aggregatorUrl",
+				"must not point at localhost outside development",
 			);
 		}
 	} else if (parsed.protocol === "http:" && !isLocalhost) {
-		throw new Error(
-			`registry.aggregatorUrl must use https (http allowed only for localhost in dev): ${aggregatorUrl}`,
+		throw new RegistryConfigurationError(
+			"REGISTRY_AGGREGATOR_URL_FORBIDDEN",
+			"experimental.registry.aggregatorUrl",
+			"must use HTTPS unless it points at localhost in development",
 		);
 	}
 
@@ -251,28 +309,30 @@ export function coerceRegistryConfig(
  * object. Returns `null` when `input` is undefined so callers can
  * spread the result directly into the manifest object.
  *
- * Throws if the aggregator URL is malformed, points at a forbidden host,
- * or `policy.minimumReleaseAge` is unparseable. These surface at
- * runtime startup as 500s from the manifest endpoint -- intended,
- * because the alternative is silently disabling the registry on
- * misconfigured sites.
- *
- * TODO: switch to a Zod schema for richer per-field error messages and
- * to surface misconfigurations to the admin UI as a banner instead of
- * a manifest 500.
+ * Throws a field-specific configuration error if the aggregator URL is
+ * malformed or forbidden, or a registry policy value cannot be normalized.
+ * The Astro integration uses this to fail during config loading. Runtime
+ * manifest generation uses {@link resolveManifestRegistryConfig} to expose
+ * recognized failures without exposing the configured value.
  */
 export function normalizeRegistryConfig(
 	input: RegistryConfigInput | undefined,
+	options: RegistryConfigurationValidationOptions = {},
 ): ManifestRegistryConfig | null {
 	const config = coerceRegistryConfig(input);
 	if (!config) return null;
 
-	const aggregatorUrl = config.aggregatorUrl?.trim();
+	const aggregatorUrl =
+		typeof config.aggregatorUrl === "string" ? config.aggregatorUrl.trim() : undefined;
 	if (!aggregatorUrl) {
-		throw new Error("registry.aggregatorUrl is required when registry is configured");
+		throw new RegistryConfigurationError(
+			"REGISTRY_AGGREGATOR_URL_REQUIRED",
+			"experimental.registry.aggregatorUrl",
+			"is required when the registry is configured",
+		);
 	}
 
-	validateAggregatorUrl(aggregatorUrl);
+	validateAggregatorUrl(aggregatorUrl, options);
 
 	const out: ManifestRegistryConfig = {
 		// Strip any trailing slash so `${aggregatorUrl}/xrpc/...` works
@@ -288,7 +348,16 @@ export function normalizeRegistryConfig(
 	let hasPolicy = false;
 
 	if (config.policy?.minimumReleaseAge !== undefined) {
-		policy.minimumReleaseAgeSeconds = parseDurationSeconds(config.policy.minimumReleaseAge);
+		try {
+			policy.minimumReleaseAgeSeconds = parseDurationSeconds(config.policy.minimumReleaseAge);
+		} catch (cause) {
+			throw new RegistryConfigurationError(
+				"REGISTRY_MINIMUM_RELEASE_AGE_INVALID",
+				"experimental.registry.policy.minimumReleaseAge",
+				'must be a duration such as "48h", "7d", or a non-negative number of seconds',
+				{ cause },
+			);
+		}
 		hasPolicy = true;
 	}
 
@@ -297,9 +366,20 @@ export function normalizeRegistryConfig(
 		// plain string compares without each one re-implementing the
 		// case-folding rule.
 		const list = config.policy.minimumReleaseAgeExclude.map((entry) => {
+			if (typeof entry !== "string") {
+				throw new RegistryConfigurationError(
+					"REGISTRY_MINIMUM_RELEASE_AGE_EXCLUDE_INVALID",
+					"experimental.registry.policy.minimumReleaseAgeExclude",
+					"minimumReleaseAgeExclude entry must be a DID or <did>/<slug>",
+				);
+			}
 			const trimmed = entry.trim();
 			if (!trimmed) {
-				throw new Error("registry.policy.minimumReleaseAgeExclude entries cannot be empty");
+				throw new RegistryConfigurationError(
+					"REGISTRY_MINIMUM_RELEASE_AGE_EXCLUDE_INVALID",
+					"experimental.registry.policy.minimumReleaseAgeExclude",
+					"entries cannot be empty",
+				);
 			}
 			const lower = trimmed.toLowerCase();
 			const [did, slug, ...extra] = lower.split("/");
@@ -309,8 +389,10 @@ export function normalizeRegistryConfig(
 				extra.length > 0 ||
 				(slug !== undefined && !REGISTRY_PACKAGE_SLUG_PATTERN.test(slug))
 			) {
-				throw new Error(
-					`registry.policy.minimumReleaseAgeExclude entry must be a DID or <did>/<slug>: ${trimmed}`,
+				throw new RegistryConfigurationError(
+					"REGISTRY_MINIMUM_RELEASE_AGE_EXCLUDE_INVALID",
+					"experimental.registry.policy.minimumReleaseAgeExclude",
+					"minimumReleaseAgeExclude entry must be a DID or <did>/<slug>",
 				);
 			}
 			return lower;
@@ -326,4 +408,18 @@ export function normalizeRegistryConfig(
 	}
 
 	return out;
+}
+
+/** Normalize registry config without allowing a known config error to hide the admin. */
+export function resolveManifestRegistryConfig(input: RegistryConfigInput | undefined): {
+	registry?: ManifestRegistryConfig;
+	error?: ManifestRegistryConfigurationError;
+} {
+	try {
+		const registry = normalizeRegistryConfig(input);
+		return registry ? { registry } : {};
+	} catch (error) {
+		if (!(error instanceof RegistryConfigurationError)) throw error;
+		return { error: { code: error.code, field: error.field } };
+	}
 }

--- a/packages/core/tests/unit/astro/integration/registry-config.test.ts
+++ b/packages/core/tests/unit/astro/integration/registry-config.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import emdash from "../../../../src/astro/integration/index.js";
+
+describe("registry integration configuration", () => {
+	it.each([
+		["a malformed aggregator URL", { aggregatorUrl: "not a URL" }, "aggregatorUrl"],
+		[
+			"an insecure non-local aggregator",
+			{ aggregatorUrl: "http://registry.example.com" },
+			"aggregatorUrl",
+		],
+		[
+			"an invalid minimum release age",
+			{
+				aggregatorUrl: "https://registry.example.com",
+				policy: { minimumReleaseAge: "tomorrow" },
+			},
+			"minimumReleaseAge",
+		],
+	] as const)("fails during integration creation for %s", (_label, registry, field) => {
+		expect(() => emdash({ experimental: { registry } })).toThrow(
+			new RegExp(`EmDash registry configuration error.*${field}`),
+		);
+	});
+
+	it("accepts shorthand and full registry configuration", () => {
+		expect(() =>
+			emdash({ experimental: { registry: "https://registry.example.com" } }),
+		).not.toThrow();
+		expect(() =>
+			emdash({
+				experimental: {
+					registry: {
+						aggregatorUrl: "https://registry.example.com/",
+						acceptLabelers: "did:web:labeler.example",
+						policy: { minimumReleaseAge: "48h" },
+					},
+				},
+			}),
+		).not.toThrow();
+	});
+});

--- a/packages/core/tests/unit/registry/config.test.ts
+++ b/packages/core/tests/unit/registry/config.test.ts
@@ -56,6 +56,23 @@ describe("normalizeRegistryConfig", () => {
 		});
 	});
 
+	it("returns a safe manifest diagnostic when release age exclusions are not an array", () => {
+		expect(
+			resolveManifestRegistryConfig({
+				aggregatorUrl: "https://registry.example.com",
+				policy: {
+					// @ts-expect-error - runtime validation covers untyped JavaScript configuration
+					minimumReleaseAgeExclude: "did:plc:publisher",
+				},
+			}),
+		).toEqual({
+			error: {
+				code: "REGISTRY_MINIMUM_RELEASE_AGE_EXCLUDE_INVALID",
+				field: "experimental.registry.policy.minimumReleaseAgeExclude",
+			},
+		});
+	});
+
 	it("does not turn unexpected failures into configuration diagnostics", () => {
 		const input = {
 			aggregatorUrl: "https://registry.example.com",

--- a/packages/core/tests/unit/registry/config.test.ts
+++ b/packages/core/tests/unit/registry/config.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeRegistryConfig } from "../../../src/registry/config.js";
+import {
+	normalizeRegistryConfig,
+	resolveManifestRegistryConfig,
+} from "../../../src/registry/config.js";
 
 describe("normalizeRegistryConfig", () => {
 	it("rejects mutable handles in the minimum release age exemption list", () => {
@@ -25,5 +28,44 @@ describe("normalizeRegistryConfig", () => {
 				minimumReleaseAgeExclude: ["did:plc:example", "did:web:publisher.example/gallery"],
 			},
 		});
+	});
+
+	it.each([
+		["a malformed URL", "not a URL", "REGISTRY_AGGREGATOR_URL_INVALID"],
+		["a forbidden target", "http://registry.example.com", "REGISTRY_AGGREGATOR_URL_FORBIDDEN"],
+	] as const)("returns a safe manifest diagnostic for %s", (_label, aggregatorUrl, code) => {
+		expect(resolveManifestRegistryConfig({ aggregatorUrl })).toEqual({
+			error: {
+				code,
+				field: "experimental.registry.aggregatorUrl",
+			},
+		});
+	});
+
+	it("returns a safe manifest diagnostic for an invalid minimum release age", () => {
+		expect(
+			resolveManifestRegistryConfig({
+				aggregatorUrl: "https://registry.example.com",
+				policy: { minimumReleaseAge: "tomorrow" },
+			}),
+		).toEqual({
+			error: {
+				code: "REGISTRY_MINIMUM_RELEASE_AGE_INVALID",
+				field: "experimental.registry.policy.minimumReleaseAge",
+			},
+		});
+	});
+
+	it("does not turn unexpected failures into configuration diagnostics", () => {
+		const input = {
+			aggregatorUrl: "https://registry.example.com",
+			policy: {
+				get minimumReleaseAge(): string {
+					throw new Error("unexpected getter failure");
+				},
+			},
+		};
+
+		expect(() => resolveManifestRegistryConfig(input)).toThrow("unexpected getter failure");
 	});
 });

--- a/packages/core/tests/unit/runtime/manifest-build.test.ts
+++ b/packages/core/tests/unit/runtime/manifest-build.test.ts
@@ -57,8 +57,7 @@ const configCollections = {
 	},
 };
 
-function buildRuntime(db: Kysely<Database>): EmDashRuntime {
-	const config: EmDashConfig = {};
+function buildRuntime(db: Kysely<Database>, config: EmDashConfig = {}): EmDashRuntime {
 	const pipelineFactoryOptions = { db } as const;
 	const hooks = createHookPipeline([], pipelineFactoryOptions);
 	const pipelineRef = { current: hooks };
@@ -336,6 +335,24 @@ describe("EmDashRuntime.getManifest()", () => {
 		const manifest = await runtime.getManifest();
 
 		expect(manifest.contentLocale).toEqual({ defaultLocale: "en", implicit: true });
+	});
+
+	it("keeps the admin manifest available with a safe registry configuration diagnostic", async () => {
+		const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+		const runtime = buildRuntime(db, {
+			experimental: { registry: { aggregatorUrl: "not a URL" } },
+		});
+
+		const manifest = await runtime.getManifest();
+
+		expect(manifest.registry).toBeUndefined();
+		expect(manifest.registryConfigurationError).toEqual({
+			code: "REGISTRY_AGGREGATOR_URL_INVALID",
+			field: "experimental.registry.aggregatorUrl",
+		});
+		expect(log).toHaveBeenCalledWith(
+			"EmDash registry configuration error in experimental.registry.aggregatorUrl (REGISTRY_AGGREGATOR_URL_INVALID)",
+		);
 	});
 
 	it("reports the configured content default independently of admin language", async () => {


### PR DESCRIPTION
## What does this PR do?

Invalid plugin registry settings now produce field-specific configuration errors while Astro loads the site. If a recognized invalid registry setting reaches runtime manifest generation, the admin remains available and shows which `experimental.registry` field to correct; unexpected manifest failures still return an error.

The diagnostic contains only a stable code and field name, so configured values and credentials are not exposed. The change adds no logged-out queries.

Part of #1350.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: n/a — bug fix
- [x] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.6

## Screenshots / test output

![Admin error banner directing the administrator to the invalid minimum release age field in astro.config.mjs](./registry-config-error.png)

- Core registry, integration, runtime, and API tests: 79 passed
- Admin browser tests: 2 passed
- Root build and typecheck passed
- Type-aware lint: 0 diagnostics
- Formatting, changeset validation, and diff checks passed

![Admin error banner directing the administrator to the invalid minimum release age field in astro.config.mjs](https://github.com/user-attachments/assets/a76ccdc2-e44d-44ab-9400-98935ec6dfcd)