### PR TITLE
fix(admin): keep folder slashes in local media preview URLs

### DIFF
--- a/.changeset/media-preview-folder-keys.md
+++ b/.changeset/media-preview-folder-keys.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the admin editor showing "Image not found" for local media whose storage key contains a folder, such as `2026/08/photo.jpg`. Image fields, featured images, galleries and the asset editor now request `/_emdash/api/media/file/2026/08/photo.jpg` instead of `2026%2F08%2Fphoto.jpg`, which the file route answered with 404. Query and fragment characters in a key are still encoded.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -36,7 +36,7 @@ import { getPreviewUrl, getDraftStatus } from "../lib/api";
 import { getContentPublishingState } from "../lib/content-publishing-state.js";
 import { fromDatetimeLocalInputValue, toDatetimeLocalInputValue } from "../lib/datetime-local.js";
 import { getEntryTitle } from "../lib/entryTitle.js";
-import { formatFileSize, getFileIcon } from "../lib/media-utils";
+import { formatFileSize, getFileIcon, localMediaFileUrl } from "../lib/media-utils";
 import { usePluginAdmins } from "../lib/plugin-context.js";
 import { contentUrl, isSafeUrl } from "../lib/url.js";
 import { cn, slugify } from "../lib/utils";
@@ -2010,12 +2010,13 @@ function FileFieldRenderer({
 		const directUrl = value.src ?? value.url;
 		const localSrc =
 			typeof directUrl === "string" && directUrl.startsWith("/_emdash/") ? directUrl : undefined;
-		// Clients can write meta.storageKey, so encode it before interpolation to
-		// keep query or fragment delimiters from escaping the route path.
+		// Clients can write meta.storageKey, so it is encoded per path segment: query or
+		// fragment delimiters cannot escape the route path, and a key with folders still
+		// reaches the [...key] route.
 		const localUrl = isLocal
 			? storageKey
-				? `/_emdash/api/media/file/${encodeURIComponent(storageKey)}`
-				: (localSrc ?? `/_emdash/api/media/file/${encodeURIComponent(value.id)}`)
+				? localMediaFileUrl(storageKey)
+				: (localSrc ?? localMediaFileUrl(value.id))
 			: undefined;
 		const externalUrl = !isLocal && directUrl && isSafeUrl(directUrl) ? directUrl : undefined;
 		return {

--- a/packages/admin/src/components/ImageFieldRenderer.tsx
+++ b/packages/admin/src/components/ImageFieldRenderer.tsx
@@ -27,6 +27,7 @@ import {
 	canonicalMediaProviderId,
 	getMediaObjectPosition,
 	getMediaPreviewUrl,
+	localMediaFileUrl,
 	metaString,
 } from "../lib/media-utils.js";
 import { FieldHelpLabel } from "./FieldHelpLabel.js";
@@ -71,9 +72,9 @@ function mediaDisplayUrl(value: ImageFieldValue | string | undefined): string | 
 	if (!value) return undefined;
 	if (value.previewUrl || value.src) return value.previewUrl || value.src;
 	if (!value.provider || value.provider === "local") {
-		return `/_emdash/api/media/file/${encodeURIComponent(
+		return localMediaFileUrl(
 			typeof value.meta?.storageKey === "string" ? value.meta.storageKey : value.id,
-		)}`;
+		);
 	}
 	return undefined;
 }

--- a/packages/admin/src/components/editor/GalleryNode.tsx
+++ b/packages/admin/src/components/editor/GalleryNode.tsx
@@ -21,6 +21,7 @@ import {
 	canonicalMediaProviderId,
 	getMediaObjectPosition,
 	getMediaPreviewUrl,
+	localMediaFileUrl,
 } from "../../lib/media-utils.js";
 import { cn } from "../../lib/utils";
 
@@ -79,7 +80,7 @@ declare module "@tiptap/react" {
 /** Resolve the admin preview URL for a gallery image. */
 export function galleryImageUrl(image: GalleryImage): string {
 	if (image.asset.url) return image.asset.url;
-	if (image.asset._ref) return `/_emdash/api/media/file/${encodeURIComponent(image.asset._ref)}`;
+	if (image.asset._ref) return localMediaFileUrl(image.asset._ref);
 	return "";
 }
 

--- a/packages/admin/src/components/media/useMediaAssetEditor.tsx
+++ b/packages/admin/src/components/media/useMediaAssetEditor.tsx
@@ -9,6 +9,7 @@ import {
 	type MediaItem,
 } from "../../lib/api.js";
 import { useCurrentUser } from "../../lib/api/current-user.js";
+import { localMediaFileUrl } from "../../lib/media-utils.js";
 import { MediaDetailPanel } from "../MediaDetailPanel.js";
 
 const ROLE_AUTHOR = 30;
@@ -59,7 +60,7 @@ export function useMediaAssetEditor(onItemChanged: (item: LocalMediaItem) => voi
 				? fetchedMedia
 				: {
 						...fetchedMedia,
-						url: `/_emdash/api/media/file/${encodeURIComponent(fetchedMedia.storageKey)}`,
+						url: localMediaFileUrl(fetchedMedia.storageKey),
 					};
 			const user = userResult.data;
 			const canEdit =

--- a/packages/admin/src/lib/media-utils.ts
+++ b/packages/admin/src/lib/media-utils.ts
@@ -103,6 +103,23 @@ export function providerItemToMediaItem(
 /** Root-absolute path prefix for locally stored media served by EmDash. */
 const INTERNAL_MEDIA_PREFIX = "/_emdash/api/media/file/";
 
+/**
+ * URL of the local media file route for a storage key or media ID.
+ *
+ * Keys can contain `/` (an existing bucket layout such as `2026/08/photo.jpg`), and the
+ * `[...key]` route matches them as path segments, so each segment is encoded on its own:
+ * `?`, `#` and `%` stay inside the path, but `/` still separates segments. A key with an
+ * empty, `.` or `..` segment is encoded whole instead, because the URL parser would
+ * collapse those segments (even percent-encoded ones) and move the request off the route.
+ */
+export function localMediaFileUrl(key: string): string {
+	const segments = key.split("/");
+	if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+		return `${INTERNAL_MEDIA_PREFIX}${encodeURIComponent(key)}`;
+	}
+	return `${INTERNAL_MEDIA_PREFIX}${segments.map(encodeURIComponent).join("/")}`;
+}
+
 export function getMediaPreviewUrl(originalUrl: string, contentHash?: string | null): string {
 	if (!contentHash || !originalUrl.startsWith(INTERNAL_MEDIA_PREFIX)) return originalUrl;
 	const separator = originalUrl.includes("?") ? "&" : "?";

--- a/packages/admin/tests/components/ImageDetailPanel.test.tsx
+++ b/packages/admin/tests/components/ImageDetailPanel.test.tsx
@@ -539,7 +539,7 @@ describe("ImageDetailPanel", () => {
 
 		await expect
 			.element(screen.getByRole("button", { name: "Use cropped asset" }))
-			.toHaveAttribute("data-item-url", "/_emdash/api/media/file/folder%2Fold%20image.jpg");
+			.toHaveAttribute("data-item-url", "/_emdash/api/media/file/folder/old%20image.jpg");
 	});
 
 	it("does not close or save the usage behind an open asset dialog", async () => {

--- a/packages/admin/tests/components/ImageFieldRenderer.test.tsx
+++ b/packages/admin/tests/components/ImageFieldRenderer.test.tsx
@@ -193,6 +193,23 @@ describe("ImageFieldRenderer", () => {
 		expect(getComputedStyle(image!.parentElement!).aspectRatio).toBe("16 / 9");
 	});
 
+	it("previews a local image whose storage key contains slashes (#2871)", async () => {
+		// Keep the current-item refresh pending so the preview comes from the stored value.
+		vi.mocked(fetchMediaItem).mockReturnValue(new Promise(() => {}));
+		const screen = await render(
+			<ImageFieldRenderer
+				label="Featured image"
+				value={{ ...selectedImage, meta: { storageKey: "2026/08/photo.jpg" } }}
+				onChange={vi.fn()}
+				variant="featured"
+			/>,
+		);
+
+		await expect.element(screen.getByText("notes-on-simplicity.jpg")).toBeVisible();
+		const image = screen.container.querySelector("img");
+		expect(image).toHaveAttribute("src", "/_emdash/api/media/file/2026/08/photo.jpg");
+	});
+
 	it("refreshes a featured local preview from the current media item", async () => {
 		vi.mocked(fetchMediaItem).mockResolvedValueOnce({
 			id: selectedImage.id,

--- a/packages/admin/tests/lib/media-file-url.test.ts
+++ b/packages/admin/tests/lib/media-file-url.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { localMediaFileUrl } from "../../src/lib/media-utils";
+
+describe("localMediaFileUrl", () => {
+	it("keeps the slashes of a key stored with folders, so the [...key] route matches it", () => {
+		expect(localMediaFileUrl("2026/08/photo.jpg")).toBe(
+			"/_emdash/api/media/file/2026/08/photo.jpg",
+		);
+	});
+
+	it("leaves a plain media ID or key unchanged", () => {
+		expect(localMediaFileUrl("01HXYZ.jpg")).toBe("/_emdash/api/media/file/01HXYZ.jpg");
+	});
+
+	it("encodes query, fragment and percent characters inside each segment", () => {
+		const url = localMediaFileUrl("uploads/a?b#c%d e.png");
+
+		expect(url).toBe("/_emdash/api/media/file/uploads/a%3Fb%23c%25d%20e.png");
+		const parsed = new URL(url, "https://example.com");
+		expect(parsed.search).toBe("");
+		expect(parsed.hash).toBe("");
+	});
+
+	it.each(["../settings", "a/../../api/settings", "./photo.jpg", "a//b.jpg", "/leading.jpg"])(
+		"encodes %s whole so the path cannot leave the media route",
+		(key) => {
+			const url = localMediaFileUrl(key);
+
+			expect(url).toBe(`/_emdash/api/media/file/${encodeURIComponent(key)}`);
+			expect(
+				new URL(url, "https://example.com").pathname.startsWith("/_emdash/api/media/file/"),
+			).toBe(true);
+		},
+	);
+});


### PR DESCRIPTION
## What does this PR do?

Local media preview URLs in the admin were built with `encodeURIComponent(storageKey)`, which turns `2026/08/photo.jpg` into `2026%2F08%2Fphoto.jpg`. The core `[...key]` file route answers 404 for that, so the editor showed "Image not found" for every image whose key contains a folder, while the media library grid and the published site (which use the raw key) rendered the same file.

`localMediaFileUrl(key)` in `lib/media-utils.ts` replaces the four whole-key `encodeURIComponent` sites: `ImageFieldRenderer`, `ContentEditor`, `GalleryNode` and `useMediaAssetEditor`.

- **Each path segment is encoded on its own.** `/` still separates segments and reaches the `[...key]` route, while `?`, `#` and `%` inside a segment stay encoded. That keeps the protection `ContentEditor`'s comment describes ("Clients can write meta.storageKey… keep query or fragment delimiters from escaping the route path").
- **A key with an empty, `.` or `..` segment is encoded whole**, as before. The WHATWG URL parser collapses dot segments even when they're percent-encoded (`%2e%2e`), so per-segment encoding alone would let a client-written key such as `a/../../api/settings` move the request off the media route. Those keys keep today's behaviour.

I left the components that already interpolate the raw key (`MediaPickerModal`, `SeoImageField`, `BlockKitMediaPickerField`, `PortableTextEditor`) alone to keep this to the bug. They could use the same helper in a follow-up.

Closes #2871

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes: not run as `tsgo` (not installed here). `tsc --noEmit -p packages/admin` reports the same single pre-existing error (`ordered-list.ts:423`) on this branch and on `main`.
- [x] `pnpm lint` passes: `oxlint --deny-warnings` on the touched files
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run: `oxfmt` on the touched files
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation: n/a, no strings added
- [x] I have added and reviewed the user-facing changeset
- [ ] New features link to an approved Discussion: n/a, bug fix
- [ ] I have included screenshots below if this PR changes the UI: see below

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Screenshots / test output

No screenshot: I don't have a storage bucket with folder keys wired to a local admin. The change is the `src` the preview requests, and the browser test asserts it directly.

- `tests/lib/media-file-url.test.ts` (new): folder keys keep their slashes; `?`, `#`, `%` and spaces are encoded within segments and don't leak into `search`/`hash`; `../settings`, `a/../../api/settings`, `./photo.jpg`, `a//b.jpg` and `/leading.jpg` are encoded whole, and the parsed pathname stays under `/_emdash/api/media/file/`.
- `tests/components/ImageFieldRenderer.test.tsx`: a featured image with `meta.storageKey: "2026/08/photo.jpg"` renders `src="/_emdash/api/media/file/2026/08/photo.jpg"`. With `main`'s `ImageFieldRenderer.tsx`:
  ```
  × previews a local image whose storage key contains slashes (#2871)
    src="/_emdash/api/media/file/2026%2F08%2Fphoto.jpg"
  ```
- `tests/components/ImageDetailPanel.test.tsx`: `builds a local preview URL when the item response omits one` pinned `folder%2Fold%20image.jpg`, the broken URL for a folder key. It now expects `folder/old%20image.jpg`.

Every admin test file mentioning `ContentEditor`, `GalleryNode`, `useMediaAssetEditor` or `media/file` (23 files): 500 passed in headless Chromium.
