### PR TITLE
fix(core): sync non-translatable fields when an entry is published

### DIFF
--- a/.changeset/non-translatable-sync-on-publish.md
+++ b/.changeset/non-translatable-sync-on-publish.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes non-translatable fields never reaching an entry's other translations on collections with revisions, which is the default. Publishing an entry now copies the non-translatable values it changed to the rest of its translation group, and a save that started from a translation's earlier version gets a conflict instead of overwriting the copied values. Values that already differ between translations stay as they are until a change to that field is published in one of them.

--- a/docs/src/content/docs/guides/internationalization.mdx
+++ b/docs/src/content/docs/guides/internationalization.mdx
@@ -406,6 +406,8 @@ Each field has a `translatable` setting (default: `true`). When creating a trans
 - **Translatable fields** are pre-filled from the source locale for editing
 - **Non-translatable fields** are copied and kept in sync across all translations in the group
 
+On a collection with revisions, publishing an entry copies the non-translatable values it changed to the other translations, and saving a draft changes only that entry. If another translation has a pending draft that changed one of those values, the draft keeps its own value, and publishing that translation copies it to the rest of the group.
+
 System fields like `status`, `published_at`, and `author_id` are always per-locale and never synced.
 
 <Aside>

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -1120,8 +1120,7 @@ export async function handleContentUpdate(
 			// translation group. Only runs when i18n is enabled, data was updated,
 			// and the item belongs to a translation group with siblings.
 			if (isI18nEnabled() && body.data && updated.translationGroup) {
-				await syncNonTranslatableFields(
-					trx,
+				await trxRepo.syncNonTranslatableFields(
 					collection,
 					updated.id,
 					updated.translationGroup,
@@ -1611,7 +1610,7 @@ export async function handleContentUnschedule(
  * Publish content immediately.
  *
  * Publication is one atomic content-row statement. On databases that support
- * transactions, the existing slug-redirect side write remains grouped with it.
+ * transactions, the slug redirect and the locale sync stay grouped with it.
  */
 export async function handleContentPublish(
 	db: Kysely<Database>,
@@ -1648,6 +1647,21 @@ export async function handleContentPublish(
 				publishConfig.routable,
 				expectedRevision,
 			);
+
+			if (
+				existing &&
+				isI18nEnabled() &&
+				publishConfig.supportsRevisions &&
+				published.translationGroup
+			) {
+				await repo.syncNonTranslatableFields(
+					collection,
+					published.id,
+					published.translationGroup,
+					published.data,
+					{ previous: existing.data },
+				);
+			}
 
 			// Leave a 301 behind when publishing changed the slug of an entry that
 			// was already published — its old URL was live and may be indexed or
@@ -2010,75 +2024,6 @@ export async function handleContentTranslations(
 			},
 		};
 	}
-}
-
-// ---------------------------------------------------------------------------
-// Non-translatable field sync
-// ---------------------------------------------------------------------------
-
-/**
- * Sync non-translatable fields to sibling locales.
- *
- * When a content item is updated and it belongs to a translation group,
- * any non-translatable fields in the update data are written to all other
- * rows in the same translation group within the same transaction.
- *
- * Non-translatable fields are **copied, not linked** — each row owns its
- * own data. This keeps queries simple and avoids cross-row joins.
- */
-async function syncNonTranslatableFields(
-	trx: Kysely<Database>,
-	collectionSlug: string,
-	updatedItemId: string,
-	translationGroup: string,
-	data: Record<string, unknown>,
-): Promise<void> {
-	// Get the collection to find its fields
-	const collection = await trx
-		.selectFrom("_emdash_collections")
-		.select("id")
-		.where("slug", "=", collectionSlug)
-		.executeTakeFirst();
-
-	if (!collection) return;
-
-	// Find non-translatable fields that are present in the update data
-	const fields = await trx
-		.selectFrom("_emdash_fields")
-		.select("slug")
-		.where("collection_id", "=", collection.id)
-		.where("translatable", "=", 0)
-		.execute();
-
-	const nonTranslatableSlugs = fields.map((f) => f.slug);
-	if (nonTranslatableSlugs.length === 0) return;
-
-	// Filter to only the non-translatable fields present in this update
-	const syncData: Record<string, unknown> = {};
-	for (const slug of nonTranslatableSlugs) {
-		if (slug in data) {
-			syncData[slug] = data[slug];
-		}
-	}
-	if (Object.keys(syncData).length === 0) return;
-
-	// Build the SET clause for sibling rows
-	validateIdentifier(collectionSlug, "collection slug");
-	const tableName = `ec_${collectionSlug}`;
-
-	// Update all sibling rows (same translation_group, different id)
-	const setClauses = Object.entries(syncData).map(([key, value]) => {
-		validateIdentifier(key, "field slug");
-		const serialized = typeof value === "object" && value !== null ? JSON.stringify(value) : value;
-		return sql`${sql.ref(key)} = ${serialized}`;
-	});
-
-	await sql`
-		UPDATE ${sql.ref(tableName)}
-		SET ${sql.join(setClauses, sql`, `)}
-		WHERE translation_group = ${translationGroup}
-		AND id != ${updatedItemId}
-	`.execute(trx);
 }
 
 /**

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -1075,6 +1075,162 @@ export class ContentRepository {
 	}
 
 	/**
+	 * Copy non-translatable field values to every other entry in the
+	 * translation group, trashed entries included.
+	 *
+	 * Only the fields present in `data` are copied. With `previous`, `data` is
+	 * the entry's complete new state and only the fields whose value differs
+	 * from `previous` are copied, an absent field as null. An entry that already
+	 * holds every copied value is left untouched, so its `updated_at` does not
+	 * move.
+	 *
+	 * On collections with revisions a changed entry also gets a new live
+	 * revision, because republishing and unpublishing read that revision rather
+	 * than the columns. A pending draft takes a value only where it still holds
+	 * the entry's previous value, so an unpublished edit to the field survives.
+	 */
+	async syncNonTranslatableFields(
+		type: string,
+		sourceId: string,
+		translationGroup: string,
+		data: Record<string, unknown>,
+		options: { previous?: Record<string, unknown> } = {},
+	): Promise<void> {
+		const tableName = getTableName(type);
+		const collectionRows = await this.db
+			.selectFrom("_emdash_collections as collection")
+			.leftJoin("_emdash_fields as field", (join) =>
+				join.onRef("field.collection_id", "=", "collection.id").on("field.translatable", "=", 0),
+			)
+			.select(["collection.supports", "field.slug as fieldSlug"])
+			.where("collection.slug", "=", type)
+			.execute();
+
+		const { previous } = options;
+		const values: Record<string, unknown> = {};
+		for (const { fieldSlug } of collectionRows) {
+			if (!fieldSlug) continue;
+			if (previous) {
+				if (!sameStoredValue(previous[fieldSlug], data[fieldSlug])) {
+					values[fieldSlug] = data[fieldSlug] ?? null;
+				}
+			} else if (fieldSlug in data) {
+				values[fieldSlug] = data[fieldSlug];
+			}
+		}
+		if (Object.keys(values).length === 0) return;
+
+		const supportsRaw = collectionRows[0]?.supports;
+		const supports: unknown = supportsRaw ? JSON.parse(supportsRaw) : [];
+		const usesRevisions = Array.isArray(supports) && supports.includes("revisions");
+
+		const siblings = await sql<Record<string, unknown>>`
+			SELECT * FROM ${sql.ref(tableName)}
+			WHERE translation_group = ${translationGroup}
+			AND id != ${sourceId}
+		`.execute(this.db);
+
+		let changed = false;
+		for (const row of siblings.rows) {
+			if (await this.syncSiblingValues(type, this.mapRow(type, row), values, usesRevisions)) {
+				changed = true;
+			}
+		}
+		if (changed) invalidateCollectionCache(type);
+	}
+
+	private async syncSiblingValues(
+		type: string,
+		initial: ContentItem,
+		values: Record<string, unknown>,
+		usesRevisions: boolean,
+	): Promise<boolean> {
+		const tableName = getTableName(type);
+		const revisionRepo = new RevisionRepository(this.db);
+		let sibling: ContentItem | null = initial;
+
+		for (let attempt = 0; sibling && attempt < MAX_DRAFT_STAGE_ATTEMPTS; attempt++) {
+			const current: ContentItem = sibling;
+			const changed: Record<string, unknown> = {};
+			for (const [field, value] of Object.entries(values)) {
+				if (!sameStoredValue(current.data[field], value)) changed[field] = value;
+			}
+			if (Object.keys(changed).length === 0) return false;
+
+			const assignments: ReturnType<typeof sql>[] = [];
+			for (const [field, value] of Object.entries(changed)) {
+				validateIdentifier(field, "content field name");
+				assignments.push(sql`${sql.ref(field)} = ${serializeValue(value)}`);
+			}
+
+			const createdRevisionIds: string[] = [];
+			const cleanUp = async () => {
+				for (const revisionId of createdRevisionIds) {
+					await this.deleteUnstagedRevision(revisionRepo, type, current.id, revisionId);
+				}
+			};
+
+			let synced: boolean;
+			try {
+				const live =
+					usesRevisions && current.liveRevisionId
+						? await revisionRepo.findById(current.liveRevisionId)
+						: null;
+				if (live) {
+					const revision = await revisionRepo.create({
+						collection: type,
+						entryId: current.id,
+						data: { ...live.data, ...changed },
+					});
+					createdRevisionIds.push(revision.id);
+					assignments.push(sql`live_revision_id = ${revision.id}`);
+				}
+
+				const draft =
+					usesRevisions && current.draftRevisionId
+						? await revisionRepo.findById(current.draftRevisionId)
+						: null;
+				const carried: Record<string, unknown> = {};
+				for (const [field, value] of Object.entries(changed)) {
+					if (draft && sameStoredValue(draft.data[field], current.data[field])) {
+						carried[field] = value;
+					}
+				}
+				if (draft && Object.keys(carried).length > 0) {
+					const revision = await revisionRepo.create({
+						collection: type,
+						entryId: current.id,
+						data: { ...draft.data, ...carried },
+					});
+					createdRevisionIds.push(revision.id);
+					assignments.push(sql`draft_revision_id = ${revision.id}`);
+				}
+
+				assignments.push(sql`updated_at = ${new Date().toISOString()}`, sql`version = version + 1`);
+				const result = await sql`
+					UPDATE ${sql.ref(tableName)}
+					SET ${sql.join(assignments, sql`, `)}
+					WHERE id = ${current.id}
+					AND version = ${current.version}
+					AND ${nullableColumnMatch("live_revision_id", current.liveRevisionId)}
+					AND ${nullableColumnMatch("draft_revision_id", current.draftRevisionId)}
+				`.execute(this.db);
+				synced = (result.numAffectedRows ?? 0n) > 0n;
+			} catch (error) {
+				await cleanUp();
+				throw error;
+			}
+
+			if (synced) return true;
+			await cleanUp();
+			sibling = await this.findByIdIncludingTrashed(type, current.id);
+		}
+
+		if (!sibling) return false;
+		throw new ContentMutationConflictError();
+	}
+
+	/**
 	 * Delete content (soft delete - moves to trash)
 	 */
 	async delete(type: string, id: string): Promise<boolean> {

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -3105,31 +3105,14 @@ export class EmDashRuntime {
 		if (hydrated.success && hydrated.data) {
 			const contentIdsToRefresh = [resolvedId];
 			if (!usesDraftRevisions && processedData) {
-				try {
-					contentIdsToRefresh.push(
-						...(await findNonTranslatableSiblingContentIds(
-							this.db,
-							collection,
-							resolvedId,
-							hydrated.data.item.translationGroup,
-							processedData,
-						)),
-					);
-				} catch (error) {
-					console.error(
-						`[media-usage] Failed to discover synced i18n siblings for ${collection}/${resolvedId}:`,
-						error,
-					);
-					try {
-						await markContentMediaUsageCollectionStale(
-							this.db,
-							collection,
-							"CONTENT_USAGE_REFRESH_ERROR",
-						);
-					} catch (staleError) {
-						console.error(`[media-usage] Failed to mark ${collection} stale:`, staleError);
-					}
-				}
+				contentIdsToRefresh.push(
+					...(await this.findSyncedSiblingsForUsageRefresh(
+						collection,
+						resolvedId,
+						hydrated.data.item.translationGroup,
+						processedData,
+					)),
+				);
 			}
 			await this.refreshContentUsageAfterSuccessfulWrite(collection, contentIdsToRefresh);
 		} else if (draftStorageChanged) {
@@ -3259,7 +3242,17 @@ export class EmDashRuntime {
 	) {
 		const result = await handleContentPublish(this.db, collection, id, options);
 		if (result.success && result.data) {
-			await this.refreshContentUsageAfterSuccessfulWrite(collection, [result.data.item.id]);
+			const { item } = result.data;
+			await this.refreshContentUsageAfterSuccessfulWrite(collection, [
+				item.id,
+				...(await this.findSyncedSiblingsForUsageRefresh(
+					collection,
+					item.id,
+					item.translationGroup,
+					item.data,
+					{ absentAsCleared: true },
+				)),
+			]);
 		}
 
 		// Run afterPublish hooks (fire-and-forget)
@@ -3585,6 +3578,40 @@ export class EmDashRuntime {
 					message: "Failed to restore revision",
 				},
 			};
+		}
+	}
+
+	private async findSyncedSiblingsForUsageRefresh(
+		collection: string,
+		contentId: string,
+		translationGroup: string | null | undefined,
+		data: Record<string, unknown>,
+		options: { absentAsCleared?: boolean } = {},
+	): Promise<string[]> {
+		try {
+			return await findNonTranslatableSiblingContentIds(
+				this.db,
+				collection,
+				contentId,
+				translationGroup,
+				data,
+				options,
+			);
+		} catch (error) {
+			console.error(
+				`[media-usage] Failed to discover synced i18n siblings for ${collection}/${contentId}:`,
+				error,
+			);
+			try {
+				await markContentMediaUsageCollectionStale(
+					this.db,
+					collection,
+					"CONTENT_USAGE_REFRESH_ERROR",
+				);
+			} catch (staleError) {
+				console.error(`[media-usage] Failed to mark ${collection} stale:`, staleError);
+			}
+			return [];
 		}
 	}
 

--- a/packages/core/src/media/usage/content-refresh.ts
+++ b/packages/core/src/media/usage/content-refresh.ts
@@ -868,6 +868,7 @@ export async function findNonTranslatableSiblingContentIds(
 	updatedContentId: string,
 	translationGroup: string | null | undefined,
 	updatedData: Record<string, unknown> | undefined,
+	options: { absentAsCleared?: boolean } = {},
 ): Promise<string[]> {
 	if (!isI18nEnabled() || !updatedData || !translationGroup) return [];
 
@@ -887,7 +888,7 @@ export async function findNonTranslatableSiblingContentIds(
 		.execute();
 
 	const touchedNonTranslatableSlugs = fields
-		.filter((field) => field.slug in updatedData)
+		.filter((field) => options.absentAsCleared || field.slug in updatedData)
 		.map((field) => field.slug);
 	if (touchedNonTranslatableSlugs.length === 0) return [];
 

--- a/packages/core/tests/integration/content/non-translatable-sync.test.ts
+++ b/packages/core/tests/integration/content/non-translatable-sync.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { EmDashRuntime } from "../../../src/emdash-runtime.js";
+import { setI18nConfig } from "../../../src/i18n/config.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { createTestRuntime } from "../../utils/mcp-runtime.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+type Result<T> = { success: true; data: T } | { success: false; error: { message: string } };
+
+function ok<T>(result: Result<T>): T {
+	if (!result.success) throw new Error(result.error.message);
+	return result.data;
+}
+
+describeEachDialect("non-translatable field sync", (dialect) => {
+	let ctx: DialectTestContext;
+	let runtime: EmDashRuntime;
+
+	beforeEach(async () => {
+		setI18nConfig({ defaultLocale: "en", locales: ["en", "de"] });
+		ctx = await setupForDialect(dialect);
+		const registry = new SchemaRegistry(ctx.db);
+		for (const [slug, supports] of [
+			["posts", undefined],
+			["pages", []],
+		] as const) {
+			await registry.createCollection({
+				slug,
+				label: slug,
+				...(supports ? { supports: [...supports] } : {}),
+			});
+			await registry.createField(slug, { slug: "title", label: "Title", type: "string" });
+			await registry.createField(slug, {
+				slug: "sku",
+				label: "SKU",
+				type: "string",
+				translatable: false,
+			});
+		}
+		runtime = createTestRuntime(ctx.db);
+	});
+
+	afterEach(async () => {
+		setI18nConfig(null);
+		await teardownForDialect(ctx);
+	});
+
+	async function createPair(collection: "posts" | "pages", sku = "SKU-1") {
+		const en = ok(
+			await runtime.handleContentCreate(collection, {
+				data: { title: "Hello", sku },
+				slug: "hello",
+				locale: "en",
+			}),
+		);
+		const de = ok(
+			await runtime.handleContentCreate(collection, {
+				data: { title: "Hallo", sku },
+				slug: "hallo",
+				locale: "de",
+				translationOf: en.item.id,
+			}),
+		);
+		return { enId: en.item.id, deId: de.item.id };
+	}
+
+	async function read(collection: "posts" | "pages", id: string, locale: string) {
+		return ok(await runtime.handleContentGet(collection, id, locale));
+	}
+
+	async function saveAndPublish(id: string, locale: string, data: Record<string, unknown>) {
+		ok(await runtime.handleContentUpdate("posts", id, { data, locale }));
+		ok(await runtime.handleContentPublish("posts", id));
+	}
+
+	async function publishWithoutSync(id: string) {
+		await new ContentRepository(ctx.db).publish("posts", id);
+	}
+
+	describe("on a collection with revisions", () => {
+		async function createPublishedPair() {
+			const pair = await createPair("posts");
+			ok(await runtime.handleContentPublish("posts", pair.enId));
+			ok(await runtime.handleContentPublish("posts", pair.deId));
+			return pair;
+		}
+
+		it("copies a published value to the other locales", async () => {
+			const { enId, deId } = await createPublishedPair();
+
+			await saveAndPublish(deId, "de", { sku: "SKU-2" });
+
+			expect((await read("posts", deId, "de")).item.data.sku).toBe("SKU-2");
+			expect((await read("posts", enId, "en")).item.data.sku).toBe("SKU-2");
+		});
+
+		it("leaves the other locales alone until the change is published", async () => {
+			const { enId, deId } = await createPublishedPair();
+			const before = await read("posts", enId, "en");
+
+			ok(
+				await runtime.handleContentUpdate("posts", deId, { data: { sku: "SKU-2" }, locale: "de" }),
+			);
+
+			const after = await read("posts", enId, "en");
+			expect(after.item.data.sku).toBe("SKU-1");
+			expect(after._rev).toBe(before._rev);
+		});
+
+		it("clears the value in the other locales when a cleared value is published", async () => {
+			const { enId, deId } = await createPublishedPair();
+
+			await saveAndPublish(deId, "de", { sku: null });
+
+			expect((await read("posts", enId, "en")).item.data.sku).toBeUndefined();
+		});
+
+		it("keeps the synced value when another locale is republished or unpublished", async () => {
+			const { enId, deId } = await createPublishedPair();
+			await saveAndPublish(deId, "de", { sku: "SKU-2" });
+
+			ok(await runtime.handleContentPublish("posts", enId));
+			expect((await read("posts", enId, "en")).item.data.sku).toBe("SKU-2");
+
+			ok(await runtime.handleContentUnpublish("posts", enId));
+			expect((await read("posts", enId, "en")).item.data.sku).toBe("SKU-2");
+
+			ok(await runtime.handleContentPublish("posts", enId));
+			expect((await read("posts", enId, "en")).item.data.sku).toBe("SKU-2");
+			expect((await read("posts", deId, "de")).item.data.sku).toBe("SKU-2");
+		});
+
+		it("carries the value into a pending draft that left the field alone", async () => {
+			const { enId, deId } = await createPublishedPair();
+			ok(
+				await runtime.handleContentUpdate("posts", enId, {
+					data: { title: "Hello again" },
+					locale: "en",
+				}),
+			);
+
+			await saveAndPublish(deId, "de", { sku: "SKU-2" });
+
+			const draft = await read("posts", enId, "en");
+			expect(draft.item.data).toMatchObject({ title: "Hello again", sku: "SKU-2" });
+
+			ok(await runtime.handleContentPublish("posts", enId));
+			expect((await read("posts", enId, "en")).item.data).toMatchObject({
+				title: "Hello again",
+				sku: "SKU-2",
+			});
+			expect((await read("posts", deId, "de")).item.data.sku).toBe("SKU-2");
+		});
+
+		it("keeps a value that a pending draft changed on its own", async () => {
+			const { enId, deId } = await createPublishedPair();
+			ok(
+				await runtime.handleContentUpdate("posts", enId, { data: { sku: "SKU-3" }, locale: "en" }),
+			);
+
+			await saveAndPublish(deId, "de", { sku: "SKU-2" });
+
+			expect((await read("posts", enId, "en")).item.data.sku).toBe("SKU-3");
+
+			ok(await runtime.handleContentPublish("posts", enId));
+			expect((await read("posts", enId, "en")).item.data.sku).toBe("SKU-3");
+			expect((await read("posts", deId, "de")).item.data.sku).toBe("SKU-3");
+		});
+
+		it("does not touch a locale that already holds the published value", async () => {
+			const { enId, deId } = await createPublishedPair();
+			ok(
+				await runtime.handleContentUpdate("posts", deId, { data: { sku: "SKU-2" }, locale: "de" }),
+			);
+			await publishWithoutSync(deId);
+			const before = await read("posts", deId, "de");
+
+			await saveAndPublish(enId, "en", { sku: "SKU-2" });
+
+			const after = await read("posts", deId, "de");
+			expect(after._rev).toBe(before._rev);
+			expect(after.item.updatedAt).toBe(before.item.updatedAt);
+		});
+
+		it("keeps the other locales' value when a translation without it is published", async () => {
+			const en = ok(
+				await runtime.handleContentCreate("posts", {
+					data: { title: "Hello", sku: "SKU-1" },
+					slug: "hello",
+					locale: "en",
+				}),
+			);
+			ok(await runtime.handleContentPublish("posts", en.item.id));
+			const de = ok(
+				await runtime.handleContentCreate("posts", {
+					data: { title: "Hallo" },
+					slug: "hallo",
+					locale: "de",
+					translationOf: en.item.id,
+				}),
+			);
+
+			ok(await runtime.handleContentPublish("posts", de.item.id));
+
+			expect((await read("posts", en.item.id, "en")).item.data.sku).toBe("SKU-1");
+		});
+
+		it("does not copy a value the publication left unchanged", async () => {
+			const { enId, deId } = await createPublishedPair();
+			ok(
+				await runtime.handleContentUpdate("posts", enId, { data: { sku: "SKU-2" }, locale: "en" }),
+			);
+			await publishWithoutSync(enId);
+
+			await saveAndPublish(deId, "de", { title: "Hallo again" });
+
+			expect((await read("posts", enId, "en")).item.data.sku).toBe("SKU-2");
+		});
+	});
+
+	describe("on a collection without revisions", () => {
+		it("advances the other locale's _rev when a sync rewrites its data", async () => {
+			const { enId, deId } = await createPair("pages");
+			const before = await read("pages", enId, "en");
+
+			ok(
+				await runtime.handleContentUpdate("pages", deId, { data: { sku: "SKU-2" }, locale: "de" }),
+			);
+
+			const after = await read("pages", enId, "en");
+			expect(after.item.data.sku).toBe("SKU-2");
+			expect(after._rev).not.toBe(before._rev);
+		});
+
+		it("refuses a write carrying the pre-sync _rev instead of losing the synced value", async () => {
+			const { enId, deId } = await createPair("pages");
+			const staleRev = (await read("pages", enId, "en"))._rev;
+
+			ok(
+				await runtime.handleContentUpdate("pages", deId, { data: { sku: "SKU-2" }, locale: "de" }),
+			);
+
+			const stale = await runtime.handleContentUpdate("pages", enId, {
+				data: { title: "Hello again", sku: "SKU-1" },
+				locale: "en",
+				_rev: staleRev,
+			});
+			expect(stale.success).toBe(false);
+			expect(stale.success ? undefined : stale.error.code).toBe("CONFLICT");
+			expect((await read("pages", enId, "en")).item.data.sku).toBe("SKU-2");
+		});
+	});
+});

--- a/packages/core/tests/integration/database/media-usage-runtime-refresh.test.ts
+++ b/packages/core/tests/integration/database/media-usage-runtime-refresh.test.ts
@@ -893,6 +893,93 @@ describeEachDialect("runtime content media usage refresh", (dialect) => {
 		).toBe(frSourceBefore?.currentGeneration);
 	});
 
+	it("refreshes i18n siblings when publishing a non-translatable image", async () => {
+		setI18nConfig({ defaultLocale: "en", locales: ["en", "fr"] });
+		const en = await runtime.handleContentCreate("posts", {
+			slug: "publish-sibling-en",
+			locale: "en",
+			data: {
+				title: "English Publish Sibling",
+				shared_hero: mediaRef("media-publish-sibling-old-en"),
+			},
+		});
+		expect(en.success).toBe(true);
+		if (!en.success) throw new Error(en.error.message);
+		const fr = await runtime.handleContentCreate("posts", {
+			slug: "publish-sibling-fr",
+			locale: "fr",
+			translationOf: en.data.item.id,
+			data: {
+				title: "French Publish Sibling",
+				shared_hero: mediaRef("media-publish-sibling-old-fr"),
+			},
+		});
+		expect(fr.success).toBe(true);
+		if (!fr.success) throw new Error(fr.error.message);
+		await runtime.handleContentPublish("posts", en.data.item.id);
+		await runtime.handleContentPublish("posts", fr.data.item.id);
+		await runtime.handleContentUpdate("posts", en.data.item.id, {
+			data: { shared_hero: mediaRef("media-publish-sibling-new") },
+		});
+
+		const published = await runtime.handleContentPublish("posts", en.data.item.id);
+
+		expect(published.success).toBe(true);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-publish-sibling-old-fr")).toEqual([]);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-publish-sibling-new")).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					source: expect.objectContaining({
+						contentId: en.data.item.id,
+						sourceVariant: "columns",
+					}),
+				}),
+				expect.objectContaining({
+					source: expect.objectContaining({
+						contentId: fr.data.item.id,
+						sourceVariant: "columns",
+					}),
+				}),
+			]),
+		);
+	});
+
+	it("refreshes i18n siblings when publishing a cleared non-translatable image", async () => {
+		setI18nConfig({ defaultLocale: "en", locales: ["en", "fr"] });
+		const en = await runtime.handleContentCreate("posts", {
+			slug: "clear-sibling-en",
+			locale: "en",
+			data: {
+				title: "English Clear Sibling",
+				shared_hero: mediaRef("media-clear-sibling-old-en"),
+			},
+		});
+		expect(en.success).toBe(true);
+		if (!en.success) throw new Error(en.error.message);
+		const fr = await runtime.handleContentCreate("posts", {
+			slug: "clear-sibling-fr",
+			locale: "fr",
+			translationOf: en.data.item.id,
+			data: {
+				title: "French Clear Sibling",
+				shared_hero: mediaRef("media-clear-sibling-old-fr"),
+			},
+		});
+		expect(fr.success).toBe(true);
+		if (!fr.success) throw new Error(fr.error.message);
+		await runtime.handleContentPublish("posts", en.data.item.id);
+		await runtime.handleContentPublish("posts", fr.data.item.id);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-clear-sibling-old-fr")).toHaveLength(1);
+		await runtime.handleContentUpdate("posts", en.data.item.id, {
+			data: { shared_hero: null },
+		});
+
+		const published = await runtime.handleContentPublish("posts", en.data.item.id);
+
+		expect(published.success).toBe(true);
+		expect(await usageRepo.findCurrentUsageByMediaId("media-clear-sibling-old-fr")).toEqual([]);
+	});
+
 	it("refreshes trashed i18n siblings when non-translatable fields sync to them", async () => {
 		setI18nConfig({ defaultLocale: "en", locales: ["en", "fr"] });
 		const { enId, frId } = await createLocalizedPostsPair(runtime, "trashed-sibling", {


### PR DESCRIPTION
## What does this PR do?

Syncs non-translatable fields to an entry's other locales when it is published, on collections with revisions, which is the default. A save there only stages a draft, and publishing promoted that draft without running the sync, so the other locales kept their old values.

The sync now runs at publication through `ContentRepository.syncNonTranslatableFields`, which also replaces the raw `UPDATE` on the save path of collections without revisions:

- Only the values the publication changed are copied, so publishing a translation that never held a shared value, or one whose value fell behind while the sync was missing, leaves the other locales' values alone.
- A locale that already holds every value is not written, so its `updated_at`, which the sitemap's `<lastmod>` reads, moves only when its live content changes.
- A changed locale gets a new `version` and `updated_at`, so a `_rev` read before the sync is refused instead of overwriting the synced value.
- On collections with revisions it also gets a new live revision, because republishing and unpublishing read that revision rather than the columns.
- A pending draft in another locale takes a value only where it still holds the previous one, so an unpublished edit to that field survives and syncs when that locale is published.
- Media usage for the other locales is refreshed after a publish, as it already was after a save.

Saving a draft still leaves the other locales and their `updated_at` alone (#2143), and hooks fire for the published entry only, as with the save-path sync. A locale that another editor holds the lock on (#2919) is still written, so an open translation never holds back publishing elsewhere, and the version bump turns that editor's next save into a conflict. On D1 the sync is not atomic with the publication, like the slug redirect written after it; the publication itself is still one content-row statement, so the `handleContentPublish` docstring keeps its opening sentence from #2349. The internationalization guide now says the copy happens at publication.

Closes #2911

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (n/a: no admin UI change)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a: bug fix)
- [ ] I have included screenshots below if this PR changes the UI (n/a: no UI change)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5

## Screenshots / test output

Not applicable, no UI change.

`non-translatable-sync.test.ts` covers both kinds of collection on SQLite and PostgreSQL. Seven of its eleven cases fail on `main`; the other four pin what the fix must leave alone. The cases for a matching locale, the new live revision, a pending draft and an unchanged or missing value each fail when that part is removed, run one mutation at a time. Both new cases in `media-usage-runtime-refresh.test.ts` fail without the runtime change. The full `packages/core` suite passes.
