### PR TITLE
feat(admin): show canonical registry plugin names

### DIFF
--- a/.changeset/bright-plugins-name.md
+++ b/.changeset/bright-plugins-name.md
@@ -1,0 +1,7 @@
+---
+"@emdash-cms/admin": minor
+---
+
+Adds public names for registry plugins in the `@publisher.example/plugin-slug` format. Registry results and installed-plugin cards display the verified public name and link to a handle-based detail URL, while exact public-name searches open the matching package.
+
+When a publisher handle conclusively fails identity verification, the admin displays **INVALID HANDLE** and prevents installation. Temporary lookup failures fall back to the stable publisher identifier without marking the handle invalid.

--- a/docs/src/content/docs/plugins/registry.mdx
+++ b/docs/src/content/docs/plugins/registry.mdx
@@ -15,6 +15,14 @@ The plugin registry is the supported catalog for sandboxed plugins. It lets admi
 
 When `experimental.registry` is configured, the admin panel displays a **Registry** section for browsing and installing plugins.
 
+## Plugin public names
+
+Every registry plugin has a public name made from its publisher's current Atmosphere account handle and its package slug. For example, a package with the slug `my-gallery` published by `example.com` appears as `@example.com/my-gallery`.
+
+The public name appears in registry results and under **Plugins** after installation. Select it to open the plugin detail page, or paste the complete name into registry search to find that exact package. EmDash resolves the handle to the publisher's stable account identifier before loading the package.
+
+If the handle conclusively stops resolving back to the publisher, EmDash displays **INVALID HANDLE** and prevents new installation from the package detail page. Existing installations remain in their current state so an identity lookup cannot disable a running site. Review the installed plugin and contact its publisher before updating it. A temporary lookup failure displays the stable publisher identifier with **Handle unavailable** instead of reporting an invalid handle.
+
 ## Enable the registry
 
 To install plugins from the registry, configure storage and an available sandbox runner. Complete the platform-specific [plugin sandbox setup](/deployment/plugin-sandbox/) first.
@@ -45,7 +53,7 @@ Use the bare hosted registry URL for the normal setup. See the [`experimental.re
 <Steps>
 
 1. Open **Registry** in the admin panel.
-2. Search for a plugin and open its detail page.
+2. Search by title, description, or a complete public name such as `@example.com/my-gallery`, then open the plugin's detail page.
 3. Select a release and review its publisher, metadata, requested permissions, and verification status.
 4. Select **Install**.
 5. Review the verification status and permissions in the consent dialog, then confirm.

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -373,7 +373,7 @@ function PluginCard({
 		<>
 			<div
 				className={cn(
-					"rounded-lg border bg-kumo-base transition-colors",
+					"rounded-lg border border-kumo-border bg-kumo-base transition-colors",
 					!plugin.enabled && "opacity-75",
 					registryIdentity?.status === "invalid" && "border-kumo-danger",
 				)}

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -56,6 +56,7 @@ import { ADMIN_NAV_ICONS } from "./admin-navigation-icons.js";
 import { CaretNext } from "./ArrowIcons.js";
 import { CapabilityConsentDialog } from "./CapabilityConsentDialog.js";
 import { DialogError, getMutationError } from "./DialogError.js";
+import { RegistryPluginIdentity, useRegistryPluginIdentity } from "./RegistryPluginIdentity.js";
 import { RouterLinkButton } from "./RouterLinkButton.js";
 
 export function MarketplaceInstallMessage() {
@@ -257,6 +258,10 @@ function PluginCard({
 
 	const isMarketplace = plugin.source === "marketplace";
 	const isRegistry = plugin.source === "registry";
+	const registryIdentity = useRegistryPluginIdentity(
+		isRegistry ? plugin.registryPublisherDid : undefined,
+		isRegistry ? plugin.registrySlug : undefined,
+	);
 	const hasUpdate = !!updateInfo && updateInfo.installed !== updateInfo.latest;
 	const mcpTools = plugin.mcpTools ?? [];
 
@@ -370,6 +375,7 @@ function PluginCard({
 				className={cn(
 					"rounded-lg border bg-kumo-base transition-colors",
 					!plugin.enabled && "opacity-75",
+					registryIdentity?.status === "invalid" && "border-kumo-danger",
 				)}
 			>
 				<div className="flex items-center gap-4 p-4">
@@ -401,15 +407,23 @@ function PluginCard({
 							<span className="text-xs text-kumo-subtle">v{plugin.version}</span>
 							{!plugin.enabled && <Badge variant="secondary">{t`Disabled`}</Badge>}
 							{isMarketplace && <Badge variant="secondary">{t`Marketplace`}</Badge>}
+							{isRegistry && <Badge variant="secondary">{t`Registry`}</Badge>}
 							{hasUpdate && (
 								<Badge variant="outline" className="border-kumo-brand text-kumo-link">
 									{t`v${updateInfo.latest} available`}
 								</Badge>
 							)}
 						</div>
+						{registryIdentity && (
+							<RegistryPluginIdentity
+								identity={registryIdentity}
+								invalidMessage={t`This publisher identity no longer resolves.`}
+								className="mt-0.5"
+							/>
+						)}
 
 						{/* Description */}
-						{plugin.description && (
+						{plugin.description && registryIdentity?.status !== "invalid" && (
 							<p className="mt-0.5 text-sm text-kumo-subtle line-clamp-1">{plugin.description}</p>
 						)}
 

--- a/packages/admin/src/components/PublisherHandle.tsx
+++ b/packages/admin/src/components/PublisherHandle.tsx
@@ -1,9 +1,9 @@
 /**
- * Publisher identity for ordinary registry views.
+ * Publisher byline for a registry package detail view.
  *
- * Mutable handles are outside the package-profile CID's moderation boundary,
- * so browse and detail pages render only an approved author name or a stable,
- * shortened DID. Routing likewise uses the full DID.
+ * Public `@handle/slug` names and links are rendered by
+ * `RegistryPluginIdentity`; this component keeps the separately approved
+ * author-name or stable-DID fallback used by the "Published by" line.
  */
 
 export interface PublisherIdentityProfile {

--- a/packages/admin/src/components/RegistryBrowse.tsx
+++ b/packages/admin/src/components/RegistryBrowse.tsx
@@ -20,12 +20,18 @@ import * as React from "react";
 
 import {
 	searchRegistryPackages,
+	resolveRegistryPackageStatus,
 	registryQueryPolicyKey,
 	type RegistryClientConfig,
 	type RegistryPackageView,
 } from "../lib/api/registry.js";
+import {
+	parseRegistryPublicName,
+	registryIdentityPublisherParam,
+} from "../lib/registry-identity.js";
+import { cn } from "../lib/utils.js";
 import { ADMIN_NAV_ICONS } from "./admin-navigation-icons.js";
-import { PublisherIdentity } from "./PublisherHandle.js";
+import { RegistryPluginIdentity, useRegistryPluginIdentity } from "./RegistryPluginIdentity.js";
 
 export interface RegistryBrowseProps {
 	/** Resolved manifest.registry block. Required -- caller checks. */
@@ -66,12 +72,22 @@ export function RegistryBrowse({ config, installedRegistryUris = new Set() }: Re
 			registryQueryPolicyKey(config),
 			debouncedQuery,
 		],
-		queryFn: ({ pageParam }) =>
-			searchRegistryPackages(config, {
+		queryFn: async ({ pageParam }) => {
+			const publicName = parseRegistryPublicName(debouncedQuery);
+			if (publicName) {
+				const result = await resolveRegistryPackageStatus(
+					config,
+					publicName.handle,
+					publicName.slug,
+				);
+				return { packages: result.status === "passed" ? [result.value] : [] };
+			}
+			return searchRegistryPackages(config, {
 				q: debouncedQuery || undefined,
 				cursor: pageParam,
 				limit: 20,
-			}),
+			});
+		},
 		initialPageParam: undefined as string | undefined,
 		getNextPageParam: (lastPage) => lastPage.cursor,
 		refetchOnMount: "always",
@@ -177,6 +193,7 @@ interface RegistryPackageCardProps {
 
 function RegistryPackageCard({ pkg, installed }: RegistryPackageCardProps) {
 	const { t } = useLingui();
+	const identity = useRegistryPluginIdentity(pkg.did, pkg.slug)!;
 	// `profile` is lexicon-validated at the DiscoveryClient boundary, so the
 	// shape is trustworthy (or `null`). These are plain text content
 	// (React-escaped) — no URL/href, so no scheme allow-list is needed here.
@@ -186,9 +203,12 @@ function RegistryPackageCard({ pkg, installed }: RegistryPackageCardProps) {
 
 	return (
 		<Link
-			to="/plugins/marketplace/$pluginId"
-			params={{ pluginId: `${pkg.did}/${pkg.slug}` }}
-			className="block rounded-md border border-kumo-border bg-kumo-surface p-4 transition-colors hover:bg-kumo-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand"
+			to="/plugins/registry/$publisher/$slug"
+			params={{ publisher: registryIdentityPublisherParam(identity), slug: pkg.slug }}
+			className={cn(
+				"block rounded-md border bg-kumo-surface p-4 transition-colors hover:bg-kumo-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-kumo-brand",
+				identity.status === "invalid" ? "border-kumo-danger" : "border-kumo-border",
+			)}
 		>
 			<div className="flex items-start gap-3">
 				<div className="mt-1 rounded-md bg-kumo-subtle p-2 text-kumo-subtle">
@@ -196,9 +216,18 @@ function RegistryPackageCard({ pkg, installed }: RegistryPackageCardProps) {
 				</div>
 				<div className="min-w-0 flex-1">
 					<h2 className="truncate font-semibold">{name ?? pkg.slug}</h2>
-					<PublisherIdentity did={pkg.did} profile={pkg.profile} variant="card" />
+					<RegistryPluginIdentity
+						identity={identity}
+						invalidMessage={t`The publisher identity cannot be verified.`}
+						className="mt-0.5"
+						linked={false}
+					/>
 
-					{description ? (
+					{identity.status === "invalid" ? (
+						<p className="mt-2 text-sm font-medium text-kumo-danger">
+							{t`Installation is unavailable.`}
+						</p>
+					) : description ? (
 						<p className="mt-2 line-clamp-2 text-sm text-kumo-default">{description}</p>
 					) : null}
 					{license ? <p className="mt-2 text-xs text-kumo-subtle">{license}</p> : null}

--- a/packages/admin/src/components/RegistryBrowse.tsx
+++ b/packages/admin/src/components/RegistryBrowse.tsx
@@ -1,14 +1,12 @@
 /**
- * Registry Browse
+ * Registry browse
  *
  * Grid of plugin cards backed by the experimental decentralized plugin
- * registry's aggregator. Search box debounces directly into the
- * aggregator's `searchPackages` XRPC -- the aggregator is a public,
- * read-only service, so no server proxy is involved.
+ * registry's public, read-only aggregator.
  *
- * Cards navigate to `/plugins/marketplace/$pluginId` (the same path the
- * marketplace browse uses); the router branches to the registry detail
- * component when `manifest.registry` is configured.
+ * Cards navigate to `/plugins/registry/$publisher/$slug`. A search that
+ * matches `@handle/slug` resolves that package directly; other input uses
+ * the aggregator's free-text `searchPackages` endpoint.
  */
 
 import { Badge, Button, Input } from "@cloudflare/kumo";

--- a/packages/admin/src/components/RegistryPluginDetail.tsx
+++ b/packages/admin/src/components/RegistryPluginDetail.tsx
@@ -7,10 +7,10 @@
  * which independently verifies publisher records, artifact, manifest, and
  * provenance before any write.
  *
- * Identified in the URL by a `pluginId` that is `${handle}/${slug}`.
- * The router wraps this component when `manifest.registry` is set on
- * the same route the marketplace detail uses, so existing bookmarks /
- * sidebar entries stay stable.
+ * `pluginId` is `${publisher}/${slug}`, where `publisher` is a verified
+ * handle (with or without `@`) or a stable DID. The dedicated registry route
+ * renders this component; the marketplace detail route forwards matching
+ * legacy DID-based links for backward compatibility.
  */
 
 import { Badge, Button, LinkButton, Select, Tabs } from "@cloudflare/kumo";

--- a/packages/admin/src/components/RegistryPluginDetail.tsx
+++ b/packages/admin/src/components/RegistryPluginDetail.tsx
@@ -54,10 +54,12 @@ import {
 	type SectionKey,
 } from "../lib/api/registry.js";
 import { renderMarkdown } from "../lib/markdown.js";
+import { registryIdentity } from "../lib/registry-identity.js";
 import { ArrowPrev } from "./ArrowIcons.js";
 import { CapabilityConsentDialog } from "./CapabilityConsentDialog.js";
 import { getMutationError } from "./DialogError.js";
 import { PublisherIdentity } from "./PublisherHandle.js";
+import { RegistryPluginIdentity } from "./RegistryPluginIdentity.js";
 
 export interface RegistryPluginDetailProps {
 	/** `${handle}/${slug}` -- the pluginId param from the route. */
@@ -103,7 +105,8 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 	// historically, though atproto handles don't; the DID form
 	// definitely doesn't).
 	const slashIdx = pluginId.lastIndexOf("/");
-	const publisher = slashIdx > 0 ? pluginId.slice(0, slashIdx) : "";
+	const publisherParam = slashIdx > 0 ? pluginId.slice(0, slashIdx) : "";
+	const publisher = publisherParam.startsWith("@") ? publisherParam.slice(1) : publisherParam;
 	const slug = slashIdx > 0 ? pluginId.slice(slashIdx + 1) : "";
 	const isDid = publisher.startsWith("did:");
 
@@ -148,6 +151,7 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 	// A conclusive round-trip mismatch blocks the UI. Indeterminate lookup failures
 	// do not participate in trust decisions; the server verifies DID-bound records.
 	const publisherHandleInvalid = publisherHandleResolution?.status === "invalid";
+	const publicIdentity = pkg ? registryIdentity(pkg.did, slug, publisherHandleResolution) : null;
 
 	// `listReleases` returns releases in descending semver order. The aggregator
 	// contains only the aggregator's approved projection. Lexicon-invalid records
@@ -524,6 +528,14 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 				</div>
 				<div className="min-w-0 flex-1">
 					<h1 className="truncate text-2xl font-semibold">{displayName ?? slug}</h1>
+					{publicIdentity ? (
+						<RegistryPluginIdentity
+							identity={publicIdentity}
+							invalidMessage={t`The publisher identity cannot be verified.`}
+							className="mt-1"
+							linked={false}
+						/>
+					) : null}
 					<p className="text-sm text-kumo-subtle">
 						<Trans>
 							Published by{" "}
@@ -637,9 +649,9 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 				>
 					<Warning className="mt-0.5 h-5 w-5 shrink-0" />
 					<div>
-						<p className="font-medium">{t`We couldn't verify this publisher's identity`}</p>
+						<p className="font-medium">{t`Publisher handle verification failed`}</p>
 						<p className="mt-1 text-sm text-kumo-default">
-							{t`This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying.`}
+							{t`This publisher's handle does not resolve back to its identity. Installation is disabled until the publisher fixes their handle.`}
 						</p>
 					</div>
 				</div>

--- a/packages/admin/src/components/RegistryPluginIdentity.tsx
+++ b/packages/admin/src/components/RegistryPluginIdentity.tsx
@@ -1,0 +1,98 @@
+import { Badge } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
+import { CheckCircle, WarningCircle } from "@phosphor-icons/react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+
+import { resolveDidToHandle } from "../lib/api/registry.js";
+import {
+	registryIdentity,
+	registryIdentityPublisherParam,
+	type RegistryIdentity,
+} from "../lib/registry-identity.js";
+import { cn } from "../lib/utils.js";
+
+export function useRegistryPluginIdentity(
+	did: string | undefined,
+	slug: string | undefined,
+): RegistryIdentity | null {
+	const { data } = useQuery({
+		queryKey: ["registry", "publisher-handle", did],
+		queryFn: () => resolveDidToHandle(did!),
+		enabled: Boolean(did && slug),
+	});
+	if (!did || !slug) return null;
+	return registryIdentity(did, slug, data);
+}
+
+export interface RegistryPluginIdentityProps {
+	identity: RegistryIdentity;
+	invalidMessage: string;
+	className?: string;
+	linked?: boolean;
+}
+
+export function RegistryPluginIdentity({
+	identity,
+	invalidMessage,
+	className,
+	linked = true,
+}: RegistryPluginIdentityProps) {
+	const { t } = useLingui();
+
+	if (identity.status === "ok") {
+		const publicName = (
+			<code className="truncate font-mono text-kumo-link" dir="auto">
+				{identity.publicName}
+			</code>
+		);
+		return (
+			<div className={cn("flex min-w-0 items-center gap-1.5 text-sm", className)}>
+				{linked ? (
+					<Link
+						to="/plugins/registry/$publisher/$slug"
+						params={{
+							publisher: registryIdentityPublisherParam(identity),
+							slug: identity.slug,
+						}}
+						className="min-w-0 hover:underline"
+					>
+						{publicName}
+					</Link>
+				) : (
+					publicName
+				)}
+				<CheckCircle
+					className="h-4 w-4 shrink-0 text-kumo-success"
+					weight="fill"
+					aria-label={t`Verified publisher`}
+				/>
+			</div>
+		);
+	}
+
+	if (identity.status === "invalid") {
+		return (
+			<div className={cn("mt-1 flex flex-wrap items-center gap-2", className)} role="alert">
+				<Badge variant="destructive">
+					<WarningCircle className="me-1 h-3.5 w-3.5" weight="fill" aria-hidden="true" />
+					{t`INVALID HANDLE`}
+				</Badge>
+				<span className="text-sm font-medium text-kumo-danger">{invalidMessage}</span>
+			</div>
+		);
+	}
+
+	return (
+		<div className={cn("text-xs text-kumo-subtle", className)}>
+			<code className="font-mono" dir="auto">
+				{identity.did}/{identity.slug}
+			</code>
+			{identity.status === "missing" ? (
+				<span className="ms-2">{t`Handle unavailable`}</span>
+			) : (
+				<span className="ms-2">{t`Resolving publisher handle...`}</span>
+			)}
+		</div>
+	);
+}

--- a/packages/admin/src/lib/registry-identity.ts
+++ b/packages/admin/src/lib/registry-identity.ts
@@ -1,0 +1,54 @@
+import { isHandle } from "@atcute/lexicons/syntax";
+
+import type { DidHandleResolution } from "./api/registry.js";
+
+const REGISTRY_SLUG_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
+
+export interface RegistryPublicName {
+	handle: string;
+	slug: string;
+}
+
+export type RegistryIdentity =
+	| { status: "pending"; did: string; slug: string }
+	| { status: "ok"; did: string; slug: string; handle: string; publicName: string }
+	| { status: "invalid"; did: string; slug: string }
+	| { status: "missing"; did: string; slug: string };
+
+export function formatRegistryPublicName(handle: string, slug: string): string {
+	return `@${handle.toLowerCase()}/${slug}`;
+}
+
+export function parseRegistryPublicName(value: string): RegistryPublicName | null {
+	const trimmed = value.trim();
+	if (!trimmed.startsWith("@")) return null;
+	const separator = trimmed.indexOf("/");
+	if (separator <= 1 || separator !== trimmed.lastIndexOf("/")) return null;
+
+	const handle = trimmed.slice(1, separator).toLowerCase();
+	const slug = trimmed.slice(separator + 1);
+	if (!isHandle(handle) || !REGISTRY_SLUG_PATTERN.test(slug)) return null;
+	return { handle, slug };
+}
+
+export function registryIdentity(
+	did: string,
+	slug: string,
+	resolution: DidHandleResolution | undefined,
+): RegistryIdentity {
+	if (!resolution) return { status: "pending", did, slug };
+	if (resolution.status === "ok") {
+		return {
+			status: "ok",
+			did,
+			slug,
+			handle: resolution.handle,
+			publicName: formatRegistryPublicName(resolution.handle, slug),
+		};
+	}
+	return { status: resolution.status, did, slug };
+}
+
+export function registryIdentityPublisherParam(identity: RegistryIdentity): string {
+	return identity.status === "ok" ? `@${identity.handle}` : identity.did;
+}

--- a/packages/admin/src/lib/registry-identity.ts
+++ b/packages/admin/src/lib/registry-identity.ts
@@ -38,12 +38,13 @@ export function registryIdentity(
 ): RegistryIdentity {
 	if (!resolution) return { status: "pending", did, slug };
 	if (resolution.status === "ok") {
+		const handle = resolution.handle.toLowerCase();
 		return {
 			status: "ok",
 			did,
 			slug,
-			handle: resolution.handle,
-			publicName: formatRegistryPublicName(resolution.handle, slug),
+			handle,
+			publicName: formatRegistryPublicName(handle, slug),
 		};
 	}
 	return { status: resolution.status, did, slug };

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -2229,6 +2229,25 @@ const marketplaceDetailRoute = createRoute({
 	component: MarketplaceDetailPage,
 });
 
+const registryDetailRoute = createRoute({
+	getParentRoute: () => adminLayoutRoute,
+	path: "/plugins/registry/$publisher/$slug",
+	component: RegistryDetailPage,
+});
+
+function RegistryDetailPage() {
+	const { t } = useLingui();
+	const { publisher, slug } = useParams({
+		from: "/_admin/plugins/registry/$publisher/$slug",
+	});
+	const { data: manifest } = useQuery({
+		queryKey: ["manifest"],
+		queryFn: fetchManifest,
+	});
+	if (!manifest?.registry) return <NotFoundPage message={t`Plugin registry is not configured.`} />;
+	return <RegistryPluginDetail pluginId={`${publisher}/${slug}`} config={manifest.registry} />;
+}
+
 function MarketplaceDetailPage() {
 	const { pluginId } = useParams({ from: "/_admin/plugins/marketplace/$pluginId" });
 
@@ -2671,6 +2690,7 @@ const adminRoutes = adminLayoutRoute.addChildren([
 	pluginManagerRoute,
 	pluginSettingsRoute,
 	marketplaceDetailRoute,
+	registryDetailRoute,
 	marketplaceBrowseRoute,
 	themeMarketplaceBrowseRoute,
 	themeMarketplaceDetailRoute,

--- a/packages/admin/tests/components/PluginManager.test.tsx
+++ b/packages/admin/tests/components/PluginManager.test.tsx
@@ -56,6 +56,7 @@ vi.mock("../../src/lib/api", async () => {
 const mockCheckPluginUpdates = vi.fn<() => Promise<PluginUpdateInfo[]>>();
 const mockUpdateMarketplacePlugin = vi.fn<() => Promise<void>>();
 const mockUninstallMarketplacePlugin = vi.fn<() => Promise<void>>();
+const mockResolveDidToHandle = vi.fn();
 
 vi.mock("../../src/lib/api/marketplace", async () => {
 	const actual = await vi.importActual("../../src/lib/api/marketplace");
@@ -65,6 +66,16 @@ vi.mock("../../src/lib/api/marketplace", async () => {
 		updateMarketplacePlugin: (...args: unknown[]) => mockUpdateMarketplacePlugin(...(args as [])),
 		uninstallMarketplacePlugin: (...args: unknown[]) =>
 			mockUninstallMarketplacePlugin(...(args as [])),
+	};
+});
+
+vi.mock("../../src/lib/api/registry", async () => {
+	const actual = await vi.importActual<typeof import("../../src/lib/api/registry")>(
+		"../../src/lib/api/registry",
+	);
+	return {
+		...actual,
+		resolveDidToHandle: (...args: unknown[]) => mockResolveDidToHandle(...args),
 	};
 });
 
@@ -137,6 +148,7 @@ describe("PluginManager", () => {
 		mockCheckPluginUpdates.mockResolvedValue([]);
 		mockUpdateMarketplacePlugin.mockResolvedValue(undefined);
 		mockUninstallMarketplacePlugin.mockResolvedValue(undefined);
+		mockResolveDidToHandle.mockResolvedValue({ status: "ok", handle: "example.com" });
 	});
 
 	it("displays plugin list with names and versions", async () => {
@@ -149,6 +161,53 @@ describe("PluginManager", () => {
 		await expect.element(screen.getByText("v1.0.0")).toBeInTheDocument();
 		await expect.element(screen.getByText("SEO Helper")).toBeInTheDocument();
 		await expect.element(screen.getByText("v2.0.0")).toBeInTheDocument();
+	});
+
+	it("shows the canonical public name for an installed registry plugin", async () => {
+		mockFetchPlugins.mockResolvedValue([
+			makePlugin({
+				id: "r_abcdefghijklmnop",
+				name: "My Gallery",
+				source: "registry",
+				registryPublisherDid: "did:plc:publisher",
+				registrySlug: "my-gallery",
+			}),
+		]);
+		const screen = await render(
+			<Wrapper>
+				<PluginManager />
+			</Wrapper>,
+		);
+
+		await expect.element(screen.getByText("@example.com/my-gallery")).toBeInTheDocument();
+		await expect.element(screen.getByText("Registry")).toBeInTheDocument();
+		const publicNameLink = screen.getByRole("link", { name: "@example.com/my-gallery" });
+		expect((publicNameLink.element() as HTMLAnchorElement).getAttribute("href")).toBe(
+			"/plugins/registry/@example.com/my-gallery",
+		);
+	});
+
+	it("shows an invalid-handle warning for an installed registry plugin", async () => {
+		mockResolveDidToHandle.mockResolvedValue({ status: "invalid" });
+		mockFetchPlugins.mockResolvedValue([
+			makePlugin({
+				id: "r_abcdefghijklmnop",
+				name: "Editorial Workflow",
+				source: "registry",
+				registryPublisherDid: "did:plc:publisher",
+				registrySlug: "editorial-workflow",
+			}),
+		]);
+		const screen = await render(
+			<Wrapper>
+				<PluginManager />
+			</Wrapper>,
+		);
+
+		await expect.element(screen.getByText("INVALID HANDLE")).toBeInTheDocument();
+		await expect
+			.element(screen.getByText("This publisher identity no longer resolves."))
+			.toBeInTheDocument();
 	});
 
 	it("enabled plugins show toggle in on state", async () => {

--- a/packages/admin/tests/components/RegistryBrowse.test.tsx
+++ b/packages/admin/tests/components/RegistryBrowse.test.tsx
@@ -10,11 +10,23 @@ vi.mock("@tanstack/react-router", async () => {
 	const actual = await vi.importActual("@tanstack/react-router");
 	return {
 		...actual,
-		Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+		Link: ({ children, to, params, ...props }: any) => {
+			let href = String(to ?? "");
+			for (const [key, value] of Object.entries(params ?? {})) {
+				href = href.replace(`$${key}`, String(value));
+			}
+			return (
+				<a href={href} {...props}>
+					{children}
+				</a>
+			);
+		},
 	};
 });
 
 const mockSearchRegistryPackages = vi.fn();
+const mockResolveRegistryPackageStatus = vi.fn();
+const mockResolveDidToHandle = vi.fn();
 
 vi.mock("../../src/lib/api/registry", async () => {
 	const actual = await vi.importActual<typeof import("../../src/lib/api/registry")>(
@@ -23,6 +35,8 @@ vi.mock("../../src/lib/api/registry", async () => {
 	return {
 		...actual,
 		searchRegistryPackages: (...args: unknown[]) => mockSearchRegistryPackages(...args),
+		resolveRegistryPackageStatus: (...args: unknown[]) => mockResolveRegistryPackageStatus(...args),
+		resolveDidToHandle: (...args: unknown[]) => mockResolveDidToHandle(...args),
 	};
 });
 
@@ -50,6 +64,7 @@ function packageView(name: string): RegistryPackageView {
 describe("RegistryBrowse listing safety", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockResolveDidToHandle.mockResolvedValue({ status: "ok", handle: "example.com" });
 	});
 
 	it("does not flash cached publisher metadata while the required fresh search is pending", async () => {
@@ -111,5 +126,71 @@ describe("RegistryBrowse listing safety", () => {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 
 		expect(screen.getByRole("heading", { name: approved }).query()).not.toBeNull();
+	});
+
+	it("shows the canonical public name and links through the handle", async () => {
+		mockSearchRegistryPackages.mockResolvedValue({ packages: [packageView("My Gallery")] });
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const screen = await render(
+			<QueryClientProvider client={queryClient}>
+				<RegistryBrowse config={CONFIG} />
+			</QueryClientProvider>,
+		);
+
+		await expect.element(screen.getByText("@example.com/unsafe")).toBeInTheDocument();
+		const link = screen.getByRole("link", { name: /My Gallery/ }).element() as HTMLAnchorElement;
+		expect(link.getAttribute("href")).toBe("/plugins/registry/@example.com/unsafe");
+	});
+
+	it("shows a conspicuous invalid-handle state without rendering an unverified handle", async () => {
+		mockSearchRegistryPackages.mockResolvedValue({ packages: [packageView("Unsafe Publisher")] });
+		mockResolveDidToHandle.mockResolvedValue({ status: "invalid" });
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const screen = await render(
+			<QueryClientProvider client={queryClient}>
+				<RegistryBrowse config={CONFIG} />
+			</QueryClientProvider>,
+		);
+
+		await expect.element(screen.getByText("INVALID HANDLE")).toBeInTheDocument();
+		await expect
+			.element(screen.getByText("The publisher identity cannot be verified."))
+			.toBeInTheDocument();
+		expect(screen.container.textContent).not.toContain("mutable.example");
+	});
+
+	it("does not report a temporary or missing handle as invalid", async () => {
+		mockSearchRegistryPackages.mockResolvedValue({ packages: [packageView("Offline Publisher")] });
+		mockResolveDidToHandle.mockResolvedValue({ status: "missing" });
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const screen = await render(
+			<QueryClientProvider client={queryClient}>
+				<RegistryBrowse config={CONFIG} />
+			</QueryClientProvider>,
+		);
+
+		await expect.element(screen.getByText("Handle unavailable")).toBeInTheDocument();
+		expect(screen.getByText("INVALID HANDLE").query()).toBeNull();
+	});
+
+	it("resolves an exact canonical-name search without sending it to free-text search", async () => {
+		mockSearchRegistryPackages.mockResolvedValue({ packages: [] });
+		mockResolveRegistryPackageStatus.mockResolvedValue({
+			status: "passed",
+			value: packageView("Exact Gallery"),
+		});
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const screen = await render(
+			<QueryClientProvider client={queryClient}>
+				<RegistryBrowse config={CONFIG} />
+			</QueryClientProvider>,
+		);
+
+		await screen.getByRole("searchbox").fill("@example.com/unsafe");
+		await expect
+			.element(screen.getByRole("heading", { name: "Exact Gallery" }))
+			.toBeInTheDocument();
+		expect(mockResolveRegistryPackageStatus).toHaveBeenCalledWith(CONFIG, "example.com", "unsafe");
+		expect(mockSearchRegistryPackages).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/admin/tests/components/RegistryPluginDetail.test.tsx
+++ b/packages/admin/tests/components/RegistryPluginDetail.test.tsx
@@ -383,9 +383,7 @@ describe("RegistryPluginDetail independent install consent", () => {
 			</Wrapper>,
 		);
 
-		await expect
-			.element(screen.getByText("We couldn't verify this publisher's identity"))
-			.toBeInTheDocument();
+		await expect.element(screen.getByText("INVALID HANDLE")).toBeInTheDocument();
 		await expect.element(screen.getByRole("button", { name: "Install" })).toBeDisabled();
 		expect(mockVerifyRegistryPlugin).not.toHaveBeenCalled();
 	});
@@ -407,7 +405,7 @@ describe("RegistryPluginDetail lastUpdated and approved publisher identity", () 
 		await expect.element(screen.getByText("Indexed")).toBeInTheDocument();
 	});
 
-	it("renders an approved author name without resolving a mutable handle", async () => {
+	it("renders the canonical public name and approved author name", async () => {
 		setup(makePackage(), [makeRelease()]);
 		const screen = await render(
 			<Wrapper>
@@ -415,8 +413,7 @@ describe("RegistryPluginDetail lastUpdated and approved publisher identity", () 
 			</Wrapper>,
 		);
 		await expect.element(screen.getByText(/Published by/)).toHaveTextContent("Published by Acme");
-		expect(screen.container.querySelector("bdi")?.textContent).toBe("Acme");
-		expect(screen.container.textContent).not.toContain("acme.dev");
+		await expect.element(screen.getByText("@acme.dev/myplugin")).toBeInTheDocument();
 	});
 
 	it("renders a fixed unavailable state without publisher content or media requests", async () => {

--- a/packages/admin/tests/lib/registry-identity.test.ts
+++ b/packages/admin/tests/lib/registry-identity.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { formatRegistryPublicName, parseRegistryPublicName } from "../../src/lib/registry-identity";
+
+describe("registry public names", () => {
+	it("formats a verified publisher handle and package slug", () => {
+		expect(formatRegistryPublicName("Example.COM", "my-gallery")).toBe("@example.com/my-gallery");
+	});
+
+	it("parses the canonical public-name form for exact search", () => {
+		expect(parseRegistryPublicName("  @example.com/my-gallery  ")).toEqual({
+			handle: "example.com",
+			slug: "my-gallery",
+		});
+	});
+
+	it("rejects incomplete and unsafe public names", () => {
+		for (const value of [
+			"example.com/my-gallery",
+			"@example.com",
+			"@example.com/My-Gallery",
+			"@example.com/my/gallery",
+			"@did:plc:publisher/my-gallery",
+		]) {
+			expect(parseRegistryPublicName(value)).toBeNull();
+		}
+	});
+});

--- a/packages/admin/tests/lib/registry-identity.test.ts
+++ b/packages/admin/tests/lib/registry-identity.test.ts
@@ -1,10 +1,29 @@
 import { describe, expect, it } from "vitest";
 
-import { formatRegistryPublicName, parseRegistryPublicName } from "../../src/lib/registry-identity";
+import {
+	formatRegistryPublicName,
+	parseRegistryPublicName,
+	registryIdentity,
+	registryIdentityPublisherParam,
+} from "../../src/lib/registry-identity";
 
 describe("registry public names", () => {
 	it("formats a verified publisher handle and package slug", () => {
 		expect(formatRegistryPublicName("Example.COM", "my-gallery")).toBe("@example.com/my-gallery");
+	});
+
+	it("normalizes resolver output before using the handle in a deep link", () => {
+		const identity = registryIdentity("did:plc:publisher", "my-gallery", {
+			status: "ok",
+			handle: "Example.COM",
+		});
+
+		expect(identity).toMatchObject({
+			status: "ok",
+			handle: "example.com",
+			publicName: "@example.com/my-gallery",
+		});
+		expect(registryIdentityPublisherParam(identity)).toBe("@example.com");
 	});
 
 	it("parses the canonical public-name form for exact search", () => {


### PR DESCRIPTION
## What does this PR do?

Adds canonical public names for registry plugins in the `@publisher.example/plugin-slug` format.

- Displays verified public names in registry results, plugin details, and the installed plugins list.
- Adds dedicated `/plugins/registry/@publisher.example/plugin-slug` deep links.
- Resolves exact public-name searches directly instead of treating them as free text.
- Shows a prominent **INVALID HANDLE** state and prevents installation when a handle conclusively fails identity verification.
- Uses the stable publisher DID and slug when handle resolution is temporarily unavailable; existing installations are not deactivated by an identity lookup.

Related Discussion: https://github.com/emdash-cms/emdash/discussions/296

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/296
- [x] I have included screenshots below if this PR changes the UI

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

### Registry listing — English

![Registry listing showing verified public plugin names and invalid handle warnings in English](https://github.com/user-attachments/assets/87170847-5bea-4eef-a7fe-13f75fe35bb2)

### Registry listing — Arabic RTL

![Registry listing showing verified public plugin names and invalid handle warnings in Arabic right-to-left layout](https://github.com/user-attachments/assets/5456877d-8b22-431c-95d4-e9b7cb66363b)

Validated on current `origin/main`:

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:json | jq '.diagnostics | length'` → `0`
- `pnpm --filter @emdash-cms/admin test --run` → 169 files, 2,317 tests passed
- `pnpm --dir docs build`
- Live registry rendering in English and Arabic RTL
