### PR TITLE
fix(cloudflare): resolve D1 databases by name without total_pages

### DIFF
--- a/.changeset/d1-name-lookup-paging.md
+++ b/.changeset/d1-name-lookup-paging.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/cloudflare": patch
+---
+
+Fixes `emdash migrate --d1 <name>` failing for every database name with "Cloudflare D1 database list total_pages is invalid". The D1 list endpoint does not return `total_pages`, so the page count is now derived from `total_count` and `per_page` when it is absent. A preview database whose name only contains the requested name (the `name` filter matches substrings) no longer fails the lookup either.

--- a/packages/cloudflare/src/db/d1-migration-target.ts
+++ b/packages/cloudflare/src/db/d1-migration-target.ts
@@ -213,8 +213,13 @@ async function databaseByName(
 			throw new Error("Cloudflare D1 database list pagination is invalid.");
 		}
 		seenCount += resultInfo.count;
+		// `name` is a substring filter, so a page can hold other databases whose names merely
+		// contain it. Only an exact match is validated as a deployment target; a preview database
+		// named `site-db-staging` must not fail the lookup for `site-db`.
 		matches.push(
-			...envelope.result.map(metadataDatabase).filter((database) => database.name === name),
+			...envelope.result
+				.filter((database) => isRecord(database) && database.name === name)
+				.map(metadataDatabase),
 		);
 		page += 1;
 	}
@@ -245,8 +250,14 @@ function listResultInfo(value: unknown, expectedPage: number, resultCount: numbe
 		perPage: listInteger(value.per_page, "per_page", 1),
 		count: listInteger(value.count, "count", 0),
 		totalCount: listInteger(value.total_count, "total_count", 0),
-		totalPages: listInteger(value.total_pages, "total_pages", 0),
+		totalPages: 0,
 	};
+	// The D1 database list returns `page`, `per_page`, `count` and `total_count` but no
+	// `total_pages`, so derive it when it is absent rather than rejecting every name lookup.
+	result.totalPages =
+		value.total_pages === undefined
+			? Math.ceil(result.totalCount / result.perPage)
+			: listInteger(value.total_pages, "total_pages", 0);
 	if (
 		result.page !== expectedPage ||
 		result.perPage > DATABASE_LIST_PAGE_SIZE ||

--- a/packages/cloudflare/tests/db/d1-migration-target.test.ts
+++ b/packages/cloudflare/tests/db/d1-migration-target.test.ts
@@ -37,6 +37,22 @@ function listApiResponse(
 	});
 }
 
+/** The envelope the live D1 list endpoint returns: `result_info` has no `total_pages` (#2840). */
+function liveListApiResponse(
+	result: unknown[],
+	page: number,
+	totalCount: number,
+	perPage = 100,
+): Response {
+	return Response.json({
+		success: true,
+		errors: [],
+		messages: [],
+		result,
+		result_info: { count: result.length, page, per_page: perPage, total_count: totalCount },
+	});
+}
+
 function database(uuid = DATABASE_ID, name = "site-db"): Record<string, unknown> {
 	return { uuid, name, version: "production" };
 }
@@ -90,6 +106,65 @@ describe("resolveD1MigrationTarget", () => {
 			"name=site-db",
 		);
 		expect(fetch).toHaveBeenCalledTimes(2);
+	});
+
+	describe("with the live list envelope, which has no total_pages (#2840)", () => {
+		const resolveByName = (fetch: typeof globalThis.fetch) =>
+			resolveD1MigrationTarget(
+				{ binding: "DB" },
+				{
+					projectRoot: "/project",
+					env: { CLOUDFLARE_ACCOUNT_ID: ACCOUNT_ID, CLOUDFLARE_API_TOKEN: TOKEN },
+					overrides: { d1: "site-db" },
+				},
+				{ fetch },
+			);
+
+		it("resolves a name from a single page", async () => {
+			const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+				liveListApiResponse([database(DATABASE_ID, "site-db")], 1, 1),
+			);
+
+			await expect(resolveByName(fetch)).resolves.toMatchObject({ databaseId: DATABASE_ID });
+			expect(fetch).toHaveBeenCalledTimes(1);
+		});
+
+		it("walks every page derived from total_count and per_page", async () => {
+			const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+				const url = new URL(input instanceof Request ? input.url : input.toString());
+				return url.searchParams.get("page") === "1"
+					? liveListApiResponse([database(undefined, "site-db-preview")], 1, 2, 1)
+					: liveListApiResponse([database(DATABASE_ID, "site-db")], 2, 2, 1);
+			});
+
+			await expect(resolveByName(fetch)).resolves.toMatchObject({ databaseId: DATABASE_ID });
+			expect(fetch).toHaveBeenCalledTimes(2);
+		});
+
+		it("ignores a preview database whose name only contains the requested name", async () => {
+			// `name` is a substring filter, so the page also lists `site-db-staging`.
+			const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+				liveListApiResponse(
+					[
+						{
+							...database("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee", "site-db-staging"),
+							version: "preview",
+						},
+						database(DATABASE_ID, "site-db"),
+					],
+					1,
+					2,
+				),
+			);
+
+			await expect(resolveByName(fetch)).resolves.toMatchObject({ databaseId: DATABASE_ID });
+		});
+
+		it("still reports a missing name", async () => {
+			const fetch = vi.fn<typeof globalThis.fetch>(async () => liveListApiResponse([], 1, 0));
+
+			await expect(resolveByName(fetch)).rejects.toThrow(/No D1 database named site-db/);
+		});
 	});
 
 	it("rejects duplicate exact names found on different result pages", async () => {


### PR DESCRIPTION
## What does this PR do?

`emdash migrate --d1 <name>` could never resolve a name. `databaseByName` validated pagination with `listInteger(value.total_pages, …)`, but the D1 list endpoint's `result_info` is `{ count, page, per_page, total_count }` with no `total_pages`, so every lookup threw `Cloudflare D1 database list total_pages is invalid.` before looking at a single row. UUIDs and `--wrangler-config` were unaffected.

- **Page count.** When `total_pages` is absent, it is derived as `ceil(total_count / per_page)`. When present it is validated as before. Everything downstream (the page loop, the cross-page consistency check, `MAX_DATABASE_LIST_PAGES`, the final `seenCount === totalCount` check) is unchanged and now runs on a value the endpoint actually implies.
- **Substring matches (the issue's secondary note).** `name` is a substring filter, and every row went through `metadataDatabase` before the exact-name filter. That throws for any non-production row, so once paging worked, a preview `site-db-staging` on the same page would still have failed the lookup for `site-db`. Rows are now filtered by exact name first, and only the matches are validated as deployment targets.

Closes #2840

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes: `tsc --noEmit -p packages/cloudflare` reports the same 7 errors on this branch and on `main` (unbuilt `emdash` workspace types), none in the touched file
- [x] `pnpm lint` passes: `oxlint --deny-warnings` on the touched files
- [x] `pnpm test` passes (or targeted tests for my change): see below
- [x] `pnpm format` has been run: `oxfmt`
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation: n/a
- [x] I have added and reviewed the user-facing changeset
- [ ] New features link to an approved Discussion: n/a, bug fix
- [ ] I have included screenshots below if this PR changes the UI: n/a

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 5 (Claude Code)

## Screenshots / test output

Not applicable (CLI). The test stub `listApiResponse` synthesized `total_pages`, which is why CI never saw this. The new cases in `packages/cloudflare/tests/db/d1-migration-target.test.ts` use a `liveListApiResponse` shaped like the endpoint the issue recorded:

- resolves a name from a single page;
- walks two pages derived from `total_count: 2, per_page: 1`;
- ignores a preview `site-db-staging` listed next to `site-db`;
- still reports `No D1 database named site-db` for an empty result.

```
main:  5 failed | 10 passed   # the 4 new cases ("total_pages is invalid") + 1 pre-existing
head:  1 failed | 14 passed   # only the pre-existing one
```

The one failure on both trees is `uses the selected Wrangler environment and its own binding array`, which asserts `/project/wrangler.jsonc` and gets a Windows path separator on this machine. CI on Linux should pass it. I did not run this against the live Cloudflare API.
