### PR TITLE
fix(core): remove taxonomy assignments when content is permanently deleted

### DIFF
--- a/.changeset/purge-entry-term-assignments.md
+++ b/.changeset/purge-entry-term-assignments.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes permanently deleting an entry leaving its taxonomy term assignments in the database. The assignments are removed with the last translation of the entry and kept while another translation exists, including one in the trash.

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -1389,6 +1389,7 @@ export async function handleContentPermanentDelete(
 		// Wrap content delete + SEO/comment cleanup in a transaction
 		const deleted = await withTransaction(db, async (trx) => {
 			const trxRepo = new ContentRepository(trx);
+			const item = await trxRepo.findByIdIncludingTrashed(collection, resolvedId);
 			const wasDeleted = await trxRepo.permanentDelete(collection, resolvedId);
 
 			if (wasDeleted) {
@@ -1402,6 +1403,21 @@ export async function handleContentPermanentDelete(
 				const revisionRepo = new RevisionRepository(trx);
 				await revisionRepo.deleteByEntry(collection, resolvedId);
 				await new EntryLockRepository(trx).releaseEntry(collection, resolvedId);
+				// Term assignments are keyed by translation_group, so they belong to the
+				// group rather than to this row. They go only once no row of the group is
+				// left, trashed ones included, since a trashed row can still be restored.
+				if (item?.translationGroup) {
+					const groupSurvives = await trxRepo.hasTranslationsIncludingTrashed(
+						collection,
+						item.translationGroup,
+					);
+					if (!groupSurvives) {
+						await new TaxonomyRepository(trx).clearEntryGroupTerms(
+							collection,
+							item.translationGroup,
+						);
+					}
+				}
 			}
 
 			return wasDeleted;

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -1665,6 +1665,19 @@ export class ContentRepository {
 		return result.rows.map((row) => this.mapRow(type, row));
 	}
 
+	/** Whether any row of `translationGroup` exists, trashed rows included. */
+	async hasTranslationsIncludingTrashed(type: string, translationGroup: string): Promise<boolean> {
+		const tableName = getTableName(type);
+
+		const result = await sql<Record<string, unknown>>`
+			SELECT id FROM ${sql.ref(tableName)}
+			WHERE translation_group = ${translationGroup}
+			LIMIT 1
+		`.execute(this.db);
+
+		return result.rows.length > 0;
+	}
+
 	/**
 	 * Batch variant of {@link findTranslations}: every (non-deleted) locale
 	 * variant for any of `translationGroups`, in one `WHERE translation_group IN

--- a/packages/core/src/database/repositories/taxonomy.ts
+++ b/packages/core/src/database/repositories/taxonomy.ts
@@ -749,7 +749,15 @@ export class TaxonomyRepository {
 	async clearEntryTerms(collection: string, entryId: string): Promise<number> {
 		const entryGroup = await this.resolveEntryTranslationGroup(collection, entryId);
 		if (!entryGroup) return 0;
+		return this.clearEntryGroupTerms(collection, entryGroup);
+	}
 
+	/**
+	 * Remove every term assignment held by an entry translation group. Takes the
+	 * group rather than an entry id, so it still works after the group's last
+	 * row has been deleted.
+	 */
+	async clearEntryGroupTerms(collection: string, entryGroup: string): Promise<number> {
 		const result = await this.db
 			.deleteFrom("content_taxonomies")
 			.where("collection", "=", collection)

--- a/packages/core/tests/integration/content/permanent-delete-terms.test.ts
+++ b/packages/core/tests/integration/content/permanent-delete-terms.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Term assignments belong to the translation group, so permanent delete
+ * removes them only with the group's last row, trashed rows included.
+ */
+
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { handleContentPermanentDelete } from "../../../src/api/handlers/content.js";
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import { TaxonomyRepository } from "../../../src/database/repositories/taxonomy.js";
+import {
+	describeEachDialect,
+	setupForDialectWithCollections,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+describeEachDialect("handleContentPermanentDelete: term assignments", (dialect) => {
+	let ctx: DialectTestContext;
+	let content: ContentRepository;
+	let taxonomies: TaxonomyRepository;
+	let termId: string;
+
+	beforeEach(async () => {
+		ctx = await setupForDialectWithCollections(dialect);
+		content = new ContentRepository(ctx.db);
+		taxonomies = new TaxonomyRepository(ctx.db);
+		const term = await taxonomies.create({ name: "tag", slug: "news", label: "News" });
+		termId = term.id;
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	async function assignmentsFor(group: string) {
+		return ctx.db
+			.selectFrom("content_taxonomies")
+			.select("taxonomy_id")
+			.where("collection", "=", "post")
+			.where("entry_id", "=", group)
+			.execute();
+	}
+
+	async function trashAndPurge(id: string) {
+		expect(await content.delete("post", id)).toBe(true);
+		const result = await handleContentPermanentDelete(ctx.db, "post", id);
+		expect(result.success).toBe(true);
+	}
+
+	async function createTranslatedPost() {
+		const en = await content.create({ type: "post", locale: "en", data: { title: "Hello" } });
+		const de = await content.create({
+			type: "post",
+			locale: "de",
+			translationOf: en.id,
+			data: { title: "Hallo" },
+		});
+		await taxonomies.attachToEntry("post", en.id, termId);
+		return { en, de, group: en.translationGroup! };
+	}
+
+	it("removes the assignments when the last translation is deleted", async () => {
+		const post = await content.create({ type: "post", data: { title: "Only" } });
+		await taxonomies.attachToEntry("post", post.id, termId);
+		expect(await assignmentsFor(post.translationGroup!)).toHaveLength(1);
+
+		await trashAndPurge(post.id);
+
+		expect(await assignmentsFor(post.translationGroup!)).toEqual([]);
+	});
+
+	it("keeps the assignments while another translation exists", async () => {
+		const { en, de, group } = await createTranslatedPost();
+
+		await trashAndPurge(en.id);
+		expect(await assignmentsFor(group)).toHaveLength(1);
+
+		await trashAndPurge(de.id);
+		expect(await assignmentsFor(group)).toEqual([]);
+	});
+
+	it("keeps the assignments while another translation is in the trash", async () => {
+		const { en, de, group } = await createTranslatedPost();
+		expect(await content.delete("post", de.id)).toBe(true);
+
+		await trashAndPurge(en.id);
+
+		expect(await assignmentsFor(group)).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Removes an entry's taxonomy assignments when its last translation is permanently deleted.

Assignments belong to the translation group rather than to a row, with no foreign key, and permanent delete never removed them, so they stayed in the database after the entry was gone. The handler now reads the row's group before the delete and removes the group's assignments once no row of it is left. A translation in the trash keeps them, since restoring it brings its terms back.

The check is the same row lookup and `hasTranslationsIncludingTrashed` helper that #1928 and #2799 add to this handler for reference edges. On D1 it runs after the delete without a transaction, like the SEO, comment and revision cleanup. On PostgreSQL, two overlapping permanent deletes of a group's last two translations each still see the other's row, so both keep the assignments, and a single `DELETE … WHERE NOT EXISTS` keeps them the same way. SQLite and D1 run one write at a time, so there the check after the second delete finds no row left. Assignments that earlier deletes left behind stay.

Part of #1683, the third gap in [the audit](https://github.com/emdash-cms/emdash/issues/1683#issuecomment-5513061968).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) (the full `emdash` suite)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. (n/a: no admin UI change)
- [x] I have added and reviewed the user-facing [changeset](https://github.com/emdash-cms/emdash/blob/main/.changeset/README.md) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a: bug fix)
- [ ] I have included screenshots below if this PR changes the UI (n/a: no UI change)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5

## Screenshots / test output

Not applicable for screenshots. Against the unmodified handler, the two cases in `permanent-delete-terms.test.ts` that delete a group's last row fail, and the trash case passes:

```
 × handleContentPermanentDelete: term assignments [sqlite] > removes the assignments when the last translation is deleted
 × handleContentPermanentDelete: term assignments [sqlite] > keeps the assignments while another translation exists
 ✓ handleContentPermanentDelete: term assignments [sqlite] > keeps the assignments while another translation is in the trash
AssertionError: expected [ Array(1) ] to deeply equal []
```

With the change, all three pass on SQLite and PostgreSQL, and the full `emdash` suite passes on SQLite:

```
 Test Files  550 passed | 2 skipped (552)
      Tests  6716 passed | 10 skipped (6726)
```
